### PR TITLE
Key trait object

### DIFF
--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -93,6 +93,11 @@ impl<const L: layered::LayerIndex> key::Context for Context<L, DefaultNestableKe
     }
 }
 
+/// simple::Context from composite::Context
+impl<const L: layered::LayerIndex> From<Context<L, DefaultNestableKey>> for () {
+    fn from(_: Context<L, DefaultNestableKey>) -> Self {}
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum PressedKeyState<const L: layered::LayerIndex = 0> {
     Simple(simple::PressedKeyState),

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -276,6 +276,17 @@ impl TryFrom<key::Event<Event>> for key::Event<layered::LayerEvent> {
     }
 }
 
+impl TryFrom<key::Event<Event>> for key::Event<simple::Event> {
+    type Error = key::EventError;
+
+    fn try_from(ev: key::Event<Event>) -> Result<Self, Self::Error> {
+        match ev {
+            key::Event::Input(ev) => Ok(key::Event::Input(ev)),
+            key::Event::Key(_) => Err(key::EventError::UnmappableEvent),
+        }
+    }
+}
+
 impl TryFrom<key::Event<Event>> for key::Event<tap_hold::Event> {
     type Error = key::EventError;
 

--- a/src/key/dynamic.rs
+++ b/src/key/dynamic.rs
@@ -3,9 +3,7 @@ use core::marker::PhantomData;
 
 use crate::{input, key};
 
-use key::{Key as _, PressedKey as _};
-
-use key::{composite, simple};
+use key::PressedKey as _;
 
 use super::ScheduledEvent;
 
@@ -105,5 +103,39 @@ where
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use key::{composite, simple};
+
+    #[test]
+    fn test_composite_dynamic_simple_key_has_no_key_code_when_released() {
+        // Assemble
+        let dyn_key: &mut dyn Key<
+            composite::Event,
+            Context = composite::Context<0, simple::Key>,
+            ContextEvent = composite::Event,
+        > = &mut DynamicKey::new(simple::Key(0x04));
+        let context = composite::Context::new();
+
+        // Act
+        let keymap_index: u16 = 5; // arbitrary
+        let _ = dyn_key.handle_event(
+            &context,
+            key::Event::Input(input::Event::Press { keymap_index }),
+        );
+        let _ = dyn_key.handle_event(
+            &context,
+            key::Event::Input(input::Event::Release { keymap_index }),
+        );
+
+        // Assert
+        let actual_key_code = dyn_key.key_code();
+        let expected_key_code = None;
+        assert_eq!(actual_key_code, expected_key_code);
     }
 }

--- a/src/key/dynamic.rs
+++ b/src/key/dynamic.rs
@@ -29,6 +29,11 @@ where
     fn key_code(&self) -> Option<u8>;
 }
 
+pub type CompositeKey<const L: key::layered::LayerIndex = 0> = dyn Key<
+    key::composite::Event,
+    Context = key::composite::Context<L, key::composite::DefaultNestableKey>,
+>;
+
 #[derive(Debug)]
 pub struct DynamicKey<K: key::Key, Ctx, Ev> {
     key: K,

--- a/src/key/dynamic.rs
+++ b/src/key/dynamic.rs
@@ -4,7 +4,7 @@ use crate::{input, key};
 
 use key::{Key as _, PressedKey as _};
 
-use key::simple;
+use key::{composite, simple};
 
 use super::ScheduledEvent;
 
@@ -47,24 +47,27 @@ impl DynamicKey {
     }
 }
 
