### PR TITLE
Allow resetting Keymap keys state

### DIFF
--- a/src/key/dynamic.rs
+++ b/src/key/dynamic.rs
@@ -27,6 +27,8 @@ where
     ) -> heapless::Vec<key::ScheduledEvent<Ev>, N>;
 
     fn key_code(&self) -> Option<u8>;
+
+    fn reset(&mut self);
 }
 
 pub type CompositeKey<const L: key::layered::LayerIndex = 0> = dyn Key<
@@ -105,6 +107,10 @@ where
         } else {
             None
         }
+    }
+
+    fn reset(&mut self) {
+        self.pressed_key = None;
     }
 }
 

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -78,12 +78,12 @@ impl EventScheduler {
 #[derive(Debug)]
 pub struct Keymap<
     I: IndexMut<
-        usize,
-        Output = dyn key::dynamic::Key<
-            key::composite::Event,
-            Context = key::composite::Context<L, key::composite::DefaultNestableKey>,
-        >,
-    >,
+            usize,
+            Output = dyn key::dynamic::Key<
+                key::composite::Event,
+                Context = key::composite::Context<L, key::composite::DefaultNestableKey>,
+            >,
+        > + crate::tuples::KeysReset,
     const L: key::layered::LayerIndex = 0,
 > {
     key_definitions: I,
@@ -94,12 +94,12 @@ pub struct Keymap<
 
 impl<
         I: IndexMut<
-            usize,
-            Output = dyn key::dynamic::Key<
-                key::composite::Event,
-                Context = key::composite::Context<L, key::composite::DefaultNestableKey>,
-            >,
-        >,
+                usize,
+                Output = dyn key::dynamic::Key<
+                    key::composite::Event,
+                    Context = key::composite::Context<L, key::composite::DefaultNestableKey>,
+                >,
+            > + crate::tuples::KeysReset,
         const L: key::layered::LayerIndex,
     > Keymap<I, L>
 {
@@ -118,6 +118,7 @@ impl<
     pub fn init(&mut self) {
         self.pressed_inputs.clear();
         self.event_scheduler.init();
+        self.key_definitions.reset();
     }
 
     pub fn handle_input(&mut self, ev: input::Event) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use key::{composite, simple, tap_hold};
 #[cfg(not(custom_keymap))]
 type KeyDefinitionsType = tuples::Keys1<Key>;
 #[cfg(not(custom_keymap))]
-const KEY_DEFINITIONS: KeyDefinitionsType   = tuples::Keys1::new((Key::Simple(simple::Key(0x04)),));
+const KEY_DEFINITIONS: KeyDefinitionsType = tuples::Keys1::new((Key::Simple(simple::Key(0x04)),));
 #[cfg(custom_keymap)]
 include!(env!("SMART_KEYMAP_CUSTOM_KEYMAP"));
 

--- a/tests/ceedling/test/test_keydef_taphold.c
+++ b/tests/ceedling/test/test_keydef_taphold.c
@@ -34,8 +34,6 @@ void test_taphold_interrupted_is_hold(void) {
 }
 
 void test_taphold_dth_uth_is_tap(void) {
-    TEST_IGNORE_MESSAGE("Known to fail, despite Cucumber equivalent passing.");
-
     // Pressing T.H., then releasing T.H., is same as tapping the tap key.
     // (Check the tap key gets pressed).
 


### PR DESCRIPTION
The ceedling tests retain state between test executions.

I'd assumed that keymap init() would reset state. #35 broke that assumption. So, we add a `reset()` method to KeysN.

I did try using `self.0.reset()`, but since `key::dynamic::Key` takes in a generic constant, the compiler doesn't like this:

```
        error[E0284]: type annotations needed
  --> src/tuples.rs:89:16
   |
89 |         self.0.reset();
   |                ^^^^^
   |
note: required by a const generic parameter in `dynamic::Key::reset`
  --> src/key/dynamic.rs:11:19
   |
11 | pub trait Key<Ev, const N: usize = 2>: Debug
   |                   ^^^^^^^^^^^^^^^^^^ required by this const generic parameter in `Key::reset`
...
31 |     fn reset(&mut self);
   |        ----- required by a bound in this associated function
help: try using a fully qualified path to specify the expected types
   |
89 |         <DynamicKey<K0, Ctx, Ev> as dynamic::Key<Ev, N>>::reset(&mut self.0);
   |         ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++       ~

error[E0284]: type annotations needed
  --> src/tuples.rs:89:16
   |
89 |         self.0.reset();
   |                ^^^^^
   |
note: required for `DynamicKey<K0, Ctx, Ev>` to implement `dynamic::Key<Ev, _>`
  --> src/key/dynamic.rs:65:7
   |
64 |         const N: usize,
   |         -------------- unsatisfied trait bound introduced here
65 |     > Key<Ev, N> for DynamicKey<K, Ctx, Ev>
   |       ^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^
help: try using a fully qualified path to specify the expected types
   |
89 |         <DynamicKey<K0, Ctx, Ev> as dynamic::Key<Ev, N>>::reset(&mut self.0);
   |         ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++       ~
```