### PR TITLE
Fix and reinstate unit test

### DIFF
--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -230,24 +230,24 @@ mod tests {
 
     use crate::tuples;
 
-    // #[test]
-    // fn test_keymap_with_simple_key() {
-    //     use key::simple;
+    #[test]
+    fn test_keymap_with_simple_key_with_composite_context() {
+        use key::simple;
 
-    //     // Assemble
-    //     let keys = tuples::Keys1::new(simple::Key(0x04));
-    //     let context = ();
-    //     let mut keymap = Keymap::new(keys, context);
+        // Assemble
+        let keys: tuples::Keys1<simple::Key, 0> = tuples::Keys1::new((simple::Key(0x04),));
+        let context = composite::Context::new();
+        let mut keymap = Keymap::new(keys, context);
 
-    //     // Act
-    //     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    //     keymap.tick();
-    //     let actual_report = keymap.boot_keyboard_report();
+        // Act
+        keymap.handle_input(input::Event::Press { keymap_index: 0 });
+        keymap.tick();
+        let actual_report = keymap.boot_keyboard_report();
 
-    //     // Assert
-    //     let expected_report: [u8; 8] = [0, 0, 0x04, 0, 0, 0, 0, 0];
-    //     assert_eq!(actual_report, expected_report);
-    // }
+        // Assert
+        let expected_report: [u8; 8] = [0, 0, 0x04, 0, 0, 0, 0, 0];
+        assert_eq!(actual_report, expected_report);
+    }
 
     #[test]
     fn test_keymap_with_composite_simple_key() {

--- a/src/tuples.rs
+++ b/src/tuples.rs
@@ -20,9 +20,9 @@ impl<K0: key::Key + Copy, const L: key::layered::LayerIndex> Keys1<K0, L> {
 
 impl<K0: key::Key + 'static, const L: key::layered::LayerIndex> Index<usize> for Keys1<K0, L>
 where
+    key::Event<<K0 as key::Key>::Event>: TryFrom<key::Event<composite::Event>>,
     key::ScheduledEvent<composite::Event>: From<key::ScheduledEvent<<K0 as key::Key>::Event>>,
     <K0 as key::Key>::Context: From<composite::Context<L, simple::Key>>,
-    key::Event<<K0 as key::Key>::Event>: From<key::Event<composite::Event>>,
 {
     type Output = dyn dynamic::Key<
         key::composite::Event,
@@ -39,9 +39,9 @@ where
 
 impl<K0: key::Key + 'static, const L: key::layered::LayerIndex> IndexMut<usize> for Keys1<K0, L>
 where
+    key::Event<<K0 as key::Key>::Event>: TryFrom<key::Event<composite::Event>>,
     key::ScheduledEvent<composite::Event>: From<key::ScheduledEvent<<K0 as key::Key>::Event>>,
     <K0 as key::Key>::Context: From<composite::Context<L, simple::Key>>,
-    key::Event<<K0 as key::Key>::Event>: From<key::Event<composite::Event>>,
 {
     fn index_mut(&mut self, idx: usize) -> &mut Self::Output {
         match idx {
@@ -72,12 +72,12 @@ impl<K0: key::Key + Copy, K1: key::Key + Copy, const L: key::layered::LayerIndex
 impl<K0: key::Key + 'static, K1: key::Key + 'static, const L: key::layered::LayerIndex> Index<usize>
     for Keys2<K0, K1, L>
 where
+    key::Event<<K0 as key::Key>::Event>: TryFrom<key::Event<composite::Event>>,
     key::ScheduledEvent<composite::Event>: From<key::ScheduledEvent<<K0 as key::Key>::Event>>,
     <K0 as key::Key>::Context: From<composite::Context<L, simple::Key>>,
-    key::Event<<K0 as key::Key>::Event>: From<key::Event<composite::Event>>,
+    key::Event<<K1 as key::Key>::Event>: TryFrom<key::Event<composite::Event>>,
     key::ScheduledEvent<composite::Event>: From<key::ScheduledEvent<<K1 as key::Key>::Event>>,
     <K1 as key::Key>::Context: From<composite::Context<L, simple::Key>>,
-    key::Event<<K1 as key::Key>::Event>: From<key::Event<composite::Event>>,
 {
     type Output = dyn dynamic::Key<
         key::composite::Event,
@@ -96,12 +96,12 @@ where
 impl<K0: key::Key + 'static, K1: key::Key + 'static, const L: key::layered::LayerIndex>
     IndexMut<usize> for Keys2<K0, K1, L>
 where
+    key::Event<<K0 as key::Key>::Event>: TryFrom<key::Event<composite::Event>>,
     key::ScheduledEvent<composite::Event>: From<key::ScheduledEvent<<K0 as key::Key>::Event>>,
     <K0 as key::Key>::Context: From<composite::Context<L, simple::Key>>,
-    key::Event<<K0 as key::Key>::Event>: From<key::Event<composite::Event>>,
+    key::Event<<K1 as key::Key>::Event>: TryFrom<key::Event<composite::Event>>,
     key::ScheduledEvent<composite::Event>: From<key::ScheduledEvent<<K1 as key::Key>::Event>>,
     <K1 as key::Key>::Context: From<composite::Context<L, simple::Key>>,
-    key::Event<<K1 as key::Key>::Event>: From<key::Event<composite::Event>>,
 {
     fn index_mut(&mut self, idx: usize) -> &mut Self::Output {
         match idx {


### PR DESCRIPTION
The keymap test which used a `simple::Key` had been commented out.

This PR fixes the `tuples::Keys1` trait bounds, and re-enables the test.

Technically, it may be desirable to have `key::simple::Context` as the context for `dynamic::Key`. But, more in a "should be possible" than "would be useful" way. -- Here instead, we use `composite::Context`.