### PR TITLE
rust: remove From<ScheduledEvent<FE>> for ScheduledEvent<E>

### DIFF
--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -302,33 +302,6 @@ impl From<key::Event<tap_hold::Event>> for key::Event<Event> {
     }
 }
 
-impl From<key::ScheduledEvent<layered::LayerEvent>> for key::ScheduledEvent<Event> {
-    fn from(ev: key::ScheduledEvent<layered::LayerEvent>) -> Self {
-        Self {
-            schedule: ev.schedule,
-            event: ev.event.into(),
-        }
-    }
-}
-
-impl From<key::ScheduledEvent<simple::Event>> for key::ScheduledEvent<Event> {
-    fn from(ev: key::ScheduledEvent<simple::Event>) -> Self {
-        Self {
-            schedule: ev.schedule,
-            event: ev.event.into(),
-        }
-    }
-}
-
-impl From<key::ScheduledEvent<tap_hold::Event>> for key::ScheduledEvent<Event> {
-    fn from(ev: key::ScheduledEvent<tap_hold::Event>) -> Self {
-        Self {
-            schedule: ev.schedule,
-            event: ev.event.into(),
-        }
-    }
-}
-
 impl TryFrom<key::Event<Event>> for key::Event<layered::LayerEvent> {
     type Error = key::EventError;
 

--- a/src/key/dynamic.rs
+++ b/src/key/dynamic.rs
@@ -71,7 +71,7 @@ impl<
     > Key<Ev, N> for DynamicKey<K, Ctx, Ev>
 where
     key::Event<K::Event>: TryFrom<key::Event<Ev>>,
-    key::ScheduledEvent<Ev>: From<key::ScheduledEvent<K::Event>>,
+    key::Event<Ev>: From<key::Event<K::Event>>,
     for<'c> &'c K::Context: From<&'c Ctx>,
 {
     type Context = Ctx;
@@ -89,7 +89,7 @@ where
                     pressed_key
                         .handle_event(event)
                         .into_iter()
-                        .map(|ev| ScheduledEvent::immediate(ev).into()),
+                        .map(|ev| ScheduledEvent::immediate(ev).into_scheduled_event()),
                 );
             }
 
@@ -100,7 +100,11 @@ where
             }
         } else if let key::Event::Input(input::Event::Press { keymap_index }) = event {
             let (pressed_key, new_events) = self.key.new_pressed_key(context.into(), keymap_index);
-            scheduled_events.extend(new_events.into_iter().map(|sch_ev| sch_ev.into()));
+            scheduled_events.extend(
+                new_events
+                    .into_iter()
+                    .map(|sch_ev| sch_ev.into_scheduled_event()),
+            );
             self.pressed_key = Some(pressed_key);
         }
 

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -217,7 +217,7 @@ pub struct ScheduledEvent<T> {
     pub event: Event<T>,
 }
 
-impl<T> ScheduledEvent<T> {
+impl<T: Copy> ScheduledEvent<T> {
     /// Constructs a [ScheduledEvent] with [Schedule::Immediate].
     #[allow(unused)]
     pub fn immediate(event: Event<T>) -> Self {
@@ -232,6 +232,17 @@ impl<T> ScheduledEvent<T> {
         ScheduledEvent {
             schedule: Schedule::After(delay),
             event,
+        }
+    }
+
+    /// Maps the ScheduledEvent into a new type.
+    pub fn into_scheduled_event<U>(&self) -> ScheduledEvent<U>
+    where
+        Event<U>: From<Event<T>>,
+    {
+        ScheduledEvent {
+            event: self.event.into(),
+            schedule: self.schedule,
         }
     }
 }

--- a/src/tuples.rs
+++ b/src/tuples.rs
@@ -41,7 +41,7 @@ impl<
     > Index<usize> for Keys1<K0, Ctx, Ev, N>
 where
     key::Event<<K0 as key::Key>::Event>: TryFrom<key::Event<Ev>>,
-    key::ScheduledEvent<Ev>: From<key::ScheduledEvent<<K0 as key::Key>::Event>>,
+    key::Event<Ev>: From<key::Event<<K0 as key::Key>::Event>>,
     for<'c> &'c <K0 as key::Key>::Context: From<&'c Ctx>,
 {
     type Output = dyn dynamic::Key<Ev, N, Context = Ctx>;
@@ -62,7 +62,7 @@ impl<
     > IndexMut<usize> for Keys1<K0, Ctx, Ev, N>
 where
     key::Event<<K0 as key::Key>::Event>: TryFrom<key::Event<Ev>>,
-    key::ScheduledEvent<Ev>: From<key::ScheduledEvent<<K0 as key::Key>::Event>>,
+    key::Event<Ev>: From<key::Event<<K0 as key::Key>::Event>>,
     for<'c> &'c <K0 as key::Key>::Context: From<&'c Ctx>,
 {
     fn index_mut(&mut self, idx: usize) -> &mut Self::Output {
@@ -81,7 +81,7 @@ impl<
     > KeysReset for Keys1<K0, Ctx, Ev, N>
 where
     key::Event<<K0 as key::Key>::Event>: TryFrom<key::Event<Ev>>,
-    key::ScheduledEvent<Ev>: From<key::ScheduledEvent<<K0 as key::Key>::Event>>,
+    key::Event<Ev>: From<key::Event<<K0 as key::Key>::Event>>,
     for<'c> &'c <K0 as key::Key>::Context: From<&'c Ctx>,
 {
     fn reset(&mut self) {
@@ -150,7 +150,7 @@ macro_rules! define_keys {
                 where
                     #(
                     key::Event<<K~I as key::Key>::Event>: TryFrom<key::Event<Ev>>,
-                    key::ScheduledEvent<Ev>: From<key::ScheduledEvent<<K~I as key::Key>::Event>>,
+                    key::Event<Ev>: From<key::Event<<K~I as key::Key>::Event>>,
                     for<'c> &'c <K~I as key::Key>::Context: From<&'c Ctx>,
                 )*
                 {
@@ -180,7 +180,7 @@ macro_rules! define_keys {
                 where
                     #(
                     key::Event<<K~I as key::Key>::Event>: TryFrom<key::Event<Ev>>,
-                    key::ScheduledEvent<Ev>: From<key::ScheduledEvent<<K~I as key::Key>::Event>>,
+                    key::Event<Ev>: From<key::Event<<K~I as key::Key>::Event>>,
                     for<'c> &'c <K~I as key::Key>::Context: From<&'c Ctx>,
                 )*
                 {
@@ -208,7 +208,7 @@ macro_rules! define_keys {
                 where
                     #(
                     key::Event<<K~I as key::Key>::Event>: TryFrom<key::Event<Ev>>,
-                    key::ScheduledEvent<Ev>: From<key::ScheduledEvent<<K~I as key::Key>::Event>>,
+                    key::Event<Ev>: From<key::Event<<K~I as key::Key>::Event>>,
                     for<'c> &'c <K~I as key::Key>::Context: From<&'c Ctx>,
                 )*
                 {


### PR DESCRIPTION
It would be possible to write an extra `impl From<ScheduledEvent<FE>> for ScheduleEvent<E>` for each `key::` that `key::composite` uses.. but, I don't think this is worth it just to be able to write `.into()`.

May be worth doing the same for the `From<key::Event<FE>>` **if** each `key`'s `Key::Event` associated type is only ever used for the `key::Event::Key` variant. (YAGNI?).