### PR TITLE
rust: refactor Simple, TapHold to key_definitions modules

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -2,7 +2,6 @@
 pub enum Event {
     Press { keymap_index: u16 },
     Release { keymap_index: u16 },
-    VirtualKeyPress { keycode: u8 },
-    VirtualKeyRelease { keycode: u8 },
-    TapHoldTimeout { keymap_index: u16 },
+    VirtualKeyPress { key_code: u8 },
+    VirtualKeyRelease { key_code: u8 },
 }

--- a/src/key_definitions/mod.rs
+++ b/src/key_definitions/mod.rs
@@ -1,0 +1,43 @@
+use crate::input;
+
+pub mod simple;
+pub mod tap_hold;
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
+pub enum Event<T> {
+    Input(input::Event),
+    Key(T),
+}
+
+impl<T> From<input::Event> for Event<T> {
+    fn from(event: input::Event) -> Self {
+        Event::Input(event)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
+pub enum Schedule {
+    Immediate,
+    After(u16),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
+pub struct ScheduledEvent<T> {
+    pub schedule: Schedule,
+    pub event: Event<T>,
+}
+
+impl<T> ScheduledEvent<T> {
+    pub fn immediate(event: Event<T>) -> Self {
+        ScheduledEvent {
+            schedule: Schedule::Immediate,
+            event,
+        }
+    }
+    pub fn after(delay: u16, event: Event<T>) -> Self {
+        ScheduledEvent {
+            schedule: Schedule::After(delay),
+            event,
+        }
+    }
+}

--- a/src/key_definitions/simple.rs
+++ b/src/key_definitions/simple.rs
@@ -1,0 +1,30 @@
+#[derive(Debug, Clone, Copy)]
+pub struct KeyDefinition(pub u8);
+
+impl KeyDefinition {
+    pub fn key_code(&self) -> u8 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+pub struct Event();
+
+#[derive(Debug, Clone, Copy)]
+pub struct PressedKey {
+    keymap_index: u16,
+}
+
+impl PressedKey {
+    pub fn new(keymap_index: u16) -> Self {
+        Self { keymap_index }
+    }
+
+    pub fn keymap_index(&self) -> u16 {
+        self.keymap_index
+    }
+
+    pub fn key_code(&self, key_def: &KeyDefinition) -> u8 {
+        key_def.key_code()
+    }
+}

--- a/src/key_definitions/tap_hold.rs
+++ b/src/key_definitions/tap_hold.rs
@@ -1,0 +1,110 @@
+use crate::input;
+use crate::key_definitions;
+
+#[derive(Debug, Clone, Copy)]
+pub struct KeyDefinition {
+    pub tap: u8,
+    pub hold: u8,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum TapHoldState {
+    Pending,
+    Tap,
+    Hold,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+pub enum Event {
+    TapHoldTimeout { keymap_index: u16 },
+}
+
+impl From<Event> for key_definitions::Event<Event> {
+    fn from(event: Event) -> Self {
+        key_definitions::Event::Key(event)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct PressedKey {
+    keymap_index: u16,
+    state: TapHoldState,
+}
+
+impl PressedKey {
+    pub fn new(keymap_index: u16) -> (Self, key_definitions::ScheduledEvent<Event>) {
+        (
+            Self {
+                keymap_index,
+                state: TapHoldState::Pending,
+            },
+            key_definitions::ScheduledEvent::after(
+                200,
+                Event::TapHoldTimeout { keymap_index }.into(),
+            ),
+        )
+    }
+
+    pub fn keymap_index(&self) -> u16 {
+        self.keymap_index
+    }
+
+    pub fn key_code(&self, key_def: &KeyDefinition) -> Option<u8> {
+        match self.state {
+            TapHoldState::Tap => Some(key_def.tap),
+            TapHoldState::Hold => Some(key_def.hold),
+            _ => None,
+        }
+    }
+
+    fn resolve(&mut self, state: TapHoldState) {
+        match self.state {
+            TapHoldState::Pending => {
+                self.state = state;
+            }
+            _ => {}
+        }
+    }
+
+    pub fn handle_event(
+        &mut self,
+        key_def: &KeyDefinition,
+        event: key_definitions::Event<Event>,
+    ) -> heapless::Vec<key_definitions::Event<Event>, 2> {
+        match event {
+            key_definitions::Event::Input(input::Event::Press { .. }) => {
+                // TapHold: any interruption resolves pending TapHold as Hold.
+                self.resolve(TapHoldState::Hold);
+                heapless::Vec::new()
+            }
+            key_definitions::Event::Input(input::Event::Release { keymap_index }) => {
+                if keymap_index == self.keymap_index {
+                    // TapHold: resolved as tap.
+                    self.resolve(TapHoldState::Tap);
+                }
+
+                match &self.state {
+                    TapHoldState::Tap => {
+                        let key_code = key_def.tap;
+                        let mut emitted_events: heapless::Vec<key_definitions::Event<Event>, 2> =
+                            heapless::Vec::new();
+                        emitted_events
+                            .push(input::Event::VirtualKeyPress { key_code }.into())
+                            .unwrap();
+                        emitted_events
+                            .push(input::Event::VirtualKeyRelease { key_code }.into())
+                            .unwrap();
+                        emitted_events
+                    }
+                    _ => heapless::Vec::new(),
+                }
+            }
+            key_definitions::Event::Key(Event::TapHoldTimeout { .. }) => {
+                // Key held long enough to resolve as hold.
+                self.resolve(TapHoldState::Hold);
+                heapless::Vec::new()
+            }
+            _ => heapless::Vec::new(),
+        }
+    }
+}

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -1,94 +1,136 @@
 use crate::input;
+use crate::key_definitions;
+use key_definitions::{simple, tap_hold};
 
 #[derive(Debug, Clone, Copy)]
 pub enum KeyDefinition {
-    Simple(u8),
-    TapHold { tap: u8, hold: u8 },
+    Simple(simple::KeyDefinition),
+    TapHold(tap_hold::KeyDefinition),
 }
 
 #[derive(Debug, Clone, Copy)]
-pub enum TapHoldState {
-    Pending,
-    // Tap,
-    Hold,
+pub enum PressedKey {
+    Simple(simple::PressedKey),
+    TapHold(tap_hold::PressedKey),
+    Virtual { key_code: u8 },
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum PressedKeyState {
-    Simple {
-        keymap_index: u16,
-    },
-    TapHold {
-        keymap_index: u16,
-        state: TapHoldState,
-    },
-    Virtual {
-        keycode: u8,
-    },
+impl From<simple::PressedKey> for PressedKey {
+    fn from(pk: simple::PressedKey) -> Self {
+        PressedKey::Simple(pk)
+    }
 }
 
-impl PressedKeyState {
+impl From<tap_hold::PressedKey> for PressedKey {
+    fn from(pk: tap_hold::PressedKey) -> Self {
+        PressedKey::TapHold(pk)
+    }
+}
+
+impl PressedKey {
     pub fn keymap_index(&self) -> Option<u16> {
         match self {
-            PressedKeyState::Simple { keymap_index } => Some(*keymap_index),
-            PressedKeyState::TapHold { keymap_index, .. } => Some(*keymap_index),
+            PressedKey::Simple(pk) => Some(pk.keymap_index()),
+            PressedKey::TapHold(pk) => Some(pk.keymap_index()),
             _ => None,
         }
     }
 
     pub fn key_code<const N: usize>(&self, key_definitions: [KeyDefinition; N]) -> Option<u8> {
         match self {
-            PressedKeyState::Simple { keymap_index } => {
-                let key_definition = key_definitions[*keymap_index as usize];
+            PressedKey::Simple(pk) => {
+                let key_definition = key_definitions[pk.keymap_index() as usize];
                 match key_definition {
-                    KeyDefinition::Simple(key_code) => Some(key_code),
+                    KeyDefinition::Simple(key_def) => Some(pk.key_code(&key_def)),
                     _ => None,
                 }
             }
-            PressedKeyState::TapHold {
-                keymap_index,
-                state,
-            } => {
-                let key_definition = key_definitions[*keymap_index as usize];
+
+            PressedKey::TapHold(pk) => {
+                let key_definition = key_definitions[pk.keymap_index() as usize];
                 match key_definition {
-                    KeyDefinition::TapHold { tap: _, hold } => match state {
-                        // TapHoldState::Tap => Some(tap),
-                        TapHoldState::Hold => Some(hold),
-                        _ => None,
-                    },
+                    KeyDefinition::TapHold(key_def) => pk.key_code(&key_def),
                     _ => None,
                 }
             }
-            PressedKeyState::Virtual { keycode } => Some(*keycode),
+
+            PressedKey::Virtual { key_code } => Some(*key_code),
         }
     }
 }
 
 pub const KEY_DEFINITIONS: [KeyDefinition; 4] = [
-    KeyDefinition::TapHold {
+    KeyDefinition::TapHold(tap_hold::KeyDefinition {
         tap: 0x06,
         hold: 0xE0,
-    }, // Tap C, Hold LCtrl
-    KeyDefinition::TapHold {
+    }), // Tap C, Hold LCtrl
+    KeyDefinition::TapHold(tap_hold::KeyDefinition {
         tap: 0x07,
         hold: 0xE1,
-    }, // Tap D, Hold LShift
-    KeyDefinition::Simple(0x04), // A
-    KeyDefinition::Simple(0x05), // B
+    }), // Tap D, Hold LShift
+    KeyDefinition::Simple(simple::KeyDefinition(0x04)), // A
+    KeyDefinition::Simple(simple::KeyDefinition(0x05)), // B
 ];
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+pub enum Event {
+    Input(input::Event),
+    Simple(simple::Event),
+    TapHold(tap_hold::Event),
+}
+
+impl From<input::Event> for Event {
+    fn from(ev: input::Event) -> Self {
+        Event::Input(ev)
+    }
+}
+
+impl From<key_definitions::Event<simple::Event>> for Event {
+    fn from(ev: key_definitions::Event<simple::Event>) -> Self {
+        match ev {
+            key_definitions::Event::Input(ev) => Event::Input(ev),
+            key_definitions::Event::Key(ev) => Event::Simple(ev),
+        }
+    }
+}
+
+impl From<key_definitions::Event<tap_hold::Event>> for Event {
+    fn from(ev: key_definitions::Event<tap_hold::Event>) -> Self {
+        match ev {
+            key_definitions::Event::Input(ev) => Event::Input(ev),
+            key_definitions::Event::Key(ev) => Event::TapHold(ev),
+        }
+    }
+}
+
+pub enum EventError {
+    UnmappableEvent,
+}
+
+impl TryFrom<Event> for key_definitions::Event<tap_hold::Event> {
+    type Error = EventError;
+
+    fn try_from(ev: Event) -> Result<Self, Self::Error> {
+        match ev {
+            Event::Input(e) => Ok(key_definitions::Event::Input(e)),
+            Event::TapHold(e) => Ok(key_definitions::Event::Key(e)),
+            _ => Err(EventError::UnmappableEvent),
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 pub struct ScheduledEvent {
     time: u32,
-    event: input::Event,
+    event: Event,
 }
 
 /// The engine (set of key definition systems),
 ///  and key definitions.
 pub struct Keymap<const N: usize> {
     key_definitions: [KeyDefinition; N],
-    pressed_keys: heapless::Vec<PressedKeyState, N>,
-    pending_events: heapless::spsc::Queue<input::Event, 256>,
+    pressed_keys: heapless::Vec<PressedKey, N>,
+    pending_events: heapless::spsc::Queue<Event, 256>,
     scheduled_events: heapless::BinaryHeap<ScheduledEvent, heapless::binary_heap::Min, 256>,
     schedule_counter: u32,
 }
@@ -112,66 +154,39 @@ impl<const N: usize> Keymap<N> {
     }
 
     pub fn handle_input(&mut self, ev: input::Event) {
+        // Update each of the PressedKeys with the event.
+        self.pressed_keys.iter_mut().for_each(|pk| {
+            if let PressedKey::TapHold(tap_hold) = pk {
+                let keymap_index = tap_hold.keymap_index();
+                if let KeyDefinition::TapHold(key_def) = self.key_definitions[keymap_index as usize]
+                {
+                    let events = tap_hold.handle_event(&key_def, ev.into());
+                    events
+                        .iter()
+                        .for_each(|ev: &key_definitions::Event<tap_hold::Event>| {
+                            self.pending_events.enqueue((*ev).into()).unwrap()
+                        });
+                }
+            }
+        });
+
         match ev {
             input::Event::Press { keymap_index } => {
-                // TapHold: any interruption resolves pending TapHold as Hold.
-                self.pressed_keys
-                    .iter_mut()
-                    .filter(|pk| {
-                        matches!(
-                            pk,
-                            PressedKeyState::TapHold {
-                                state: TapHoldState::Pending,
-                                ..
-                            }
-                        )
-                    })
-                    .for_each(|pk| {
-                        if let PressedKeyState::TapHold { state, .. } = pk {
-                            *state = TapHoldState::Hold;
-                        }
-                    });
-
                 let key_definition = self.key_definitions[keymap_index as usize];
                 match key_definition {
                     KeyDefinition::Simple(_) => {
-                        let pressed_key = PressedKeyState::Simple { keymap_index };
-                        self.pressed_keys.push(pressed_key).unwrap();
+                        let pressed_key = simple::PressedKey::new(keymap_index);
+                        self.pressed_keys.push(pressed_key.into()).unwrap();
                     }
-                    KeyDefinition::TapHold { tap: _, hold: _ } => {
-                        let pressed_key = PressedKeyState::TapHold {
-                            keymap_index,
-                            state: TapHoldState::Pending,
-                        };
-                        self.pressed_keys.push(pressed_key).unwrap();
+                    KeyDefinition::TapHold(_) => {
+                        let (pressed_key, new_event) = tap_hold::PressedKey::new(keymap_index);
+                        self.pressed_keys.push(pressed_key.into()).unwrap();
 
-                        self.schedule_after(200, input::Event::TapHoldTimeout { keymap_index });
+                        self.schedule_event(new_event);
                     }
                 }
             }
             input::Event::Release { keymap_index } => {
-                // TapHold: resolved as tap (unless it's already resolved as a Hold).
-                // But, since the key is released,
-                //  we need to enque the tap keycode in the pending events.
-                let key_definition = self.key_definitions[keymap_index as usize];
-                if let KeyDefinition::TapHold { tap, .. } = key_definition {
-                    if let Some(PressedKeyState::TapHold {
-                        state: TapHoldState::Pending,
-                        ..
-                    }) = self
-                        .pressed_keys
-                        .iter_mut()
-                        .find(|pk| pk.keymap_index() == Some(keymap_index))
-                    {
-                        self.pending_events
-                            .enqueue(input::Event::VirtualKeyPress { keycode: tap })
-                            .unwrap();
-                        self.pending_events
-                            .enqueue(input::Event::VirtualKeyRelease { keycode: tap })
-                            .unwrap();
-                    }
-                }
-
                 self.pressed_keys
                     .iter()
                     .position(|&k| k.keymap_index() == Some(keymap_index))
@@ -181,7 +196,23 @@ impl<const N: usize> Keymap<N> {
         }
     }
 
-    pub fn schedule_after(&mut self, delay: u32, event: input::Event) {
+    fn schedule_event<T>(&mut self, scheduled_event: key_definitions::ScheduledEvent<T>)
+    where
+        Event: From<key_definitions::Event<T>>,
+    {
+        match scheduled_event.schedule {
+            key_definitions::Schedule::Immediate => {
+                self.pending_events
+                    .enqueue(scheduled_event.event.into())
+                    .unwrap();
+            }
+            key_definitions::Schedule::After(delay) => {
+                self.schedule_after(delay as u32, scheduled_event.event.into());
+            }
+        }
+    }
+
+    pub fn schedule_after(&mut self, delay: u32, event: Event) {
         let time = self.schedule_counter + delay;
         self.scheduled_events
             .push(ScheduledEvent { time, event })
@@ -204,36 +235,40 @@ impl<const N: usize> Keymap<N> {
 
         // take from pending
         if let Some(ev) = self.pending_events.dequeue() {
+            // Update each of the PressedKeys with the input event.
+            self.pressed_keys.iter_mut().for_each(|pk| {
+                if let PressedKey::TapHold(tap_hold) = pk {
+                    let keymap_index = tap_hold.keymap_index();
+                    if let KeyDefinition::TapHold(key_def) =
+                        self.key_definitions[keymap_index as usize]
+                    {
+                        if let Ok(ev) = key_definitions::Event::try_from(ev) {
+                            let events = tap_hold.handle_event(&key_def, ev);
+                            events.iter().for_each(
+                                |ev: &key_definitions::Event<tap_hold::Event>| {
+                                    self.pending_events.enqueue((*ev).into()).unwrap()
+                                },
+                            );
+                        }
+                    }
+                }
+            });
+
             match ev {
-                input::Event::VirtualKeyPress { keycode } => {
-                    // Add keycode to pressed keys.
-                    let pressed_key = PressedKeyState::Virtual { keycode };
+                Event::Input(input::Event::VirtualKeyPress { key_code }) => {
+                    // Add to pressed keys.
+                    let pressed_key = PressedKey::Virtual { key_code };
                     self.pressed_keys.push(pressed_key).unwrap();
                 }
-                input::Event::VirtualKeyRelease { keycode } => {
-                    // Remove keycode from pressed keys.
+                Event::Input(input::Event::VirtualKeyRelease { key_code }) => {
+                    // Remove from pressed keys.
                     self.pressed_keys
                         .iter()
                         .position(|&k| match k {
-                            PressedKeyState::Virtual { keycode: kc } => keycode == kc,
+                            PressedKey::Virtual { key_code: kc } => key_code == kc,
                             _ => false,
                         })
                         .map(|i| self.pressed_keys.remove(i));
-                }
-                input::Event::TapHoldTimeout { keymap_index } => {
-                    // Resolve the TapHold key at the given keymap index to "Hold"
-                    //  if it's pressed, and if it's pressed key state is pending.
-                    if let Some(pk) = self
-                        .pressed_keys
-                        .iter_mut()
-                        .find(|pk| pk.keymap_index() == Some(keymap_index))
-                    {
-                        if let PressedKeyState::TapHold { state, .. } = pk {
-                            if let TapHoldState::Pending = state {
-                                *state = TapHoldState::Hold;
-                            }
-                        }
-                    }
                 }
                 _ => {}
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 mod input;
+mod key_definitions;
 mod keymap;
 
 static mut KEYMAP: keymap::Keymap<4> = keymap::Keymap::new(keymap::KEY_DEFINITIONS);


### PR DESCRIPTION
A "+300 / -100" is obviously an increase in complexity.

This PR changes it so the logic of Simple, TapHold key definitions is implemented in separate modules.

Essentially, each key definition module has its own `KeyDefinition`, and a `PressedKey`, and may have its own `Event`.

`keymap.rs`'s `KeyDefinition`, `PressedKey` and `Event` types then wrap around each of these.