### PR TITLE
Record-ize the ncl code

### DIFF
--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -1,39 +1,54 @@
-let keymap = import "keymap.json" in
-
-let simple = {
-  key_type = "crate::key::simple::Key",
-  rust_expr = fun key => "crate::key::simple::Key(%{std.to_string key})",
-}
-in
-
-let keymap_len = std.array.length keymap in
-let keys_id = "Keys%{std.to_string keymap_len}" in
-
-let key_type_of_key = match {
-  { simple = key } => simple.key_type,
-  _ => "unknown_key_type"
-}
-in
-
-let rust_expr_of_key = match {
-  { simple = key } => simple.rust_expr key,
-  _ => "unknown_key_type"
-}
-in
-
-let key_types =
+{
   keymap
-  |> std.array.map key_type_of_key
-  |> std.string.join ","
-in
+    | doc "The imported keymap.json."
+    = import "keymap.json",
 
-let key_exprs =
-  keymap
-  |> std.array.map (fun key => "%{rust_expr_of_key key},")
-  |> std.string.join ""
-in
+  simple
+    | doc "Generates type declaration and value expression for smart_keymap::key::simple::Key."
+    = {
+      key_type = "crate::key::simple::Key",
+      rust_expr = fun key => "crate::key::simple::Key(%{std.to_string key})",
+    },
 
-m%"
+  keymap_len
+    | doc "The keymap length."
+    = std.array.length keymap,
+
+  keys_id
+    | doc "The identifier for the KeysN tuple struct used in the generated keymap.rs."
+    = "Keys%{std.to_string keymap_len}",
+
+  key_type_of_key
+    | doc "The type declaration for the key."
+    = match {
+      { simple = key } => simple.key_type,
+      _ => "unknown_key_type"
+    },
+
+  rust_expr_of_key
+    | doc "The Rust expression for the key."
+    = match {
+      { simple = key } => simple.rust_expr key,
+      _ => "unknown_key_type"
+    },
+
+  key_types
+    | doc "The comma-separated list of key types, passed to the KeysN generics."
+    =
+      keymap
+      |> std.array.map key_type_of_key
+      |> std.string.join ",",
+
+  key_exprs
+    | doc "The comma-separated list of key expressions, passed to the KeysN constructor."
+    =
+      keymap
+      |> std.array.map (fun key => "%{rust_expr_of_key key},")
+      |> std.string.join "",
+
+  keymap_rs
+    | doc "Text contents of the keymap.rs generated from the keymap.json"
+    = m%"
 crate::tuples::define_keys!(%{std.to_string keymap_len});
 
 type KeyDefinitionsType = %{keys_id}<
@@ -44,3 +59,4 @@ const KEY_DEFINITIONS: KeyDefinitionsType = %{keys_id}::new((
 %{key_exprs}
 ));
 "%
+}

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -1,10 +1,19 @@
-let keymap | { layers : Array (Array Number) } = import "keymap.ncl" in
+{
+  keymap
+    | { layers : Array (Array Number) }
+    | doc "The keymap.ncl file that gets rendered to JSON"
+    = import "keymap.ncl",
 
-let make_key = fun v =>
-  if std.is_number v then
-    { "simple" = v }
-  else
-    std.fail_with "unsupported value"
-in
+  make_key
+    | doc "Constructs a JSON-representable key value from the given value from keymap.ncl."
+    = fun v =>
+      if std.is_number v then
+        { "simple" = v }
+      else
+        std.fail_with "unsupported value",
 
-keymap.layers |> std.array.at 0 |> std.array.map make_key
+  keymap_json
+    | doc "The keymap.json output value."
+    =
+      keymap.layers |> std.array.at 0 |> std.array.map make_key,
+}

--- a/ncl/scripts/keymap-codegen.sh
+++ b/ncl/scripts/keymap-codegen.sh
@@ -18,6 +18,7 @@ DEST="${KEYMAP_DIR}/keymap.rs"
 nickel export \
   --format=raw \
   --import-path="${KEYMAP_DIR}" \
+  --field="keymap_rs" \
   "${NCL_DIR}/keymap-codegen.ncl" \
   > "${DEST}"
 

--- a/ncl/scripts/keymap-ncl-to-json.sh
+++ b/ncl/scripts/keymap-ncl-to-json.sh
@@ -19,5 +19,6 @@ nickel export \
   --format=json \
   --import-path="${KEYMAP_DIR}" \
   --import-path="${NCL_DIR}" \
+  --field="keymap_json" \
   "${NCL_DIR}/keymap-ncl-to-json.ncl" \
   > "${DEST}"


### PR DESCRIPTION
Nickel files seem to prefer being records, rather than one giant `let ... in ...` expression. -- It's easier to re-use functions, and add `doc` annotations.