### PR TITLE
rust: key: add Context to Key

### DIFF
--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -14,16 +14,18 @@ pub enum Key {
 }
 
 impl key::Key for Key {
+    type Context = Context;
     type Event = Event;
     type PressedKey = PressedKey;
 
     fn new_pressed_key(
         &self,
+        _context: &Self::Context,
         keymap_index: u16,
     ) -> (PressedKey, Option<key::ScheduledEvent<Event>>) {
         match self {
             Key::Simple(k) => {
-                let (pressed_key, _new_event) = k.new_pressed_key(keymap_index);
+                let pressed_key = simple::PressedKey::new(k.key_code());
                 (pressed_key.into(), None)
             }
             Key::TapHold(_) => {
@@ -32,6 +34,26 @@ impl key::Key for Key {
             }
         }
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Context {}
+
+impl Context {
+    pub const fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for Context {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl key::Context for Context {
+    type Event = Event;
+    fn handle_event(&mut self, _event: Self::Event) {}
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -8,13 +8,25 @@ pub mod tap_hold;
 pub mod composite;
 
 pub trait Key {
+    type Context: Context;
     type PressedKey: PressedKey<Key = Self, Event = Self::Event> + Debug;
     type Event: Copy + Debug + Ord;
 
     fn new_pressed_key(
         &self,
+        context: &Self::Context,
         keymap_index: u16,
     ) -> (Self::PressedKey, Option<ScheduledEvent<Self::Event>>);
+}
+
+pub trait Context {
+    type Event;
+    fn handle_event(&mut self, event: Self::Event);
+}
+
+impl Context for () {
+    type Event = ();
+    fn handle_event(&mut self, _event: Self::Event) {}
 }
 
 pub trait PressedKey {

--- a/src/key/simple.rs
+++ b/src/key/simple.rs
@@ -28,11 +28,13 @@ impl PressedKey {
 }
 
 impl key::Key for Key {
+    type Context = ();
     type Event = Event;
     type PressedKey = PressedKey;
 
     fn new_pressed_key(
         &self,
+        _context: &Self::Context,
         _keymap_index: u16,
     ) -> (Self::PressedKey, Option<key::ScheduledEvent<Self::Event>>) {
         (PressedKey::new(self.0), None)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,8 @@ pub const KEY_DEFINITIONS: [Key; 1] = [
 #[cfg(custom_keymap)]
 include!(env!("SMART_KEYMAP_CUSTOM_KEYMAP"));
 
-static mut KEYMAP: keymap::Keymap<{ KEY_DEFINITIONS.len() }> = keymap::Keymap::new(KEY_DEFINITIONS);
+static mut KEYMAP: keymap::Keymap<{ KEY_DEFINITIONS.len() }> =
+    keymap::Keymap::new(KEY_DEFINITIONS, key::composite::Context::new());
 
 #[allow(static_mut_refs)]
 #[no_mangle]


### PR DESCRIPTION
It's useful to have a `Context` which provides information when pressing a key.