### PR TITLE
Keydef/TapHold eventually holds

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1,7 +1,8 @@
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
 pub enum Event {
     Press { keymap_index: u16 },
     Release { keymap_index: u16 },
     VirtualKeyPress { keycode: u8 },
     VirtualKeyRelease { keycode: u8 },
+    TapHoldTimeout { keymap_index: u16 },
 }

--- a/tests/ceedling/test/test_keydef_taphold.c
+++ b/tests/ceedling/test/test_keydef_taphold.c
@@ -67,3 +67,21 @@ void test_taphold_dth_uth_eventually_clears(void) {
 
     TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report, 8);
 }
+
+void test_taphold_dth_eventually_holds(void) {
+    // Pressing T.H., is eventually the same as holding the hold key.
+
+    uint8_t expected_report[8] = {MOD_LCTL, 0, 0, 0, 0, 0, 0, 0};
+    uint8_t actual_report[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+    keymap_init();
+
+    keymap_register_input_keypress(0); // First key in keymap is TapHold(C, _)
+
+    // Wait 500ms
+    for (int i = 0; i < 500; i++) {
+        keymap_tick(actual_report);
+    }
+
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report, 8);
+}


### PR DESCRIPTION
This PR adds a test which checks that a TapHold eventually resolves as a hold, and implements enough functionality to get this to pass.

Implementation-wise:

- I'm not sure `input::Event` is the right place for `TapHoldResolved`. I think it'd be good to have each key definition implementation is in its own module; and in that sense, TapHoldResolved could be a TapHold event that gets handled by the TapHold module.

- Input event handling happens in both the `handle_input` and `tick` methods on the `Keymap` struct. That smells.

- Might be better to have this scheduling in its own struct, and have KeyMap use that.

