### PR TITLE
rust: key: simple::PressedKey distinguishable

### DIFF
--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -22,8 +22,8 @@ impl key::Key for Key {
         keymap_index: u16,
     ) -> (PressedKey, Option<key::ScheduledEvent<Event>>) {
         match self {
-            Key::Simple(_) => {
-                let pressed_key = simple::PressedKey::new();
+            Key::Simple(k) => {
+                let (pressed_key, _new_event) = k.new_pressed_key(keymap_index);
                 (pressed_key.into(), None)
             }
             Key::TapHold(_) => {

--- a/src/key/simple.rs
+++ b/src/key/simple.rs
@@ -12,22 +12,18 @@ impl Key {
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Event();
 
-#[derive(Debug, Clone, Copy)]
-pub struct PressedKey {}
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PressedKey {
+    key_code: u8,
+}
 
 impl PressedKey {
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(key_code: u8) -> Self {
+        Self { key_code }
     }
 
     pub fn key_code(&self, key_def: &Key) -> u8 {
         key_def.key_code()
-    }
-}
-
-impl Default for PressedKey {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -39,7 +35,7 @@ impl key::Key for Key {
         &self,
         _keymap_index: u16,
     ) -> (Self::PressedKey, Option<key::ScheduledEvent<Self::Event>>) {
-        (PressedKey::new(), None)
+        (PressedKey::new(self.0), None)
     }
 }
 


### PR DESCRIPTION
For unit testing, it's useful to be able to distinguish between `simple::PressedKey`s.