### PR TITLE
rust: add Key trait, refactor Keymap to use that

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -11,3 +11,9 @@ pub enum PressedInput<K> {
     Key { keymap_index: u16, key: K },
     Virtual { key_code: u8 },
 }
+
+impl<K> PressedInput<K> {
+    pub fn new_pressed_key(keymap_index: u16, key: K) -> Self {
+        Self::Key { keymap_index, key }
+    }
+}


### PR DESCRIPTION
Some of the smart keymap functionality is best described in terms of 'higher-kinded keys'. -- "in this case, act like this key; otherwise, act like this key".

Having a `Key` trait is useful towards this, and further decouples the `Keymap` implementation from 'knowing' the implementation details of the composite key.

This PR:

- adds a `Key` trait, updates the `PressedKey` trait.
- adjusts `KeyMap` struct & impl. to use `Key` rather than the composite `KeyDefinition` directly.