### PR TITLE
Refactor layered keys

### DIFF
--- a/features/deserialization/key_deserialization.feature
+++ b/features/deserialization/key_deserialization.feature
@@ -23,9 +23,9 @@ Feature: Key Deserialization
   Example: Deserialize a composite::Key (TapHold variant)
     When a composite::Key is deserialized from the RON string
       """
-      TapHold(Key(tap: 0x04, hold: 0xE0))
+      TapHold(key: Key(tap: 0x04, hold: 0xE0))
       """
     Then the result is same value as deserializing the JSON string
       """
-      { "TapHold": { "tap": 4, "hold": 224 } }
+      { "TapHold": { "key": { "tap": 4, "hold": 224 } } }
       """

--- a/features/keymap/simple.feature
+++ b/features/keymap/simple.feature
@@ -3,7 +3,7 @@ Feature: Simple Key
   Example: Deserialize a simple::Key
     Given a keymap, expressed as a RON string
       """
-      [Simple(Key(0x04)), Simple(Key(0x05))]
+      [Simple(key: Key(0x04)), Simple(key: Key(0x05))]
       """
     When the keymap registers the following input
       """

--- a/features/keymap/tap_hold.feature
+++ b/features/keymap/tap_hold.feature
@@ -14,7 +14,7 @@ Feature: TapHold Key
 
     Given a keymap, expressed as a RON string
       """
