### PR TITLE
rust: use SMART_KEYMAP_CUSTOM_KEYMAP for custom keymap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,11 @@ generate-header: include/smart_keymap.h
 
 .PHONY: test
 test:
+	$(CARGO) clean
 	$(CARGO) test --features "std"
+	$(CARGO) clean
+	env SMART_KEYMAP_CUSTOM_KEYMAP="$(shell pwd)/tests/keymaps/simple_keymap.rs" \
+	  $(CARGO) build --features "std"
 	cd tests/ceedling && ceedling
 
 .PHONY: clean

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+use std::env;
+
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(custom_keymap)");
+    if env::var("SMART_KEYMAP_CUSTOM_KEYMAP").is_ok() {
+        println!("cargo:rustc-cfg=custom_keymap");
+        println!("cargo:rerun-if-changed=NULL");
+    }
+}

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -106,19 +106,6 @@ impl PressedKey for CompositePressedKey {
     }
 }
 
-pub const KEY_DEFINITIONS: [KeyDefinition; 4] = [
-    KeyDefinition::TapHold(tap_hold::KeyDefinition {
-        tap: 0x06,
-        hold: 0xE0,
-    }), // Tap C, Hold LCtrl
-    KeyDefinition::TapHold(tap_hold::KeyDefinition {
-        tap: 0x07,
-        hold: 0xE1,
-    }), // Tap D, Hold LShift
-    KeyDefinition::Simple(simple::KeyDefinition(0x04)), // A
-    KeyDefinition::Simple(simple::KeyDefinition(0x05)), // B
-];
-
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 pub enum CompositeEvent {
     TapHold(tap_hold::Event),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,19 @@ mod input;
 mod key;
 mod keymap;
 
-static mut KEYMAP: keymap::Keymap<4> = keymap::Keymap::new(keymap::KEY_DEFINITIONS);
+#[allow(unused)]
+use key::{simple, tap_hold};
+#[allow(unused)]
+use keymap::KeyDefinition;
+
+#[cfg(not(custom_keymap))]
+pub const KEY_DEFINITIONS: [KeyDefinition; 1] = [
+    KeyDefinition::Simple(simple::KeyDefinition(0x04)), // A
+];
+#[cfg(custom_keymap)]
+include!(env!("SMART_KEYMAP_CUSTOM_KEYMAP"));
+
+static mut KEYMAP: keymap::Keymap<{ KEY_DEFINITIONS.len() }> = keymap::Keymap::new(KEY_DEFINITIONS);
 
 #[allow(static_mut_refs)]
 #[no_mangle]

--- a/tests/keymaps/simple_keymap.rs
+++ b/tests/keymaps/simple_keymap.rs
@@ -1,0 +1,12 @@
+pub const KEY_DEFINITIONS: [KeyDefinition; 4] = [
+    KeyDefinition::TapHold(tap_hold::KeyDefinition {
+        tap: 0x06,
+        hold: 0xE0,
+    }), // Tap C, Hold LCtrl
+    KeyDefinition::TapHold(tap_hold::KeyDefinition {
+        tap: 0x07,
+        hold: 0xE1,
+    }), // Tap D, Hold LShift
+    KeyDefinition::Simple(simple::KeyDefinition(0x04)), // A
+    KeyDefinition::Simple(simple::KeyDefinition(0x05)), // B
+];


### PR DESCRIPTION
This PR allows build-time configuration of the keymap for the static library by setting the `SMART_KEYMAP_CUSTOM_KEYMAP` environment variable to a path to a snippet of Rust code. (As opposed to having to edit the source code to change the keymap).

The custom keymap file is expected to have a form like (c.f. `tests/keymaps/`):

```
pub const KEY_DEFINITIONS: [KeyDefinition; 4] = [
    ...
];
```

This `KEY_DEFINITIONS` variable is used to construct the `KeyMap` used as the global instance for the C interface of the static library.

I still like the idea of using Nickel to generate keymaps, as fak/kirei does. -- This is a step towards that. -- As it is currently, the Rust syntax for defining `KEY_DEFINITIONS` is verbose; and by having it as a snippet that gets `include!()`'d, it's difficult to write (no LSP/tooling).

This does make it more cumbersome to run the tests by directly running `ceedling`, though; e.g. the C tests assume that the `libsmart_keymap.a` has been compiled with an appropriate keymap. `make test` has the correct commands.

I think going forward, the approach to testing I'd like to take is:

- Have the C tests for checking that the library can be used through the C interface. Have a single keymap which allows checking various features.
- Use Rust for more comprehensive integration testing, since it's easier to construct `KeyMap` values with different key maps.