### PR TITLE
Add doctest demonstrating deserialization from JSON

### DIFF
--- a/src/key/doc_de_simple.md
+++ b/src/key/doc_de_simple.md
@@ -1,0 +1,11 @@
+# JSON
+
+```rust
+use smart_keymap::key::simple::Key;
+let json = r#"
+  4
+"#;
+let expected_key: Key = Key(0x04);
+let actual_key: Key = serde_json::from_str(json).unwrap();
+assert_eq!(actual_key, expected_key);
+```

--- a/src/key/doc_de_tap_hold.md
+++ b/src/key/doc_de_tap_hold.md
@@ -1,0 +1,12 @@
+# JSON
+
+```rust
+use smart_keymap::key::tap_hold::Key;
+let json = r#"
+  { "hold": 224, "tap": 4 }
+"#;
+let expected_key: Key = Key { hold: 224, tap: 4 };
+let actual_key: Key = serde_json::from_str(json).unwrap();
+assert_eq!(actual_key, expected_key);
+```
+

--- a/src/key/simple.rs
+++ b/src/key/simple.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("doc_de_simple.md")]
+
 use serde::Deserialize;
 
 use crate::{input, key};

--- a/src/key/tap_hold.rs
+++ b/src/key/tap_hold.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("doc_de_tap_hold.md")]
+
 use serde::Deserialize;
 
 use crate::input;


### PR DESCRIPTION
The Rust doc `doctests` get executed with `cargo test`.

This change adds `docs_de_*.md` for some of the keys (simple, tap hold), and includes these docs in the module documentation for the key.

I would have hoped that `#![doc = include_str!(...)]` could have been used for the `struct Key` too, but that's not allowed.