### PR TITLE
Initial key::layered implementation

### DIFF
--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -1,0 +1,311 @@
+use crate::input;
+use crate::key;
+
+pub type LayerIndex = usize;
+
+/// Modifier layer key affects what layers are active.
+#[derive(Debug, Clone, Copy)]
+pub enum ModifierKey<const L: LayerIndex> {
+    Hold(LayerIndex),
+}
+
+impl<const L: LayerIndex> ModifierKey<L> {
+    fn new_pressed_key(
+        &self,
+        keymap_index: u16,
+    ) -> (PressedModifierKey, Option<key::ScheduledEvent<LayerEvent>>) {
+        match self {
+            ModifierKey::Hold(layer) => {
+                let event = LayerEvent::LayerActivated(*layer);
+                (
+                    PressedModifierKey::new(keymap_index),
+                    Some(key::ScheduledEvent::immediate(key::Event::Key(event))),
+                )
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Context<const L: LayerIndex, C: key::Context> {
+    active_layers: [bool; L],
+    inner_context: C,
+}
+
+impl<const L: LayerIndex, C: key::Context> Context<L, C> {
+    pub fn new(inner_context: C) -> Self {
+        Self {
+            active_layers: [false; L],
+            inner_context,
+        }
+    }
+
+    pub fn handle_event(&mut self, event: LayerEvent) {
+        match event {
+            LayerEvent::LayerActivated(layer) => {
+                self.active_layers[layer] = true;
+            }
+            LayerEvent::LayerDeactivated(layer) => {
+                self.active_layers[layer] = false;
+            }
+        }
+    }
+
+    pub fn active_layers(&self) -> &[bool; L] {
+        &self.active_layers
+    }
+}
+
+/// A key whose behavior depends on which layer is active.
+pub struct LayeredKey<const L: LayerIndex, K: key::Key> {
+    base: K,
+    layered: [Option<K>; L],
+}
+
+impl<const L: LayerIndex, K: key::Key> LayeredKey<L, K> {
+    fn new_pressed_key(
+        &self,
+        context: &Context<L, K::Context>,
+        keymap_index: u16,
+    ) -> (K::PressedKey, Option<key::ScheduledEvent<K::Event>>) {
+        for index in 1..=L {
+            let i = L - index;
+            if context.active_layers()[i] {
+                if let Some(key) = &self.layered[i] {
+                    return key.new_pressed_key(&context.inner_context, keymap_index);
+                }
+            }
+        }
+
+        self.base
+            .new_pressed_key(&context.inner_context, keymap_index)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+pub enum LayerEvent {
+    LayerActivated(LayerIndex),
+    LayerDeactivated(LayerIndex),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct PressedModifierKey {
+    keymap_index: u16,
+}
+
+impl PressedModifierKey {
+    pub fn new(keymap_index: u16) -> Self {
+        Self { keymap_index }
+    }
+
+    fn handle_event<const L: LayerIndex>(
+        &mut self,
+        key_definition: &ModifierKey<L>,
+        event: key::Event<LayerEvent>,
+    ) -> Option<key::Event<LayerEvent>> {
+        match key_definition {
+            ModifierKey::Hold(layer) => match event {
+                key::Event::Input(input::Event::Release { keymap_index }) => {
+                    if keymap_index == self.keymap_index {
+                        Some(key::Event::Key(LayerEvent::LayerDeactivated(*layer)))
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use key::{simple, Key};
+
+    #[test]
+    fn test_pressing_hold_modifier_key_emits_event_activate_layer() {
+        let layer = 0;
+        let key = ModifierKey::<3>::Hold(layer);
+
+        let keymap_index = 9; // arbitrary
+        let (_pressed_key, scheduled_event) = key.new_pressed_key(keymap_index);
+
+        if let Some(key::ScheduledEvent {
+            event: key::Event::Key(key_ev),
+            ..
+        }) = scheduled_event
+        {
+            assert_eq!(key_ev, LayerEvent::LayerActivated(layer));
+        } else {
+            panic!("Expected Some scheduled event");
+        }
+    }
+
+    #[test]
+    fn test_releasing_hold_modifier_key_emits_event_deactivate_layer() {
+        // Assemble: press a Hold layer modifier key
+        let layer = 0;
+        let key = ModifierKey::<3>::Hold(layer);
+        let keymap_index = 9; // arbitrary
+        let (mut pressed_key, _) = key.new_pressed_key(keymap_index);
+
+        // Act: the modifier key handles "release key" input event
+        let actual_events = pressed_key.handle_event(
+            &key,
+            key::Event::Input(input::Event::Release { keymap_index }),
+        );
+
+        // Assert: the pressed key should have emitted a layer deactivation event
+        if let Some(key::Event::Key(actual_layer_event)) = actual_events {
+            let expected_layer_event = LayerEvent::LayerDeactivated(layer);
+            assert_eq!(actual_layer_event, expected_layer_event);
+        } else {
+            panic!("Expected Some LayerDeactivated event");
+        }
+    }
+
+    #[test]
+    fn test_releasing_different_hold_modifier_key_does_not_emit_event() {
+        // Assemble: press a Hold layer modifier key
+        let layer = 0;
+        let key = ModifierKey::<3>::Hold(layer);
+        let keymap_index = 9; // arbitrary
+        let (mut pressed_key, _) = key.new_pressed_key(keymap_index);
+
+        // Act: the modifier key handles "release key" input event for a different key
+        let different_keymap_index = keymap_index + 1;
+        let different_key_released_ev = key::Event::Input(input::Event::Release {
+            keymap_index: different_keymap_index,
+        });
+        let actual_events = pressed_key.handle_event(&key, different_key_released_ev);
+
+        // Assert: the pressed key should not emit an event
+        if actual_events.is_some() {
+            panic!("Expected no event emitted");
+        }
+    }
+
+    #[test]
+    fn test_context_handling_event_adjusts_active_layers() {
+        let mut context: Context<3, ()> = Context::new(());
+
+        context.handle_event(LayerEvent::LayerActivated(1));
+
+        let actual_active_layers = context.active_layers();
+        assert_eq!(&[false, true, false], actual_active_layers);
+    }
+
+    #[test]
+    fn test_pressing_layered_key_acts_as_base_key_when_no_layers_active() {
+        // Assemble
+        const L: usize = 3;
+        let context: Context<L, ()> = Context::new(());
+        let expected_key = simple::Key(0x04);
+        let layered_key = LayeredKey {
+            base: expected_key,
+            layered: [
+                Some(simple::Key(0x05)),
+                Some(simple::Key(0x06)),
+                Some(simple::Key(0x07)),
+            ],
+        };
+
+        // Act: without activating a layer, press the layered key
+        let keymap_index = 9; // arbitrary
+        let (actual_pressed_key, actual_event) =
+            layered_key.new_pressed_key(&context, keymap_index);
+
+        // Assert
+        let (expected_pressed_key, expected_event) =
+            expected_key.new_pressed_key(&(), keymap_index);
+        assert_eq!(actual_pressed_key, expected_pressed_key);
+        assert_eq!(actual_event, expected_event);
+    }
+
+    // Terminology:
+    //   "defined layer" = LayeredKey.layered[] is Some for that layer;
+    //   "active layer" = Context.active_layers[] = true for that layer.
+
+    #[test]
+    fn test_pressing_layered_key_falls_through_undefined_active_layers() {
+        // Assemble: layered key (with no layered definitions)
+        const L: usize = 3;
+        let mut context: Context<L, ()> = Context::new(());
+        let expected_key = simple::Key(0x04);
+        let layered_key = LayeredKey {
+            base: expected_key,
+            layered: [None, None, None],
+        };
+
+        // Act: activate all layers, press layered key
+        context.handle_event(LayerEvent::LayerActivated(0));
+        context.handle_event(LayerEvent::LayerActivated(1));
+        context.handle_event(LayerEvent::LayerActivated(2));
+        let keymap_index = 9; // arbitrary
+        let (actual_pressed_key, actual_event) =
+            layered_key.new_pressed_key(&context, keymap_index);
+
+        // Assert
+        let (expected_pressed_key, expected_event) =
+            expected_key.new_pressed_key(&(), keymap_index);
+        assert_eq!(actual_pressed_key, expected_pressed_key);
+        assert_eq!(actual_event, expected_event);
+    }
+
+    #[test]
+    fn test_pressing_layered_key_acts_as_highest_defined_active_layer() {
+        // Assemble: layered key (with no layered definitions)
+        const L: usize = 3;
+        let mut context: Context<L, ()> = Context::new(());
+        let expected_key = simple::Key(0x09);
+        let layered_key = LayeredKey {
+            base: simple::Key(0x04),
+            layered: [
+                Some(simple::Key(0x05)),
+                Some(simple::Key(0x06)),
+                Some(expected_key),
+            ],
+        };
+
+        // Act: activate all layers, press layered key
+        context.handle_event(LayerEvent::LayerActivated(0));
+        context.handle_event(LayerEvent::LayerActivated(1));
+        context.handle_event(LayerEvent::LayerActivated(2));
+        let keymap_index = 9; // arbitrary
+        let (actual_pressed_key, actual_event) =
+            layered_key.new_pressed_key(&context, keymap_index);
+
+        // Assert
+        let (expected_pressed_key, expected_event) =
+            expected_key.new_pressed_key(&(), keymap_index);
+        assert_eq!(actual_pressed_key, expected_pressed_key);
+        assert_eq!(actual_event, expected_event);
+    }
+
+    #[test]
+    fn test_pressing_layered_key_with_some_transparency_acts_as_highest_defined_active_layer() {
+        // Assemble: layered key (with no layered definitions)
+        const L: usize = 3;
+        let mut context: Context<L, ()> = Context::new(());
+        let expected_key = simple::Key(0x09);
+        let layered_key = LayeredKey {
+            base: simple::Key(0x04),
+            layered: [Some(expected_key), Some(simple::Key(0x06)), None],
+        };
+
+        // Act: activate all layers, press layered key
+        context.handle_event(LayerEvent::LayerActivated(0));
+        context.handle_event(LayerEvent::LayerActivated(2));
+        let keymap_index = 9; // arbitrary
+        let (actual_pressed_key, actual_event) =
+            layered_key.new_pressed_key(&context, keymap_index);
+
+        // Assert
+        let (expected_pressed_key, expected_event) =
+            expected_key.new_pressed_key(&(), keymap_index);
+        assert_eq!(actual_pressed_key, expected_pressed_key);
+        assert_eq!(actual_event, expected_event);
+    }
+}

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -8,9 +8,9 @@ pub mod tap_hold;
 
 pub mod composite;
 
-pub trait Key {
+pub trait Key<PK = Self> {
     type Context: Context;
-    type PressedKey: PressedKey<Key = Self, Event = Self::Event> + Debug;
+    type PressedKey: PressedKey<Key = PK, Event = Self::Event> + Debug;
     type Event: Copy + Debug + Ord;
 
     fn new_pressed_key(

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -2,6 +2,7 @@ use core::fmt::Debug;
 
 use crate::input;
 
+pub mod layered;
 pub mod simple;
 pub mod tap_hold;
 


### PR DESCRIPTION
This isn't quite a complete implementation, but I think it's close enough that it's still worth merging. -- I'd rather have smaller, iterated changes than wait until it's perfect.

This PR adds an initial implementation of `key::layered`, with a `ModifierKey` and a `LayeredKey`.

The `ModifierKey` is intended for keys which modify which layers are active. In this PR, there's only `Hold` (which activates the layer when held down). -- FWIW, other smart keyboard firmwares have other layer activation keys, like "Toggle".

The `LayeredKey` has the logic for layer implementation. -- This is an example of what `key::Context` is for.

Some unit tests have been included for `key::layered`, which demonstrate some of the functionality.

`ModifierKey` implements the `key::Key` trait (& its `PressedModifierKey` implements the `key::PressedKey` trait). `LayeredKey` implements the `Key` trait. -- There's no `PressedLayeredKey`, since I think it's enough just to return the inner key type.

This PR doesn't integrate `key::layered` with `key::Composite`, nor does it add C integration tests. -- These can be added later.