### PR TITLE
Update 60-key checkkeys keymap

### DIFF
--- a/.github/workflows/keymaps.yaml
+++ b/.github/workflows/keymaps.yaml
@@ -1,0 +1,31 @@
+name: Build Keymaps
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  cargo-build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          rustup target add riscv32imac-unknown-none-elf
+
+      - name: Build checkkeys_60key_keymap
+        run: |
+          env SMART_KEYMAP_CUSTOM_KEYMAP="$(pwd)/tests/keymaps/checkkeys_60key_keymap.rs" cargo build --target riscv32imac-unknown-none-elf --features "usbd-human-interface-device" --release

--- a/Makefile
+++ b/Makefile
@@ -22,5 +22,13 @@ clean:
 	rm -f include/smart_keymap.h
 	$(CARGO) clean
 
+.PHONY: rv-check60
+rv-check60:
+	env SMART_KEYMAP_CUSTOM_KEYMAP="$(shell pwd)/tests/keymaps/checkkeys_60key_keymap.rs" \
+	  $(CARGO) build \
+	    --target riscv32imac-unknown-none-elf \
+	    --features "usbd-human-interface-device" \
+	    --release
+
 include/smart_keymap.h:
 	$(CBINDGEN) -c cbindgen.toml -o include/smart_keymap.h

--- a/tests/keymaps/checkkeys_60key_keymap.rs
+++ b/tests/keymaps/checkkeys_60key_keymap.rs
@@ -1,5 +1,12 @@
-#[rustfmt::skip]
-pub const KEY_DEFINITIONS: [Key; 60] = {
+use seq_macro::seq;
+seq!(I in 0..60 {
+    type KeyDefinitionsType = tuples::Keys60<
+        #(
+            Key,
+        )*
+    >;
+});
+pub const KEY_DEFINITIONS: KeyDefinitionsType = {
     #[cfg(not(feature = "usbd-human-interface-device"))]
     compile_error!("usbd-human-interface-device feature is not enabled");
 
@@ -13,11 +20,11 @@ pub const KEY_DEFINITIONS: [Key; 60] = {
         A, B, C, D, E, F, G, H, I, J, K, L,
     ];
 
-    let mut key_codes = [Key::Simple(simple::Key(0x00)); 60];
-    let mut i = 0;
-    while i < 60 {
-        key_codes[i] = Key::Simple(simple::Key(codes[i] as u8));
-        i += 1;
-    }
-    key_codes
+    seq!(I in 0..60 {
+        tuples::Keys60::new((
+            #(
+                Key::Simple(simple::Key(codes[I] as u8)),
+            )*
+        ))
+    })
 };


### PR DESCRIPTION
The checkkeys 60key keymap was also broken by #35.

I don't think it's really practical to write non-trivial keymaps directly with Rust. -- I think maybe a procedural macro, or more likely fak-style codegen are a better answer.

A CI check has been added for building the keymap.