### PR TITLE
NCL modularise firmware CH58x codegen

### DIFF
--- a/firmware/ch58x-ble-hid-keyboard-c/Makefile
+++ b/firmware/ch58x-ble-hid-keyboard-c/Makefile
@@ -5,6 +5,15 @@ all: generated/matrix.c
 clean:
 	rm generated/matrix.c
 
+.PHONY: test
+test:
+	nickel \
+	  eval \
+	  --field=keymap_indices \
+	  ncl/wabble-60.ncl \
+	  ncl/test-expected-wabble-60.ncl \
+	  ncl/test-actual-wabble-60.ncl
+
 generated/matrix.c:
 	nickel export \
 	  --format=raw \

--- a/firmware/ch58x-ble-hid-keyboard-c/Makefile
+++ b/firmware/ch58x-ble-hid-keyboard-c/Makefile
@@ -9,4 +9,6 @@ generated/matrix.c:
 	nickel export \
 	  --format=raw \
 	  --field=output \
-	  ncl/matrix_scan.ncl > generated/matrix.c
+	  ncl/wabble-60.ncl \
+	  ncl/matrix_scan.ncl \
+	  > generated/matrix.c

--- a/firmware/ch58x-ble-hid-keyboard-c/ncl/matrix_scan.ncl
+++ b/firmware/ch58x-ble-hid-keyboard-c/ncl/matrix_scan.ncl
@@ -17,58 +17,37 @@
       rows | Array { port | String, pin | Number },
       num_keys | Number,
     }
-    | doc "the cols/rows, and number of keys, used for generating the matrix scan code."
-    =
-      let gp = gpio_pins in
-      {
-        cols = [gp.A4, gp.A5, gp.A15, gp.A14, gp.A13, gp.A12, gp.A11, gp.A10],
-        rows = [gp.A8, gp.A9, gp.B15, gp.B14, gp.B13, gp.B12, gp.B7, gp.B4],
-        num_keys = 60,
-      },
+    | doc "the cols/rows, and number of keys, used for generating the matrix scan code.",
 
-  init_col
+  keymap_index_for_key
+    | doc "Returns the keymap index for the key corresponding to the (0-based) digital column_index and row_index.",
+
+  init_col_fragment
     | doc "Generates C fragment for initializing the given column pin, for keyboard_matrix_init."
     = fun { port, pin, .. } =>
       m%"
       GPIO%{port}_ModeCfg(GPIO_Pin_%{std.to_string pin}, GPIO_ModeOut_PP_5mA); // %{port}%{std.to_string pin}
   "%,
 
-  init_row
+  init_row_fragment
     | doc "Generates C fragment for initializing the given row pin, for keyboard_matrix_init"
     = fun { port, pin, .. } =>
       m%"
       GPIO%{port}_ModeCfg(GPIO_Pin_%{std.to_string pin}, GPIO_ModeIN_PD); // %{port}%{std.to_string pin}
   "%,
 
-  matrix_init
+  keyboard_matrix_init
     | doc "Generates C fragment with the keyboard_matrix_init function, for the given cols/rows."
     = fun { cols, rows, .. } =>
       m%"
   void keyboard_matrix_init(void) {
       // Cols
-      %{cols |> std.array.map init_col |> std.string.join "\n"}
+      %{cols |> std.array.map init_col_fragment |> std.string.join "\n"}
 
       // Rows
-      %{rows |> std.array.map init_row |>std.string.join "\n"}
+      %{rows |> std.array.map init_row_fragment |>std.string.join "\n"}
   }
   "%,
-
-  # The WABBLE-60 uses a digital matrix of 8x8 rows and columns,
-  #  forming a physical 5x12 matrix of keys.
-  #
-  # The physical matrix arranges keys column-wise.
-  #
-  # Want the keymap index to refer to keys row-wise.
-  #
-  # The given column_index and row_index refer to (digital) row/col, 0..7.
-  keymap_index_for_key
-    | doc "Returns the keymap index for the key corresponding to the (0-based) digital column_index and row_index."
-    = fun { column_index | Number, row_index | Number, .. } =>
-      let columnwise_index = column_index * 8 + row_index in
-      let physical_column_index = std.number.floor (columnwise_index / 5) in
-      let physical_row_index = columnwise_index % 5 in
-      let rowwise_index = physical_row_index * 12 + physical_column_index in
-      rowwise_index,
 
   matrix_scan_row_for_column
     | doc "Generates C fragment for reading a row, as part of COL2ROW scanning."
@@ -96,6 +75,15 @@
       GPIO%{col.port}_ResetBits(GPIO_Pin_%{std.to_string col.pin});
   "%,
 