-impl<const N: usize> Key<simple::Event, N> for DynamicKey {
-    type Context = ();
-    type ContextEvent = ();
+impl<const N: usize> Key<composite::Event, N> for DynamicKey {
+    type Context = composite::Context<0, simple::Key>;
+    type ContextEvent = composite::Event;
 
     fn handle_event(
         &mut self,
         context: &Self::Context,
-        event: key::Event<simple::Event>,
-    ) -> heapless::Vec<key::ScheduledEvent<simple::Event>, N> {
-        let mut scheduled_events = heapless::Vec::new();
+        event: key::Event<composite::Event>,
+    ) -> heapless::Vec<key::ScheduledEvent<composite::Event>, N> {
+        let mut scheduled_events: heapless::Vec<key::ScheduledEvent<composite::Event>, N> =
+            heapless::Vec::new();
 
         if let Some(mut pressed_key) = self.pressed_key {
-            scheduled_events.extend(
-                pressed_key
-                    .handle_event(event)
-                    .into_iter()
-                    .map(|ev| ScheduledEvent::immediate(ev)),
-            );
+            if let Ok(event) = event.try_into() {
+                scheduled_events.extend(
+                    pressed_key
+                        .handle_event(event)
+                        .into_iter()
+                        .map(|ev| ScheduledEvent::immediate(ev).into()),
+                );
+            }
 
             if let key::Event::Input(input::Event::Release { keymap_index }) = event {
                 if keymap_index == pressed_key.keymap_index {
@@ -73,8 +76,9 @@ impl<const N: usize> Key<simple::Event, N> for DynamicKey {
             }
         } else {
             if let key::Event::Input(input::Event::Press { keymap_index }) = event {
-                let (pressed_key, new_events) = self.key.new_pressed_key(context, keymap_index);
-                scheduled_events.extend(new_events.into_iter());
+                let (pressed_key, new_events) =
+                    self.key.new_pressed_key(context.into(), keymap_index);
+                scheduled_events.extend(new_events.into_iter().map(|sch_ev| sch_ev.into()));
                 self.pressed_key = Some(pressed_key);
             }
         }

--- a/src/key/dynamic.rs
+++ b/src/key/dynamic.rs
@@ -41,7 +41,7 @@ pub struct DynamicKey<K: key::Key, Ctx, Ev> {
 }
 
 impl<K: key::Key, Ctx, Ev> DynamicKey<K, Ctx, Ev> {
-    pub fn new(key: K) -> Self {
+    pub const fn new(key: K) -> Self {
         Self {
             key,
             pressed_key: None,

--- a/src/key/dynamic.rs
+++ b/src/key/dynamic.rs
@@ -1,0 +1,92 @@
+use core::fmt::Debug;
+
+use crate::{input, key};
+
+use key::{Key as _, PressedKey as _};
+
+use key::simple;
+
+use super::ScheduledEvent;
+
+/// A dyn-compatible Key trait.
+pub trait Key<Ev, const N: usize = 2>: Debug
+where
+    Ev: Copy + Debug + Ord,
+    Self::ContextEvent: From<Ev>,
+{
+    type Context: key::Context<Event = Self::ContextEvent>;
+    type ContextEvent;
+
+    /// Handles events in two cases:
+    /// - an unpressed key will only receive [input::Event::Press]
+    ///   for the keymap index for that key.
+    ///   (i.e. an unpressed key won't receive [input::Event::Press] for other keys,
+    ///    nor other [input::Event] types),
+    /// - a pressed key will receive all kinds of [input::Event].
+    fn handle_event(
+        &mut self,
+        context: &Self::Context,
+        event: key::Event<Ev>,
+    ) -> heapless::Vec<key::ScheduledEvent<Ev>, N>;
+
+    fn key_code(&self) -> Option<u8>;
+}
+
+#[derive(Debug)]
+pub struct DynamicKey {
+    key: simple::Key,
+    pressed_key: Option<input::PressedKey<simple::Key, <simple::Key as key::Key>::PressedKeyState>>,
+}
+
+impl DynamicKey {
+    pub fn new(key: simple::Key) -> Self {
+        Self {
+            key,
+            pressed_key: None,
+        }
+    }
+}
+
+impl<const N: usize> Key<simple::Event, N> for DynamicKey {
+    type Context = ();
+    type ContextEvent = ();
+
+    fn handle_event(
+        &mut self,
+        context: &Self::Context,
+        event: key::Event<simple::Event>,
+    ) -> heapless::Vec<key::ScheduledEvent<simple::Event>, N> {
+        let mut scheduled_events = heapless::Vec::new();
+
+        if let Some(mut pressed_key) = self.pressed_key {
+            scheduled_events.extend(
+                pressed_key
+                    .handle_event(event)
+                    .into_iter()
+                    .map(|ev| ScheduledEvent::immediate(ev)),
+            );
+
+            if let key::Event::Input(input::Event::Release { keymap_index }) = event {
+                if keymap_index == pressed_key.keymap_index {
+                    self.pressed_key = None;
+                }
+            }
+        } else {
+            if let key::Event::Input(input::Event::Press { keymap_index }) = event {
+                let (pressed_key, new_events) = self.key.new_pressed_key(context, keymap_index);
+                scheduled_events.extend(new_events.into_iter());
+                self.pressed_key = Some(pressed_key);
+            }
+        }
+
+        scheduled_events
+    }
+
+    fn key_code(&self) -> Option<u8> {
+        if let Some(pressed_key) = self.pressed_key {
+            pressed_key.key_code()
+        } else {
+            None
+        }
+    }
+}

--- a/src/key/dynamic.rs
+++ b/src/key/dynamic.rs
@@ -90,13 +90,10 @@ where
                     self.pressed_key = None;
                 }
             }
-        } else {
-            if let key::Event::Input(input::Event::Press { keymap_index }) = event {
-                let (pressed_key, new_events) =
-                    self.key.new_pressed_key(context.into(), keymap_index);
-                scheduled_events.extend(new_events.into_iter().map(|sch_ev| sch_ev.into()));
-                self.pressed_key = Some(pressed_key);
-            }
+        } else if let key::Event::Input(input::Event::Press { keymap_index }) = event {
+            let (pressed_key, new_events) = self.key.new_pressed_key(context.into(), keymap_index);
+            scheduled_events.extend(new_events.into_iter().map(|sch_ev| sch_ev.into()));
+            self.pressed_key = Some(pressed_key);
         }
 
         scheduled_events

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -8,7 +8,7 @@ pub mod tap_hold;
 
 pub mod composite;
 
-pub trait Key<PK: Key = Self>: Debug + Sized
+pub trait Key<PK: Key = Self>: Debug
 where
     Self::ContextEvent: From<Self::Event>,
 {

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -8,6 +8,8 @@ pub mod tap_hold;
 
 pub mod composite;
 
+pub mod dynamic;
+
 pub trait Key<PK: Key = Self>: Debug
 where
     Self::ContextEvent: From<Self::Event>,


### PR DESCRIPTION
This was implemented as part of #35, where I checked that `keymap::Keymap` could be implemented to use this new `mod`.

I'll defer the rationale to that PR.

