### PR TITLE
Use PressedKeyEvents from PressedKeyState

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -44,7 +44,7 @@ impl<K: crate::key::Key, S: crate::key::PressedKeyState<K, Event = K::Event>> cr
     fn handle_event(
         &mut self,
         event: crate::key::Event<Self::Event>,
-    ) -> impl IntoIterator<Item = crate::key::Event<Self::Event>> {
+    ) -> crate::key::PressedKeyEvents<Self::Event> {
         self.pressed_key_state
             .handle_event_for(self.keymap_index, &self.key, event)
     }

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -266,33 +266,33 @@ where
         keymap_index: u16,
         key: &Key<DefaultNestableKey, L>,
         event: key::Event<Self::Event>,
-    ) -> impl IntoIterator<Item = key::Event<Self::Event>> {
+    ) -> key::PressedKeyEvents<Self::Event> {
         match (key, self) {
             (Key::TapHold { key, .. }, PressedKeyState::TapHold(pks)) => {
                 if let Ok(ev) = key::Event::try_from(event) {
                     let events = pks.handle_event_for(keymap_index, key, ev);
-                    events.into_iter().map(|ev| ev.into()).collect()
+                    events.into_events()
                 } else {
-                    heapless::Vec::<key::Event<Self::Event>, 2>::new()
+                    key::PressedKeyEvents::no_events()
                 }
             }
             (Key::LayerModifier { key, .. }, PressedKeyState::LayerModifier(pks)) => {
                 if let Ok(ev) = key::Event::try_from(event) {
                     let events = pks.handle_event_for(keymap_index, key, ev);
-                    events.into_iter().map(|ev| ev.into()).collect()
+                    events.into_events()
                 } else {
-                    heapless::Vec::<key::Event<Self::Event>, 2>::new()
+                    key::PressedKeyEvents::no_events()
                 }
             }
             (Key::Layered { key, .. }, PressedKeyState::Layered(pks)) => {
                 if let Ok(ev) = key::Event::try_from(event) {
                     let events = pks.handle_event_for(keymap_index, key, ev);
-                    events.into_iter().map(|ev| ev.into()).collect()
+                    events.into_events()
                 } else {
-                    heapless::Vec::<key::Event<Self::Event>, 2>::new()
+                    key::PressedKeyEvents::no_events()
                 }
             }
-            _ => heapless::Vec::new(),
+            _ => key::PressedKeyEvents::no_events(),
         }
     }
 
