### PR TITLE
Deserialize LayeredKeys allow deserialising from smaller arrays

### DIFF
--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -642,7 +642,7 @@ mod tests {
     fn test_deserialize_ron_layered_key_simple_0layer() {
         type L = ArrayImpl<0>;
         let actual_key: LayeredKey<key::simple::Key, L> =
-            ron::from_str("(base: (0x04), layered: ())").unwrap();
+            ron::from_str("(base: (0x04), layered: [])").unwrap();
         let expected_key: LayeredKey<key::simple::Key, L> = LayeredKey {
             base: key::simple::Key(0x04),
             layered: [],
@@ -666,7 +666,7 @@ mod tests {
     fn test_deserialize_ron_layered_key_simple_1layer_none() {
         type L = ArrayImpl<1>;
         let actual_key: LayeredKey<key::simple::Key, L> =
-            ron::from_str("LayeredKey(base: Key(0x04), layered: (None))").unwrap();
+            ron::from_str("LayeredKey(base: Key(0x04), layered: [None])").unwrap();
         let expected_key: LayeredKey<key::simple::Key, L> = LayeredKey {
             base: key::simple::Key(0x04),
             layered: [None],

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -58,7 +58,7 @@ fn nickel_to_json_for_hid_report(keymap_ncl: &str) -> io::Result<String> {
 }
 
 type NestedKey = key::composite::DefaultNestableKey;
-type LayersImpl = key::layered::ArrayImpl<1>;
+type LayersImpl = key::layered::ArrayImpl<16>;
 type Key = key::composite::Key<NestedKey, LayersImpl>;
 type Context = key::composite::Context<NestedKey, LayersImpl>;
 


### PR DESCRIPTION
The Keys must be `Copy`able, hence can't use `Vec`s.

This isn't a problem for keymaps proper, where the `keymap.ncl` can calculate the number of layers exactly.

It's tedious for the Cucumber test suit, since tests may vary in the number of layers they have. -- serde doesn't deserialise `[T; 3]` into `[T; 10000]`, for example; and so to deserialise a list of layers `[Option<Key>; N]`, we have to know `N` in advance. -- If the Cucumber step definitions all have to have the number of layers known, then all the `.features` would have to have the same number of layers.

This PR works around the issue by telling `serde` to deserialise with a custom function. -- The function deserialises into a Vec, then tries to construct `Layers` from that vec.