### PR TITLE
Keydef/TapHold: tapping of TapHold results in tap

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,7 @@
 #[derive(Debug, Clone, Copy)]
 pub enum Event {
-    Press(u16),
-    Release(u16),
+    Press { keymap_index: u16 },
+    Release { keymap_index: u16 },
+    VirtualKeyPress { keycode: u8 },
+    VirtualKeyRelease { keycode: u8 },
 }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -14,30 +14,44 @@ pub enum TapHoldState {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub enum PressedKeyStateKeyData {
-    Simple,
-    TapHold(TapHoldState),
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct PressedKeyState {
-    pub keymap_index: u16,
-    pub key_data: PressedKeyStateKeyData,
+pub enum PressedKeyState {
+    Simple { keymap_index: u16 },
+    TapHold { keymap_index: u16, state: TapHoldState },
+    Virtual { keycode: u8, },
 }
 
 impl PressedKeyState {
+    pub fn keymap_index(self: &Self) -> Option<u16> {
+        match self {
+            PressedKeyState::Simple { keymap_index } => Some(*keymap_index),
+            PressedKeyState::TapHold { keymap_index, .. } => Some(*keymap_index),
+            _ => None,
+        }
+    }
+
     pub fn key_code<const N: usize>(self: &Self, key_definitions: [KeyDefinition; N]) -> Option<u8> {
-        let key_definition = key_definitions[self.keymap_index as usize];
-        match key_definition {
-            KeyDefinition::Simple(key_code) => Some(key_code),
-            KeyDefinition::TapHold { tap, hold } => {
-                match self.key_data {
-                    PressedKeyStateKeyData::TapHold(TapHoldState::Tap) => Some(tap),
-                    PressedKeyStateKeyData::TapHold(TapHoldState::Hold) => Some(hold),
+        match self {
+            PressedKeyState::Simple { keymap_index } => {
+                let key_definition = key_definitions[*keymap_index as usize];
+                match key_definition {
+                    KeyDefinition::Simple(key_code) => Some(key_code),
                     _ => None,
                 }
-            }
-            _ => None,
+            },
+            PressedKeyState::TapHold { keymap_index, state } => {
+                let key_definition = key_definitions[*keymap_index as usize];
+                match key_definition {
+                    KeyDefinition::TapHold { tap, hold } => {
+                        match state {
+                            TapHoldState::Tap => Some(tap),
+                            TapHoldState::Hold => Some(hold),
+                            _ => None,
+                        }
+                    },
+                    _ => None,
+                }
+            },
+            PressedKeyState::Virtual { keycode } => Some(*keycode),
         }
     }
 }
@@ -54,6 +68,7 @@ pub const KEY_DEFINITIONS: [KeyDefinition; 4] = [
 pub struct Keymap<const N: usize> {
     key_definitions: [KeyDefinition; N],
     pressed_keys: heapless::Vec<PressedKeyState, N>,
+    pending_events: heapless::spsc::Queue<input::Event, 256>,
 }
 
 impl<const N: usize> Keymap<N> {
@@ -61,50 +76,103 @@ impl<const N: usize> Keymap<N> {
         Self {
             key_definitions,
             pressed_keys: heapless::Vec::new(),
+            pending_events: heapless::spsc::Queue::new(),
         }
     }
 
     pub fn init(self: &mut Self) {
         self.pressed_keys.clear();
+        while let Some(_) = self.pending_events.dequeue() {}
     }
 
     pub fn handle_input(self: &mut Self, ev: input::Event) {
         match ev {
-            input::Event::Press(keymap_index) => {
+            input::Event::Press { keymap_index } => {
                 // TapHold: any interruption resolves pending TapHold as Hold.
                 self.pressed_keys.iter_mut()
                                  .filter(|pk| {
-                                     match pk.key_data {
-                                         PressedKeyStateKeyData::TapHold(TapHoldState::Pending) => true,
+                                     match pk {
+                                         PressedKeyState::TapHold { state: TapHoldState::Pending, .. } => true,
                                          _ => false,
                                      }
                                  })
                                  .for_each(|pk| {
-                                     pk.key_data = PressedKeyStateKeyData::TapHold(TapHoldState::Hold);
+                                     match pk {
+                                         PressedKeyState::TapHold { state, .. } => {
+                                             *state = TapHoldState::Hold;
+                                         },
+                                         _ => {}
+                                     }
                                  });
 
                 let key_definition = self.key_definitions[keymap_index as usize];
                 match key_definition {
                     KeyDefinition::Simple(_) => {
-                        let pressed_key = PressedKeyState {
+                        let pressed_key = PressedKeyState::Simple {
                             keymap_index,
-                            key_data: PressedKeyStateKeyData::Simple,
                         };
                         self.pressed_keys.push(pressed_key).unwrap();
                     },
                     KeyDefinition::TapHold { tap: _, hold: _ } => {
-                        let pressed_key = PressedKeyState {
+                        let pressed_key = PressedKeyState::TapHold {
                             keymap_index,
-                            key_data: PressedKeyStateKeyData::TapHold(TapHoldState::Pending),
+                            state: TapHoldState::Pending,
                         };
                         self.pressed_keys.push(pressed_key).unwrap();
                     },
                     _ => {}
                 }
             },
-            input::Event::Release(keymap_index) => {
-                self.pressed_keys.iter().position(|&k| k.keymap_index == keymap_index)
+            input::Event::Release { keymap_index } => {
+                // TapHold: resolved as tap (unless it's already resolved as a Hold).
+                // But, since the key is released,
+                //  we need to enque the tap keycode in the pending events.
+                let key_definition = self.key_definitions[keymap_index as usize];
+                match key_definition {
+                    KeyDefinition::TapHold { tap, hold: _ } => {
+                        if let Some(pressed_key) = self.pressed_keys.iter_mut().find(|pk| {
+                            pk.keymap_index() == Some(keymap_index)
+                        }) {
+                           match pressed_key {
+                               PressedKeyState::TapHold { state: TapHoldState::Pending, .. } => {
+                                   self.pending_events.enqueue(input::Event::VirtualKeyPress { keycode: tap }).unwrap();
+                                   self.pending_events.enqueue(input::Event::VirtualKeyRelease { keycode: tap }).unwrap();
+                               },
+                               _ => {}
+                           }
+                        }
+                    },
+                    _ => {}
+                }
+
+                self.pressed_keys.iter().position(|&k| k.keymap_index() == Some(keymap_index))
                                         .map(|i| self.pressed_keys.remove(i));
+            }
+            _ => {}
+        }
+    }
+
+    pub fn tick(self: &mut Self) {
+        // take from pending
+        if let Some(ev) = self.pending_events.dequeue() {
+            match ev {
+                input::Event::VirtualKeyPress { keycode } => {
+                    // Add keycode to pressed keys.
+                    let pressed_key = PressedKeyState::Virtual {
+                        keycode,
+                    };
+                    self.pressed_keys.push(pressed_key).unwrap();
+                },
+                input::Event::VirtualKeyRelease { keycode } => {
+                    // Remove keycode from pressed keys.
+                    self.pressed_keys.iter().position(|&k| {
+                        match k {
+                            PressedKeyState::Virtual { keycode: kc } => keycode == kc,
+                            _ => false,
+                        }
+                    }).map(|i| self.pressed_keys.remove(i));
+                },
+                _ => {}
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,16 +14,16 @@ pub extern "C" fn keymap_init() {
 }
 
 #[no_mangle]
-pub extern "C" fn keymap_register_input_keypress(index: u16) {
+pub extern "C" fn keymap_register_input_keypress(keymap_index: u16) {
     unsafe {
-        KEYMAP.handle_input(input::Event::Press(index));
+        KEYMAP.handle_input(input::Event::Press { keymap_index });
     }
 }
 
 #[no_mangle]
-pub extern "C" fn keymap_register_input_keyrelease(index: u16) {
+pub extern "C" fn keymap_register_input_keyrelease(keymap_index: u16) {
     unsafe {
-        KEYMAP.handle_input(input::Event::Release(index));
+        KEYMAP.handle_input(input::Event::Release { keymap_index });
     }
 }
 
@@ -39,6 +39,8 @@ pub extern "C" fn keymap_tick(buf: *mut u8) {
     }
 
     unsafe {
+        KEYMAP.tick();
+
         let report = KEYMAP.boot_keyboard_report();
         core::ptr::copy_nonoverlapping(report.as_ptr(), buf, report.len());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,23 @@ pub extern "C" fn keymap_register_input_keyrelease(index: u16) {
     }
 }
 
+/// Run Keymap processing.
+///
+/// Should be called every ms.
+///
+/// The HID keyboard report is copied to the given buffer.
+#[no_mangle]
+pub extern "C" fn keymap_tick(buf: *mut u8) {
+    if buf.is_null() {
+        return;
+    }
+
+    unsafe {
+        let report = KEYMAP.boot_keyboard_report();
+        core::ptr::copy_nonoverlapping(report.as_ptr(), buf, report.len());
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn copy_hid_boot_keyboard_report(buf: *mut u8) {
     if buf.is_null() {

--- a/tests/ceedling/test/test_keydef_taphold.c
+++ b/tests/ceedling/test/test_keydef_taphold.c
@@ -19,7 +19,7 @@ void tearDown(void) {
 void test_taphold_interrupted_is_hold(void) {
     // Interrupting a taphold results in the 'hold' key.
     //
-    // Pressing T.H, then A, is same as "Hold key + A"
+    // Pressing T.H., then A, is same as "Hold key + A"
 
     uint8_t expected_report[8] = {MOD_LCTL, 0, KC_A, 0, 0, 0, 0, 0};
     uint8_t actual_report[8] = {0, 0, 0, 0, 0, 0, 0, 0};
@@ -30,5 +30,40 @@ void test_taphold_interrupted_is_hold(void) {
     keymap_register_input_keypress(2); // Third key in the keymap is A
 
     copy_hid_boot_keyboard_report(actual_report);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report, 8);
+}
+
+void test_taphold_dth_uth_is_tap(void) {
+    // Pressing T.H., then releasing T.H., is same as tapping the tap key.
+    // (Check the tap key gets pressed).
+
+    uint8_t expected_report[8] = {0, 0, KC_C, 0, 0, 0, 0, 0};
+    uint8_t actual_report[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+    keymap_init();
+
+    keymap_register_input_keypress(0); // First key in keymap is TapHold(C, _)
+    keymap_register_input_keyrelease(0);
+
+    keymap_tick(actual_report);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report, 8);
+}
+
+void test_taphold_dth_uth_eventually_clears(void) {
+    // Pressing T.H., then releasing T.H., is same as tapping the tap key.
+    // (Check the tap key releases).
+
+    uint8_t expected_report[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    uint8_t actual_report[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+    keymap_init();
+
+    keymap_register_input_keypress(0); // First key in keymap is TapHold(C, _)
+    keymap_register_input_keyrelease(0);
+
+    keymap_tick(actual_report);
+
+    keymap_tick(actual_report); // The 'tap' from the TapHold key should be released.
+
     TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report, 8);
 }


### PR DESCRIPTION
- Adjusted `input::Event` enum variants, to better distinguish when the argument is `keymap_index` compared to when it's a `keycode`. Added Virtual key press/release events.

- Adjusted `PressedKeyState` to allow `Virtual` keycodes to be active.

- Releasing a TapHold key results in virtual key press, release events for the TapHold's tap keycode. (Covered by a couple of tests in `tests/ceedling`).

- Added a `keymap_tick(...)` to the C library interface, which processes the Keymap's pending events.