### PR TITLE
rust: refactor key_code to key_output

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -49,8 +49,8 @@ impl<K: crate::key::Key, S: crate::key::PressedKeyState<K, Event = K::Event>> cr
             .handle_event_for(self.keymap_index, &self.key, event)
     }
 
-    fn key_code(&self) -> Option<u8> {
-        self.pressed_key_state.key_code(&self.key)
+    fn key_output(&self) -> Option<crate::key::KeyOutput> {
+        self.pressed_key_state.key_output(&self.key)
     }
 }
 

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -254,13 +254,13 @@ where
         }
     }
 
-    fn key_code(&self, key: &Key<DefaultNestableKey, L>) -> Option<u8> {
+    fn key_output(&self, key: &Key<DefaultNestableKey, L>) -> Option<key::KeyOutput> {
         match (key, self) {
             (Key::LayerModifier { key, .. }, PressedKeyState::LayerModifier(pk)) => {
-                pk.key_code(key)
+                pk.key_output(key)
             }
-            (Key::Simple { key, .. }, PressedKeyState::Simple(pk)) => pk.key_code(key),
-            (Key::TapHold { key, .. }, PressedKeyState::TapHold(pk)) => pk.key_code(key),
+            (Key::Simple { key, .. }, PressedKeyState::Simple(pk)) => pk.key_output(key),
+            (Key::TapHold { key, .. }, PressedKeyState::TapHold(pk)) => pk.key_output(key),
             _ => None,
         }
     }
@@ -487,10 +487,10 @@ mod tests {
         // Act
         let keymap_index: u16 = 2;
         let (pressed_key, _) = keys[keymap_index as usize].new_pressed_key(&context, keymap_index);
-        let actual_keycode = pressed_key.key_code();
+        let actual_keycode = pressed_key.key_output();
 
         // Assert
-        let expected_keycode = Some(0x06);
+        let expected_keycode = Some(key::KeyOutput::from_key_code(0x06));
         assert_eq!(actual_keycode, expected_keycode);
     }
 
@@ -515,10 +515,10 @@ mod tests {
         // Act
         let keymap_index: u16 = 1;
         let (pressed_key, _) = keys[keymap_index as usize].new_pressed_key(&context, keymap_index);
-        let actual_keycode = pressed_key.key_code();
+        let actual_keycode = pressed_key.key_output();
 
         // Assert
-        let expected_keycode = Some(0x04);
+        let expected_keycode = Some(key::KeyOutput::from_key_code(0x04));
         assert_eq!(actual_keycode, expected_keycode);
     }
 }

--- a/src/key/dynamic.rs
+++ b/src/key/dynamic.rs
@@ -28,7 +28,7 @@ where
     ) -> heapless::Vec<key::ScheduledEvent<Ev>, N>;
 
     /// Output HID keyboard code for the [Key].
-    fn key_code(&self) -> Option<u8>;
+    fn key_output(&self) -> Option<key::KeyOutput>;
 
     /// Resets the [Key] to its initial state.
     fn reset(&mut self);
@@ -107,9 +107,9 @@ where
         scheduled_events
     }
 
-    fn key_code(&self) -> Option<u8> {
+    fn key_output(&self) -> Option<key::KeyOutput> {
         if let Some(pressed_key) = &self.pressed_key {
-            pressed_key.key_code()
+            pressed_key.key_output()
         } else {
             None
         }
@@ -145,7 +145,7 @@ mod tests {
         );
 
         // Assert
-        let actual_key_code = dyn_key.key_code();
+        let actual_key_code = dyn_key.key_output();
         let expected_key_code = None;
         assert_eq!(actual_key_code, expected_key_code);
     }

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -268,7 +268,7 @@ impl key::PressedKeyState<ModifierKey> for PressedModifierKeyState {
         }
     }
 
-    fn key_code(&self, _key: &ModifierKey) -> Option<u8> {
+    fn key_output(&self, _key: &ModifierKey) -> Option<key::KeyOutput> {
         None
     }
 }

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -74,6 +74,22 @@ impl Context for () {
     fn handle_event(&mut self, _event: Self::Event) {}
 }
 
+/// Struct for the output from [PressedKey].
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
+pub struct KeyOutput(u8);
+
+impl KeyOutput {
+    /// Constructs a [KeyOutput] from a key code.
+    pub fn from_key_code(key_code: u8) -> Self {
+        KeyOutput(key_code)
+    }
+
+    /// Returns the key code value.
+    pub fn key_code(self) -> u8 {
+        self.0
+    }
+}
+
 /// [PressedKeyState] for a stateful pressed key value.
 pub trait PressedKey {
     /// The type of `Event` the pressed key handles.
@@ -86,7 +102,7 @@ pub trait PressedKey {
     ) -> impl IntoIterator<Item = Event<Self::Event>>;
 
     /// Output for the pressed key.
-    fn key_code(&self) -> Option<u8>;
+    fn key_output(&self) -> Option<KeyOutput>;
 }
 
 /// Implements functionality for the pressed key.
@@ -106,7 +122,7 @@ pub trait PressedKeyState<K: Key>: Debug {
     ) -> impl IntoIterator<Item = Event<Self::Event>>;
 
     /// Output for the pressed key state.
-    fn key_code(&self, key: &K) -> Option<u8>;
+    fn key_output(&self, key: &K) -> Option<KeyOutput>;
 }
 
 /// Errors for [TryFrom] implementations.

--- a/src/key/simple.rs
+++ b/src/key/simple.rs
@@ -69,7 +69,7 @@ impl key::PressedKeyState<Key> for PressedKeyState {
     }
 
     /// Simple key always has a key_code.
-    fn key_code(&self, key: &Key) -> Option<u8> {
-        Some(key.key_code())
+    fn key_output(&self, key: &Key) -> Option<key::KeyOutput> {
+        Some(key::KeyOutput::from_key_code(key.key_code()))
     }
 }

--- a/src/key/tap_hold.rs
+++ b/src/key/tap_hold.rs
@@ -140,10 +140,10 @@ impl key::PressedKeyState<Key> for PressedKeyState {
         }
     }
 
-    fn key_code(&self, key: &Key) -> Option<u8> {
+    fn key_output(&self, key: &Key) -> Option<key::KeyOutput> {
         match self.state {
-            TapHoldState::Tap => Some(key.tap),
-            TapHoldState::Hold => Some(key.hold),
+            TapHoldState::Tap => Some(key::KeyOutput::from_key_code(key.tap)),
+            TapHoldState::Hold => Some(key::KeyOutput::from_key_code(key.hold)),
             _ => None,
         }
     }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -209,7 +209,7 @@ impl<
         let pressed_keys = self.pressed_inputs.iter().filter_map(|pi| match pi {
             input::PressedInput::Key { keymap_index, .. } => {
                 let key = &self.key_definitions[*keymap_index as usize];
-                key.key_code()
+                key.key_output().map(|ko| ko.key_code())
             }
             input::PressedInput::Virtual { key_code } => Some(*key_code),
         });


### PR DESCRIPTION
Eventually, we'll want keys to be able to have output other than just a Keyboard page code; or for more than just Keyboard HID reports:

- e.g. Media keys use the Consumer page, mouse keys use Mouse.

- May want to chord output. e.g. press "super + pgup".

- May want to output codes to outside the smart keymap; e.g. perhaps RGB effect codes, or Bluetooth switching.

This refactoring replaces `key_code(&self) -> Option<u8>` methods with `key_output(&self) -> Option<KeyOutput>`, where `KeyOutput` is just a tuple struct of a u8.

This should make it clearer/easier later to handle cases like the above.