### PR TITLE
rust: use &Context instead of Context in dynamic::Key

### DIFF
--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -97,6 +97,11 @@ impl<const L: layered::LayerIndex> key::Context for Context<L, DefaultNestableKe
 impl<const L: layered::LayerIndex> From<Context<L, DefaultNestableKey>> for () {
     fn from(_: Context<L, DefaultNestableKey>) -> Self {}
 }
+impl<const L: layered::LayerIndex> From<&Context<L, DefaultNestableKey>> for &() {
+    fn from(_: &Context<L, DefaultNestableKey>) -> Self {
+        &()
+    }
+}
 
 #[derive(Debug, Clone, Copy)]
 pub enum PressedKeyState<const L: layered::LayerIndex = 0> {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -125,7 +125,7 @@ impl<
         self.pressed_inputs.iter_mut().for_each(|pi| {
             if let input::PressedInput::Key { keymap_index, .. } = pi {
                 let key = &mut self.key_definitions[*keymap_index as usize];
-                key.handle_event(self.context, ev.into())
+                key.handle_event(&self.context, ev.into())
                     .into_iter()
                     .for_each(|sch_ev| self.event_scheduler.schedule_event(sch_ev));
             }
@@ -135,7 +135,7 @@ impl<
             input::Event::Press { keymap_index } => {
                 let key = &mut self.key_definitions[keymap_index as usize];
 
-                key.handle_event(self.context, ev.into())
+                key.handle_event(&self.context, ev.into())
                     .into_iter()
                     .for_each(|sch_ev| self.event_scheduler.schedule_event(sch_ev));
 
@@ -181,7 +181,7 @@ impl<
             self.pressed_inputs.iter_mut().for_each(|pi| {
                 if let input::PressedInput::Key { keymap_index, .. } = pi {
                     let key = &mut self.key_definitions[*keymap_index as usize];
-                    key.handle_event(self.context, ev)
+                    key.handle_event(&self.context, ev)
                         .into_iter()
                         .for_each(|sch_ev| self.event_scheduler.schedule_event(sch_ev));
                 }

--- a/src/tuples.rs
+++ b/src/tuples.rs
@@ -35,7 +35,7 @@ impl<
 where
     key::Event<<K0 as key::Key>::Event>: TryFrom<key::Event<Ev>>,
     key::ScheduledEvent<Ev>: From<key::ScheduledEvent<<K0 as key::Key>::Event>>,
-    <K0 as key::Key>::Context: From<Ctx>,
+    for<'c> &'c <K0 as key::Key>::Context: From<&'c Ctx>,
 {
     type Output = dyn dynamic::Key<Ev, N, Context = Ctx>;
 
@@ -56,7 +56,7 @@ impl<
 where
     key::Event<<K0 as key::Key>::Event>: TryFrom<key::Event<Ev>>,
     key::ScheduledEvent<Ev>: From<key::ScheduledEvent<<K0 as key::Key>::Event>>,
-    <K0 as key::Key>::Context: From<Ctx>,
+    for<'c> &'c <K0 as key::Key>::Context: From<&'c Ctx>,
 {
     fn index_mut(&mut self, idx: usize) -> &mut Self::Output {
         match idx {
@@ -102,10 +102,10 @@ impl<
 where
     key::Event<<K0 as key::Key>::Event>: TryFrom<key::Event<Ev>>,
     key::ScheduledEvent<Ev>: From<key::ScheduledEvent<<K0 as key::Key>::Event>>,
-    <K0 as key::Key>::Context: From<Ctx>,
+    for<'c> &'c <K0 as key::Key>::Context: From<&'c Ctx>,
     key::Event<<K1 as key::Key>::Event>: TryFrom<key::Event<Ev>>,
     key::ScheduledEvent<Ev>: From<key::ScheduledEvent<<K1 as key::Key>::Event>>,
-    <K1 as key::Key>::Context: From<Ctx>,
+    for<'c> &'c <K1 as key::Key>::Context: From<&'c Ctx>,
 {
     type Output = dyn dynamic::Key<Ev, N, Context = Ctx>;
 
@@ -128,10 +128,10 @@ impl<
 where
     key::Event<<K0 as key::Key>::Event>: TryFrom<key::Event<Ev>>,
     key::ScheduledEvent<Ev>: From<key::ScheduledEvent<<K0 as key::Key>::Event>>,
-    <K0 as key::Key>::Context: From<Ctx>,
+    for<'c> &'c <K0 as key::Key>::Context: From<&'c Ctx>,
     key::Event<<K1 as key::Key>::Event>: TryFrom<key::Event<Ev>>,
     key::ScheduledEvent<Ev>: From<key::ScheduledEvent<<K1 as key::Key>::Event>>,
-    <K1 as key::Key>::Context: From<Ctx>,
+    for<'c> &'c <K1 as key::Key>::Context: From<&'c Ctx>,
 {
     fn index_mut(&mut self, idx: usize) -> &mut Self::Output {
         match idx {


### PR DESCRIPTION
The bounds are quite strict on `Context`, `Event`, and `Key` such that they can't contain references to anything that lives less than `'static`. -- I'm fine with that.

This code updates `dynamic::Key` to take `&Context` as a reference. Mostly because I couldn't figure the lifetimes out for #35.

