### PR TITLE
Build fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,8 @@ CARGO = cargo
 CBINDGEN = cbindgen
 
 .PHONY: all
-all: generate-header
+all: include/smart_keymap.h
 	$(CARGO) build
-
-.PHONY: generate-header
-generate-header: include/smart_keymap.h
 
 .PHONY: test
 test: include/smart_keymap.h

--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,5 @@ clean:
 	rm -f include/smart_keymap.h
 	$(CARGO) clean
 
-include/smart_keymap.h:
+include/smart_keymap.h: src/lib.rs
 	$(CBINDGEN) -c cbindgen.toml -o include/smart_keymap.h

--- a/justfile
+++ b/justfile
@@ -1,5 +1,8 @@
 default: test
 
+bindgen:
+	cbindgen -c cbindgen.toml -o include/smart_keymap.h
+
 clean:
     make clean
 


### PR DESCRIPTION
The `include/smart_keymap.h` depends on `src/lib.rs`, because this is the only Rust file with `pub extern "C"` declarations (& other statements that `bindgen` uses about).