### PR TITLE
Handle release layer modifier key

### DIFF
--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -237,6 +237,35 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_composite_pressedkey_layerpressedmodifier_handles_release_event() {
+        use crate::input;
+        use key::{composite, layered, Key, PressedKey};
+
+        // Assemble
+        const L: layered::LayerIndex = 1;
+        let keymap_index: u16 = 0;
+        let key = composite::Key::<L>::LayerModifier(layered::ModifierKey::Hold(0));
+        let context = composite::Context::<L, DefaultNestableKey>::new();
+        let (mut pressed_lmod_key, _) = key.new_pressed_key(&context, keymap_index);
+
+        // Act
+        let events = pressed_lmod_key.handle_event(
+            &key,
+            key::Event::Input(input::Event::Release { keymap_index }),
+        );
+
+        // Assert
+        let _key_ev = match events.into_iter().next() {
+            Some(key::Event::Key(Event::LayerModification(
+                layered::LayerEvent::LayerDeactivated(layer),
+            ))) => {
+                assert_eq!(layer, 0);
+            }
+            _ => panic!("Expected an Event::Key(LayerModification(LayerDeactivated(layer)))"),
+        };
+    }
+
+    #[test]
     fn test_composite_context_updates_with_composite_layermodifier_press_event() {
         use key::{composite, layered, simple, Context, Key};
 

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -163,7 +163,7 @@ impl<const L: LayerIndex> PressedModifierKey<L> {
         Self { keymap_index }
     }
 
-    fn handle_event(
+    pub fn handle_event(
         &mut self,
         key_definition: &ModifierKey<L>,
         event: key::Event<LayerEvent>,

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -62,6 +62,10 @@ impl<const L: LayerIndex, C: key::Context> Context<L, C> {
         }
     }
 
+    pub fn activate_layer(&mut self, layer: LayerIndex) {
+        self.active_layers[layer] = true;
+    }
+
     pub fn active_layers(&self) -> &[bool; L] {
         &self.active_layers
     }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -278,4 +278,66 @@ mod tests {
         let expected_report: [u8; 8] = [0, 0, 0x05, 0, 0, 0, 0, 0];
         assert_eq!(actual_report, expected_report);
     }
+
+    #[test]
+    fn test_keymap_with_composite_layered_key_press_retained_when_layer_mod_released() {
+        use key::{composite, layered, simple};
+
+        // Assemble
+        const L: layered::LayerIndex = 1;
+        let keys: [composite::Key<L>; 2] = [
+            composite::Key::<L>::LayerModifier(layered::ModifierKey::Hold(0)),
+            composite::Key::<L>::Layered(layered::LayeredKey::new(
+                simple::Key(0x04),
+                [Some(simple::Key(0x05))],
+            )),
+        ];
+        let context = composite::Context::<L, composite::DefaultNestableKey>::new();
+        let mut keymap: Keymap<[composite::Key<L>; 2], composite::Key<L>> =
+            Keymap::new(keys, context);
+
+        // Act
+        keymap.handle_input(input::Event::Press { keymap_index: 0 });
+        keymap.tick();
+        keymap.handle_input(input::Event::Press { keymap_index: 1 });
+        keymap.tick();
+        keymap.handle_input(input::Event::Release { keymap_index: 0 });
+        keymap.tick();
+        let actual_report = keymap.boot_keyboard_report();
+
+        // Assert
+        let expected_report: [u8; 8] = [0, 0, 0x05, 0, 0, 0, 0, 0];
+        assert_eq!(actual_report, expected_report);
+    }
+
+    #[test]
+    fn test_keymap_with_composite_layered_key_uses_base_when_pressed_after_layer_mod_released() {
+        use key::{composite, layered, simple};
+
+        // Assemble
+        const L: layered::LayerIndex = 1;
+        let keys: [composite::Key<L>; 2] = [
+            composite::Key::<L>::LayerModifier(layered::ModifierKey::Hold(0)),
+            composite::Key::<L>::Layered(layered::LayeredKey::new(
+                simple::Key(0x04),
+                [Some(simple::Key(0x05))],
+            )),
+        ];
+        let context = composite::Context::<L, composite::DefaultNestableKey>::new();
+        let mut keymap: Keymap<[composite::Key<L>; 2], composite::Key<L>> =
+            Keymap::new(keys, context);
+
+        // Act
+        keymap.handle_input(input::Event::Press { keymap_index: 0 });
+        keymap.tick();
+        keymap.handle_input(input::Event::Release { keymap_index: 0 });
+        keymap.tick();
+        keymap.handle_input(input::Event::Press { keymap_index: 1 });
+        keymap.tick();
+        let actual_report = keymap.boot_keyboard_report();
+
+        // Assert
+        let expected_report: [u8; 8] = [0, 0, 0x04, 0, 0, 0, 0, 0];
+        assert_eq!(actual_report, expected_report);
+    }
 }


### PR DESCRIPTION
"event from key release" is implemented using `PressedKey::handle_event`.

This PR implements handling of `layered::PressedModifierKey::handle_event` in `composite::PressedKey::handle_event`, and adds some unit tests covering relevant cases for `keymap::Keymap`, `key::composite`.