### PR TITLE
devenv: enable riscv32imac-unknown-none-elf target

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -17,6 +17,26 @@
         "type": "github"
       }
     },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1734849150,
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "6c2c568c407a0489295194900be09e75c6603a25",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -112,8 +132,25 @@
     "root": {
       "inputs": {
         "devenv": "devenv",
+        "fenix": "fenix",
         "nixpkgs": "nixpkgs",
         "pre-commit-hooks": "pre-commit-hooks"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1734874959,
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "fa4a40bbe867ed54f5a7c905b591fd7d60ba35eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     }
   },

--- a/devenv.nix
+++ b/devenv.nix
@@ -9,7 +9,11 @@
   languages = {
     c.enable = true;
     ruby.enable = true;
-    rust.enable = true;
+    rust = {
+      channel = "stable";
+      enable = true;
+      targets = ["riscv32imac-unknown-none-elf"];
+    };
   };
 
   packages = [

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,4 +1,8 @@
-# yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
 inputs:
+  fenix:
+    url: github:nix-community/fenix
+    inputs:
+      nixpkgs:
+        follows: nixpkgs
   nixpkgs:
     url: github:cachix/devenv-nixpkgs/rolling


### PR DESCRIPTION
In order to use `libsmart_keyboard.a` with CH32X035 or similar MCUs, it has to be built for the target `riscv32imac-unknown-none-elf`.

This PR updates the devenv to include this target.