### PR TITLE
rust: refactor key::PressedKeyEvents for Key::new_pressed_key events

### DIFF
--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -87,25 +87,25 @@ where
         keymap_index: u16,
     ) -> (
         input::PressedKey<Self, Self::PressedKeyState>,
-        Option<key::ScheduledEvent<Event>>,
+        key::PressedKeyEvents<Self::Event>,
     ) {
         match self {
             Key::Simple { key, .. } => {
-                let (pressed_key, _new_event) = key.new_pressed_key(&(), keymap_index);
-                (pressed_key.into(), None)
+                let (pressed_key, events) = key.new_pressed_key(&(), keymap_index);
+                (pressed_key.into(), events.into_events())
             }
             Key::TapHold { key, .. } => {
-                let (pressed_key, new_event) = key.new_pressed_key(&(), keymap_index);
-                (pressed_key.into(), new_event.map(|ev| ev.into()))
+                let (pressed_key, events) = key.new_pressed_key(&(), keymap_index);
+                (pressed_key.into(), events.into_events())
             }
             Key::LayerModifier { key, .. } => {
-                let (pressed_key, new_event) = key.new_pressed_key(keymap_index);
-                (pressed_key.into(), Some(new_event.into()))
+                let (pressed_key, events) = key::Key::new_pressed_key(key, &(), keymap_index);
+                (pressed_key.into(), events.into_events())
             }
             Key::Layered { key, .. } => {
                 let Context { layer_context } = context;
-                let (pressed_key, new_event) = key.new_pressed_key(layer_context, keymap_index);
-                (pressed_key.into(), new_event.map(|ev| ev.into()))
+                let (pressed_key, events) = key.new_pressed_key(layer_context, keymap_index);
+                (pressed_key.into(), events.into_events())
             }
         }
     }
@@ -413,7 +413,8 @@ mod tests {
             )),
         ];
         let mut context = Ctx::new();
-        let (_pressed_key, maybe_ev) = keys[0].new_pressed_key(&context, 0);
+        let (_pressed_key, pressed_key_events) = keys[0].new_pressed_key(&context, 0);
+        let maybe_ev = pressed_key_events.into_iter().next();
 
         // Act
         let event = match maybe_ev {

--- a/src/key/simple.rs
+++ b/src/key/simple.rs
@@ -27,7 +27,7 @@ impl key::Key for Key {
         keymap_index: u16,
     ) -> (
         input::PressedKey<Self, Self::PressedKeyState>,
-        Option<key::ScheduledEvent<Self::Event>>,
+        key::PressedKeyEvents<Self::Event>,
     ) {
         (
             input::PressedKey {
@@ -35,7 +35,7 @@ impl key::Key for Key {
                 key: *self,
                 pressed_key_state: PressedKeyState,
             },
-            None,
+            key::PressedKeyEvents::no_events(),
         )
     }
 }

--- a/src/key/tap_hold.rs
+++ b/src/key/tap_hold.rs
@@ -30,7 +30,7 @@ impl key::Key for Key {
         keymap_index: u16,
     ) -> (
         input::PressedKey<Self, Self::PressedKeyState>,
-        Option<key::ScheduledEvent<Self::Event>>,
+        key::PressedKeyEvents<Self::Event>,
     ) {
         (
             input::PressedKey {
@@ -40,10 +40,7 @@ impl key::Key for Key {
                     state: TapHoldState::Pending,
                 },
             },
-            Some(key::ScheduledEvent::after(
-                200,
-                Event::TapHoldTimeout { keymap_index }.into(),
-            )),
+            key::PressedKeyEvents::scheduled_key_event(200, Event::TapHoldTimeout { keymap_index }),
         )
     }
 }


### PR DESCRIPTION
With simple, tap-hold, layered.. each pressed key emits at-most one event. (Either a timeout event, or an event that gets passed to context).

This refactoring gathers the `Option<key::ScheduledEvent<Event>>` type into a separate struct, and provides some convenience constructors for these. (Later, `PressedKeyEvents` can be changed to allow both a timeout event and an event that context receives).

Clippy had been suggesting that `new_pressed_key`'s return type was too complex.

* * *

My intuition still conflicts with Rust: my intuition suggests if I have `Event<E>: From<Event<EF>>`, then I should be able to use this as a bound and generically implement `KeyPressedEvents<E>: From<KeyEvents<EF>>`. -- But, this conflicts with "T: From<T>".

Rather than impl. a bunch of straightforward `key::PressedKeyEvents<composite::Event>: From<...>`, I opted to just add `into_events` for `PressedKeyEvents`.

(I notice that e.g. `key::dynamic` implementation has the bound `key::ScheduledEvent<Ev>: From<key::ScheduledEvent<K::Event>>`. Again, this seems unnecessary).