### PR TITLE
rust: use crate-type "lib"; optionally build as "staticlib"

### DIFF
--- a/.github/workflows/keymaps.yaml
+++ b/.github/workflows/keymaps.yaml
@@ -29,8 +29,10 @@ jobs:
       - name: Build checkkeys_60key_keymap
         run: |
           env SMART_KEYMAP_CUSTOM_KEYMAP="$(pwd)/tests/keymaps/checkkeys_60key_keymap.rs" \
-            cargo build \
+            cargo rustc \
+              --crate-type "staticlib" \
               --target riscv32imac-unknown-none-elf \
               --release \
               --no-default-features \
+              --features "staticlib" \
               --features "usbd-human-interface-device"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["std"]
+default = ["std", "staticlib"]
 std = []
+staticlib = []
 usbd-human-interface-device = ["dep:usbd-human-interface-device"]
 
 [lib]
 name = "smart_keymap"
-crate-type = ["lib", "staticlib"]
+crate-type = ["lib"]
 
 [[test]]
 name = "cucumber-deserialization"

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all: include/smart_keymap.h
 test: include/smart_keymap.h
 	$(CARGO) test
 	env SMART_KEYMAP_CUSTOM_KEYMAP="$(shell pwd)/tests/keymaps/simple_keymap.rs" \
-	  $(CARGO) build
+	  $(CARGO) rustc --crate-type "staticlib"
 	cd tests/ceedling && ceedling
 
 .PHONY: clean

--- a/justfile
+++ b/justfile
@@ -17,9 +17,10 @@ build-test-keymap-rv-checkkeys_60key: (build-keymap-rv `pwd`/"tests/keymaps/chec
 build-keymap-rv $SMART_KEYMAP_CUSTOM_KEYMAP: (build-keymap-target SMART_KEYMAP_CUSTOM_KEYMAP "riscv32imac-unknown-none-elf")
 
 build-keymap-target $SMART_KEYMAP_CUSTOM_KEYMAP target:
-    cargo build \
+    cargo rustc \
+        --crate-type "staticlib" \
         --target riscv32imac-unknown-none-elf \
         --release \
         --no-default-features \
+        --features "staticlib" \
         --features "usbd-human-interface-device"
-

--- a/ncl/scripts/test-ncl-builds.sh
+++ b/ncl/scripts/test-ncl-builds.sh
@@ -29,7 +29,9 @@ SMART_KEYMAP_CUSTOM_KEYMAP=$(realpath "${KEYMAP_DIR}/keymap.rs")
 
 export SMART_KEYMAP_CUSTOM_KEYMAP
 
-cargo build \
+cargo rustc \
+    --crate-type "staticlib" \
     --target riscv32imac-unknown-none-elf \
     --release \
+    --features "staticlib" \
     --no-default-features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ pub unsafe extern "C" fn copy_hid_boot_keyboard_report(buf: *mut u8) {
     }
 }
 
-#[cfg(not(feature = "std"))]
+#[cfg(all(not(feature = "std"), feature = "staticlib"))]
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
     loop {}


### PR DESCRIPTION
Also towards #69, an RP2040 firmware example in rust, using smart keymap as a Rust library.

AFAIU, there's some friction using Rust with both staticlib and lib crate-types for no_std:

- staticlib requires a panic handler.

- When the rp2040 firmware example (which depends on smart-keymap with a local path) compiled.. the smart keymap library needs to build as a staticlib (because its crate type includes staticlib). It's a compiler error for the smart keymap lib to omit a panic handler. But, when the smart keymap lib includes panic handler, the rp2040 binary fails, because now there are multiple panic handlers. 
  - Omitting the panic handler from the RP2040 binary is *not* a good solution.. since this would constrain all library users to the same panic handler.

This PR works around the issue:

- The panic handler is gated by a cargo feature. (I was unable to find a `'#[cfg]` that knew the crate type. I thought `#![cfg_attr(..., crate-type=...])` would be cute, but the compiler authors were way ahead of me there).

- The scripts which require a static lib then pass `--crate-type=staticlib` to the `cargo rustc` (instead of `cargo build`) command.

An alternative (and conceptually cleaner) approach that probably would have worked would be to split `smart-keymap` up in a cargo workspace, with a (Rust) core and a staticlib other crate. -- It may be worth arranging like this later; especially if a basic keyboard firmware is provided alongside the smart keymap lib.