### PR TITLE
rust: add some documentation to all items

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1,17 +1,38 @@
 use serde::Deserialize;
 
+/// Input events for [crate::keymap::Keymap].
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
 pub enum Event {
-    Press { keymap_index: u16 },
-    Release { keymap_index: u16 },
-    VirtualKeyPress { key_code: u8 },
-    VirtualKeyRelease { key_code: u8 },
+    /// A physical key press for a given `keymap_index`.
+    Press {
+        /// The index of the key in the keymap.
+        keymap_index: u16,
+    },
+    /// A physical key release for a given `keymap_index`.
+    Release {
+        /// The index of the key in the keymap.
+        keymap_index: u16,
+    },
+    /// A virtual key press for a given `key_code`.
+    VirtualKeyPress {
+        /// The virtual key code.
+        key_code: u8,
+    },
+    /// A virtual key release for a given `key_code`.
+    VirtualKeyRelease {
+        /// The virtual key code.
+        key_code: u8,
+    },
 }
 
+/// A struct for associating a [crate::key::Key] with a [crate::key::PressedKeyState].
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PressedKey<K, S> {
+    /// The index of the pressed key in some keymap.
     pub keymap_index: u16,
+    /// The pressed key.
     pub key: K,
+    /// The pressed key state.
     pub pressed_key_state: S,
 }
 
@@ -33,13 +54,23 @@ impl<K: crate::key::Key, S: crate::key::PressedKeyState<K, Event = K::Event>> cr
     }
 }
 
+/// State resulting from [Event].
 #[derive(Debug, Clone, Copy)]
 pub enum PressedInput {
-    Key { keymap_index: u16 },
-    Virtual { key_code: u8 },
+    /// Physically pressed key.
+    Key {
+        /// The index of the pressed key in the keymap.
+        keymap_index: u16,
+    },
+    /// Virtually pressed key.
+    Virtual {
+        /// The pressed key code.
+        key_code: u8,
+    },
 }
 
 impl PressedInput {
+    /// Constructor for a [PressedInput::Key].
     pub fn new_pressed_key(keymap_index: u16) -> Self {
         Self::Key { keymap_index }
     }

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -14,16 +14,22 @@ pub trait NestableKey: key::Key + Sized {}
 
 impl NestableKey for simple::Key {}
 
+/// Default [NestableKey] for [Key] and its associated types.
 pub type DefaultNestableKey = simple::Key;
 
+/// An aggregate of [key::Key] types.
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq)]
 pub enum Key<const L: layered::LayerIndex = 0, K: NestableKey = DefaultNestableKey>
 where
     [Option<K>; L]: serde::de::DeserializeOwned,
 {
+    /// A simple key.
     Simple(simple::Key),
+    /// A tap-hold key.
     TapHold(tap_hold::Key),
+    /// A layer modifier key.
     LayerModifier(layered::ModifierKey<L>),
+    /// A layered key.
     Layered(layered::LayeredKey<L, K>),
 }
 
@@ -66,12 +72,14 @@ where
     }
 }
 
+/// An aggregate context for [key::Context]s.
 #[derive(Debug, Clone, Copy)]
 pub struct Context<const L: layered::LayerIndex, K: key::Key> {
     layer_context: layered::Context<L, K::Context>,
 }
 
 impl<const L: layered::LayerIndex> Context<L, DefaultNestableKey> {
+    /// Constructs a new [Context].
     pub const fn new() -> Self {
         let layer_context = layered::Context::new(());
         Self { layer_context }
@@ -100,13 +108,18 @@ impl<const L: layered::LayerIndex> From<&Context<L, DefaultNestableKey>> for &()
     }
 }
 
+/// Aggregates the [key::PressedKeyState] types.
 #[derive(Debug, Clone, Copy)]
 pub enum PressedKeyState<const L: layered::LayerIndex = 0> {
+    /// A simple key's pressed state.
     Simple(simple::PressedKeyState),
+    /// A tap-hold key's pressed state.
     TapHold(tap_hold::PressedKeyState),
+    /// A layer modifier key's pressed state.
     LayerModifier(layered::PressedModifierKeyState),
 }
 
+/// Convenience type alias for a [key::PressedKey] with a [PressedKeyState].
 pub type PressedKey<const L: layered::LayerIndex> =
     input::PressedKey<Key<L, DefaultNestableKey>, PressedKeyState<L>>;
 
@@ -211,9 +224,12 @@ where
     }
 }
 
