### PR TITLE
rust: generalise Keys1, Keys2 tuples structs

### DIFF
--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -232,10 +232,13 @@ mod tests {
 
     #[test]
     fn test_keymap_with_simple_key_with_composite_context() {
+        use key::composite::{Context, DefaultNestableKey, Event};
         use key::simple;
+        use tuples::Keys1;
 
         // Assemble
-        let keys: tuples::Keys1<simple::Key, 0> = tuples::Keys1::new((simple::Key(0x04),));
+        let keys: Keys1<simple::Key, Context<0, DefaultNestableKey>, Event> =
+            Keys1::new((simple::Key(0x04),));
         let context = composite::Context::new();
         let mut keymap = Keymap::new(keys, context);
 
@@ -252,9 +255,13 @@ mod tests {
     #[test]
     fn test_keymap_with_composite_simple_key() {
         use key::{composite, simple};
+        use tuples::Keys1;
+
+        use composite::{Context, DefaultNestableKey, Event};
 
         // Assemble
-        let keys = tuples::Keys1::new((composite::Key::<0>::Simple(simple::Key(0x04)),));
+        let keys: Keys1<composite::Key, Context<0, DefaultNestableKey>, Event> =
+            Keys1::new((composite::Key::<0>::Simple(simple::Key(0x04)),));
         let context = composite::Context::new();
         let mut keymap = Keymap::new(keys, context);
 
@@ -271,10 +278,18 @@ mod tests {
     #[test]
     fn test_keymap_with_composite_layered_key_press_base_key() {
         use key::{composite, layered, simple};
+        use tuples::Keys2;
+
+        use composite::{Context, DefaultNestableKey, Event};
 
         // Assemble
         const L: layered::LayerIndex = 1;
-        let keys = tuples::Keys2::new((
+        let keys: Keys2<
+            composite::Key<L>,
+            composite::Key<L>,
+            Context<L, DefaultNestableKey>,
+            Event,
+        > = tuples::Keys2::new((
             composite::Key::<L>::LayerModifier(layered::ModifierKey::Hold(0)),
             composite::Key::<L>::Layered(layered::LayeredKey::new(
                 simple::Key(0x04),
@@ -296,10 +311,18 @@ mod tests {
     #[test]
     fn test_keymap_with_composite_layered_key_press_active_layer_when_layer_mod_held() {
         use key::{composite, layered, simple};
+        use tuples::Keys2;
+
+        use composite::{Context, DefaultNestableKey, Event};
 
         // Assemble
         const L: layered::LayerIndex = 1;
-        let keys = tuples::Keys2::new((
+        let keys: Keys2<
+            composite::Key<L>,
+            composite::Key<L>,
+            Context<L, DefaultNestableKey>,
+            Event,
+        > = tuples::Keys2::new((
             composite::Key::<L>::LayerModifier(layered::ModifierKey::Hold(0)),
             composite::Key::<L>::Layered(layered::LayeredKey::new(
                 simple::Key(0x04),
@@ -323,10 +346,18 @@ mod tests {
     #[test]
     fn test_keymap_with_composite_layered_key_press_retained_when_layer_mod_released() {
         use key::{composite, layered, simple};
+        use tuples::Keys2;
+
+        use composite::{Context, DefaultNestableKey, Event};
 
         // Assemble
         const L: layered::LayerIndex = 1;
-        let keys = tuples::Keys2::new((
+        let keys: Keys2<
+            composite::Key<L>,
+            composite::Key<L>,
+            Context<L, DefaultNestableKey>,
+            Event,
+        > = tuples::Keys2::new((
             composite::Key::<L>::LayerModifier(layered::ModifierKey::Hold(0)),
             composite::Key::<L>::Layered(layered::LayeredKey::new(
                 simple::Key(0x04),
@@ -353,10 +384,18 @@ mod tests {
     #[test]
     fn test_keymap_with_composite_layered_key_uses_base_when_pressed_after_layer_mod_released() {
         use key::{composite, layered, simple};
+        use tuples::Keys2;
+
+        use composite::{Context, DefaultNestableKey, Event};
 
         // Assemble
         const L: layered::LayerIndex = 1;
-        let keys = tuples::Keys2::new((
+        let keys: Keys2<
+            composite::Key<L>,
+            composite::Key<L>,
+            Context<L, DefaultNestableKey>,
+            Event,
+        > = tuples::Keys2::new((
             composite::Key::<L>::LayerModifier(layered::ModifierKey::Hold(0)),
             composite::Key::<L>::Layered(layered::LayeredKey::new(
                 simple::Key(0x04),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub mod tuples;
 #[allow(unused)]
 use key::composite::Key;
 #[allow(unused)]
-use key::{simple, tap_hold};
+use key::{composite, simple, tap_hold};
 
 #[cfg(not(custom_keymap))]
 const KEY_DEFINITIONS: tuples::Keys1<Key> = tuples::Keys1::new((Key::Simple(simple::Key(0x04)),));

--- a/src/tuples.rs
+++ b/src/tuples.rs
@@ -3,31 +3,41 @@ use core::ops::{Index, IndexMut};
 
 use crate::key;
 
-use key::{composite, dynamic, simple};
+use key::{composite, dynamic};
 
 #[derive(Debug)]
 #[allow(dead_code)]
-pub struct Keys1<K0: key::Key, const L: key::layered::LayerIndex = 0>(
-    dynamic::DynamicKey<K0, composite::Context<L, composite::DefaultNestableKey>, composite::Event>,
-    key::layered::LayerIndex,
-);
+pub struct Keys1<
+    K0: key::Key,
+    Ctx: key::Context<Event = Ev> + Debug = composite::Context<0, composite::DefaultNestableKey>,
+    Ev: Copy + Debug + Ord = composite::Event,
+    const N: usize = 2,
+>(dynamic::DynamicKey<K0, Ctx, Ev>);
 
-impl<K0: key::Key + Copy, const L: key::layered::LayerIndex> Keys1<K0, L> {
+impl<
+        K0: key::Key + Copy,
+        Ctx: key::Context<Event = Ev> + Debug,
+        Ev: Copy + Debug + Ord,
+        const N: usize,
+    > Keys1<K0, Ctx, Ev, N>
+{
     pub const fn new((k0,): (K0,)) -> Self {
-        Keys1(dynamic::DynamicKey::new(k0), L)
+        Keys1(dynamic::DynamicKey::new(k0))
     }
 }
 
-impl<K0: key::Key + 'static, const L: key::layered::LayerIndex> Index<usize> for Keys1<K0, L>
+impl<
+        K0: key::Key + 'static,
+        Ctx: key::Context<Event = Ev> + Debug + 'static,
+        Ev: Copy + Debug + Ord + 'static,
+        const N: usize,
+    > Index<usize> for Keys1<K0, Ctx, Ev, N>
 where
-    key::Event<<K0 as key::Key>::Event>: TryFrom<key::Event<composite::Event>>,
-    key::ScheduledEvent<composite::Event>: From<key::ScheduledEvent<<K0 as key::Key>::Event>>,
-    <K0 as key::Key>::Context: From<composite::Context<L, simple::Key>>,
+    key::Event<<K0 as key::Key>::Event>: TryFrom<key::Event<Ev>>,
+    key::ScheduledEvent<Ev>: From<key::ScheduledEvent<<K0 as key::Key>::Event>>,
+    <K0 as key::Key>::Context: From<Ctx>,
 {
-    type Output = dyn dynamic::Key<
-        key::composite::Event,
-        Context = key::composite::Context<L, key::composite::DefaultNestableKey>,
-    >;
+    type Output = dyn dynamic::Key<Ev, N, Context = Ctx>;
 
     fn index(&self, idx: usize) -> &Self::Output {
         match idx {
@@ -37,11 +47,16 @@ where
     }
 }
 
-impl<K0: key::Key + 'static, const L: key::layered::LayerIndex> IndexMut<usize> for Keys1<K0, L>
+impl<
+        K0: key::Key + 'static,
+        Ctx: key::Context<Event = Ev> + Debug + 'static,
+        Ev: Copy + Debug + Ord + 'static,
+        const N: usize,
+    > IndexMut<usize> for Keys1<K0, Ctx, Ev, N>
 where
-    key::Event<<K0 as key::Key>::Event>: TryFrom<key::Event<composite::Event>>,
-    key::ScheduledEvent<composite::Event>: From<key::ScheduledEvent<<K0 as key::Key>::Event>>,
-    <K0 as key::Key>::Context: From<composite::Context<L, simple::Key>>,
+    key::Event<<K0 as key::Key>::Event>: TryFrom<key::Event<Ev>>,
+    key::ScheduledEvent<Ev>: From<key::ScheduledEvent<<K0 as key::Key>::Event>>,
+    <K0 as key::Key>::Context: From<Ctx>,
 {
     fn index_mut(&mut self, idx: usize) -> &mut Self::Output {
         match idx {
@@ -53,36 +68,46 @@ where
 
 #[derive(Debug)]
 #[allow(dead_code)]
-pub struct Keys2<K0: key::Key, K1: key::Key, const L: key::layered::LayerIndex = 0>(
-    dynamic::DynamicKey<K0, composite::Context<L, composite::DefaultNestableKey>, composite::Event>,
-    dynamic::DynamicKey<K1, composite::Context<L, composite::DefaultNestableKey>, composite::Event>,
-    key::layered::LayerIndex,
+pub struct Keys2<
+    K0: key::Key,
+    K1: key::Key,
+    Ctx: key::Context<Event = Ev> + Debug = composite::Context<0, composite::DefaultNestableKey>,
+    Ev: Copy + Debug + Ord = composite::Event,
+    const N: usize = 2,
+>(
+    dynamic::DynamicKey<K0, Ctx, Ev>,
+    dynamic::DynamicKey<K1, Ctx, Ev>,
 );
 
-impl<K0: key::Key + Copy, K1: key::Key + Copy, const L: key::layered::LayerIndex> Keys2<K0, K1, L> {
+impl<
+        K0: key::Key + Copy,
+        K1: key::Key + Copy,
+        Ctx: key::Context<Event = Ev> + Debug,
+        Ev: Copy + Debug + Ord,
+        const N: usize,
+    > Keys2<K0, K1, Ctx, Ev, N>
+{
     pub const fn new((k0, k1): (K0, K1)) -> Self {
-        Keys2(
-            dynamic::DynamicKey::new(k0),
-            dynamic::DynamicKey::new(k1),
-            L,
-        )
+        Keys2(dynamic::DynamicKey::new(k0), dynamic::DynamicKey::new(k1))
     }
 }
 
-impl<K0: key::Key + 'static, K1: key::Key + 'static, const L: key::layered::LayerIndex> Index<usize>
-    for Keys2<K0, K1, L>
+impl<
+        K0: key::Key + 'static,
+        K1: key::Key + 'static,
+        Ctx: key::Context<Event = Ev> + Debug + 'static,
+        Ev: Copy + Debug + Ord + 'static,
+        const N: usize,
+    > Index<usize> for Keys2<K0, K1, Ctx, Ev, N>
 where
-    key::Event<<K0 as key::Key>::Event>: TryFrom<key::Event<composite::Event>>,
-    key::ScheduledEvent<composite::Event>: From<key::ScheduledEvent<<K0 as key::Key>::Event>>,
-    <K0 as key::Key>::Context: From<composite::Context<L, simple::Key>>,
-    key::Event<<K1 as key::Key>::Event>: TryFrom<key::Event<composite::Event>>,
-    key::ScheduledEvent<composite::Event>: From<key::ScheduledEvent<<K1 as key::Key>::Event>>,
-    <K1 as key::Key>::Context: From<composite::Context<L, simple::Key>>,
+    key::Event<<K0 as key::Key>::Event>: TryFrom<key::Event<Ev>>,
+    key::ScheduledEvent<Ev>: From<key::ScheduledEvent<<K0 as key::Key>::Event>>,
+    <K0 as key::Key>::Context: From<Ctx>,
+    key::Event<<K1 as key::Key>::Event>: TryFrom<key::Event<Ev>>,
+    key::ScheduledEvent<Ev>: From<key::ScheduledEvent<<K1 as key::Key>::Event>>,
+    <K1 as key::Key>::Context: From<Ctx>,
 {
-    type Output = dyn dynamic::Key<
-        key::composite::Event,
-        Context = key::composite::Context<L, key::composite::DefaultNestableKey>,
-    >;
+    type Output = dyn dynamic::Key<Ev, N, Context = Ctx>;
 
     fn index(&self, idx: usize) -> &Self::Output {
         match idx {
@@ -93,15 +118,20 @@ where
     }
 }
 
-impl<K0: key::Key + 'static, K1: key::Key + 'static, const L: key::layered::LayerIndex>
-    IndexMut<usize> for Keys2<K0, K1, L>
+impl<
+        K0: key::Key + 'static,
+        K1: key::Key + 'static,
+        Ctx: key::Context<Event = Ev> + Debug + 'static,
+        Ev: Copy + Debug + Ord + 'static,
+        const N: usize,
+    > IndexMut<usize> for Keys2<K0, K1, Ctx, Ev, N>
 where
-    key::Event<<K0 as key::Key>::Event>: TryFrom<key::Event<composite::Event>>,
-    key::ScheduledEvent<composite::Event>: From<key::ScheduledEvent<<K0 as key::Key>::Event>>,
-    <K0 as key::Key>::Context: From<composite::Context<L, simple::Key>>,
-    key::Event<<K1 as key::Key>::Event>: TryFrom<key::Event<composite::Event>>,
-    key::ScheduledEvent<composite::Event>: From<key::ScheduledEvent<<K1 as key::Key>::Event>>,
-    <K1 as key::Key>::Context: From<composite::Context<L, simple::Key>>,
+    key::Event<<K0 as key::Key>::Event>: TryFrom<key::Event<Ev>>,
+    key::ScheduledEvent<Ev>: From<key::ScheduledEvent<<K0 as key::Key>::Event>>,
+    <K0 as key::Key>::Context: From<Ctx>,
+    key::Event<<K1 as key::Key>::Event>: TryFrom<key::Event<Ev>>,
+    key::ScheduledEvent<Ev>: From<key::ScheduledEvent<<K1 as key::Key>::Event>>,
+    <K1 as key::Key>::Context: From<Ctx>,
 {
     fn index_mut(&mut self, idx: usize) -> &mut Self::Output {
         match idx {


### PR DESCRIPTION
The `tuples` implementation required a `const L: layered::LayerIndex` trait, which did smell a bit.

Here, we relax the generics to match what `dynamic::Key` needs.

The compiler somewhat 'dislikes' this; the `keymap` tests now need the types declared, when they didn't before.