### PR TITLE
rust: move Key, PressedKey traits to key mod

### DIFF
--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -7,15 +7,13 @@ use core::fmt::Debug;
 use crate::key;
 use key::{simple, tap_hold};
 
-use crate::keymap;
-
 #[derive(Debug, Clone, Copy)]
 pub enum Key {
     Simple(simple::Key),
     TapHold(tap_hold::Key),
 }
 
-impl keymap::Key for Key {
+impl key::Key for Key {
     type Event = Event;
     type PressedKey = PressedKey;
 
@@ -54,7 +52,7 @@ impl From<tap_hold::PressedKey> for PressedKey {
     }
 }
 
-impl keymap::PressedKey for PressedKey {
+impl key::PressedKey for PressedKey {
     type Event = Event;
     type Key = Key;
 
@@ -119,7 +117,7 @@ impl From<key::ScheduledEvent<tap_hold::Event>> for key::ScheduledEvent<Event> {
 }
 
 impl TryFrom<key::Event<Event>> for key::Event<tap_hold::Event> {
-    type Error = keymap::EventError;
+    type Error = key::EventError;
 
     fn try_from(ev: key::Event<Event>) -> Result<Self, Self::Error> {
         match ev {

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -1,9 +1,37 @@
+use core::fmt::Debug;
+
 use crate::input;
 
 pub mod simple;
 pub mod tap_hold;
 
 pub mod composite;
+
+pub trait Key {
+    type PressedKey: PressedKey<Key = Self, Event = Self::Event> + Debug;
+    type Event: Copy + Debug + Ord;
+
+    fn new_pressed_key(
+        keymap_index: u16,
+        key_definition: &Self,
+    ) -> (Self::PressedKey, Option<ScheduledEvent<Self::Event>>);
+}
+
+pub trait PressedKey {
+    type Event;
+    type Key: Key;
+    fn handle_event(
+        &mut self,
+        key_definition: &Self::Key,
+        event: Event<Self::Event>,
+    ) -> impl IntoIterator<Item = Event<Self::Event>>;
+    fn key_code(&self, key_definition: &Self::Key) -> Option<u8>;
+}
+
+#[allow(unused)]
+pub enum EventError {
+    UnmappableEvent,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
 pub enum Event<T> {

--- a/src/key/simple.rs
+++ b/src/key/simple.rs
@@ -1,3 +1,5 @@
+use crate::key;
+
 #[derive(Debug, Clone, Copy)]
 pub struct Key(pub u8);
 
@@ -29,22 +31,19 @@ impl Default for PressedKey {
     }
 }
 
-impl crate::keymap::Key for Key {
+impl key::Key for Key {
     type Event = Event;
     type PressedKey = PressedKey;
 
     fn new_pressed_key(
         _keymap_index: u16,
         _key_definition: &Self,
-    ) -> (
-        Self::PressedKey,
-        Option<crate::key::ScheduledEvent<Self::Event>>,
-    ) {
+    ) -> (Self::PressedKey, Option<key::ScheduledEvent<Self::Event>>) {
         (PressedKey::new(), None)
     }
 }
 
-impl crate::keymap::PressedKey for PressedKey {
+impl key::PressedKey for PressedKey {
     type Event = Event;
     type Key = Key;
 
@@ -52,8 +51,8 @@ impl crate::keymap::PressedKey for PressedKey {
     fn handle_event(
         &mut self,
         _key_definition: &Self::Key,
-        _event: crate::key::Event<Self::Event>,
-    ) -> impl IntoIterator<Item = crate::key::Event<Self::Event>> {
+        _event: key::Event<Self::Event>,
+    ) -> impl IntoIterator<Item = key::Event<Self::Event>> {
         None
     }
 


### PR DESCRIPTION
Move the `Key`, `PressedKey` traits from the `keymap` module to the `key` module.