### PR TITLE
rust: move keymap::KeyDef to key::composite::Key

### DIFF
--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -1,0 +1,130 @@
+//! This module implements the `keymap::Key` for a 'composite' key,
+//!  which can be any of the other key definitions,
+//!  and is the default Key for the `keymap::KeyMap` implementation.
+
+use core::fmt::Debug;
+
+use crate::key;
+use key::{simple, tap_hold};
+
+use crate::keymap;
+
+#[derive(Debug, Clone, Copy)]
+pub enum Key {
+    Simple(simple::Key),
+    TapHold(tap_hold::Key),
+}
+
+impl keymap::Key for Key {
+    type Event = Event;
+    type PressedKey = PressedKey;
+
+    fn new_pressed_key(
+        keymap_index: u16,
+        key_definition: &Key,
+    ) -> (PressedKey, Option<key::ScheduledEvent<Event>>) {
+        match key_definition {
+            Key::Simple(_) => {
+                let pressed_key = simple::PressedKey::new();
+                (pressed_key.into(), None)
+            }
+            Key::TapHold(_) => {
+                let (pressed_key, new_event) = tap_hold::PressedKey::new(keymap_index);
+                (pressed_key.into(), Some(new_event.into()))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum PressedKey {
+    Simple(simple::PressedKey),
+    TapHold(tap_hold::PressedKey),
+}
+
+impl From<simple::PressedKey> for PressedKey {
+    fn from(pk: simple::PressedKey) -> Self {
+        PressedKey::Simple(pk)
+    }
+}
+
+impl From<tap_hold::PressedKey> for PressedKey {
+    fn from(pk: tap_hold::PressedKey) -> Self {
+        PressedKey::TapHold(pk)
+    }
+}
+
+impl keymap::PressedKey for PressedKey {
+    type Event = Event;
+    type Key = Key;
+
+    fn key_code(&self, key_definition: &Key) -> Option<u8> {
+        match self {
+            PressedKey::Simple(pk) => match key_definition {
+                Key::Simple(key_def) => Some(pk.key_code(key_def)),
+                _ => None,
+            },
+
+            PressedKey::TapHold(pk) => match key_definition {
+                Key::TapHold(key_def) => pk.key_code(key_def),
+                _ => None,
+            },
+        }
+    }
+
+    fn handle_event(
+        &mut self,
+        key_definition: &Key,
+        event: key::Event<Self::Event>,
+    ) -> impl IntoIterator<Item = key::Event<Self::Event>> {
+        if let PressedKey::TapHold(tap_hold) = self {
+            if let Key::TapHold(key_def) = key_definition {
+                if let Ok(ev) = key::Event::try_from(event) {
+                    let events: heapless::Vec<key::Event<tap_hold::Event>, 2> =
+                        tap_hold.handle_event(key_def, ev);
+                    events.into_iter().map(|ev| ev.into()).collect()
+                } else {
+                    heapless::Vec::<key::Event<Self::Event>, 2>::new()
+                }
+            } else {
+                heapless::Vec::new()
+            }
+        } else {
+            heapless::Vec::new()
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+pub enum Event {
+    TapHold(tap_hold::Event),
+}
+
+impl From<key::Event<tap_hold::Event>> for key::Event<Event> {
+    fn from(ev: key::Event<tap_hold::Event>) -> Self {
+        match ev {
+            key::Event::Input(ev) => key::Event::Input(ev),
+            key::Event::Key(ev) => key::Event::Key(Event::TapHold(ev)),
+        }
+    }
+}
+
+impl From<key::ScheduledEvent<tap_hold::Event>> for key::ScheduledEvent<Event> {
+    fn from(ev: key::ScheduledEvent<tap_hold::Event>) -> Self {
+        Self {
+            schedule: ev.schedule,
+            event: ev.event.into(),
+        }
+    }
+}
+
+impl TryFrom<key::Event<Event>> for key::Event<tap_hold::Event> {
+    type Error = keymap::EventError;
+
+    fn try_from(ev: key::Event<Event>) -> Result<Self, Self::Error> {
+        match ev {
+            key::Event::Input(ev) => Ok(key::Event::Input(ev)),
+            key::Event::Key(Event::TapHold(ev)) => Ok(key::Event::Key(ev)),
+        }
+    }
+}

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -3,6 +3,8 @@ use crate::input;
 pub mod simple;
 pub mod tap_hold;
 
+pub mod composite;
+
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
 pub enum Event<T> {
     Input(input::Event),

--- a/src/key/simple.rs
+++ b/src/key/simple.rs
@@ -1,7 +1,7 @@
 #[derive(Debug, Clone, Copy)]
-pub struct KeyDefinition(pub u8);
+pub struct Key(pub u8);
 
-impl KeyDefinition {
+impl Key {
     pub fn key_code(&self) -> u8 {
         self.0
     }
@@ -18,7 +18,13 @@ impl PressedKey {
         Self {}
     }
 
-    pub fn key_code(&self, key_def: &KeyDefinition) -> u8 {
+    pub fn key_code(&self, key_def: &Key) -> u8 {
         key_def.key_code()
+    }
+}
+
+impl Default for PressedKey {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/key/tap_hold.rs
+++ b/src/key/tap_hold.rs
@@ -2,7 +2,7 @@ use crate::input;
 use crate::key;
 
 #[derive(Debug, Clone, Copy)]
-pub struct KeyDefinition {
+pub struct Key {
     pub tap: u8,
     pub hold: u8,
 }
@@ -42,7 +42,7 @@ impl PressedKey {
         )
     }
 
-    pub fn key_code(&self, key_def: &KeyDefinition) -> Option<u8> {
+    pub fn key_code(&self, key_def: &Key) -> Option<u8> {
         match self.state {
             TapHoldState::Tap => Some(key_def.tap),
             TapHoldState::Hold => Some(key_def.hold),
@@ -58,7 +58,7 @@ impl PressedKey {
 
     pub fn handle_event(
         &mut self,
-        key_def: &KeyDefinition,
+        key_def: &Key,
         event: key::Event<Event>,
     ) -> heapless::Vec<key::Event<Event>, 2> {
         match event {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,17 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-mod input;
-mod key;
-mod keymap;
+pub mod input;
+pub mod key;
+pub mod keymap;
 
+#[allow(unused)]
+use key::composite::Key;
 #[allow(unused)]
 use key::{simple, tap_hold};
-#[allow(unused)]
-use keymap::KeyDefinition;
 
 #[cfg(not(custom_keymap))]
-pub const KEY_DEFINITIONS: [KeyDefinition; 1] = [
-    KeyDefinition::Simple(simple::KeyDefinition(0x04)), // A
+pub const KEY_DEFINITIONS: [Key; 1] = [
+    Key::Simple(simple::Key(0x04)), // A
 ];
 #[cfg(custom_keymap)]
 include!(env!("SMART_KEYMAP_CUSTOM_KEYMAP"));

--- a/tests/keymaps/simple_keymap.rs
+++ b/tests/keymaps/simple_keymap.rs
@@ -1,12 +1,12 @@
-pub const KEY_DEFINITIONS: [KeyDefinition; 4] = [
-    KeyDefinition::TapHold(tap_hold::KeyDefinition {
+pub const KEY_DEFINITIONS: [Key; 4] = [
+    Key::TapHold(tap_hold::Key {
         tap: 0x06,
         hold: 0xE0,
     }), // Tap C, Hold LCtrl
-    KeyDefinition::TapHold(tap_hold::KeyDefinition {
+    Key::TapHold(tap_hold::Key {
         tap: 0x07,
         hold: 0xE1,
     }), // Tap D, Hold LShift
-    KeyDefinition::Simple(simple::KeyDefinition(0x04)), // A
-    KeyDefinition::Simple(simple::KeyDefinition(0x05)), // B
+    Key::Simple(simple::Key(0x04)), // A
+    Key::Simple(simple::Key(0x05)), // B
 ];


### PR DESCRIPTION
Now that `keymap::KeyMap` uses `keymap::Key`, it makes sense to move `keymap::KeyDefinition` (and its associated `CompositePressedKey`, `CompositeEvent`) to `key::composite`.

Also, I renamed `KeyDefinition` to `Key`.