### PR TITLE
Factor out common input::PressedKey, using key::PressedKeyState

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -9,16 +9,22 @@ pub enum Event {
 }
 
 #[derive(Debug, Clone, Copy)]
+pub struct PressedKey<K> {
+    pub keymap_index: u16,
+    pub pressed_key: K,
+}
+
+#[derive(Debug, Clone, Copy)]
 pub enum PressedInput<K> {
-    Key { keymap_index: u16, pressed_key: K },
+    Key(PressedKey<K>),
     Virtual { key_code: u8 },
 }
 
 impl<K> PressedInput<K> {
     pub fn new_pressed_key(keymap_index: u16, pressed_key: K) -> Self {
-        Self::Key {
+        Self::Key(PressedKey {
             keymap_index,
             pressed_key,
-        }
+        })
     }
 }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -47,7 +47,7 @@ impl<I: Index<usize, Output = K>, K: Key> Keymap<I, K> {
     pub fn handle_input(&mut self, ev: input::Event) {
         // Update each of the PressedKeys with the event.
         self.pressed_inputs.iter_mut().for_each(|pi| {
-            if let input::PressedInput::Key { pressed_key, .. } = pi {
+            if let input::PressedInput::Key(input::PressedKey { pressed_key, .. }) = pi {
                 let events = pressed_key.handle_event(ev.into());
                 events
                     .into_iter()
@@ -75,9 +75,9 @@ impl<I: Index<usize, Output = K>, K: Key> Keymap<I, K> {
                 self.pressed_inputs
                     .iter()
                     .position(|pi| match pi {
-                        input::PressedInput::Key {
+                        input::PressedInput::Key(input::PressedKey {
                             keymap_index: ki, ..
-                        } => keymap_index == *ki,
+                        }) => keymap_index == *ki,
                         _ => false,
                     })
                     .map(|i| self.pressed_inputs.remove(i));
@@ -136,7 +136,7 @@ impl<I: Index<usize, Output = K>, K: Key> Keymap<I, K> {
         if let Some(ev) = self.pending_events.dequeue() {
             // Update each of the PressedKeys with the event.
             self.pressed_inputs.iter_mut().for_each(|pi| {
-                if let input::PressedInput::Key { pressed_key, .. } = pi {
+                if let input::PressedInput::Key(input::PressedKey { pressed_key, .. }) = pi {
                     let events = pressed_key.handle_event(ev);
                     events
                         .into_iter()
@@ -159,10 +159,9 @@ impl<I: Index<usize, Output = K>, K: Key> Keymap<I, K> {
         let mut report = [0u8; 8];
 
         let pressed_keys = self.pressed_inputs.iter().filter_map(|pi| match pi {
-            input::PressedInput::Key {
-                keymap_index: _,
-                pressed_key,
-            } => pressed_key.key_code(),
+            input::PressedInput::Key(input::PressedKey { pressed_key, .. }) => {
+                pressed_key.key_code()
+            }
             input::PressedInput::Virtual { key_code } => Some(*key_code),
         });
 


### PR DESCRIPTION
The `PressedKey` implementations all had `keymap_index` and `key`. These have been factored out to a common `input::PressedKey` value struct.

The `input::PressedKey` struct then proxies the key-specific logic to `key::PressedKeyState` traits. -- e.g. the `tap_hold::PressedKeyState` is 'pending', until either it's interrupted or is held for long enough.

This continues the efforts of #31 and #32.