### PR TITLE
Refactor NCL for matrix scanning C codegen in the CH58x firmware demo

### DIFF
--- a/firmware/ch58x-ble-hid-keyboard-c/Makefile
+++ b/firmware/ch58x-ble-hid-keyboard-c/Makefile
@@ -6,4 +6,7 @@ clean:
 	rm generated/matrix.c
 
 generated/matrix.c:
-	nickel export --format=raw ncl/matrix_scan.ncl > generated/matrix.c
+	nickel export \
+	  --format=raw \
+	  --field=output \
+	  ncl/matrix_scan.ncl > generated/matrix.c

--- a/firmware/ch58x-ble-hid-keyboard-c/ncl/matrix_scan.ncl
+++ b/firmware/ch58x-ble-hid-keyboard-c/ncl/matrix_scan.ncl
@@ -1,33 +1,49 @@
 {
-  gpio_pins =
-    let ports = ["A", "B"] in
-    let pins = std.array.range 0 24 in
+  gpio_pins
+    : { _ : { port : String, pin : Number } }
+    | doc "Record with A1, A2, ... A23, B1, B2, ..., B24, mapped to { port, pin } records."
+    =
+      let ports = ["A", "B"] in
+      let pins = std.array.range 0 24 in
 
-    std.array.flat_map
-      (fun port_name => std.array.map (fun pin_num => { "%{port_name}%{std.to_string pin_num}" = { "port" = port_name, "pin" = pin_num } }) pins)
-      ports
-    |> std.array.fold_left (&) {},
+      std.array.flat_map
+        (fun port_name => std.array.map (fun pin_num => { "%{port_name}%{std.to_string pin_num}" = { "port" = port_name, "pin" = pin_num } }) pins)
+        ports
+      |> (std.array.fold_left (&) {}) | { _ : { port : String, pin : Number } },
 
-  board =
-    let gp = gpio_pins in
-    {
-      cols = [gp.A4, gp.A5, gp.A15, gp.A14, gp.A13, gp.A12, gp.A11, gp.A10],
-      rows = [gp.A8, gp.A9, gp.B15, gp.B14, gp.B13, gp.B12, gp.B7, gp.B4],
-      num_keys = 60,
-    },
+  board
+    | {
+      cols | Array { port | String, pin | Number },
+      rows | Array { port | String, pin | Number },
+      num_keys | Number,
+    }
+    | doc "the cols/rows, and number of keys, used for generating the matrix scan code."
+    =
+      let gp = gpio_pins in
+      {
+        cols = [gp.A4, gp.A5, gp.A15, gp.A14, gp.A13, gp.A12, gp.A11, gp.A10],
+        rows = [gp.A8, gp.A9, gp.B15, gp.B14, gp.B13, gp.B12, gp.B7, gp.B4],
+        num_keys = 60,
+      },
 
-  init_col = fun { port, pin, .. } =>
-    m%"
+  init_col
+    | doc "Generates C fragment for initializing the given column pin, for keyboard_matrix_init."
+    = fun { port, pin, .. } =>
+      m%"
       GPIO%{port}_ModeCfg(GPIO_Pin_%{std.to_string pin}, GPIO_ModeOut_PP_5mA); // %{port}%{std.to_string pin}
   "%,
 
-  init_row = fun { port, pin, .. } =>
-    m%"
+  init_row
+    | doc "Generates C fragment for initializing the given row pin, for keyboard_matrix_init"
+    = fun { port, pin, .. } =>
+      m%"
       GPIO%{port}_ModeCfg(GPIO_Pin_%{std.to_string pin}, GPIO_ModeIN_PD); // %{port}%{std.to_string pin}
   "%,
 
-  matrix_init = fun { cols, rows, .. } =>
-    m%"
+  matrix_init
+    | doc "Generates C fragment with the keyboard_matrix_init function, for the given cols/rows."
+    = fun { cols, rows, .. } =>
+      m%"
   void keyboard_matrix_init(void) {
       // Cols
       %{cols |> std.array.map init_col |> std.string.join "\n"}
@@ -45,16 +61,20 @@
   # Want the keymap index to refer to keys row-wise.
   #
   # The given column_index and row_index refer to (digital) row/col, 0..7.
-  keymap_index_for_key = fun { column_index, row_index, .. } =>
-    let columnwise_index = column_index * 8 + row_index in
-    let physical_column_index = std.number.floor (columnwise_index / 5) in
-    let physical_row_index = columnwise_index % 5 in
-    let rowwise_index = physical_row_index * 12 + physical_column_index in
-    rowwise_index,
+  keymap_index_for_key
+    | doc "Returns the keymap index for the key corresponding to the (0-based) digital column_index and row_index."
+    = fun { column_index | Number, row_index | Number, .. } =>
+      let columnwise_index = column_index * 8 + row_index in
+      let physical_column_index = std.number.floor (columnwise_index / 5) in
+      let physical_row_index = columnwise_index % 5 in
+      let rowwise_index = physical_row_index * 12 + physical_column_index in
+      rowwise_index,
 
-  matrix_scan_row_for_column = fun args @ { column_index, row_index, col, row, .. } =>
-    let idx = std.to_string (keymap_index_for_key args) in
-    m%"
+  matrix_scan_row_for_column
+    | doc "Generates C fragment for reading a row, as part of COL2ROW scanning."
+    = fun args @ { column_index, row_index, col, row, .. } =>
+      let idx = std.to_string (keymap_index_for_key args) in
+      m%"
       // Read row %{std.to_string row_index} = %{row.port}%{std.to_string row.pin}
       currentScan[%{idx}] = GPIO%{row.port}_ReadPortPin(GPIO_Pin_%{std.to_string row.pin}) != 0;
 
@@ -62,8 +82,10 @@
       handle_index(%{idx});
   "%,
 
-  matrix_scan_column = fun args @ { column_index, col, rows, .. } =>
-    m%"
+  matrix_scan_column
+    | doc "Generates C fragment for reading a column, as part of COL2ROW scanning."
+    = fun args @ { column_index, col, rows, .. } =>
+      m%"
       // Scan column %{std.to_string column_index} = %{col.port}%{std.to_string col.pin}
       GPIO%{col.port}_SetBits(GPIO_Pin_%{std.to_string col.pin});
       mDelayuS(5);
@@ -74,7 +96,9 @@
       GPIO%{col.port}_ResetBits(GPIO_Pin_%{std.to_string col.pin});
   "%,
 
-  output = m%"
+  output
+    | doc "C code with keyboard_matrix_init and keyboard_matrix_scan functions."
+    = m%"
   #include <stdbool.h>
 
   #include "CH58x_common.h"

--- a/firmware/ch58x-ble-hid-keyboard-c/ncl/matrix_scan.ncl
+++ b/firmware/ch58x-ble-hid-keyboard-c/ncl/matrix_scan.ncl
@@ -1,110 +1,104 @@
-let gpio_pins =
-  let ports = ["A", "B"] in
-  let pins = std.array.range 0 24 in
+{
+  gpio_pins =
+    let ports = ["A", "B"] in
+    let pins = std.array.range 0 24 in
 
-  std.array.flat_map
-    (fun port_name => std.array.map (fun pin_num => { "%{port_name}%{std.to_string pin_num}" = { "port" = port_name, "pin" = pin_num } }) pins)
-    ports
-  |> std.array.fold_left (&) {}
-in
+    std.array.flat_map
+      (fun port_name => std.array.map (fun pin_num => { "%{port_name}%{std.to_string pin_num}" = { "port" = port_name, "pin" = pin_num } }) pins)
+      ports
+    |> std.array.fold_left (&) {},
 
-let board =
-  let gp = gpio_pins in
-  {
-    cols = [gp.A4, gp.A5, gp.A15, gp.A14, gp.A13, gp.A12, gp.A11, gp.A10],
-    rows = [gp.A8, gp.A9, gp.B15, gp.B14, gp.B13, gp.B12, gp.B7, gp.B4],
-    num_keys = 60,
+  board =
+    let gp = gpio_pins in
+    {
+      cols = [gp.A4, gp.A5, gp.A15, gp.A14, gp.A13, gp.A12, gp.A11, gp.A10],
+      rows = [gp.A8, gp.A9, gp.B15, gp.B14, gp.B13, gp.B12, gp.B7, gp.B4],
+      num_keys = 60,
+    },
+
+  init_col = fun { port, pin, .. } =>
+    m%"
+      GPIO%{port}_ModeCfg(GPIO_Pin_%{std.to_string pin}, GPIO_ModeOut_PP_5mA); // %{port}%{std.to_string pin}
+  "%,
+
+  init_row = fun { port, pin, .. } =>
+    m%"
+      GPIO%{port}_ModeCfg(GPIO_Pin_%{std.to_string pin}, GPIO_ModeIN_PD); // %{port}%{std.to_string pin}
+  "%,
+
+  matrix_init = fun { cols, rows, .. } =>
+    m%"
+  void keyboard_matrix_init(void) {
+      // Cols
+      %{cols |> std.array.map init_col |> std.string.join "\n"}
+
+      // Rows
+      %{rows |> std.array.map init_row |>std.string.join "\n"}
   }
-in
+  "%,
 
-let init_col = fun { port, pin, .. } =>
-  m%"
-    GPIO%{port}_ModeCfg(GPIO_Pin_%{std.to_string pin}, GPIO_ModeOut_PP_5mA); // %{port}%{std.to_string pin}
-"%
-in
+  # The WABBLE-60 uses a digital matrix of 8x8 rows and columns,
+  #  forming a physical 5x12 matrix of keys.
+  #
+  # The physical matrix arranges keys column-wise.
+  #
+  # Want the keymap index to refer to keys row-wise.
+  #
+  # The given column_index and row_index refer to (digital) row/col, 0..7.
+  keymap_index_for_key = fun { column_index, row_index, .. } =>
+    let columnwise_index = column_index * 8 + row_index in
+    let physical_column_index = std.number.floor (columnwise_index / 5) in
+    let physical_row_index = columnwise_index % 5 in
+    let rowwise_index = physical_row_index * 12 + physical_column_index in
+    rowwise_index,
 
-let init_row = fun { port, pin, .. } =>
-  m%"
-    GPIO%{port}_ModeCfg(GPIO_Pin_%{std.to_string pin}, GPIO_ModeIN_PD); // %{port}%{std.to_string pin}
-"%
-in
+  matrix_scan_row_for_column = fun args @ { column_index, row_index, col, row, .. } =>
+    let idx = std.to_string (keymap_index_for_key args) in
+    m%"
+      // Read row %{std.to_string row_index} = %{row.port}%{std.to_string row.pin}
+      currentScan[%{idx}] = GPIO%{row.port}_ReadPortPin(GPIO_Pin_%{std.to_string row.pin}) != 0;
 
-let matrix_init = fun { cols, rows, .. } =>
-  m%"
-void keyboard_matrix_init(void) {
-    // Cols
-    %{cols |> std.array.map init_col |> std.string.join "\n"}
+      // Register presses/events based on changes
+      handle_index(%{idx});
+  "%,
 
-    // Rows
-    %{rows |> std.array.map init_row |>std.string.join "\n"}
+  matrix_scan_column = fun args @ { column_index, col, rows, .. } =>
+    m%"
+      // Scan column %{std.to_string column_index} = %{col.port}%{std.to_string col.pin}
+      GPIO%{col.port}_SetBits(GPIO_Pin_%{std.to_string col.pin});
+      mDelayuS(5);
+
+      // Read the row pins
+      %{rows |> std.array.map_with_index (fun idx r => matrix_scan_row_for_column (args & { row = r, row_index = idx })) |> std.string.join "\n"}
+
+      GPIO%{col.port}_ResetBits(GPIO_Pin_%{std.to_string col.pin});
+  "%,
+
+  output = m%"
+  #include <stdbool.h>
+
+  #include "CH58x_common.h"
+
+  bool previousScan[%{std.to_string board.num_keys}] = { false };
+  bool currentScan[%{std.to_string board.num_keys}] = { false };
+
+  %{matrix_init board}
+
+  void handle_index(uint32_t index) {
+      if (previousScan[index] != currentScan[index]) {
+          if (currentScan[index]) {
+              keymap_register_input_keypress(index);
+          } else {
+              keymap_register_input_keyrelease(index);
+          }
+
+          previousScan[index] = currentScan[index];
+      }
+  }
+
+  void keyboard_matrix_scan(void) {
+      %{board.cols |> std.array.map_with_index (fun idx c => matrix_scan_column ({ col = c, column_index = idx, rows = board.rows })) |> std.string.join "\n"}
+  }
+
+  "%
 }
-"%
-in
-
-# The WABBLE-60 uses a digital matrix of 8x8 rows and columns,
-#  forming a physical 5x12 matrix of keys.
-#
-# The physical matrix arranges keys column-wise.
-#
-# Want the keymap index to refer to keys row-wise.
-#
-# The given column_index and row_index refer to (digital) row/col, 0..7.
-let keymap_index_for_key = fun { column_index, row_index, .. } =>
-  let columnwise_index = column_index * 8 + row_index in
-  let physical_column_index = std.number.floor (columnwise_index / 5) in
-  let physical_row_index = columnwise_index % 5 in
-  let rowwise_index = physical_row_index * 12 + physical_column_index in
-  rowwise_index
-in
-
-let matrix_scan_row_for_column = fun args @ { column_index, row_index, col, row, .. } =>
-  let idx = std.to_string (keymap_index_for_key args) in
-  m%"
-    // Read row %{std.to_string row_index} = %{row.port}%{std.to_string row.pin}
-    currentScan[%{idx}] = GPIO%{row.port}_ReadPortPin(GPIO_Pin_%{std.to_string row.pin}) != 0;
-
-    // Register presses/events based on changes
-    handle_index(%{idx});
-"%
-in
-
-let matrix_scan_column = fun args @ { column_index, col, rows, .. } =>
-  m%"
-    // Scan column %{std.to_string column_index} = %{col.port}%{std.to_string col.pin}
-    GPIO%{col.port}_SetBits(GPIO_Pin_%{std.to_string col.pin});
-    mDelayuS(5);
-
-    // Read the row pins
-    %{rows |> std.array.map_with_index (fun idx r => matrix_scan_row_for_column (args & { row = r, row_index = idx })) |> std.string.join "\n"}
-
-    GPIO%{col.port}_ResetBits(GPIO_Pin_%{std.to_string col.pin});
-"%
-in
-
-m%"
-#include <stdbool.h>
-
-#include "CH58x_common.h"
-
-bool previousScan[%{std.to_string board.num_keys}] = { false };
-bool currentScan[%{std.to_string board.num_keys}] = { false };
-
-%{matrix_init board}
-
-void handle_index(uint32_t index) {
-    if (previousScan[index] != currentScan[index]) {
-        if (currentScan[index]) {
-            keymap_register_input_keypress(index);
-        } else {
-            keymap_register_input_keyrelease(index);
-        }
-
-        previousScan[index] = currentScan[index];
-    }
-}
-
-void keyboard_matrix_scan(void) {
-    %{board.cols |> std.array.map_with_index (fun idx c => matrix_scan_column ({ col = c, column_index = idx, rows = board.rows })) |> std.string.join "\n"}
-}
-
-"%

--- a/firmware/ch58x-ble-hid-keyboard-c/ncl/matrix_scan.ncl
+++ b/firmware/ch58x-ble-hid-keyboard-c/ncl/matrix_scan.ncl
@@ -3,7 +3,7 @@ let gpio_pins =
   let pins = std.array.range 0 24 in
 
   std.array.flat_map
-    (fun port => std.array.map (fun pin => { "%{port}%{std.to_string pin}" = { "port_name" = port, "pin_number" = pin } }) pins)
+    (fun port_name => std.array.map (fun pin_num => { "%{port_name}%{std.to_string pin_num}" = { "port" = port_name, "pin" = pin_num } }) pins)
     ports
   |> std.array.fold_left (&) {}
 in
@@ -17,15 +17,15 @@ let board =
   }
 in
 
-let init_col = fun { port_name, pin_number, .. } =>
+let init_col = fun { port, pin, .. } =>
   m%"
-    GPIO%{port_name}_ModeCfg(GPIO_Pin_%{std.to_string pin_number}, GPIO_ModeOut_PP_5mA); // %{port_name}%{std.to_string pin_number}
+    GPIO%{port}_ModeCfg(GPIO_Pin_%{std.to_string pin}, GPIO_ModeOut_PP_5mA); // %{port}%{std.to_string pin}
 "%
 in
 
-let init_row = fun { port_name, pin_number, .. } =>
+let init_row = fun { port, pin, .. } =>
   m%"
-    GPIO%{port_name}_ModeCfg(GPIO_Pin_%{std.to_string pin_number}, GPIO_ModeIN_PD); // %{port_name}%{std.to_string pin_number}
+    GPIO%{port}_ModeCfg(GPIO_Pin_%{std.to_string pin}, GPIO_ModeIN_PD); // %{port}%{std.to_string pin}
 "%
 in
 
@@ -60,8 +60,8 @@ in
 let matrix_scan_row_for_column = fun args @ { column_index, row_index, col, row, .. } =>
   let idx = std.to_string (keymap_index_for_key args) in
   m%"
-    // Read row %{std.to_string row_index} = %{row.port_name}%{std.to_string row.pin_number}
-    currentScan[%{idx}] = GPIO%{row.port_name}_ReadPortPin(GPIO_Pin_%{std.to_string row.pin_number}) != 0;
+    // Read row %{std.to_string row_index} = %{row.port}%{std.to_string row.pin}
+    currentScan[%{idx}] = GPIO%{row.port}_ReadPortPin(GPIO_Pin_%{std.to_string row.pin}) != 0;
 
     // Register presses/events based on changes
     handle_index(%{idx});
@@ -70,14 +70,14 @@ in
 
 let matrix_scan_column = fun args @ { column_index, col, rows, .. } =>
   m%"
-    // Scan column %{std.to_string column_index} = %{col.port_name}%{std.to_string col.pin_number}
-    GPIO%{col.port_name}_SetBits(GPIO_Pin_%{std.to_string col.pin_number});
+    // Scan column %{std.to_string column_index} = %{col.port}%{std.to_string col.pin}
+    GPIO%{col.port}_SetBits(GPIO_Pin_%{std.to_string col.pin});
     mDelayuS(5);
 
     // Read the row pins
     %{rows |> std.array.map_with_index (fun idx r => matrix_scan_row_for_column (args & { row = r, row_index = idx })) |> std.string.join "\n"}
 
-    GPIO%{col.port_name}_ResetBits(GPIO_Pin_%{std.to_string col.pin_number});
+    GPIO%{col.port}_ResetBits(GPIO_Pin_%{std.to_string col.pin});
 "%
 in
 


### PR DESCRIPTION
Still building intuition for Nickel's types/contracts.

Nickel types are quite concrete. `Number`, `String`, `Array`, etc., and there's not really a way for a user to define type aliases that can be used, afaict. (e.g. `let x: Number = 5 in x` works, but `let T = Number in let x: T = 5 in x` does not).

Contracts are an expressive and powerful part of Nickel. -- Since they can be quite restrictive, Nickel docs advise against using these for functions, but in favour of using these for configs (e.g. for the `keymap.ncl`). https://nickel-lang.org/user-manual/types-vs-contracts/

I think what's tripping me up is that one of my favourite idioms is destructuring a record and using this as a broad function arg. e.g. using `{ rows, cols, num_keys }` as an argument to `fun { rows, cols, .. } => rows`. -- I couldn't figure out how to cleanly express "this type has rows and cols, and maybe other stuff".

This PR is a straightforward PR which changes the Nickel doc from `let ... in "C output"` to `{ ..., output = "C output" }`.

This is more idiomatic to Nickel, afaict. For a simpler example:

```
{
  add1 = fun x => x + 1,
  input,
  output = add1 input,
}
```

This file (`add1.ncl`) can then be used in Nickel like:

```
(import "add1.ncl") & { input = 4, }
```

or 

```
let lib = (import "add1.ncl") in
lib.add1 4
```

This is a pretty neat way of configuring things. https://nickel-lang.org/user-manual/modular-configurations

This PR also adds some `doc` annotations.

(Perhaps later, common parts of this matrix codegen file can be used for e.g. the CH32X firmware demo).