@@ -403,7 +403,7 @@ mod tests {
             .handle_event(key::Event::Input(input::Event::Release { keymap_index }));
 
         // Assert
-        let _key_ev = match events.into_iter().next() {
+        let _key_ev = match events.into_iter().next().map(|sch_ev| sch_ev.event) {
             Some(key::Event::Key(Event::LayerModification(
                 layered::LayerEvent::LayerDeactivated(layer),
             ))) => {
@@ -469,7 +469,7 @@ mod tests {
         context.layer_context.activate_layer(0);
         let events = pressed_lmod_key
             .handle_event(key::Event::Input(input::Event::Release { keymap_index: 0 }));
-        let key_ev = match events.into_iter().next() {
+        let key_ev = match events.into_iter().next().map(|sch_ev| sch_ev.event) {
             Some(key::Event::Key(ev)) => ev,
             _ => panic!("Expected an Event::Key(_)"),
         };

--- a/src/key/dynamic.rs
+++ b/src/key/dynamic.rs
@@ -8,7 +8,7 @@ use key::PressedKey as _;
 use super::ScheduledEvent;
 
 /// A dyn-compatible Key trait.
-pub trait Key<Ev, const N: usize = 2>: Debug
+pub trait Key<Ev, const M: usize = 2>: Debug
 where
     Ev: Copy + Debug + Ord,
 {
@@ -25,7 +25,7 @@ where
         &mut self,
         context: &Self::Context,
         event: key::Event<Ev>,
-    ) -> heapless::Vec<key::ScheduledEvent<Ev>, N>;
+    ) -> heapless::Vec<key::ScheduledEvent<Ev>, M>;
 
     /// Output HID keyboard code for the [Key].
     fn key_output(&self) -> Option<key::KeyOutput>;
@@ -67,8 +67,8 @@ impl<
         K: key::Key,
         Ctx: key::Context<Event = Ev> + Debug + 'static,
         Ev: Copy + Debug + Ord,
-        const N: usize,
-    > Key<Ev, N> for DynamicKey<K, Ctx, Ev>
+        const M: usize,
+    > Key<Ev, M> for DynamicKey<K, Ctx, Ev>
 where
     key::Event<K::Event>: TryFrom<key::Event<Ev>>,
     key::Event<Ev>: From<key::Event<K::Event>>,
@@ -80,8 +80,8 @@ where
         &mut self,
         context: &Self::Context,
         event: key::Event<Ev>,
-    ) -> heapless::Vec<key::ScheduledEvent<Ev>, N> {
-        let mut scheduled_events: heapless::Vec<key::ScheduledEvent<Ev>, N> = heapless::Vec::new();
+    ) -> heapless::Vec<key::ScheduledEvent<Ev>, M> {
+        let mut scheduled_events: heapless::Vec<key::ScheduledEvent<Ev>, M> = heapless::Vec::new();
 
         if let Some(ref mut pressed_key) = &mut self.pressed_key {
             if let Ok(event) = event.try_into() {

--- a/src/key/dynamic.rs
+++ b/src/key/dynamic.rs
@@ -5,8 +5,6 @@ use crate::{input, key};
 
 use key::PressedKey as _;
 
-use super::ScheduledEvent;
-
 /// A dyn-compatible Key trait.
 pub trait Key<Ev, const M: usize = 2>: Debug
 where
@@ -89,7 +87,7 @@ where
                     pressed_key
                         .handle_event(event)
                         .into_iter()
-                        .map(|ev| ScheduledEvent::immediate(ev).into_scheduled_event()),
+                        .map(|ev| ev.into_scheduled_event()),
                 );
             }
 

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -26,6 +26,11 @@ impl<E: Copy + Debug> PressedKeyEvents<E> {
     }
 
     /// Constructs a [PressedKeyEvents] with an immediate [Event].
+    pub fn event(event: Event<E>) -> Self {
+        PressedKeyEvents(Some(ScheduledEvent::immediate(event)).into_iter().collect())
+    }
+
+    /// Constructs a [PressedKeyEvents] with an immediate [Event].
     pub fn key_event(key_event: E) -> Self {
         PressedKeyEvents(
             Some(ScheduledEvent::immediate(Event::Key(key_event)))
@@ -41,6 +46,11 @@ impl<E: Copy + Debug> PressedKeyEvents<E> {
                 .into_iter()
                 .collect(),
         )
+    }
+
+    /// Adds an event with the schedule to the [PressedKeyEvents].
+    pub fn schedule_event(&mut self, delay: u16, event: Event<E>) {
+        self.0.push(ScheduledEvent::after(delay, event)).unwrap();
     }
 
     /// Maps the PressedKeyEvents to a new type.
@@ -148,10 +158,7 @@ pub trait PressedKey {
     type Event;
 
     /// Used to update the [PressedKey]'s state, and possibly yield event(s).
-    fn handle_event(
-        &mut self,
-        event: Event<Self::Event>,
-    ) -> impl IntoIterator<Item = Event<Self::Event>>;
+    fn handle_event(&mut self, event: Event<Self::Event>) -> PressedKeyEvents<Self::Event>;
 
     /// Output for the pressed key.
     fn key_output(&self) -> Option<KeyOutput>;
@@ -171,7 +178,7 @@ pub trait PressedKeyState<K: Key>: Debug {
         keymap_index: u16,
         key: &K,
         event: Event<Self::Event>,
-    ) -> impl IntoIterator<Item = Event<Self::Event>>;
+    ) -> PressedKeyEvents<Self::Event>;
 
     /// Output for the pressed key state.
     fn key_output(&self, key: &K) -> Option<KeyOutput>;

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -45,11 +45,6 @@ impl<E: Copy> PressedKeyEvents<E> {
             event: scheduled_event.event.into(),
         }))
     }
-
-    /// Returns the [ScheduledEvent] if it exists.
-    pub fn into_option(self) -> Option<ScheduledEvent<E>> {
-        self.0
-    }
 }
 
 impl<E> IntoIterator for PressedKeyEvents<E> {

--- a/src/key/simple.rs
+++ b/src/key/simple.rs
@@ -64,8 +64,8 @@ impl key::PressedKeyState<Key> for PressedKeyState {
         _keymap_index: u16,
         _key: &Key,
         _event: key::Event<Self::Event>,
-    ) -> impl IntoIterator<Item = key::Event<Self::Event>> {
-        None
+    ) -> key::PressedKeyEvents<Self::Event> {
+        key::PressedKeyEvents::no_events()
     }
 
     /// Simple key always has a key_code.

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -287,7 +287,6 @@ mod tests {
 
         // Act
         keymap.handle_input(input::Event::Press { keymap_index: 0 });
-        keymap.tick();
         let actual_report = keymap.boot_keyboard_report();
 
         // Assert
@@ -310,7 +309,6 @@ mod tests {
 
         // Act
         keymap.handle_input(input::Event::Press { keymap_index: 0 });
-        keymap.tick();
         let actual_report = keymap.boot_keyboard_report();
 
         // Assert
@@ -340,7 +338,6 @@ mod tests {
 
         // Act
         keymap.handle_input(input::Event::Press { keymap_index: 0 });
-        keymap.tick();
         keymap.handle_input(input::Event::Press { keymap_index: 1 });
         let actual_report = keymap.boot_keyboard_report();
 
@@ -403,7 +400,6 @@ mod tests {
 
         // Act
         keymap.handle_input(input::Event::Press { keymap_index: 0 });
-        keymap.tick();
         keymap.handle_input(input::Event::Press { keymap_index: 1 });
         let actual_report = keymap.boot_keyboard_report();
 
@@ -435,11 +431,8 @@ mod tests {
 
         // Act
         keymap.handle_input(input::Event::Press { keymap_index: 0 });
-        keymap.tick();
         keymap.handle_input(input::Event::Press { keymap_index: 1 });
-        keymap.tick();
         keymap.handle_input(input::Event::Release { keymap_index: 0 });
-        keymap.tick();
         let actual_report = keymap.boot_keyboard_report();
 
         // Assert
@@ -470,11 +463,8 @@ mod tests {
 
         // Act
         keymap.handle_input(input::Event::Press { keymap_index: 0 });
-        keymap.tick();
         keymap.handle_input(input::Event::Release { keymap_index: 0 });
-        keymap.tick();
         keymap.handle_input(input::Event::Press { keymap_index: 1 });
-        keymap.tick();
         let actual_report = keymap.boot_keyboard_report();
 
         // Assert

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -172,6 +172,8 @@ impl<
             }
         });
 
+        self.handle_all_pending_events();
+
         match ev {
             input::Event::Press { keymap_index } => {
                 let key = &mut self.key_definitions[keymap_index as usize];
@@ -211,14 +213,13 @@ impl<
                     .map(|i| self.pressed_inputs.remove(i));
             }
         }
+
+        self.handle_all_pending_events();
     }
 
-    /// Advances the state of the keymap by one tick.
-    pub fn tick(&mut self) {
-        self.event_scheduler.tick();
-
+    fn handle_all_pending_events(&mut self) {
         // take from pending
-        if let Some(ev) = self.event_scheduler.dequeue() {
+        while let Some(ev) = self.event_scheduler.dequeue() {
             // Update each of the pressed keys with the event.
             self.pressed_inputs.iter_mut().for_each(|pi| {
                 if let input::PressedInput::Key { keymap_index, .. } = pi {
@@ -238,6 +239,13 @@ impl<
                 self.handle_input(input_ev);
             }
         }
+    }
+
+    /// Advances the state of the keymap by one tick.
+    pub fn tick(&mut self) {
+        self.event_scheduler.tick();
+
+        self.handle_all_pending_events();
     }
 
     /// Returns the the pressed key codes.

--- a/src/tuples.rs
+++ b/src/tuples.rs
@@ -17,15 +17,15 @@ pub struct Keys1<
     K0: key::Key,
     Ctx: key::Context<Event = Ev> + Debug = composite::Context<composite::DefaultNestableKey>,
     Ev: Copy + Debug + Ord = composite::Event,
-    const N: usize = 2,
+    const M: usize = 2,
 >(dynamic::DynamicKey<K0, Ctx, Ev>);
 
 impl<
         K0: key::Key,
         Ctx: key::Context<Event = Ev> + Debug,
         Ev: Copy + Debug + Ord,
-        const N: usize,
-    > Keys1<K0, Ctx, Ev, N>
+        const M: usize,
+    > Keys1<K0, Ctx, Ev, M>
 {
     /// Constructs a KeysN for the given tuple.
     pub const fn new((k0,): (K0,)) -> Self {
@@ -37,14 +37,14 @@ impl<
         K0: key::Key + 'static,
         Ctx: key::Context<Event = Ev> + Debug + 'static,
         Ev: Copy + Debug + Ord + 'static,
-        const N: usize,
-    > Index<usize> for Keys1<K0, Ctx, Ev, N>
+        const M: usize,
+    > Index<usize> for Keys1<K0, Ctx, Ev, M>
 where
     key::Event<<K0 as key::Key>::Event>: TryFrom<key::Event<Ev>>,
     key::Event<Ev>: From<key::Event<<K0 as key::Key>::Event>>,
     for<'c> &'c <K0 as key::Key>::Context: From<&'c Ctx>,
 {
-    type Output = dyn dynamic::Key<Ev, N, Context = Ctx>;
+    type Output = dyn dynamic::Key<Ev, M, Context = Ctx>;
 
     fn index(&self, idx: usize) -> &Self::Output {
         match idx {
@@ -58,8 +58,8 @@ impl<
         K0: crate::key::Key + 'static,
         Ctx: crate::key::Context<Event = Ev> + Debug + 'static,
         Ev: Copy + Debug + Ord + 'static,
-        const N: usize,
-    > IndexMut<usize> for Keys1<K0, Ctx, Ev, N>
+        const M: usize,
+    > IndexMut<usize> for Keys1<K0, Ctx, Ev, M>
 where
     crate::key::Event<<K0 as crate::key::Key>::Event>: TryFrom<crate::key::Event<Ev>>,
     crate::key::Event<Ev>: From<crate::key::Event<<K0 as crate::key::Key>::Event>>,
@@ -77,15 +77,15 @@ impl<
         K0: crate::key::Key + 'static,
         Ctx: crate::key::Context<Event = Ev> + Debug + 'static,
         Ev: Copy + Debug + Ord + 'static,
-        const N: usize,
-    > KeysReset for Keys1<K0, Ctx, Ev, N>
+        const M: usize,
+    > KeysReset for Keys1<K0, Ctx, Ev, M>
 where
     crate::key::Event<<K0 as crate::key::Key>::Event>: TryFrom<crate::key::Event<Ev>>,
     crate::key::Event<Ev>: From<crate::key::Event<<K0 as crate::key::Key>::Event>>,
     for<'c> &'c <K0 as crate::key::Key>::Context: From<&'c Ctx>,
 {
     fn reset(&mut self) {
-        <dynamic::DynamicKey<K0, Ctx, Ev> as dynamic::Key<Ev, N>>::reset(&mut self.0)
+        <dynamic::DynamicKey<K0, Ctx, Ev> as dynamic::Key<Ev, M>>::reset(&mut self.0)
     }
 }
 

--- a/tests/ceedling/test/test_keydef_taphold.c
+++ b/tests/ceedling/test/test_keydef_taphold.c
@@ -63,7 +63,11 @@ void test_taphold_dth_uth_eventually_clears(void) {
 
     keymap_tick(actual_report);
 
-    keymap_tick(actual_report); // The 'tap' from the TapHold key should be released.
+    // The 'tap' from the TapHold key should be released.
+    // after ten ticks.
+    for (int i = 0; i < 20; i++) {
+        keymap_tick(actual_report);
+    }
 
     TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report, 8);
 }

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -152,7 +152,6 @@ fn perform_input(world: &mut KeymapWorld, step: &Step) {
 
     for input in inputs {
         world.keymap.handle_input(input);
-        world.keymap.tick();
     }
 }
 


### PR DESCRIPTION
Fixes issues mentioned in #85:

- The 'tap' from TapHold now occurs after 10 ticks; this makes the testing a bit less fragile about it.

- All pending events get processed when received; so now activating a layer modifier immediately activates the layer, instead of having to wait until the next keymap tick is invoked.