### PR TITLE
rust: refactor layered::LayeredKey PressedKeyState

### DIFF
--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -69,7 +69,7 @@ impl<E> IntoIterator for PressedKeyEvents<E> {
 ///  produces.
 /// (e.g. [layered::LayeredKey]'s pressed key state passes-through to
 ///  the keys of its layers).
-pub trait Key<PK: Key = Self>: Copy + Debug + PartialEq {
+pub trait Key: Copy + Debug + PartialEq {
     /// The associated [Context] is used to provide state that
     ///  may affect behaviour when pressing the key.
     /// (e.g. the behaviour of [layered::LayeredKey] depends on which
@@ -84,7 +84,7 @@ pub trait Key<PK: Key = Self>: Copy + Debug + PartialEq {
     ///  for the pressed key.
     /// (e.g. [tap_hold::PressedKeyState] implements behaviour resolving
     ///  the pressed tap hold key as either 'tap' or 'hold').
-    type PressedKeyState: PressedKeyState<PK, Event = Self::Event>;
+    type PressedKeyState: PressedKeyState<Self, Event = Self::Event>;
 
     /// [Key::new_pressed_key] produces a pressed key value, and may
     ///  yield some [ScheduledEvent]s.
@@ -95,7 +95,7 @@ pub trait Key<PK: Key = Self>: Copy + Debug + PartialEq {
         context: &Self::Context,
         keymap_index: u16,
     ) -> (
-        input::PressedKey<PK, Self::PressedKeyState>,
+        input::PressedKey<Self, Self::PressedKeyState>,
         PressedKeyEvents<Self::Event>,
     );
 }


### PR DESCRIPTION
As noted in #79, seems like `key::layered::LayeredKey` caused issues because its `key::Key` trait implementation's associated `PressedKey`'s `key::Key` generic wasn't self.

(e.g. `simple::Key`'s `PressedKey`'s `key::Key` generic is `simple::Key`, but `LayeredKey`'s `PressedKey` used a generic key). 

Many smart keys act as 'key modifiers', where the smart key might pass-through and behave as another key. e.g. tap-hold is the same as its tap key when tapped. But, certainly tap-hold's pressed key state involves keeping track of whether the tap-hold key has resolved as a tap or a hold.

` LayeredKey` similarly passes- through its functionality to other keys. -- It happens to not have any particular pressed key state; but other than that, might as well "pass-through" as another key with an implementation similar to what other smart keys have.