### PR TITLE
Implement Layering behaviour in composite key

### DIFF
--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -128,10 +128,7 @@ where
                 _ => None,
             },
 
-            PressedKey::Simple(pk) => match key_definition {
-                Key::Simple(key_def) => Some(pk.key_code(key_def)),
-                _ => None,
-            },
+            PressedKey::Simple(pk) => Some(pk.key_code()),
 
             PressedKey::TapHold(pk) => match key_definition {
                 Key::TapHold(key_def) => pk.key_code(key_def),

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -270,4 +270,30 @@ mod tests {
         let expected_active_layers = &[true];
         assert_eq!(actual_active_layers, expected_active_layers);
     }
+
+    #[test]
+    fn test_composite_simple_pressed_key_has_key_code_for_composite_simple_key_def() {
+        use key::{composite, layered, simple, Key, PressedKey};
+
+        // Assemble
+        const L: layered::LayerIndex = 1;
+        let keys: [composite::Key<L>; 3] = [
+            composite::Key::<L>::LayerModifier(layered::ModifierKey::Hold(0)),
+            composite::Key::<L>::Layered(layered::LayeredKey::new(
+                simple::Key(0x04),
+                [Some(simple::Key(0x05))],
+            )),
+            composite::Key::<L>::Simple(simple::Key(0x06)),
+        ];
+        let context = composite::Context::<L, DefaultNestableKey>::new();
+
+        // Act
+        let keymap_index: u16 = 2;
+        let (pressed_key, _) = keys[keymap_index as usize].new_pressed_key(&context, keymap_index);
+        let actual_keycode = pressed_key.key_code(&keys[keymap_index as usize]);
+
+        // Assert
+        let expected_keycode = Some(0x06);
+        assert_eq!(actual_keycode, expected_keycode);
+    }
 }

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -32,6 +32,7 @@ where
     [Option<DefaultNestableKey>; L]: serde::de::DeserializeOwned,
 {
     type Context = Context<L, DefaultNestableKey>;
+    type ContextEvent = Event;
     type Event = Event;
     type PressedKey = PressedKey<L>;
 
@@ -82,7 +83,11 @@ impl<const L: layered::LayerIndex> Default for Context<L, DefaultNestableKey> {
 
 impl<const L: layered::LayerIndex> key::Context for Context<L, DefaultNestableKey> {
     type Event = Event;
-    fn handle_event(&mut self, _event: Self::Event) {}
+    fn handle_event(&mut self, event: Self::Event) {
+        if let Event::LayerModification(ev) = event {
+            self.layer_context.handle_event(ev);
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -10,21 +10,22 @@ use crate::key;
 use key::{layered, simple, tap_hold};
 
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
-pub enum Key {
+pub enum Key<const L: layered::LayerIndex = 0> {
     Simple(simple::Key),
     TapHold(tap_hold::Key),
+    LayerModifier(layered::ModifierKey<L>),
 }
 
-impl key::Key for Key {
+impl<const L: layered::LayerIndex> key::Key for Key<L> {
     type Context = Context;
     type Event = Event;
-    type PressedKey = PressedKey;
+    type PressedKey = PressedKey<L>;
 
     fn new_pressed_key(
         &self,
         _context: &Self::Context,
         keymap_index: u16,
-    ) -> (PressedKey, Option<key::ScheduledEvent<Event>>) {
+    ) -> (Self::PressedKey, Option<key::ScheduledEvent<Event>>) {
         match self {
             Key::Simple(k) => {
                 let pressed_key = simple::PressedKey::new(k.key_code());
@@ -32,6 +33,10 @@ impl key::Key for Key {
             }
             Key::TapHold(_) => {
                 let (pressed_key, new_event) = tap_hold::PressedKey::new(keymap_index);
+                (pressed_key.into(), Some(new_event.into()))
+            }
+            Key::LayerModifier(k) => {
+                let (pressed_key, new_event) = k.new_pressed_key(keymap_index);
                 (pressed_key.into(), Some(new_event.into()))
             }
         }
@@ -59,29 +64,41 @@ impl key::Context for Context {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub enum PressedKey {
+pub enum PressedKey<const L: layered::LayerIndex = 0> {
     Simple(simple::PressedKey),
     TapHold(tap_hold::PressedKey),
+    LayerModifier(layered::PressedModifierKey<L>),
 }
 
-impl From<simple::PressedKey> for PressedKey {
+impl<const L: layered::LayerIndex> From<layered::PressedModifierKey<L>> for PressedKey<L> {
+    fn from(pk: layered::PressedModifierKey<L>) -> Self {
+        PressedKey::LayerModifier(pk)
+    }
+}
+
+impl<const L: layered::LayerIndex> From<simple::PressedKey> for PressedKey<L> {
     fn from(pk: simple::PressedKey) -> Self {
         PressedKey::Simple(pk)
     }
 }
 
-impl From<tap_hold::PressedKey> for PressedKey {
+impl<const L: layered::LayerIndex> From<tap_hold::PressedKey> for PressedKey<L> {
     fn from(pk: tap_hold::PressedKey) -> Self {
         PressedKey::TapHold(pk)
     }
 }
 
-impl key::PressedKey for PressedKey {
+impl<const L: layered::LayerIndex> key::PressedKey for PressedKey<L> {
     type Event = Event;
-    type Key = Key;
+    type Key = Key<L>;
 
-    fn key_code(&self, key_definition: &Key) -> Option<u8> {
+    fn key_code(&self, key_definition: &Key<L>) -> Option<u8> {
         match self {
+            PressedKey::LayerModifier(pk) => match key_definition {
+                Key::LayerModifier(key_def) => pk.key_code(key_def),
+                _ => None,
+            },
+
             PressedKey::Simple(pk) => match key_definition {
                 Key::Simple(key_def) => Some(pk.key_code(key_def)),
                 _ => None,
@@ -96,7 +113,7 @@ impl key::PressedKey for PressedKey {
 
     fn handle_event(
         &mut self,
-        key_definition: &Key,
+        key_definition: &Key<L>,
         event: key::Event<Self::Event>,
     ) -> impl IntoIterator<Item = key::Event<Self::Event>> {
         if let PressedKey::TapHold(tap_hold) = self {

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -296,4 +296,30 @@ mod tests {
         let expected_keycode = Some(0x06);
         assert_eq!(actual_keycode, expected_keycode);
     }
+
+    #[test]
+    fn test_composite_simple_pressed_key_has_key_code_for_composite_layered_key_def() {
+        use key::{composite, layered, simple, Key, PressedKey};
+
+        // Assemble
+        const L: layered::LayerIndex = 1;
+        let keys: [composite::Key<L>; 3] = [
+            composite::Key::<L>::LayerModifier(layered::ModifierKey::Hold(0)),
+            composite::Key::<L>::Layered(layered::LayeredKey::new(
+                simple::Key(0x04),
+                [Some(simple::Key(0x05))],
+            )),
+            composite::Key::<L>::Simple(simple::Key(0x06)),
+        ];
+        let context = composite::Context::<L, DefaultNestableKey>::new();
+
+        // Act
+        let keymap_index: u16 = 1;
+        let (pressed_key, _) = keys[keymap_index as usize].new_pressed_key(&context, keymap_index);
+        let actual_keycode = pressed_key.key_code(&keys[keymap_index as usize]);
+
+        // Assert
+        let expected_keycode = Some(0x04);
+        assert_eq!(actual_keycode, expected_keycode);
+    }
 }

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -14,7 +14,7 @@ pub trait NestableKey: key::Key + Sized {}
 
 impl NestableKey for simple::Key {}
 
-type DefaultNestableKey = simple::Key;
+pub type DefaultNestableKey = simple::Key;
 
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq)]
 pub enum Key<const L: layered::LayerIndex = 0, K: NestableKey = DefaultNestableKey>

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -88,9 +88,8 @@ impl<const L: layered::LayerIndex> From<tap_hold::PressedKey> for PressedKey<L> 
     }
 }
 
-impl<const L: layered::LayerIndex> key::PressedKey for PressedKey<L> {
+impl<const L: layered::LayerIndex> key::PressedKey<Key<L>> for PressedKey<L> {
     type Event = Event;
-    type Key = Key<L>;
 
     fn key_code(&self, key_definition: &Key<L>) -> Option<u8> {
         match self {

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -6,7 +6,7 @@ use crate::key;
 pub type LayerIndex = usize;
 
 /// Modifier layer key affects what layers are active.
-#[derive(Debug, Deserialize, Clone, Copy)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq)]
 pub enum ModifierKey<const L: LayerIndex> {
     Hold(LayerIndex),
 }

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -28,8 +28,13 @@ impl<const L: LayerIndex> ModifierKey<L> {
     }
 }
 
+impl From<LayerEvent> for () {
+    fn from(_: LayerEvent) -> Self {}
+}
+
 impl<const L: LayerIndex> key::Key for ModifierKey<L> {
     type Context = ();
+    type ContextEvent = ();
     type PressedKey = PressedModifierKey<L>;
     type Event = LayerEvent;
 
@@ -100,7 +105,7 @@ impl<const L: LayerIndex, K: key::Key> LayeredKey<L, K>
 where
     [Option<K>; L]: serde::de::DeserializeOwned,
 {
-    fn new_pressed_key(
+    pub fn new_pressed_key(
         &self,
         context: &Context<L, K::Context>,
         keymap_index: u16,
@@ -122,8 +127,10 @@ where
 impl<const L: LayerIndex, K: key::Key> key::Key<K> for LayeredKey<L, K>
 where
     [Option<K>; L]: serde::de::DeserializeOwned,
+    LayerEvent: From<<K as key::Key>::Event>,
 {
     type Context = Context<L, K::Context>;
+    type ContextEvent = LayerEvent;
     type PressedKey = K::PressedKey;
     type Event = K::Event;
 

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -50,7 +50,7 @@ pub struct Context<const L: LayerIndex, C: key::Context> {
 }
 
 impl<const L: LayerIndex, C: key::Context> Context<L, C> {
-    pub fn new(inner_context: C) -> Self {
+    pub const fn new(inner_context: C) -> Self {
         Self {
             active_layers: [false; L],
             inner_context,

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -15,16 +15,13 @@ impl<const L: LayerIndex> ModifierKey<L> {
     pub fn new_pressed_key(
         &self,
         keymap_index: u16,
-    ) -> (
-        PressedModifierKey<L>,
-        Option<key::ScheduledEvent<LayerEvent>>,
-    ) {
+    ) -> (PressedModifierKey<L>, key::ScheduledEvent<LayerEvent>) {
         match self {
             ModifierKey::Hold(layer) => {
                 let event = LayerEvent::LayerActivated(*layer);
                 (
                     PressedModifierKey::new(keymap_index),
-                    Some(key::ScheduledEvent::immediate(key::Event::Key(event))),
+                    key::ScheduledEvent::immediate(key::Event::Key(event)),
                 )
             }
         }
@@ -41,7 +38,8 @@ impl<const L: LayerIndex> key::Key for ModifierKey<L> {
         _context: &Self::Context,
         keymap_index: u16,
     ) -> (Self::PressedKey, Option<key::ScheduledEvent<Self::Event>>) {
-        self.new_pressed_key(keymap_index)
+        let (pk, ev) = self.new_pressed_key(keymap_index);
+        (pk, Some(ev))
     }
 }
 
@@ -196,10 +194,10 @@ mod tests {
         let keymap_index = 9; // arbitrary
         let (_pressed_key, scheduled_event) = key.new_pressed_key(keymap_index);
 
-        if let Some(key::ScheduledEvent {
+        if let key::ScheduledEvent {
             event: key::Event::Key(key_ev),
             ..
-        }) = scheduled_event
+        } = scheduled_event
         {
             assert_eq!(key_ev, LayerEvent::LayerActivated(layer));
         } else {
@@ -408,7 +406,7 @@ mod tests {
     #[test]
     fn test_deserialize_json_option_simple() {
         let actual: Option<key::simple::Key> = serde_json::from_str(r#"4"#).unwrap();
-        let mut expected: Option<key::simple::Key> = Some(simple::Key(0x04));
+        let expected: Option<key::simple::Key> = Some(simple::Key(0x04));
         assert_eq!(actual, expected);
     }
 
@@ -417,7 +415,7 @@ mod tests {
         let actual: heapless::Vec<Option<key::simple::Key>, 1> =
             serde_json::from_str(r#"[4]"#).unwrap();
         let mut expected: heapless::Vec<Option<key::simple::Key>, 1> = heapless::Vec::new();
-        expected.push(Some(simple::Key(0x04)));
+        expected.push(Some(simple::Key(0x04))).unwrap();
         assert_eq!(actual, expected);
     }
 

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -91,6 +91,15 @@ impl<const L: LayerIndex, K: key::Key> LayeredKey<L, K>
 where
     [Option<K>; L]: serde::de::DeserializeOwned,
 {
+    pub fn new(base: K, layered: [Option<K>; L]) -> Self {
+        Self { base, layered }
+    }
+}
+
+impl<const L: LayerIndex, K: key::Key> LayeredKey<L, K>
+where
+    [Option<K>; L]: serde::de::DeserializeOwned,
+{
     fn new_pressed_key(
         &self,
         context: &Context<L, K::Context>,

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -163,19 +163,18 @@ impl<const L: LayerIndex> PressedModifierKey<L> {
     }
 }
 
-impl<const L: LayerIndex> key::PressedKey for PressedModifierKey<L> {
+impl<const L: LayerIndex> key::PressedKey<ModifierKey<L>> for PressedModifierKey<L> {
     type Event = LayerEvent;
-    type Key = ModifierKey<L>;
 
     fn handle_event(
         &mut self,
-        key_definition: &Self::Key,
+        key_definition: &ModifierKey<L>,
         event: key::Event<Self::Event>,
     ) -> impl IntoIterator<Item = key::Event<Self::Event>> {
         self.handle_event(key_definition, event)
     }
 
-    fn key_code(&self, _key_definition: &Self::Key) -> Option<u8> {
+    fn key_code(&self, _key_definition: &ModifierKey<L>) -> Option<u8> {
         None
     }
 }

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -12,7 +12,7 @@ pub enum ModifierKey<const L: LayerIndex> {
 }
 
 impl<const L: LayerIndex> ModifierKey<L> {
-    fn new_pressed_key(
+    pub fn new_pressed_key(
         &self,
         keymap_index: u16,
     ) -> (

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -8,8 +8,12 @@ pub mod tap_hold;
 
 pub mod composite;
 
-pub trait Key<PK: Key = Self> {
-    type Context: Context;
+pub trait Key<PK: Key = Self>
+where
+    Self::ContextEvent: From<Self::Event>,
+{
+    type Context: Context<Event = Self::ContextEvent>;
+    type ContextEvent;
     type PressedKey: PressedKey<PK, Event = Self::Event> + Debug;
     type Event: Copy + Debug + Ord;
 

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -8,9 +8,9 @@ pub mod tap_hold;
 
 pub mod composite;
 
-pub trait Key<PK = Self> {
+pub trait Key<PK: Key = Self> {
     type Context: Context;
-    type PressedKey: PressedKey<Key = PK, Event = Self::Event> + Debug;
+    type PressedKey: PressedKey<PK, Event = Self::Event> + Debug;
     type Event: Copy + Debug + Ord;
 
     fn new_pressed_key(
@@ -30,15 +30,14 @@ impl Context for () {
     fn handle_event(&mut self, _event: Self::Event) {}
 }
 
-pub trait PressedKey {
+pub trait PressedKey<K: Key> {
     type Event;
-    type Key: Key;
     fn handle_event(
         &mut self,
-        key_definition: &Self::Key,
+        key_definition: &K,
         event: Event<Self::Event>,
     ) -> impl IntoIterator<Item = Event<Self::Event>>;
-    fn key_code(&self, key_definition: &Self::Key) -> Option<u8>;
+    fn key_code(&self, key_definition: &K) -> Option<u8>;
 }
 
 #[allow(unused)]

--- a/src/key/simple.rs
+++ b/src/key/simple.rs
@@ -43,21 +43,20 @@ impl key::Key for Key {
     }
 }
 
-impl key::PressedKey for PressedKey {
+impl key::PressedKey<Key> for PressedKey {
     type Event = Event;
-    type Key = Key;
 
     /// Simple key never emits events.
     fn handle_event(
         &mut self,
-        _key_definition: &Self::Key,
+        _key_definition: &Key,
         _event: key::Event<Self::Event>,
     ) -> impl IntoIterator<Item = key::Event<Self::Event>> {
         None
     }
 
     /// Simple key always has a key_code.
-    fn key_code(&self, key_definition: &Self::Key) -> Option<u8> {
+    fn key_code(&self, key_definition: &Key) -> Option<u8> {
         Some(self.key_code(key_definition))
     }
 }

--- a/src/key/simple.rs
+++ b/src/key/simple.rs
@@ -24,8 +24,8 @@ impl PressedKey {
         Self { key_code }
     }
 
-    pub fn key_code(&self, key_def: &Key) -> u8 {
-        key_def.key_code()
+    pub fn key_code(&self) -> u8 {
+        self.key_code
     }
 }
 
@@ -61,7 +61,7 @@ impl key::PressedKey<Key> for PressedKey {
     }
 
     /// Simple key always has a key_code.
-    fn key_code(&self, key_definition: &Key) -> Option<u8> {
-        Some(self.key_code(key_definition))
+    fn key_code(&self, _key_definition: &Key) -> Option<u8> {
+        Some(self.key_code())
     }
 }

--- a/src/key/simple.rs
+++ b/src/key/simple.rs
@@ -29,8 +29,13 @@ impl PressedKey {
     }
 }
 
+impl From<Event> for () {
+    fn from(_: Event) -> Self {}
+}
+
 impl key::Key for Key {
     type Context = ();
+    type ContextEvent = ();
     type Event = Event;
     type PressedKey = PressedKey;
 

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -177,3 +177,46 @@ impl<I: Index<usize, Output = K>, K: Key> Keymap<I, K> {
         report
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_keymap_with_simple_key() {
+        use key::simple;
+
+        // Assemble
+        let keys: [simple::Key; 1] = [simple::Key(0x04)];
+        let context = ();
+        let mut keymap: Keymap<[simple::Key; 1], simple::Key> = Keymap::new(keys, context);
+
+        // Act
+        keymap.handle_input(input::Event::Press { keymap_index: 0 });
+        keymap.tick();
+        let actual_report = keymap.boot_keyboard_report();
+
+        // Assert
+        let expected_report: [u8; 8] = [0, 0, 0x04, 0, 0, 0, 0, 0];
+        assert_eq!(actual_report, expected_report);
+    }
+
+    #[test]
+    fn test_keymap_with_composite_simple_key() {
+        use key::{composite, simple};
+
+        // Assemble
+        let keys: [composite::Key; 1] = [composite::Key::Simple(simple::Key(0x04))];
+        let context = composite::Context::new();
+        let mut keymap: Keymap<[composite::Key; 1]> = Keymap::new(keys, context);
+
+        // Act
+        keymap.handle_input(input::Event::Press { keymap_index: 0 });
+        keymap.tick();
+        let actual_report = keymap.boot_keyboard_report();
+
+        // Assert
+        let expected_report: [u8; 8] = [0, 0, 0x04, 0, 0, 0, 0, 0];
+        assert_eq!(actual_report, expected_report);
+    }
+}

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -4,7 +4,7 @@ use core::ops::Index;
 use crate::input;
 use crate::key;
 
-use key::{composite, Event, Key, PressedKey};
+use key::{composite, Context, Event, Key, PressedKey};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 pub struct ScheduledEvent<E> {
@@ -145,6 +145,11 @@ impl<I: Index<usize, Output = K>, K: Key> Keymap<I, K> {
                         .for_each(|ev: Event<K::Event>| self.pending_events.enqueue(ev).unwrap());
                 }
             });
+
+            // Update context with the event
+            if let key::Event::Key(ev) = ev {
+                self.context.handle_event(ev.into());
+            }
 
             if let Event::Input(input_ev) = ev {
                 self.handle_input(input_ev);

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -219,4 +219,32 @@ mod tests {
         let expected_report: [u8; 8] = [0, 0, 0x04, 0, 0, 0, 0, 0];
         assert_eq!(actual_report, expected_report);
     }
+
+    #[test]
+    fn test_keymap_with_composite_layered_key_press_base_key() {
+        use key::{composite, layered, simple};
+
+        // Assemble
+        const L: layered::LayerIndex = 1;
+        let keys: [composite::Key<L>; 2] = [
+            composite::Key::<L>::LayerModifier(layered::ModifierKey::Hold(0)),
+            composite::Key::<L>::Layered(layered::LayeredKey::new(
+                simple::Key(0x04),
+                [Some(simple::Key(0x05))],
+            )),
+        ];
+        let context = composite::Context::<L, composite::DefaultNestableKey>::new();
+        let mut keymap: Keymap<[composite::Key<L>; 2], composite::Key<L>> =
+            Keymap::new(keys, context);
+
+        // Act
+        keymap.handle_input(input::Event::Press { keymap_index: 0 });
+        keymap.handle_input(input::Event::Press { keymap_index: 1 });
+        keymap.tick();
+        let actual_report = keymap.boot_keyboard_report();
+
+        // Assert
+        let expected_report: [u8; 8] = [0, 0, 0x05, 0, 0, 0, 0, 0];
+        assert_eq!(actual_report, expected_report);
+    }
 }


### PR DESCRIPTION
Whew. I found this one a difficult changeset to write.

This PR implements layering functionality of `key::layered` into `key::composite`.

In no particular order, I'll remark:

- Roughly, the biggest fundamental challenge in this PR is that `layered::LayeredKey` is a slightly different `key::Key`.
  - Previously, `key::Key` is the trait which has associated `key::PressedKey`, `Event`, `Context` types. So e.g. a `simple::Key` is a `key::Key`, when pressed results in a `simple::PressedKey`.
  - Whereas, `layered::LayeredKey` is more heterogenous in two cases:
    - `LayeredKey` takes `layered::Context` for its `new_pressed_key` fn, but `layered::Context` handles `layered::LayerEvent` (which is not directly related to `LayeredKey`).
    - `LayeredKey<K>`'s associated `PressedKey` is `K::PressedKey`. -- The layered key acts-as another key by returning the proxied key directly. (Though it may be necessary later to return the pressed key through some kind of PressedLayeredKey indirection).

- This similarly breaks the assumption that a `PressedKey` is of the same 'kind' of key as the key definition. (Might need to have `PressedKey` implementations reference 'actual' key definition?).

- Dealing with derived Serde deserialisation means that I need to add the `where` bound `where [Option<DefaultNestableKey>; L]: serde::de::DeserializeOwned,` for the `layered::LayeredKey` & everywhere that this touches (e.g. throughout the `composite` mod). -- For `DeserializeOwned`, see: <https://serde.rs/lifetimes.html>.

- I didn't quickly notice that the `ron` serde deserializer uses a different syntax for deserialising into Rust `Vec` compared to arrays.

- Naming everything with the same identifier (trait `key::Key` vs enums/structs `composite::Key`, `simple::Key`, etc.) has some downsides. -- Being able to use the trait functions/methods requires having the trait name in scope. -- May just be worth either prefixing traits with `I`, (`IKey`, etc.), or smurf naming the implementations (`CompositeKey`, `SimpleKey`, etc.).

- Rust is strict about recursive data structures on the stack. Roughly `List<T> = Empty | Cons(T, List<T>)` doesn't work, since this could require allocating an infinite amount of stack space. -- Here, we have `Key<K> = Simple | Layered(K, [K])`. -- The solution I came up with is to use a generic which implements `NestedKey` trait; then implement `NestedKey` for valid permutations of nested `Key`.

- Without the right mindset / alignment with the compiler, the experience of changing the `Key`, `PressedKey` traits etc. felt like the Simpsons joke where Sideshow Bob has a rake smack his face whichever direction he steps. -- Sometimes the Rust compiler is difficult to work with over implementation-level things (such as whether traits have `Copy`/`Clone`), sometimes it's more interface level. (e.g. a `Key` and `<<K as Key>::PressedKey as PressedKey>::Key` not necessarily being the same implementation).

- e.g. the new `composite::PressedKey` is written with: `impl<const L: layered::LayerIndex> key::PressedKey<Key<L, DefaultNestableKey>> for PressedKey<L>`
  - Rather, changed from `trait PressedKey { type Key; ... }` to `trait PressedKey<K>`. The motivation was because `composite`'s `Key<L, DefaultNestableKey>` needs to have `L` as a parameter, but the previous trait definition didn't refer to `L` in any way. -- See: https://doc.rust-lang.org/error_codes/E0207.html

Further work:

- The assumption about "pressed key = key" was relaxed for `composite::Key::Simple`, but not other variants. -- Notably at the moment, `TapHold` isn't a `key::Key`, and only takes in `u8`; so at the moment `TapHold(simple, layer_mod)` isn't possible.

- `composite::Key` is only implemented specifically for `nested key = simple::Key`.

- Didn't cover test for releasing the modifier key.

- I still think the `features/` remain more readable than "read the Rust unit tests". -- It would be good to implement some for the `layered` keys.