### PR TITLE
Refactor Key::Event associated type to Key<Ev> generic

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1,3 +1,5 @@
+use core::fmt::Debug;
+
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
@@ -15,10 +17,13 @@ pub struct PressedKey<K, S> {
     pub pressed_key_state: S,
 }
 
-impl<K: crate::key::Key, S: crate::key::PressedKeyState<K, Event = K::Event>> crate::key::PressedKey
-    for PressedKey<K, S>
+impl<K, Ev, S> crate::key::PressedKey for PressedKey<K, S>
+where
+    K: crate::key::Key<Ev>,
+    Ev: Copy + Debug + Ord,
+    S: crate::key::PressedKeyState<K, Event = Ev>,
 {
-    type Event = K::Event;
+    type Event = Ev;
 
     fn handle_event(
         &mut self,

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -8,14 +8,14 @@ pub mod tap_hold;
 
 pub mod composite;
 
-pub trait Key<PK: Key = Self>: Debug
+pub trait Key<Ev, PK: Key<Ev> = Self>: Debug
 where
-    Self::ContextEvent: From<Self::Event>,
+    Ev: Copy + Debug + Ord,
+    Self::ContextEvent: From<Ev>,
 {
     type Context: Context<Event = Self::ContextEvent>;
     type ContextEvent;
-    type Event: Copy + Debug + Ord;
-    type PressedKeyState: PressedKeyState<PK, Event = Self::Event>;
+    type PressedKeyState: PressedKeyState<PK, Event = Ev>;
 
     fn new_pressed_key(
         &self,
@@ -23,7 +23,7 @@ where
         keymap_index: u16,
     ) -> (
         input::PressedKey<PK, Self::PressedKeyState>,
-        Option<ScheduledEvent<Self::Event>>,
+        Option<ScheduledEvent<Ev>>,
     );
 }
 
@@ -47,8 +47,8 @@ pub trait PressedKey {
     fn key_code(&self) -> Option<u8>;
 }
 
-pub trait PressedKeyState<K: Key>: Debug {
-    type Event;
+pub trait PressedKeyState<K: Key<Self::Event>>: Debug {
+    type Event: Copy + Debug + Ord;
 
     fn handle_event_for(
         &mut self,

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -8,7 +8,7 @@ pub mod tap_hold;
 
 pub mod composite;
 
-pub trait Key<PK: Key = Self>: Debug + Sized
+pub trait Key<PK: Key = Self>: Debug
 where
     Self::ContextEvent: From<Self::Event>,
 {

--- a/src/key/simple.rs
+++ b/src/key/simple.rs
@@ -35,7 +35,7 @@ impl key::Key<Event> for Key {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Deserialize, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Event;
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/src/key/simple.rs
+++ b/src/key/simple.rs
@@ -11,10 +11,9 @@ impl Key {
     }
 }
 
-impl key::Key for Key {
+impl key::Key<Event> for Key {
     type Context = ();
     type ContextEvent = ();
-    type Event = Event;
     type PressedKeyState = PressedKeyState;
 
     fn new_pressed_key(
@@ -23,7 +22,7 @@ impl key::Key for Key {
         keymap_index: u16,
     ) -> (
         input::PressedKey<Self, Self::PressedKeyState>,
-        Option<key::ScheduledEvent<Self::Event>>,
+        Option<key::ScheduledEvent<Event>>,
     ) {
         (
             input::PressedKey {
@@ -37,7 +36,7 @@ impl key::Key for Key {
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
-pub struct Event();
+pub struct Event;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PressedKeyState;

--- a/src/key/tap_hold.rs
+++ b/src/key/tap_hold.rs
@@ -13,10 +13,9 @@ impl From<Event> for () {
     fn from(_: Event) -> Self {}
 }
 
-impl key::Key for Key {
+impl key::Key<Event> for Key {
     type Context = ();
     type ContextEvent = ();
-    type Event = Event;
     type PressedKeyState = PressedKeyState;
 
     fn new_pressed_key(
@@ -25,7 +24,7 @@ impl key::Key for Key {
         keymap_index: u16,
     ) -> (
         input::PressedKey<Self, Self::PressedKeyState>,
-        Option<key::ScheduledEvent<Self::Event>>,
+        Option<key::ScheduledEvent<Event>>,
     ) {
         (
             input::PressedKey {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,9 @@ pub mod key;
 pub mod keymap;
 
 #[allow(unused)]
-use key::composite::Key;
+use composite::{Event, Key};
 #[allow(unused)]
-use key::{simple, tap_hold};
+use key::{composite, simple, tap_hold};
 
 #[cfg(not(custom_keymap))]
 pub const KEY_DEFINITIONS: [Key; 1] = [
@@ -16,7 +16,7 @@ pub const KEY_DEFINITIONS: [Key; 1] = [
 #[cfg(custom_keymap)]
 include!(env!("SMART_KEYMAP_CUSTOM_KEYMAP"));
 
-static mut KEYMAP: keymap::Keymap<[Key; KEY_DEFINITIONS.len()]> =
+static mut KEYMAP: keymap::Keymap<[Key; KEY_DEFINITIONS.len()], Key, Event> =
     keymap::Keymap::new(KEY_DEFINITIONS, key::composite::Context::new());
 
 #[allow(static_mut_refs)]

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -7,7 +7,7 @@ use smart_keymap::input;
 use smart_keymap::key;
 use smart_keymap::keymap::Keymap;
 
-use key::composite::Key;
+use key::composite::{Event, Key};
 
 mod common;
 
@@ -16,7 +16,7 @@ use common::Deserializer;
 #[derive(Debug, World)]
 pub struct KeymapWorld {
     input_deserializer: Deserializer,
-    keymap: Keymap<Vec<Key>>,
+    keymap: Keymap<Vec<Key>, Key, Event>,
 }
 
 impl Default for KeymapWorld {


### PR DESCRIPTION
This was surprisingly tedious. -- In Rust, the types are expressive enough that they permeate throughout the codebase. So, changing a fundamental type in the codebase will result in many changes.

This PR refactors the `Event` type from being an associated type of the trait `key::Key`, to a generic type of the trait.

Essentially none of the code changed; only the types and generics.

Having `Event` is a step towards allowing multiple implementations of `trait::Key`.