### PR TITLE
Remove &Key from PressedKey method signature

### DIFF
--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -38,10 +38,9 @@ pub trait PressedKey<K: Key> {
     type Event;
     fn handle_event(
         &mut self,
-        key_definition: &K,
         event: Event<Self::Event>,
     ) -> impl IntoIterator<Item = Event<Self::Event>>;
-    fn key_code(&self, key_definition: &K) -> Option<u8>;
+    fn key_code(&self) -> Option<u8>;
 }
 
 #[allow(unused)]

--- a/src/key/simple.rs
+++ b/src/key/simple.rs
@@ -54,14 +54,13 @@ impl key::PressedKey<Key> for PressedKey {
     /// Simple key never emits events.
     fn handle_event(
         &mut self,
-        _key_definition: &Key,
         _event: key::Event<Self::Event>,
     ) -> impl IntoIterator<Item = key::Event<Self::Event>> {
         None
     }
 
     /// Simple key always has a key_code.
-    fn key_code(&self, _key_definition: &Key) -> Option<u8> {
+    fn key_code(&self) -> Option<u8> {
         Some(self.key_code())
     }
 }

--- a/src/key/tap_hold.rs
+++ b/src/key/tap_hold.rs
@@ -31,23 +31,25 @@ impl From<Event> for key::Event<Event> {
 pub struct PressedKey {
     keymap_index: u16,
     state: TapHoldState,
+    key_def: Key,
 }
 
 impl PressedKey {
-    pub fn new(keymap_index: u16) -> (Self, key::ScheduledEvent<Event>) {
+    pub fn new(keymap_index: u16, key_def: Key) -> (Self, key::ScheduledEvent<Event>) {
         (
             Self {
                 keymap_index,
                 state: TapHoldState::Pending,
+                key_def,
             },
             key::ScheduledEvent::after(200, Event::TapHoldTimeout { keymap_index }.into()),
         )
     }
 
-    pub fn key_code(&self, key_def: &Key) -> Option<u8> {
+    pub fn key_code(&self) -> Option<u8> {
         match self.state {
-            TapHoldState::Tap => Some(key_def.tap),
-            TapHoldState::Hold => Some(key_def.hold),
+            TapHoldState::Tap => Some(self.key_def.tap),
+            TapHoldState::Hold => Some(self.key_def.hold),
             _ => None,
         }
     }
@@ -60,7 +62,6 @@ impl PressedKey {
 
     pub fn handle_event(
         &mut self,
-        key_def: &Key,
         event: key::Event<Event>,
     ) -> heapless::Vec<key::Event<Event>, 2> {
         match event {
@@ -77,7 +78,7 @@ impl PressedKey {
 
                 match &self.state {
                     TapHoldState::Tap => {
-                        let key_code = key_def.tap;
+                        let key_code = self.key_def.tap;
                         let mut emitted_events: heapless::Vec<key::Event<Event>, 2> =
                             heapless::Vec::new();
                         emitted_events

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -47,13 +47,8 @@ impl<I: Index<usize, Output = K>, K: Key> Keymap<I, K> {
     pub fn handle_input(&mut self, ev: input::Event) {
         // Update each of the PressedKeys with the event.
         self.pressed_inputs.iter_mut().for_each(|pi| {
-            if let input::PressedInput::Key {
-                keymap_index,
-                pressed_key,
-            } = pi
-            {
-                let key_definition = &self.key_definitions[*keymap_index as usize];
-                let events = pressed_key.handle_event(key_definition, ev.into());
+            if let input::PressedInput::Key { pressed_key, .. } = pi {
+                let events = pressed_key.handle_event(ev.into());
                 events
                     .into_iter()
                     .for_each(|ev: Event<K::Event>| self.pending_events.enqueue(ev).unwrap());
@@ -141,13 +136,8 @@ impl<I: Index<usize, Output = K>, K: Key> Keymap<I, K> {
         if let Some(ev) = self.pending_events.dequeue() {
             // Update each of the PressedKeys with the event.
             self.pressed_inputs.iter_mut().for_each(|pi| {
-                if let input::PressedInput::Key {
-                    keymap_index,
-                    pressed_key,
-                } = pi
-                {
-                    let key_definition = &self.key_definitions[*keymap_index as usize];
-                    let events = pressed_key.handle_event(key_definition, ev);
+                if let input::PressedInput::Key { pressed_key, .. } = pi {
+                    let events = pressed_key.handle_event(ev);
                     events
                         .into_iter()
                         .for_each(|ev: Event<K::Event>| self.pending_events.enqueue(ev).unwrap());
@@ -170,12 +160,9 @@ impl<I: Index<usize, Output = K>, K: Key> Keymap<I, K> {
 
         let pressed_keys = self.pressed_inputs.iter().filter_map(|pi| match pi {
             input::PressedInput::Key {
-                keymap_index,
-                pressed_key: key,
-            } => {
-                let key_definition = &self.key_definitions[*keymap_index as usize];
-                key.key_code(key_definition)
-            }
+                keymap_index: _,
+                pressed_key,
+            } => pressed_key.key_code(),
             input::PressedInput::Virtual { key_code } => Some(*key_code),
         });
 


### PR DESCRIPTION
This PR removes the `&Key` from the `.key_code()`, `.handle_event()` methods of PressedKey.

This does seem to be a more natural interface. -- I'd not done it this way, since adding `key` to all the pressed key implementations seemed a bit silly. -- I think all the `key::PressedKey` implementations will need `keymap_index` and may need `key`, so I think it's worth refactoring further.

The motivation for this was concern about the `composite::Key` enum type. -- Conceptually, it makes sense to have something like `Key = Simple | TapHold(...) | Layered | ...`. However, by having `composite::Key` as an enum, each key is as large as the largest `composite::Key` variant. By having `composite::Key<NestedKey>`, this increases the size of each key depending on how deeply the `NestedKey` goes. So e.g. having a key which has 10 levels of nesting would make it all keys quite large. (e.g. `LayeredKey<K, const L: usize>(K, K[L])` would then be L times this). -- I hadn't actually measured it, but it feels like this could easily get too big for e.g. a 75-key keymap.

I think there are ways of working around that; but I'm sure removing `&Key` from the pressed key definition is required either way.