### PR TITLE
Add Layers Cucumber spec

### DIFF
--- a/features/keymap/layered.feature
+++ b/features/keymap/layered.feature
@@ -1,0 +1,48 @@
+Feature: Layers
+
+  Background:
+
+    Layers can be used by setting using the `layers` property
+     of a keymap.ncl.
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        layers = [
+          [
+            { layer_modifier = { hold = 0 } }, K.A,
+          ],
+          [
+            K.TTTT, K.B,
+          ],
+        ],
+      }
+      """
+
+  Example: acts base key when no layer active
+    When the keymap registers the following input
+      """
+      [
+        Press(keymap_index: 1),
+      ]
+      """
+    Then the HID keyboard report from the next tick() should equal
+      """
+      let K = import "hid-usage-keyboard.ncl" in
+      { key_codes = [K.A] }
+      """
+
+  Example: acts the key on that layer when layer modifier held
+    When the keymap registers the following input
+      """
+      [
+        Press(keymap_index: 0),
+        Press(keymap_index: 1),
+      ]
+      """
+    Then the HID keyboard report from the next tick() should equal
+      """
+      let K = import "hid-usage-keyboard.ncl" in
+      { key_codes = [K.B] }
+      """

--- a/features/keymap/tap_hold.feature
+++ b/features/keymap/tap_hold.feature
@@ -26,7 +26,7 @@ Feature: TapHold Key
         Release(keymap_index: 0)
       ]
       """
-    Then the HID keyboard report from the next tick() should equal
+    Then the HID keyboard report should equal
       """
       let K = import "hid-usage-keyboard.ncl" in
       { key_codes = [K.A] }

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -25,6 +25,8 @@
       { key_code = kc } => kc,
       # Make key::layered::ModifierKey
       { layer_modifier = { hold = hold_layer } } => { Hold = hold_layer },
+      # Null values (None) stay null
+      null => null,
       _ => std.fail_with "unsupported item in keymap.ncl",
     },
 
@@ -43,6 +45,8 @@
       # Make key::layered::ModifierKey
       k@{ layer_modifier = { hold = hold_layer } } =>
         { LayerModifier = { key = to_json_serialized_key k } },
+      # Null values (None) stay null
+      null => null,
       _ => std.fail_with "unsupported item in keymap.ncl",
     },
 

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -152,6 +152,7 @@ fn perform_input(world: &mut KeymapWorld, step: &Step) {
 
     for input in inputs {
         world.keymap.handle_input(input);
+        world.keymap.tick();
     }
 }
 

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -58,7 +58,7 @@ fn nickel_to_json_for_hid_report(keymap_ncl: &str) -> io::Result<String> {
 }
 
 type NestedKey = key::composite::DefaultNestableKey;
-type LayersImpl = key::layered::ArrayImpl<0>;
+type LayersImpl = key::layered::ArrayImpl<1>;
 type Key = key::composite::Key<NestedKey, LayersImpl>;
 type Context = key::composite::Context<NestedKey, LayersImpl>;
 

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -10,8 +10,6 @@ use smart_keymap::key;
 use smart_keymap::keymap::Keymap;
 use smart_keymap::tuples;
 
-use key::composite::Key;
-
 mod common;
 
 use common::Deserializer;
@@ -59,11 +57,16 @@ fn nickel_to_json_for_hid_report(keymap_ncl: &str) -> io::Result<String> {
     String::from_utf8(output.stdout).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
 }
 
+type NestedKey = key::composite::DefaultNestableKey;
+type LayersImpl = key::layered::ArrayImpl<0>;
+type Key = key::composite::Key<NestedKey, LayersImpl>;
+type Context = key::composite::Context<NestedKey, LayersImpl>;
+
 #[derive(Debug)]
 enum LoadedKeymap {
     NoKeymap,
-    Keymap1(Keymap<tuples::Keys1<Key>>),
-    Keymap2(Keymap<tuples::Keys2<Key, Key>>),
+    Keymap1(Keymap<tuples::Keys1<Key, Context>, LayersImpl>),
+    Keymap2(Keymap<tuples::Keys2<Key, Key, Context>, LayersImpl>),
 }
 
 impl LoadedKeymap {


### PR DESCRIPTION
There are a few things that are quite fragile about this:

- The TapHold's "tap" only lasts for 1 tick.. -- This should be adjusted to last for e.g. 10 ticks.

- The Layer Modifier key's effect doesn't affect the context until after tick() occurs. -- I wonder if this is necessary? -- Should be possible all 'immediate' events to be handled asap.

- Deserialising into `LayeredKey` requires knowing how many layers there are. -- Ideally, e.g. can deserialise a keymap.ncl with 3 layers into a LK with 64 layers.