### PR TITLE
Deserialize layered keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,6 +510,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
  "hash32",
+ "serde",
  "stable_deref_trait",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ path = "tests/cucumber/keymap.rs"
 harness = false
 
 [dependencies]
-heapless = "0.8"
+heapless = { version = "0.8", features = ["serde"] }
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"], default-features = false }
 usbd-human-interface-device = { version = "0.5.0", optional = true }

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -372,4 +372,92 @@ mod tests {
         assert_eq!(actual_pressed_key, expected_pressed_key);
         assert_eq!(actual_event, expected_event);
     }
+
+    #[test]
+    fn test_deserialize_ron_simple() {
+        use key::simple;
+
+        let actual_key: key::simple::Key = ron::from_str("Key(0x04)").unwrap();
+        let expected_key: key::simple::Key = simple::Key(0x04);
+        assert_eq!(actual_key, expected_key);
+    }
+
+    #[test]
+    fn test_deserialize_ron_option_simple() {
+        use key::simple;
+
+        let actual_key: Option<key::simple::Key> = ron::from_str("Some(Key(0x04))").unwrap();
+        let expected_key: Option<key::simple::Key> = Some(simple::Key(0x04));
+        assert_eq!(actual_key, expected_key);
+    }
+
+    #[test]
+    fn test_deserialize_ron_array1_u8() {
+        let actual: [u8; 1] = ron::from_str("(5)").unwrap();
+        let expected: [u8; 1] = [5];
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_deserialize_ron_array1_option_simple() {
+        let actual: [Option<key::simple::Key>; 1] = ron::from_str("(Some(Key(0x04)))").unwrap();
+        let expected: [Option<key::simple::Key>; 1] = [Some(simple::Key(0x04))];
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_deserialize_json_option_simple() {
+        let actual: Option<key::simple::Key> = serde_json::from_str(r#"4"#).unwrap();
+        let mut expected: Option<key::simple::Key> = Some(simple::Key(0x04));
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_deserialize_json_vec1_option_simple() {
+        let actual: heapless::Vec<Option<key::simple::Key>, 1> =
+            serde_json::from_str(r#"[4]"#).unwrap();
+        let mut expected: heapless::Vec<Option<key::simple::Key>, 1> = heapless::Vec::new();
+        expected.push(Some(simple::Key(0x04)));
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_deserialize_json_array1_option_simple() {
+        let actual: [Option<key::simple::Key>; 1] = serde_json::from_str("[4]").unwrap();
+        let expected: [Option<key::simple::Key>; 1] = [Some(simple::Key(0x04))];
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_deserialize_ron_layered_key_simple_0layer() {
+        let actual_key: LayeredKey<0, key::simple::Key> =
+            ron::from_str("(base: (0x04), layered: ())").unwrap();
+        let expected_key: LayeredKey<0, key::simple::Key> = LayeredKey {
+            base: key::simple::Key(0x04),
+            layered: [],
+        };
+        assert_eq!(actual_key, expected_key);
+    }
+
+    #[test]
+    fn test_deserialize_json_layered_key_simple_0layer() {
+        let actual_key: LayeredKey<0, key::simple::Key> =
+            serde_json::from_str(r#"{"base": 4, "layered": []}"#).unwrap();
+        let expected_key: LayeredKey<0, key::simple::Key> = LayeredKey {
+            base: key::simple::Key(0x04),
+            layered: [],
+        };
+        assert_eq!(actual_key, expected_key);
+    }
+
+    #[test]
+    fn test_deserialize_ron_layered_key_simple_1layer_none() {
+        let actual_key: LayeredKey<1, key::simple::Key> =
+            ron::from_str("LayeredKey(base: Key(0x04), layered: (None))").unwrap();
+        let expected_key: LayeredKey<1, key::simple::Key> = LayeredKey {
+            base: key::simple::Key(0x04),
+            layered: [None],
+        };
+        assert_eq!(actual_key, expected_key);
+    }
 }

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -1,10 +1,12 @@
+use serde::Deserialize;
+
 use crate::input;
 use crate::key;
 
 pub type LayerIndex = usize;
 
 /// Modifier layer key affects what layers are active.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Deserialize, Clone, Copy)]
 pub enum ModifierKey<const L: LayerIndex> {
     Hold(LayerIndex),
 }
@@ -78,12 +80,19 @@ impl<const L: LayerIndex, C: key::Context> key::Context for Context<L, C> {
 }
 
 /// A key whose behavior depends on which layer is active.
-pub struct LayeredKey<const L: LayerIndex, K: key::Key> {
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq)]
+pub struct LayeredKey<const L: LayerIndex, K: key::Key>
+where
+    [Option<K>; L]: serde::de::DeserializeOwned,
+{
     base: K,
     layered: [Option<K>; L],
 }
 
-impl<const L: LayerIndex, K: key::Key> LayeredKey<L, K> {
+impl<const L: LayerIndex, K: key::Key> LayeredKey<L, K>
+where
+    [Option<K>; L]: serde::de::DeserializeOwned,
+{
     fn new_pressed_key(
         &self,
         context: &Context<L, K::Context>,
@@ -103,7 +112,10 @@ impl<const L: LayerIndex, K: key::Key> LayeredKey<L, K> {
     }
 }
 
-impl<const L: LayerIndex, K: key::Key> key::Key<K> for LayeredKey<L, K> {
+impl<const L: LayerIndex, K: key::Key> key::Key<K> for LayeredKey<L, K>
+where
+    [Option<K>; L]: serde::de::DeserializeOwned,
+{
     type Context = Context<L, K::Context>;
     type PressedKey = K::PressedKey;
     type Event = K::Event;


### PR DESCRIPTION
This was a bit tedious to figure out.

- `ron` uses different syntax for vectors compared to arrays. I'm not sure, since `serde_json` doesn't.

- Adding the trait bound `where [Option<K>; L]: serde::de::DeserializeOwned` took some time to figure out.

- Previously I'd written Cucumber features which covered deserialization of keys. However, to deserialize to `layered::LayeredKey`, the generic types for the `LayeredKey` need to be set. That's a slightly different pattern that the other deserialization tests use, so I opted just for unit tests.

- I added unit tests for deserialization to demonstrate/clarify examples of the RON/JSON strings for the `key::layered::LayeredKey`.