### PR TITLE
rust: rename input::Key's field to pressed_key

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -10,12 +10,15 @@ pub enum Event {
 
 #[derive(Debug, Clone, Copy)]
 pub enum PressedInput<K> {
-    Key { keymap_index: u16, key: K },
+    Key { keymap_index: u16, pressed_key: K },
     Virtual { key_code: u8 },
 }
 
 impl<K> PressedInput<K> {
-    pub fn new_pressed_key(keymap_index: u16, key: K) -> Self {
-        Self::Key { keymap_index, key }
+    pub fn new_pressed_key(keymap_index: u16, pressed_key: K) -> Self {
+        Self::Key {
+            keymap_index,
+            pressed_key,
+        }
     }
 }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -47,9 +47,13 @@ impl<I: Index<usize, Output = K>, K: Key> Keymap<I, K> {
     pub fn handle_input(&mut self, ev: input::Event) {
         // Update each of the PressedKeys with the event.
         self.pressed_inputs.iter_mut().for_each(|pi| {
-            if let input::PressedInput::Key { keymap_index, key } = pi {
+            if let input::PressedInput::Key {
+                keymap_index,
+                pressed_key,
+            } = pi
+            {
                 let key_definition = &self.key_definitions[*keymap_index as usize];
-                let events = key.handle_event(key_definition, ev.into());
+                let events = pressed_key.handle_event(key_definition, ev.into());
                 events
                     .into_iter()
                     .for_each(|ev: Event<K::Event>| self.pending_events.enqueue(ev).unwrap());
@@ -137,9 +141,13 @@ impl<I: Index<usize, Output = K>, K: Key> Keymap<I, K> {
         if let Some(ev) = self.pending_events.dequeue() {
             // Update each of the PressedKeys with the event.
             self.pressed_inputs.iter_mut().for_each(|pi| {
-                if let input::PressedInput::Key { keymap_index, key } = pi {
+                if let input::PressedInput::Key {
+                    keymap_index,
+                    pressed_key,
+                } = pi
+                {
                     let key_definition = &self.key_definitions[*keymap_index as usize];
-                    let events = key.handle_event(key_definition, ev);
+                    let events = pressed_key.handle_event(key_definition, ev);
                     events
                         .into_iter()
                         .for_each(|ev: Event<K::Event>| self.pending_events.enqueue(ev).unwrap());
@@ -161,7 +169,10 @@ impl<I: Index<usize, Output = K>, K: Key> Keymap<I, K> {
         let mut report = [0u8; 8];
 
         let pressed_keys = self.pressed_inputs.iter().filter_map(|pi| match pi {
-            input::PressedInput::Key { keymap_index, key } => {
+            input::PressedInput::Key {
+                keymap_index,
+                pressed_key: key,
+            } => {
                 let key_definition = &self.key_definitions[*keymap_index as usize];
                 key.key_code(key_definition)
             }


### PR DESCRIPTION
Minor refactor.

The codebase uses the identifiers `Key` and `PressedKey` throughout.

I found it confusing that `key` refers to a `PressedKey` (even in the context of `input::PressedInput`.