+/// Aggregates the [key::Event] types.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 pub enum Event {
+    /// A tap-hold event.
     TapHold(tap_hold::Event),
+    /// A layer modification event.
     LayerModification(layered::LayerEvent),
 }
 

--- a/src/key/dynamic.rs
+++ b/src/key/dynamic.rs
@@ -12,6 +12,7 @@ pub trait Key<Ev, const N: usize = 2>: Debug
 where
     Ev: Copy + Debug + Ord,
 {
+    /// The context type for the key.
     type Context: key::Context<Event = Ev>;
 
     /// Handles events in two cases:
@@ -26,16 +27,20 @@ where
         event: key::Event<Ev>,
     ) -> heapless::Vec<key::ScheduledEvent<Ev>, N>;
 
+    /// Output HID keyboard code for the [Key].
     fn key_code(&self) -> Option<u8>;
 
+    /// Resets the [Key] to its initial state.
     fn reset(&mut self);
 }
 
+/// Convenience type alias for [Key] which uses [crate::key::composite::Event] and [crate::key::composite::Context].
 pub type CompositeKey<const L: key::layered::LayerIndex = 0> = dyn Key<
     key::composite::Event,
     Context = key::composite::Context<L, key::composite::DefaultNestableKey>,
 >;
 
+/// Generic implementation of [Key] for a [key::Key] and some `Ctx`/`Ev`.
 #[derive(Debug)]
 pub struct DynamicKey<K: key::Key, Ctx, Ev> {
     key: K,
@@ -46,6 +51,7 @@ pub struct DynamicKey<K: key::Key, Ctx, Ev> {
 }
 
 impl<K: key::Key, Ctx, Ev> DynamicKey<K, Ctx, Ev> {
+    /// Constructs a [DynamicKey] with the given key.
     pub const fn new(key: K) -> Self {
         Self {
             key,

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -2,23 +2,51 @@ use core::fmt::Debug;
 
 use crate::input;
 
+/// Layered keys. (Layering functionality).
 pub mod layered;
+/// Simple keys.
 pub mod simple;
+/// Tap-Hold keys.
 pub mod tap_hold;
 
+/// "Composite" keys; an aggregate type used for a common context and event.
 pub mod composite;
 
+/// dyn-compatible `Key` trait, and generic implementation.
 pub mod dynamic;
 
+/// The interface for `Key` behaviour.
+///
+/// A `Key` has an associated [Context], `Event`, and [PressedKeyState].
+///
+/// The generic `PK` is used as the type of the `PressedKey` that the `Key`
+///  produces.
+/// (e.g. [layered::LayeredKey]'s pressed key state passes-through to
+///  the keys of its layers).
 pub trait Key<PK: Key = Self>: Debug
 where
     Self::ContextEvent: From<Self::Event>,
 {
+    /// The associated [Context] is used to provide state that
+    ///  may affect behaviour when pressing the key.
+    /// (e.g. the behaviour of [layered::LayeredKey] depends on which
+    ///  layers are active in [layered::Context]).
     type Context: Context<Event = Self::ContextEvent>;
+    /// The event used by the [Key]'s associated [Context].
     type ContextEvent;
+    /// The associated `Event` is to be handled by the associated [Context],
+    ///  and any active [PressedKeyState]s.
     type Event: Copy + Debug + Ord;
+    /// The associated [PressedKeyState] implements functionality
+    ///  for the pressed key.
+    /// (e.g. [tap_hold::PressedKeyState] implements behaviour resolving
+    ///  the pressed tap hold key as either 'tap' or 'hold').
     type PressedKeyState: PressedKeyState<PK, Event = Self::Event>;
 
+    /// [Key::new_pressed_key] produces a pressed key value, and may
+    ///  yield some [ScheduledEvent]s.
+    /// (e.g. [tap_hold::Key] schedules a [tap_hold::Event::TapHoldTimeout]
+    ///  so that holding the key resolves as a hold).
     fn new_pressed_key(
         &self,
         context: &Self::Context,
@@ -29,8 +57,15 @@ where
     );
 }
 
+/// Used to provide state that may affect behaviour when pressing the key.
+///
+/// e.g. the behaviour of [layered::LayeredKey] depends on which
+///  layers are active in [layered::Context].
 pub trait Context {
+    /// The type of `Event` the context handles.
     type Event;
+
+    /// Used to update the [Context]'s state.
     fn handle_event(&mut self, event: Self::Event);
 }
 
@@ -39,19 +74,30 @@ impl Context for () {
     fn handle_event(&mut self, _event: Self::Event) {}
 }
 
+/// [PressedKeyState] for a stateful pressed key value.
 pub trait PressedKey {
+    /// The type of `Event` the pressed key handles.
     type Event;
+
+    /// Used to update the [PressedKey]'s state, and possibly yield event(s).
     fn handle_event(
         &mut self,
         event: Event<Self::Event>,
     ) -> impl IntoIterator<Item = Event<Self::Event>>;
 
+    /// Output for the pressed key.
     fn key_code(&self) -> Option<u8>;
 }
 
+/// Implements functionality for the pressed key.
+///
+/// e.g. [tap_hold::PressedKeyState] implements behaviour resolving
+///  the pressed tap hold key as either 'tap' or 'hold'.
 pub trait PressedKeyState<K: Key>: Debug {
+    /// The type of `Event` the pressed key state handles.
     type Event;
 
+    /// Used to update the [PressedKeyState]'s state, and possibly yield event(s).
     fn handle_event_for(
         &mut self,
         keymap_index: u16,
@@ -59,17 +105,28 @@ pub trait PressedKeyState<K: Key>: Debug {
         event: Event<Self::Event>,
     ) -> impl IntoIterator<Item = Event<Self::Event>>;
 
+    /// Output for the pressed key state.
     fn key_code(&self, key: &K) -> Option<u8>;
 }
 
+/// Errors for [TryFrom] implementations.
 #[allow(unused)]
 pub enum EventError {
+    /// Error when mapping isn't possible.
+    ///
+    /// e.g. trying to map variants of [composite::Event] to [tap_hold::Event].
     UnmappableEvent,
 }
 
+/// Events which are either input, or for a particular [Key::Event].
+///
+/// It's useful for [Key] implementations to use [Event] with [Key::Event],
+///  and map [Key::Event] to and partially from [composite::Event].
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
 pub enum Event<T> {
+    /// Keymap input events, such as physical key presses.
     Input(input::Event),
+    /// [Key] implementation specific events.
     Key(T),
 }
 
@@ -79,20 +136,27 @@ impl<T> From<input::Event> for Event<T> {
     }
 }
 
+/// Schedule for a [ScheduledEvent].
 #[allow(unused)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
 pub enum Schedule {
+    /// Immediately.
     Immediate,
+    /// After a given number of `tick`s.
     After(u16),
 }
 
+/// Schedules a given `T` with [Event], for some [Schedule].
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
 pub struct ScheduledEvent<T> {
+    /// Whether to handle the event immediately, or after some delay.
     pub schedule: Schedule,
+    /// The event.
     pub event: Event<T>,
 }
 
 impl<T> ScheduledEvent<T> {
+    /// Constructs a [ScheduledEvent] with [Schedule::Immediate].
     #[allow(unused)]
     pub fn immediate(event: Event<T>) -> Self {
         ScheduledEvent {
@@ -100,6 +164,8 @@ impl<T> ScheduledEvent<T> {
             event,
         }
     }
+
+    /// Constructs a [ScheduledEvent] with [Schedule::After].
     pub fn after(delay: u16, event: Event<T>) -> Self {
         ScheduledEvent {
             schedule: Schedule::After(delay),

--- a/src/key/simple.rs
+++ b/src/key/simple.rs
@@ -2,10 +2,12 @@ use serde::Deserialize;
 
 use crate::{input, key};
 
+/// A simple key that only has a key code.
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct Key(pub u8);
 
 impl Key {
+    /// Gets the key code from [Key].
     pub fn key_code(&self) -> u8 {
         self.0
     }
@@ -36,12 +38,15 @@ impl key::Key for Key {
     }
 }
 
+/// Unit-like struct for event. (crate::key::simple doesn't use events).
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Event();
 
+/// Unit-like struct for [crate::key::PressedKeyState]. (crate::key::simple pressed keys don't have state).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PressedKeyState;
 
+/// Convenience type alias for [input::PressedKey] with [Key] and [PressedKeyState].
 pub type PressedKey = input::PressedKey<Key, PressedKeyState>;
 
 impl From<Event> for () {

--- a/src/key/tap_hold.rs
+++ b/src/key/tap_hold.rs
@@ -3,9 +3,12 @@ use serde::Deserialize;
 use crate::input;
 use crate::key;
 
+/// A key with tap-hold functionality.
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct Key {
+    /// The 'tap' key.
     pub tap: u8,
+    /// The 'hold' key.
     pub hold: u8,
 }
 
@@ -43,16 +46,25 @@ impl key::Key for Key {
     }
 }
 
+/// The state of a tap-hold key.
 #[derive(Debug, Clone, Copy)]
 pub enum TapHoldState {
+    /// Not yet resolved as tap or hold.
     Pending,
+    /// Resolved as tap.
     Tap,
+    /// Resolved as hold.
     Hold,
 }
 
+/// Events emitted by a tap-hold key.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 pub enum Event {
-    TapHoldTimeout { keymap_index: u16 },
+    /// Event indicating the key has been held long enough to resolve as hold.
+    TapHoldTimeout {
+        /// The keymap index of the key the timeout is for.
+        keymap_index: u16,
+    },
 }
 
 impl From<Event> for key::Event<Event> {
@@ -61,20 +73,24 @@ impl From<Event> for key::Event<Event> {
     }
 }
 
+/// The state of a pressed tap-hold key.
 #[derive(Debug, Clone, Copy)]
 pub struct PressedKeyState {
     state: TapHoldState,
 }
 
+/// Convenience type for a pressed tap-hold key.
 pub type PressedKey = input::PressedKey<Key, PressedKeyState>;
 
 impl PressedKeyState {
+    /// Resolves the state of the key, unless it has already been resolved.
     fn resolve(&mut self, state: TapHoldState) {
         if let TapHoldState::Pending = self.state {
             self.state = state;
         }
     }
 }
+
 impl key::PressedKeyState<Key> for PressedKeyState {
     type Event = Event;
 

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -73,8 +73,7 @@ impl EventScheduler {
     }
 }
 
-/// The engine (set of key definition systems),
-///  and key definitions.
+/// State for a keymap that handles input, and outputs HID keyboard reports.
 #[derive(Debug)]
 pub struct Keymap<
     I: IndexMut<
@@ -103,6 +102,7 @@ impl<
         const L: key::layered::LayerIndex,
     > Keymap<I, L>
 {
+    /// Constructs a new keymap with the given key definitions and context.
     pub const fn new(
         key_definitions: I,
         context: composite::Context<L, composite::DefaultNestableKey>,
@@ -115,12 +115,14 @@ impl<
         }
     }
 
+    /// Initializes or resets the keyboard to an initial state.
     pub fn init(&mut self) {
         self.pressed_inputs.clear();
         self.event_scheduler.init();
         self.key_definitions.reset();
     }
 
+    /// Handles input events.
     pub fn handle_input(&mut self, ev: input::Event) {
         // Update each of the pressed keys with the event.
         self.pressed_inputs.iter_mut().for_each(|pi| {
@@ -173,6 +175,7 @@ impl<
         }
     }
 
+    /// Advances the state of the keymap by one tick.
     pub fn tick(&mut self) {
         self.event_scheduler.tick();
 
@@ -199,6 +202,7 @@ impl<
         }
     }
 
+    /// Returns the current HID keyboard report.
     pub fn boot_keyboard_report(&self) -> [u8; 8] {
         let mut report = [0u8; 8];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,58 @@
+#![warn(missing_docs)]
+
+//! Smart Keymap library.
+//!
+//! A "smart keyboard" is a keyboard where the keys can perform
+//!  multiple actions, depending on the context.
+//! Features such as layering, tap-hold, and tap-dance are
+//!  examples of smart keyboard functionality.
+//!
+//! The smart keymap library provides an interface for the "smart keymap"
+//!  part of smart keyboard firmware.
+//! i.e. the part that takes key presses and releases as input,
+//!  and outputs HID keyboard reports (or other smart keyboard outputs).
+//!
+//! This crate can be used directly with Rust, or built as a C library.
+//!
+//! # Usage as a C library
+//!
+//! ## Custom Keymap
+//!
+//! When used as a C library, the library should be built by setting
+//!  the environment variable `SMART_KEYMAP_CUSTOM_KEYMAP` to the path
+//!  of a custom keymap file.
+//!
+//! The most user friendly way to do this is to use `ncl/keymap-codegen.ncl`
+//!  to produce a `keymap.rs` file from a `keymap.json` file.
+//!
+//! ## Keyboard Firmware Implementation
+//!
+//! When used as a C library, the firmware should call to
+//!  `keymap_init`, `keymap_register_input_keypress`, `keymap_register_input_keyrelease`,
+//!  and `keymap_tick` functions.
+//! The `keymap_tick` function should be called every ms, and should copy the
+//!  HID keyboard report to the given buffer.
+//!
+//! # Implementation Overview
+//!
+//! The heart of the library is the [key] module, and its
+//! [key::Key], [key::Context], [key::PressedKey] traits.
+//!
+//! These provide the interface with which 'smart keys' are implemented.
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
+/// Structs for input to the keymap.
 pub mod input;
+/// Smart key interface and implementations.
+///
+/// The core interface for the smart keymap library is [key::Key],
+///  and its associated [key::Context] and [key::PressedKeyState] types.
+/// Together, these are used to define smart key behaviour.
 pub mod key;
+/// Keymap implementation.
 pub mod keymap;
+/// Keys1, Keys2, etc. tuple structs for defining keymaps.
 pub mod tuples;
 
 #[allow(unused)]
@@ -20,6 +70,7 @@ include!(env!("SMART_KEYMAP_CUSTOM_KEYMAP"));
 static mut KEYMAP: keymap::Keymap<KeyDefinitionsType> =
     keymap::Keymap::new(KEY_DEFINITIONS, key::composite::Context::new());
 
+/// Initialize the global keymap instance.
 #[allow(static_mut_refs)]
 #[no_mangle]
 pub extern "C" fn keymap_init() {
@@ -28,6 +79,7 @@ pub extern "C" fn keymap_init() {
     }
 }
 
+/// Register a keypress event to the global keymap instance.
 #[allow(static_mut_refs)]
 #[no_mangle]
 pub extern "C" fn keymap_register_input_keypress(keymap_index: u16) {
@@ -36,6 +88,7 @@ pub extern "C" fn keymap_register_input_keypress(keymap_index: u16) {
     }
 }
 
+/// Register a keyrelease event to the global keymap instance.
 #[allow(static_mut_refs)]
 #[no_mangle]
 pub extern "C" fn keymap_register_input_keyrelease(keymap_index: u16) {
@@ -49,6 +102,8 @@ pub extern "C" fn keymap_register_input_keyrelease(keymap_index: u16) {
 /// Should be called every ms.
 ///
 /// The HID keyboard report is copied to the given buffer.
+///
+/// The `buf` report is for the HID boot keyboard.
 ///
 /// # Safety
 ///
@@ -68,6 +123,11 @@ pub unsafe extern "C" fn keymap_tick(buf: *mut u8) {
     }
 }
 
+/// Copy the HID keyboard report to the given buffer.
+///
+/// It's better to use [keymap_tick] copy the report to the buffer,
+///  because the report won't change between [keymap_tick] calls.
+///
 /// # Safety
 ///
 /// `buf` must be a valid pointer to a buffer of at least 8 bytes.

--- a/src/tuples.rs
+++ b/src/tuples.rs
@@ -5,10 +5,13 @@ use crate::key;
 
 use key::{composite, dynamic};
 
+/// A trait for resetting all keys in a tuple struct.
 pub trait KeysReset {
+    /// Reset all keys.
     fn reset(&mut self);
 }
 
+/// A tuple struct for 1 key.
 #[derive(Debug)]
 pub struct Keys1<
     K0: key::Key,
@@ -24,6 +27,7 @@ impl<
         const N: usize,
     > Keys1<K0, Ctx, Ev, N>
 {
+    /// Constructs a KeysN for the given tuple.
     pub const fn new((k0,): (K0,)) -> Self {
         Keys1(dynamic::DynamicKey::new(k0))
     }
@@ -91,6 +95,7 @@ macro_rules! define_keys {
     ($n:expr) => {
         paste::paste! {
             seq_macro::seq!(I in 0..$n {
+                /// A tuple struct for some number of keys.
                 #[derive(core::fmt::Debug)]
                 pub struct [<Keys $n>]<
                     #(
@@ -117,6 +122,7 @@ macro_rules! define_keys {
                 Ctx, Ev, M
                     >
                 {
+                    /// Constructs a KeysN tuple struct with the given tuple.
                     pub const fn new((
                         #(k~I,)*
                     ): (


### PR DESCRIPTION
For this project, I've done a reasonable job at using tests to drive development.

I've heard the argument that it's good to also write documentation first, since this forces thinking about the design of the interface.

Lots of this effort is wasted:

- There's zero benefit to documenting the `keymap_index` field in a struct named `PressedInput::Key`.
- The Rust docs aren't really the right place to document smart key behaviour. (The interface of the key needs to be documented for users who write keymaps).

However, it's valuable to document the `key` module and the traits in that.