-      [TapHold(Key(tap: 0x04, hold: 0xE0)), Simple(Key(0x05))]
+      [TapHold(key: Key(tap: 0x04, hold: 0xE0)), Simple(key: Key(0x05))]
       """
 
   Example: acts as 'tap' when tapped

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -24,7 +24,7 @@ pub type DefaultNestableKey = simple::Key;
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq)]
 pub enum Key<
     const L: layered::LayerIndex = 0,
-    K: NestableKey = DefaultNestableKey,
+    K: NestableKey + Copy = DefaultNestableKey,
     LS: layered::LayerState = [bool; 0],
 > where
     [Option<K>; L]: serde::de::DeserializeOwned,
@@ -47,7 +47,7 @@ pub enum Key<
     /// A layered key.
     Layered {
         /// The layered key.
-        key: layered::LayeredKey<L, K>,
+        key: layered::LayeredKey<K, [Option<K>; L]>,
         /// Marker for the LayerState, for LayeredKey new_pressed_key.
         #[serde(skip)]
         _phantom: PhantomData<LS>,
@@ -74,7 +74,9 @@ where
     }
 
     /// Constructs a [Key::Layered] from the given [layered::LayeredKey].
-    pub const fn layered(key: layered::LayeredKey<L, DefaultNestableKey>) -> Self {
+    pub const fn layered(
+        key: layered::LayeredKey<DefaultNestableKey, [Option<DefaultNestableKey>; L]>,
+    ) -> Self {
         Self::Layered {
             key,
             _phantom: PhantomData,

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -2,12 +2,15 @@
 //!  which can be any of the other key definitions,
 //!  and is the default Key for the `keymap::KeyMap` implementation.
 
-use serde::Deserialize;
-
 use core::fmt::Debug;
+use core::marker::PhantomData;
+
+use serde::Deserialize;
 
 use crate::{input, key};
 use key::{layered, simple, tap_hold};
+
+use super::layered::LayerState;
 
 /// Used to implement nested combinations of [Key].
 pub trait NestableKey: key::Key + Sized {}
@@ -19,8 +22,11 @@ pub type DefaultNestableKey = simple::Key;
 
 /// An aggregate of [key::Key] types.
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq)]
-pub enum Key<const L: layered::LayerIndex = 0, K: NestableKey = DefaultNestableKey>
-where
+pub enum Key<
+    const L: layered::LayerIndex = 0,
+    K: NestableKey = DefaultNestableKey,
+    LS: layered::LayerState = [bool; 0],
+> where
     [Option<K>; L]: serde::de::DeserializeOwned,
 {
     /// A simple key.
@@ -30,14 +36,33 @@ where
     /// A layer modifier key.
     LayerModifier(layered::ModifierKey<L>),
     /// A layered key.
-    Layered(layered::LayeredKey<L, K>),
+    Layered {
+        /// The layered key.
+        key: layered::LayeredKey<L, K>,
+        /// Marker for the LayerState, for LayeredKey new_pressed_key.
+        _phantom: PhantomData<LS>,
+    },
 }
 
-impl<const L: layered::LayerIndex> key::Key for Key<L, DefaultNestableKey>
+impl<const L: layered::LayerIndex, LS: layered::LayerState + Debug> Key<L, DefaultNestableKey, LS>
 where
     [Option<DefaultNestableKey>; L]: serde::de::DeserializeOwned,
 {
-    type Context = Context<L, DefaultNestableKey>;
+    /// Constructs a [Key::Layered] from the given [layered::LayeredKey].
+    pub fn layered(key: layered::LayeredKey<L, DefaultNestableKey>) -> Self {
+        Self::Layered {
+            key,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<const L: layered::LayerIndex, LS: layered::LayerState + Debug> key::Key
+    for Key<L, DefaultNestableKey, LS>
+where
+    [Option<DefaultNestableKey>; L]: serde::de::DeserializeOwned,
+{
+    type Context = Context<DefaultNestableKey, LS>;
     type ContextEvent = Event;
     type Event = Event;
     type PressedKeyState = PressedKeyState<L>;
@@ -63,9 +88,9 @@ where
                 let (pressed_key, new_event) = k.new_pressed_key(keymap_index);
                 (pressed_key.into(), Some(new_event.into()))
             }
-            Key::Layered(k) => {
+            Key::Layered { key, .. } => {
                 let Context { layer_context } = context;
-                let (pressed_key, new_event) = k.new_pressed_key(layer_context, keymap_index);
+                let (pressed_key, new_event) = key.new_pressed_key(layer_context, keymap_index);
                 (pressed_key.into(), new_event.map(|ev| ev.into()))
             }
         }
@@ -74,11 +99,11 @@ where
 
 /// An aggregate context for [key::Context]s.
 #[derive(Debug, Clone, Copy)]
-pub struct Context<const L: layered::LayerIndex, K: key::Key> {
-    layer_context: layered::Context<L, K::Context>,
+pub struct Context<K: key::Key, LS: layered::LayerState = [bool; 0]> {
+    layer_context: layered::Context<K::Context, LS>,
 }
 
-impl<const L: layered::LayerIndex> Context<L, DefaultNestableKey> {
+impl<const L: usize> Context<DefaultNestableKey, [bool; L]> {
     /// Constructs a new [Context].
     pub const fn new() -> Self {
         let layer_context = layered::Context::new(());
@@ -86,13 +111,13 @@ impl<const L: layered::LayerIndex> Context<L, DefaultNestableKey> {
     }
 }
 
-impl<const L: layered::LayerIndex> Default for Context<L, DefaultNestableKey> {
+impl<const L: usize> Default for Context<DefaultNestableKey, [bool; L]> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<const L: layered::LayerIndex> key::Context for Context<L, DefaultNestableKey> {
+impl<LS: LayerState> key::Context for Context<DefaultNestableKey, LS> {
     type Event = Event;
     fn handle_event(&mut self, event: Self::Event) {
         if let Event::LayerModification(ev) = event {
@@ -102,8 +127,8 @@ impl<const L: layered::LayerIndex> key::Context for Context<L, DefaultNestableKe
 }
 
 /// simple::Context from composite::Context
-impl<const L: layered::LayerIndex> From<&Context<L, DefaultNestableKey>> for &() {
-    fn from(_: &Context<L, DefaultNestableKey>) -> Self {
+impl<LS: layered::LayerState> From<&Context<DefaultNestableKey, LS>> for &() {
+    fn from(_: &Context<DefaultNestableKey, LS>) -> Self {
         &()
     }
 }
@@ -120,10 +145,11 @@ pub enum PressedKeyState<const L: layered::LayerIndex = 0> {
 }
 
 /// Convenience type alias for a [key::PressedKey] with a [PressedKeyState].
-pub type PressedKey<const L: layered::LayerIndex> =
-    input::PressedKey<Key<L, DefaultNestableKey>, PressedKeyState<L>>;
+pub type PressedKey<const L: layered::LayerIndex, LS> =
+    input::PressedKey<Key<L, DefaultNestableKey, LS>, PressedKeyState<L>>;
 
-impl<const L: layered::LayerIndex> From<layered::PressedModifierKey<L>> for PressedKey<L>
+impl<const L: layered::LayerIndex, LS: layered::LayerState> From<layered::PressedModifierKey<L>>
+    for PressedKey<L, LS>
 where
     [Option<DefaultNestableKey>; L]: serde::de::DeserializeOwned,
 {
@@ -142,7 +168,8 @@ where
     }
 }
 
-impl<const L: layered::LayerIndex> From<simple::PressedKey> for PressedKey<L>
+impl<const L: layered::LayerIndex, LS: layered::LayerState> From<simple::PressedKey>
+    for PressedKey<L, LS>
 where
     [Option<DefaultNestableKey>; L]: serde::de::DeserializeOwned,
 {
@@ -161,7 +188,8 @@ where
     }
 }
 
-impl<const L: layered::LayerIndex> From<tap_hold::PressedKey> for PressedKey<L>
+impl<const L: layered::LayerIndex, LS: layered::LayerState> From<tap_hold::PressedKey>
+    for PressedKey<L, LS>
 where
     [Option<DefaultNestableKey>; L]: serde::de::DeserializeOwned,
 {
@@ -180,8 +208,8 @@ where
     }
 }
 
-impl<const L: layered::LayerIndex> key::PressedKeyState<Key<L, DefaultNestableKey>>
-    for PressedKeyState<L>
+impl<const L: layered::LayerIndex, LS: layered::LayerState + Debug>
+    key::PressedKeyState<Key<L, DefaultNestableKey, LS>> for PressedKeyState<L>
 where
     [Option<DefaultNestableKey>; L]: serde::de::DeserializeOwned,
 {
@@ -190,7 +218,7 @@ where
     fn handle_event_for(
         &mut self,
         keymap_index: u16,
-        key: &Key<L, DefaultNestableKey>,
+        key: &Key<L, DefaultNestableKey, LS>,
         event: key::Event<Self::Event>,
     ) -> impl IntoIterator<Item = key::Event<Self::Event>> {
         match (key, self) {
@@ -214,7 +242,7 @@ where
         }
     }
 
-    fn key_code(&self, key: &Key<L, DefaultNestableKey>) -> Option<u8> {
+    fn key_code(&self, key: &Key<L, DefaultNestableKey, LS>) -> Option<u8> {
         match (key, self) {
             (Key::LayerModifier(k), PressedKeyState::LayerModifier(pk)) => pk.key_code(k),
             (Key::Simple(k), PressedKeyState::Simple(pk)) => pk.key_code(k),
@@ -333,9 +361,12 @@ mod tests {
 
         // Assemble
         const L: layered::LayerIndex = 1;
+        type LS = [bool; L];
+        type Ctx = composite::Context<DefaultNestableKey, LS>;
+        type K = composite::Key<L, DefaultNestableKey, LS>;
         let keymap_index: u16 = 0;
-        let key = composite::Key::<L>::LayerModifier(layered::ModifierKey::Hold(0));
-        let context = composite::Context::<L, DefaultNestableKey>::new();
+        let key = K::LayerModifier(layered::ModifierKey::Hold(0));
+        let context = Ctx::new();
         let (mut pressed_lmod_key, _) = key.new_pressed_key(&context, keymap_index);
 
         // Act
@@ -359,14 +390,17 @@ mod tests {
 
         // Assemble
         const L: layered::LayerIndex = 1;
-        let keys: [composite::Key<L>; 2] = [
-            composite::Key::<L>::LayerModifier(layered::ModifierKey::Hold(0)),
-            composite::Key::<L>::Layered(layered::LayeredKey::new(
+        type LS = [bool; L];
+        type Ctx = composite::Context<DefaultNestableKey, LS>;
+        type K = composite::Key<L, DefaultNestableKey, LS>;
+        let keys: [K; 2] = [
+            K::LayerModifier(layered::ModifierKey::Hold(0)),
+            K::layered(layered::LayeredKey::new(
                 simple::Key(0x04),
                 [Some(simple::Key(0x05))],
             )),
         ];
-        let mut context = composite::Context::<L, DefaultNestableKey>::new();
+        let mut context = Ctx::new();
         let (_pressed_key, maybe_ev) = keys[0].new_pressed_key(&context, 0);
 
         // Act
@@ -378,7 +412,7 @@ mod tests {
             _ => panic!("Expected Some(ScheduledEvent(Event::Key(_)))"),
         };
         context.handle_event(event);
-        let actual_active_layers = context.layer_context.active_layers();
+        let actual_active_layers = context.layer_context.layer_state();
 
         // Assert
         let expected_active_layers = &[true];
@@ -392,14 +426,17 @@ mod tests {
 
         // Assemble
         const L: layered::LayerIndex = 1;
-        let keys: [composite::Key<L>; 2] = [
-            composite::Key::<L>::LayerModifier(layered::ModifierKey::Hold(0)),
-            composite::Key::<L>::Layered(layered::LayeredKey::new(
+        type LS = [bool; L];
+        type Ctx = composite::Context<DefaultNestableKey, LS>;
+        type K = composite::Key<L, DefaultNestableKey, LS>;
+        let keys: [K; 2] = [
+            K::LayerModifier(layered::ModifierKey::Hold(0)),
+            K::layered(layered::LayeredKey::new(
                 simple::Key(0x04),
                 [Some(simple::Key(0x05))],
             )),
         ];
-        let mut context = composite::Context::<L, DefaultNestableKey>::new();
+        let mut context = Ctx::new();
         let (mut pressed_lmod_key, _) = keys[0].new_pressed_key(&context, 0);
         context.layer_context.activate_layer(0);
         let events = pressed_lmod_key
@@ -411,7 +448,7 @@ mod tests {
 
         // Act
         context.handle_event(key_ev);
-        let actual_active_layers = context.layer_context.active_layers();
+        let actual_active_layers = context.layer_context.layer_state();
 
         // Assert
         let expected_active_layers = &[false];
@@ -424,15 +461,18 @@ mod tests {
 
         // Assemble
         const L: layered::LayerIndex = 1;
-        let keys: [composite::Key<L>; 3] = [
-            composite::Key::<L>::LayerModifier(layered::ModifierKey::Hold(0)),
-            composite::Key::<L>::Layered(layered::LayeredKey::new(
+        type LS = [bool; L];
+        type Ctx = composite::Context<DefaultNestableKey, LS>;
+        type K = composite::Key<L, DefaultNestableKey, LS>;
+        let keys: [K; 3] = [
+            K::LayerModifier(layered::ModifierKey::Hold(0)),
+            K::layered(layered::LayeredKey::new(
                 simple::Key(0x04),
                 [Some(simple::Key(0x05))],
             )),
-            composite::Key::<L>::Simple(simple::Key(0x06)),
+            K::Simple(simple::Key(0x06)),
         ];
-        let context = composite::Context::<L, DefaultNestableKey>::new();
+        let context = Ctx::new();
 
         // Act
         let keymap_index: u16 = 2;
@@ -450,15 +490,18 @@ mod tests {
 
         // Assemble
         const L: layered::LayerIndex = 1;
-        let keys: [composite::Key<L>; 3] = [
-            composite::Key::<L>::LayerModifier(layered::ModifierKey::Hold(0)),
-            composite::Key::<L>::Layered(layered::LayeredKey::new(
+        type LS = [bool; L];
+        type Ctx = composite::Context<DefaultNestableKey, LS>;
+        type K = composite::Key<L, DefaultNestableKey, LS>;
+        let keys: [K; 3] = [
+            K::LayerModifier(layered::ModifierKey::Hold(0)),
+            K::layered(layered::LayeredKey::new(
                 simple::Key(0x04),
                 [Some(simple::Key(0x05))],
             )),
-            composite::Key::<L>::Simple(simple::Key(0x06)),
+            K::Simple(simple::Key(0x06)),
         ];
-        let context = composite::Context::<L, DefaultNestableKey>::new();
+        let context = Ctx::new();
 
         // Act
         let keymap_index: u16 = 1;

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -42,7 +42,7 @@ pub enum Key<
     /// A layer modifier key.
     LayerModifier {
         /// The layer modifier key.
-        key: layered::ModifierKey<L>,
+        key: layered::ModifierKey,
     },
     /// A layered key.
     Layered {
@@ -69,7 +69,7 @@ where
     }
 
     /// Constructs a [Key::LayerModifier] from the given [layered::ModifierKey].
-    pub const fn layer_modifier(key: layered::ModifierKey<L>) -> Self {
+    pub const fn layer_modifier(key: layered::ModifierKey) -> Self {
         Self::LayerModifier { key }
     }
 
@@ -176,7 +176,7 @@ pub type PressedKey<const L: layered::LayerIndex, LS> =
     input::PressedKey<Key<L, DefaultNestableKey, LS>, PressedKeyState<L>>;
 
 impl<const L: layered::LayerIndex, LS: layered::LayerState + Debug>
-    From<layered::PressedModifierKey<L>> for PressedKey<L, LS>
+    From<layered::PressedModifierKey> for PressedKey<L, LS>
 where
     [Option<DefaultNestableKey>; L]: serde::de::DeserializeOwned,
 {
@@ -185,7 +185,7 @@ where
             keymap_index,
             key,
             pressed_key_state,
-        }: layered::PressedModifierKey<L>,
+        }: layered::PressedModifierKey,
     ) -> Self {
         input::PressedKey {
             key: Key::layer_modifier(key),

--- a/src/key/dynamic.rs
+++ b/src/key/dynamic.rs
@@ -37,7 +37,7 @@ where
 /// Convenience type alias for [Key] which uses [crate::key::composite::Event] and [crate::key::composite::Context].
 pub type CompositeKey<const L: key::layered::LayerIndex = 0> = dyn Key<
     key::composite::Event,
-    Context = key::composite::Context<L, key::composite::DefaultNestableKey>,
+    Context = key::composite::Context<key::composite::DefaultNestableKey, [bool; L]>,
 >;
 
 /// Generic implementation of [Key] for a [key::Key] and some `Ctx`/`Ev`.
@@ -129,7 +129,7 @@ mod tests {
     #[test]
     fn test_composite_dynamic_simple_key_has_no_key_code_when_released() {
         // Assemble
-        let dyn_key: &mut dyn Key<composite::Event, Context = composite::Context<0, simple::Key>> =
+        let dyn_key: &mut dyn Key<composite::Event, Context = composite::Context<simple::Key>> =
             &mut DynamicKey::new(simple::Key(0x04));
         let context = composite::Context::new();
 

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -8,12 +8,12 @@ pub type LayerIndex = usize;
 
 /// Modifier layer key affects what layers are active.
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq)]
-pub enum ModifierKey<const L: LayerIndex> {
+pub enum ModifierKey {
     /// Activates the given layer when the held.
     Hold(LayerIndex),
 }
 
-impl<const L: LayerIndex> ModifierKey<L> {
+impl ModifierKey {
     /// Create a new [input::PressedKey] and [key::ScheduledEvent] for the given keymap index.
     ///
     /// Pressing a [ModifierKey::Hold] emits a [LayerEvent::LayerActivated] event.
@@ -44,7 +44,7 @@ impl From<LayerEvent> for () {
     fn from(_: LayerEvent) -> Self {}
 }
 
-impl<const L: LayerIndex> key::Key for ModifierKey<L> {
+impl key::Key for ModifierKey {
     type Context = ();
     type ContextEvent = ();
     type Event = LayerEvent;
@@ -230,16 +230,15 @@ pub enum LayerEvent {
 pub struct PressedModifierKeyState;
 
 /// Type alias for [crate::input::PressedKey] of [ModifierKey].
-pub type PressedModifierKey<const L: LayerIndex> =
-    input::PressedKey<ModifierKey<L>, PressedModifierKeyState>;
+pub type PressedModifierKey = input::PressedKey<ModifierKey, PressedModifierKeyState>;
 
-impl<const L: LayerIndex> key::PressedKeyState<ModifierKey<L>> for PressedModifierKeyState {
+impl key::PressedKeyState<ModifierKey> for PressedModifierKeyState {
     type Event = LayerEvent;
 
     fn handle_event_for(
         &mut self,
         keymap_index: u16,
-        key: &ModifierKey<L>,
+        key: &ModifierKey,
         event: key::Event<Self::Event>,
     ) -> impl IntoIterator<Item = key::Event<Self::Event>> {
         match key {
@@ -256,7 +255,7 @@ impl<const L: LayerIndex> key::PressedKeyState<ModifierKey<L>> for PressedModifi
         }
     }
 
-    fn key_code(&self, _key: &ModifierKey<L>) -> Option<u8> {
+    fn key_code(&self, _key: &ModifierKey) -> Option<u8> {
         None
     }
 }
@@ -270,7 +269,7 @@ mod tests {
     #[test]
     fn test_pressing_hold_modifier_key_emits_event_activate_layer() {
         let layer = 0;
-        let key = ModifierKey::<3>::Hold(layer);
+        let key = ModifierKey::Hold(layer);
 
         let keymap_index = 9; // arbitrary
         let (_pressed_key, scheduled_event) = key.new_pressed_key(keymap_index);
@@ -290,7 +289,7 @@ mod tests {
     fn test_releasing_hold_modifier_key_emits_event_deactivate_layer() {
         // Assemble: press a Hold layer modifier key
         let layer = 0;
-        let key = ModifierKey::<3>::Hold(layer);
+        let key = ModifierKey::Hold(layer);
         let keymap_index = 9; // arbitrary
         let (mut pressed_key, _) = key.new_pressed_key(keymap_index);
 
@@ -313,7 +312,7 @@ mod tests {
     fn test_releasing_different_hold_modifier_key_does_not_emit_event() {
         // Assemble: press a Hold layer modifier key
         let layer = 0;
-        let key = ModifierKey::<3>::Hold(layer);
+        let key = ModifierKey::Hold(layer);
         let keymap_index = 9; // arbitrary
         let (mut pressed_key, _) = key.new_pressed_key(keymap_index);
 

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -162,20 +162,14 @@ pub struct LayeredKey<K: key::Key, Ly: Layers<K>> {
     layered: Ly,
 }
 
-impl<const L: LayerIndex, K: key::Key + Copy> LayeredKey<K, [Option<K>; L]>
-where
-    [Option<K>; L]: serde::de::DeserializeOwned,
-{
+impl<const L: LayerIndex, K: key::Key + Copy> LayeredKey<K, [Option<K>; L]> {
     /// Constructs a new [LayeredKey].
     pub fn new(base: K, layered: [Option<K>; L]) -> Self {
         Self { base, layered }
     }
 }
 
-impl<const L: LayerIndex, K: key::Key + Copy> LayeredKey<K, [Option<K>; L]>
-where
-    [Option<K>; L]: serde::de::DeserializeOwned,
-{
+impl<const L: LayerIndex, K: key::Key + Copy> LayeredKey<K, [Option<K>; L]> {
     /// Create a new [input::PressedKey], depending on the active layers in [Context].
     pub fn new_pressed_key<LS: LayerState>(
         &self,
@@ -196,7 +190,6 @@ where
 
 impl<const L: LayerIndex, K: key::Key + Copy> key::Key<K> for LayeredKey<K, [Option<K>; L]>
 where
-    [Option<K>; L]: serde::de::DeserializeOwned,
     LayerEvent: From<<K as key::Key>::Event>,
 {
     type Context = Context<K::Context, [bool; L]>; // LS = [bool; L]

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -1,3 +1,5 @@
+use core::marker::Copy;
+
 use serde::Deserialize;
 
 use crate::input;
@@ -5,6 +7,22 @@ use crate::key;
 
 /// The type used for layer index.
 pub type LayerIndex = usize;
+
+/// Implementation of associated [Layers] and [LayerState].
+pub trait LayerImpl {
+    /// The associated [LayerState] type.
+    type LayerState: LayerState;
+    /// The associated [Layers] type.
+    type Layers<K: key::Key + Copy>: Layers<K>;
+}
+
+/// Tuple struct indicating array-based layer implementation.
+pub struct ArrayImpl<const L: usize>;
+
+impl<const L: usize> LayerImpl for ArrayImpl<L> {
+    type LayerState = [bool; L];
+    type Layers<K: key::Key + Copy> = [Option<K>; L];
+}
 
 /// Modifier layer key affects what layers are active.
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq)]

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -23,7 +23,7 @@ pub mod dynamic;
 ///  produces.
 /// (e.g. [layered::LayeredKey]'s pressed key state passes-through to
 ///  the keys of its layers).
-pub trait Key<PK: Key = Self>: Debug
+pub trait Key<PK: Key = Self>: Copy + Debug + PartialEq
 where
     Self::ContextEvent: From<Self::Event>,
 {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -80,13 +80,13 @@ pub struct Keymap<
             usize,
             Output = dyn key::dynamic::Key<
                 key::composite::Event,
-                Context = key::composite::Context<L, key::composite::DefaultNestableKey>,
+                Context = key::composite::Context<key::composite::DefaultNestableKey, LS>,
             >,
         > + crate::tuples::KeysReset,
-    const L: key::layered::LayerIndex = 0,
+    LS: key::layered::LayerState = [bool; 0],
 > {
     key_definitions: I,
-    context: composite::Context<L, composite::DefaultNestableKey>,
+    context: composite::Context<composite::DefaultNestableKey, LS>,
     pressed_inputs: heapless::Vec<input::PressedInput, 16>,
     event_scheduler: EventScheduler,
 }
@@ -96,16 +96,16 @@ impl<
                 usize,
                 Output = dyn key::dynamic::Key<
                     key::composite::Event,
-                    Context = key::composite::Context<L, key::composite::DefaultNestableKey>,
+                    Context = key::composite::Context<key::composite::DefaultNestableKey, LS>,
                 >,
             > + crate::tuples::KeysReset,
-        const L: key::layered::LayerIndex,
-    > Keymap<I, L>
+        LS: key::layered::LayerState,
+    > Keymap<I, LS>
 {
     /// Constructs a new keymap with the given key definitions and context.
     pub const fn new(
         key_definitions: I,
-        context: composite::Context<L, composite::DefaultNestableKey>,
+        context: composite::Context<composite::DefaultNestableKey, LS>,
     ) -> Self {
         Self {
             key_definitions,
@@ -242,7 +242,7 @@ mod tests {
         use tuples::Keys1;
 
         // Assemble
-        let keys: Keys1<simple::Key, Context<0, DefaultNestableKey>, Event> =
+        let keys: Keys1<simple::Key, Context<DefaultNestableKey>, Event> =
             Keys1::new((simple::Key(0x04),));
         let context = composite::Context::new();
         let mut keymap = Keymap::new(keys, context);
@@ -265,7 +265,7 @@ mod tests {
         use composite::{Context, DefaultNestableKey, Event};
 
         // Assemble
-        let keys: Keys1<composite::Key, Context<0, DefaultNestableKey>, Event> =
+        let keys: Keys1<composite::Key, Context<DefaultNestableKey>, Event> =
             Keys1::new((composite::Key::<0>::Simple(simple::Key(0x04)),));
         let context = composite::Context::new();
         let mut keymap = Keymap::new(keys, context);
@@ -289,19 +289,17 @@ mod tests {
 
         // Assemble
         const L: layered::LayerIndex = 1;
-        let keys: Keys2<
-            composite::Key<L>,
-            composite::Key<L>,
-            Context<L, DefaultNestableKey>,
-            Event,
-        > = tuples::Keys2::new((
-            composite::Key::<L>::LayerModifier(layered::ModifierKey::Hold(0)),
-            composite::Key::<L>::Layered(layered::LayeredKey::new(
+        type LS = [bool; L];
+        type Ctx = Context<DefaultNestableKey, LS>;
+        type K = composite::Key<L, DefaultNestableKey, LS>;
+        let keys: Keys2<K, K, Ctx, Event> = tuples::Keys2::new((
+            K::LayerModifier(layered::ModifierKey::Hold(0)),
+            K::layered(layered::LayeredKey::new(
                 simple::Key(0x04),
                 [Some(simple::Key(0x05))],
             )),
         ));
-        let context = composite::Context::<L, composite::DefaultNestableKey>::new();
+        let context = Ctx::new();
         let mut keymap = Keymap::new(keys, context);
 
         // Act
@@ -322,19 +320,18 @@ mod tests {
 
         // Assemble
         const L: layered::LayerIndex = 1;
-        let keys: Keys2<
-            composite::Key<L>,
-            composite::Key<L>,
-            Context<L, DefaultNestableKey>,
-            Event,
-        > = tuples::Keys2::new((
-            composite::Key::<L>::LayerModifier(layered::ModifierKey::Hold(0)),
-            composite::Key::<L>::Layered(layered::LayeredKey::new(
+        type LS = [bool; L];
+        type Ctx = Context<DefaultNestableKey, LS>;
+        type K = composite::Key<L, DefaultNestableKey, LS>;
+        let keys: Keys2<K, K, Ctx, Event> = tuples::Keys2::new((
+            K::LayerModifier(layered::ModifierKey::Hold(0)),
+            K::layered(layered::LayeredKey::new(
                 simple::Key(0x04),
                 [Some(simple::Key(0x05))],
             )),
         ));
-        let context = composite::Context::<L, composite::DefaultNestableKey>::new();
+        let context = Ctx::new();
+
         let mut keymap = Keymap::new(keys, context);
 
         // Act
@@ -357,19 +354,17 @@ mod tests {
 
         // Assemble
         const L: layered::LayerIndex = 1;
-        let keys: Keys2<
-            composite::Key<L>,
-            composite::Key<L>,
-            Context<L, DefaultNestableKey>,
-            Event,
-        > = tuples::Keys2::new((
-            composite::Key::<L>::LayerModifier(layered::ModifierKey::Hold(0)),
-            composite::Key::<L>::Layered(layered::LayeredKey::new(
+        type LS = [bool; L];
+        type Ctx = Context<DefaultNestableKey, LS>;
+        type K = composite::Key<L, DefaultNestableKey, LS>;
+        let keys: Keys2<K, K, Ctx, Event> = tuples::Keys2::new((
+            K::LayerModifier(layered::ModifierKey::Hold(0)),
+            K::layered(layered::LayeredKey::new(
                 simple::Key(0x04),
                 [Some(simple::Key(0x05))],
             )),
         ));
-        let context = composite::Context::<L, composite::DefaultNestableKey>::new();
+        let context = Ctx::new();
         let mut keymap = Keymap::new(keys, context);
 
         // Act
@@ -395,19 +390,17 @@ mod tests {
 
         // Assemble
         const L: layered::LayerIndex = 1;
-        let keys: Keys2<
-            composite::Key<L>,
-            composite::Key<L>,
-            Context<L, DefaultNestableKey>,
-            Event,
-        > = tuples::Keys2::new((
-            composite::Key::<L>::LayerModifier(layered::ModifierKey::Hold(0)),
-            composite::Key::<L>::Layered(layered::LayeredKey::new(
+        type LS = [bool; L];
+        type Ctx = Context<DefaultNestableKey, LS>;
+        type K = composite::Key<L, DefaultNestableKey, LS>;
+        let keys: Keys2<K, K, Ctx, Event> = tuples::Keys2::new((
+            K::LayerModifier(layered::ModifierKey::Hold(0)),
+            K::layered(layered::LayeredKey::new(
                 simple::Key(0x04),
                 [Some(simple::Key(0x05))],
             )),
         ));
-        let context = composite::Context::<L, composite::DefaultNestableKey>::new();
+        let context = Ctx::new();
         let mut keymap = Keymap::new(keys, context);
 
         // Act

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -80,13 +80,13 @@ pub struct Keymap<
             usize,
             Output = dyn key::dynamic::Key<
                 key::composite::Event,
-                Context = key::composite::Context<key::composite::DefaultNestableKey, LS>,
+                Context = key::composite::Context<key::composite::DefaultNestableKey, L>,
             >,
         > + crate::tuples::KeysReset,
-    LS: key::layered::LayerState = [bool; 0],
+    L: key::layered::LayerImpl = key::layered::ArrayImpl<0>,
 > {
     key_definitions: I,
-    context: composite::Context<composite::DefaultNestableKey, LS>,
+    context: composite::Context<composite::DefaultNestableKey, L>,
     pressed_inputs: heapless::Vec<input::PressedInput, 16>,
     event_scheduler: EventScheduler,
 }
@@ -96,16 +96,16 @@ impl<
                 usize,
                 Output = dyn key::dynamic::Key<
                     key::composite::Event,
-                    Context = key::composite::Context<key::composite::DefaultNestableKey, LS>,
+                    Context = key::composite::Context<key::composite::DefaultNestableKey, L>,
                 >,
             > + crate::tuples::KeysReset,
-        LS: key::layered::LayerState,
-    > Keymap<I, LS>
+        L: key::layered::LayerImpl,
+    > Keymap<I, L>
 {
     /// Constructs a new keymap with the given key definitions and context.
     pub const fn new(
         key_definitions: I,
-        context: composite::Context<composite::DefaultNestableKey, LS>,
+        context: composite::Context<composite::DefaultNestableKey, L>,
     ) -> Self {
         Self {
             key_definitions,
@@ -266,7 +266,7 @@ mod tests {
 
         // Assemble
         let keys: Keys1<composite::Key, Context<DefaultNestableKey>, Event> =
-            Keys1::new((composite::Key::<0>::simple(simple::Key(0x04)),));
+            Keys1::new((composite::Key::simple(simple::Key(0x04)),));
         let context = composite::Context::new();
         let mut keymap = Keymap::new(keys, context);
 
@@ -285,13 +285,12 @@ mod tests {
         use key::{composite, layered, simple};
         use tuples::Keys2;
 
-        use composite::{Context, DefaultNestableKey, Event};
+        use composite::{DefaultNestableKey, Event};
 
         // Assemble
-        const L: layered::LayerIndex = 1;
-        type LS = [bool; L];
-        type Ctx = Context<DefaultNestableKey, LS>;
-        type K = composite::Key<L, DefaultNestableKey, LS>;
+        type L = layered::ArrayImpl<1>;
+        type Ctx = composite::Context<DefaultNestableKey, L>;
+        type K = composite::Key<DefaultNestableKey, L>;
         let keys: Keys2<K, K, Ctx, Event> = tuples::Keys2::new((
             K::layer_modifier(layered::ModifierKey::Hold(0)),
             K::layered(layered::LayeredKey::new(
@@ -316,13 +315,12 @@ mod tests {
         use key::{composite, layered, simple};
         use tuples::Keys2;
 
-        use composite::{Context, DefaultNestableKey, Event};
+        use composite::{DefaultNestableKey, Event};
 
         // Assemble
-        const L: layered::LayerIndex = 1;
-        type LS = [bool; L];
-        type Ctx = Context<DefaultNestableKey, LS>;
-        type K = composite::Key<L, DefaultNestableKey, LS>;
+        type L = layered::ArrayImpl<1>;
+        type Ctx = composite::Context<DefaultNestableKey, L>;
+        type K = composite::Key<DefaultNestableKey, L>;
         let keys: Keys2<K, K, Ctx, Event> = tuples::Keys2::new((
             K::layer_modifier(layered::ModifierKey::Hold(0)),
             K::layered(layered::LayeredKey::new(
@@ -350,13 +348,12 @@ mod tests {
         use key::{composite, layered, simple};
         use tuples::Keys2;
 
-        use composite::{Context, DefaultNestableKey, Event};
+        use composite::{DefaultNestableKey, Event};
 
         // Assemble
-        const L: layered::LayerIndex = 1;
-        type LS = [bool; L];
-        type Ctx = Context<DefaultNestableKey, LS>;
-        type K = composite::Key<L, DefaultNestableKey, LS>;
+        type L = layered::ArrayImpl<1>;
+        type Ctx = composite::Context<DefaultNestableKey, L>;
+        type K = composite::Key<DefaultNestableKey, L>;
         let keys: Keys2<K, K, Ctx, Event> = tuples::Keys2::new((
             K::layer_modifier(layered::ModifierKey::Hold(0)),
             K::layered(layered::LayeredKey::new(
@@ -386,13 +383,12 @@ mod tests {
         use key::{composite, layered, simple};
         use tuples::Keys2;
 
-        use composite::{Context, DefaultNestableKey, Event};
+        use composite::{DefaultNestableKey, Event};
 
         // Assemble
-        const L: layered::LayerIndex = 1;
-        type LS = [bool; L];
-        type Ctx = Context<DefaultNestableKey, LS>;
-        type K = composite::Key<L, DefaultNestableKey, LS>;
+        type L = layered::ArrayImpl<1>;
+        type Ctx = composite::Context<DefaultNestableKey, L>;
+        type K = composite::Key<DefaultNestableKey, L>;
         let keys: Keys2<K, K, Ctx, Event> = tuples::Keys2::new((
             K::layer_modifier(layered::ModifierKey::Hold(0)),
             K::layered(layered::LayeredKey::new(

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -266,7 +266,7 @@ mod tests {
 
         // Assemble
         let keys: Keys1<composite::Key, Context<DefaultNestableKey>, Event> =
-            Keys1::new((composite::Key::<0>::Simple(simple::Key(0x04)),));
+            Keys1::new((composite::Key::<0>::simple(simple::Key(0x04)),));
         let context = composite::Context::new();
         let mut keymap = Keymap::new(keys, context);
 
@@ -293,7 +293,7 @@ mod tests {
         type Ctx = Context<DefaultNestableKey, LS>;
         type K = composite::Key<L, DefaultNestableKey, LS>;
         let keys: Keys2<K, K, Ctx, Event> = tuples::Keys2::new((
-            K::LayerModifier(layered::ModifierKey::Hold(0)),
+            K::layer_modifier(layered::ModifierKey::Hold(0)),
             K::layered(layered::LayeredKey::new(
                 simple::Key(0x04),
                 [Some(simple::Key(0x05))],
@@ -324,7 +324,7 @@ mod tests {
         type Ctx = Context<DefaultNestableKey, LS>;
         type K = composite::Key<L, DefaultNestableKey, LS>;
         let keys: Keys2<K, K, Ctx, Event> = tuples::Keys2::new((
-            K::LayerModifier(layered::ModifierKey::Hold(0)),
+            K::layer_modifier(layered::ModifierKey::Hold(0)),
             K::layered(layered::LayeredKey::new(
                 simple::Key(0x04),
                 [Some(simple::Key(0x05))],
@@ -358,7 +358,7 @@ mod tests {
         type Ctx = Context<DefaultNestableKey, LS>;
         type K = composite::Key<L, DefaultNestableKey, LS>;
         let keys: Keys2<K, K, Ctx, Event> = tuples::Keys2::new((
-            K::LayerModifier(layered::ModifierKey::Hold(0)),
+            K::layer_modifier(layered::ModifierKey::Hold(0)),
             K::layered(layered::LayeredKey::new(
                 simple::Key(0x04),
                 [Some(simple::Key(0x05))],
@@ -394,7 +394,7 @@ mod tests {
         type Ctx = Context<DefaultNestableKey, LS>;
         type K = composite::Key<L, DefaultNestableKey, LS>;
         let keys: Keys2<K, K, Ctx, Event> = tuples::Keys2::new((
-            K::LayerModifier(layered::ModifierKey::Hold(0)),
+            K::layer_modifier(layered::ModifierKey::Hold(0)),
             K::layered(layered::LayeredKey::new(
                 simple::Key(0x04),
                 [Some(simple::Key(0x05))],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ use key::{composite, simple, tap_hold};
 #[cfg(not(custom_keymap))]
 type KeyDefinitionsType = tuples::Keys1<Key>;
 #[cfg(not(custom_keymap))]
-const KEY_DEFINITIONS: KeyDefinitionsType = tuples::Keys1::new((Key::Simple(simple::Key(0x04)),));
+const KEY_DEFINITIONS: KeyDefinitionsType = tuples::Keys1::new((Key::simple(simple::Key(0x04)),));
 #[cfg(custom_keymap)]
 include!(env!("SMART_KEYMAP_CUSTOM_KEYMAP"));
 

--- a/src/tuples.rs
+++ b/src/tuples.rs
@@ -15,7 +15,7 @@ pub trait KeysReset {
 #[derive(Debug)]
 pub struct Keys1<
     K0: key::Key,
-    Ctx: key::Context<Event = Ev> + Debug = composite::Context<0, composite::DefaultNestableKey>,
+    Ctx: key::Context<Event = Ev> + Debug = composite::Context<composite::DefaultNestableKey>,
     Ev: Copy + Debug + Ord = composite::Event,
     const N: usize = 2,
 >(dynamic::DynamicKey<K0, Ctx, Ev>);
@@ -101,7 +101,7 @@ macro_rules! define_keys {
                     #(
                         K~I: key::Key,
                     )*
-                Ctx: key::Context<Event = Ev> + core::fmt::Debug = composite::Context<0, composite::DefaultNestableKey>,
+                Ctx: key::Context<Event = Ev> + core::fmt::Debug = composite::Context<composite::DefaultNestableKey>,
                 Ev: Copy + core::fmt::Debug + Ord = composite::Event,
                 const M: usize = 2,
                 >(

--- a/tests/keymaps/checkkeys_60key_keymap.rs
+++ b/tests/keymaps/checkkeys_60key_keymap.rs
@@ -26,7 +26,7 @@ pub const KEY_DEFINITIONS: KeyDefinitionsType = {
     seq!(I in 0..60 {
         Keys60::new((
             #(
-                Key::Simple(simple::Key(codes[I] as u8)),
+                Key::simple(simple::Key(codes[I] as u8)),
             )*
         ))
     })

--- a/tests/keymaps/simple_keymap.rs
+++ b/tests/keymaps/simple_keymap.rs
@@ -5,14 +5,14 @@ type KeyDefinitionsType = tuples::Keys4<
     Key,
 >;
 pub const KEY_DEFINITIONS: KeyDefinitionsType = tuples::Keys4::new((
-    Key::TapHold(tap_hold::Key {
+    Key::tap_hold(tap_hold::Key {
         tap: 0x06,
         hold: 0xE0,
     }), // Tap C, Hold LCtrl
-    Key::TapHold(tap_hold::Key {
+    Key::tap_hold(tap_hold::Key {
         tap: 0x07,
         hold: 0xE1,
     }), // Tap D, Hold LShift
-    Key::Simple(simple::Key(0x04)), // A
-    Key::Simple(simple::Key(0x05)), // B
+    Key::simple(simple::Key(0x04)), // A
+    Key::simple(simple::Key(0x05)), // B
 ));


### PR DESCRIPTION
Refactoring towards writing Cucumber specs for `key::layered`.

It would be good to eventually construct `key::layered::LayeredKey` using either `[Option<K>; L]` or `Vec<Option<K>>`.

What blocks this is that the `key::LayeredKey` needs to know the number of layers, since its layers are tracked with `[bool; L]` and `[Option<K>; L]`. (And, because Rust is quite strict, this `<const L: usize>` generic percolates up through the types, and so `Keymap` needs to know this, and so the Cucumber `World` struct needs to know..).

I like the idea of: instead of having the `L` be generic, have `key::Context` be generic over the `LayerState` it uses. (For embedded, it can use `[bool; L]` or a `bitset` or whatever. For running Cucumber tests, the `LayerState` can be a `Vec<bool>` (or a `Set<LayerIndex>` or something) which doesn't need to be constrained by some `<L>`.

(As part of this refactoring, I attached some `PhantomData` in `composite::Key`. -- Hence, changed `composite::Key` variants to structs, and added convenience `const` constructors for each variant).

* * *

Though, using `Vec<bool>` isn't possible at this time.

Recall, `Copy` means "can be bit-for-bit copied". And the heap-based `Vec` obviously isn't `Copy`. Hence, the `key::Key` trait should not use `Copy`. -- However, dropping this trait bound is out of scope for this PR.

* * *

Some other thoughts:

Mixed thoughts on Rust.

- In many languages, switching between `[Option<K>; L]`, and `Vec<Option<K>>` would be trivial. With Rust, there's significant friction.

- Though to an extent, I do like using `trait`s to be able to abstract things.