+  keyboard_matrix_scan
+    | doc "Generates C fragment with the keyboard_matrix_scan function, for the given cols/rows."
+    = fun { cols, rows, .. } =>
+      m%"
+  void keyboard_matrix_scan(void) {
+      %{board.cols |> std.array.map_with_index (fun idx c => matrix_scan_column ({ col = c, column_index = idx, rows = board.rows })) |> std.string.join "\n"}
+  }
+  "%,
+
   output
     | doc "C code with keyboard_matrix_init and keyboard_matrix_scan functions."
     = m%"
@@ -106,7 +94,7 @@
   bool previousScan[%{std.to_string board.num_keys}] = { false };
   bool currentScan[%{std.to_string board.num_keys}] = { false };
 
-  %{matrix_init board}
+  %{keyboard_matrix_init board}
 
   void handle_index(uint32_t index) {
       if (previousScan[index] != currentScan[index]) {
@@ -120,9 +108,7 @@
       }
   }
 
-  void keyboard_matrix_scan(void) {
-      %{board.cols |> std.array.map_with_index (fun idx c => matrix_scan_column ({ col = c, column_index = idx, rows = board.rows })) |> std.string.join "\n"}
-  }
+  %{keyboard_matrix_scan board}
 
   "%
 }

--- a/firmware/ch58x-ble-hid-keyboard-c/ncl/test-actual-wabble-60.ncl
+++ b/firmware/ch58x-ble-hid-keyboard-c/ncl/test-actual-wabble-60.ncl
@@ -1,0 +1,14 @@
+{
+    keymap_index_for_key,
+    # = fun { column_index | Number, row_index | Number, .. } =>
+    keymap_indices = {
+      sw_1_1 = keymap_index_for_key { row_index = 0, column_index = 0},
+      sw_2_1 = keymap_index_for_key { row_index = 1, column_index = 0},
+      sw_3_1 = keymap_index_for_key { row_index = 2, column_index = 0},
+      sw_4_1 = keymap_index_for_key { row_index = 3, column_index = 0},
+      sw_5_1 = keymap_index_for_key { row_index = 4, column_index = 0},
+
+      sw_8_7 = keymap_index_for_key { row_index = 7, column_index = 6},
+      sw_4_8 = keymap_index_for_key { row_index = 3, column_index = 7},
+    },
+}

--- a/firmware/ch58x-ble-hid-keyboard-c/ncl/test-expected-wabble-60.ncl
+++ b/firmware/ch58x-ble-hid-keyboard-c/ncl/test-expected-wabble-60.ncl
@@ -1,0 +1,14 @@
+{
+    keymap_index_for_key,
+    # = fun { column_index | Number, row_index | Number, .. } =>
+    keymap_indices = {
+      sw_1_1 = 0,
+      sw_2_1 = 12,
+      sw_3_1 = 24,
+      sw_4_1 = 36,
+      sw_5_1 = 48,
+
+      sw_8_7 = 11,
+      sw_4_8 = 59,
+    },
+}

--- a/firmware/ch58x-ble-hid-keyboard-c/ncl/wabble-60.ncl
+++ b/firmware/ch58x-ble-hid-keyboard-c/ncl/wabble-60.ncl
@@ -1,0 +1,35 @@
+{
+  gpio_pins,
+
+  board
+    | {
+      cols | Array { port | String, pin | Number },
+      rows | Array { port | String, pin | Number },
+      num_keys | Number,
+    }
+    | doc "the cols/rows, and number of keys, used for generating the matrix scan code."
+    =
+      let gp = gpio_pins in
+      {
+        cols = [gp.A4, gp.A5, gp.A15, gp.A14, gp.A13, gp.A12, gp.A11, gp.A10],
+        rows = [gp.A8, gp.A9, gp.B15, gp.B14, gp.B13, gp.B12, gp.B7, gp.B4],
+        num_keys = 60,
+      },
+
+  # The WABBLE-60 uses a digital matrix of 8x8 rows and columns,
+  #  forming a physical 5x12 matrix of keys.
+  #
+  # The physical matrix arranges keys column-wise.
+  #
+  # Want the keymap index to refer to keys row-wise.
+  #
+  # The given column_index and row_index refer to (digital) row/col, 0..7.
+  keymap_index_for_key
+    | doc "Returns the keymap index for the key corresponding to the (0-based) digital column_index and row_index."
+    = fun { column_index | Number, row_index | Number, .. } =>
+      let columnwise_index = column_index * 8 + row_index in
+      let physical_column_index = std.number.floor (columnwise_index / 5) in
+      let physical_row_index = columnwise_index % 5 in
+      let rowwise_index = physical_row_index * 12 + physical_column_index in
+      rowwise_index,
+}


### PR DESCRIPTION
`.ncl` files are often better as records.

https://nickel-lang.org/user-manual/modular-configurations

By using records, I can put the `{ board }` in `wabble-60.ncl`, and the matrix scanning codegen in its file, and combine the two *without any `import` necessary!*.

Another neat thing this enables is "expected config" / "actual config"; checking this can be done with `nickel eval expected actual`. -- Here, I added some tests to assert about the keymap index calculations. 