### PR TITLE
rust: copy Context as values

### DIFF
--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -84,7 +84,7 @@ where
 
     fn new_pressed_key(
         &self,
-        context: &Self::Context,
+        context: Self::Context,
         keymap_index: u16,
     ) -> (
         input::PressedKey<Self, Self::PressedKeyState>,
@@ -92,15 +92,15 @@ where
     ) {
         match self {
             Key::Simple { key, .. } => {
-                let (pressed_key, events) = key.new_pressed_key(&(), keymap_index);
+                let (pressed_key, events) = key.new_pressed_key((), keymap_index);
                 (pressed_key.into(), events.into_events())
             }
             Key::TapHold { key, .. } => {
-                let (pressed_key, events) = key.new_pressed_key(&(), keymap_index);
+                let (pressed_key, events) = key.new_pressed_key((), keymap_index);
                 (pressed_key.into(), events.into_events())
             }
             Key::LayerModifier { key, .. } => {
-                let (pressed_key, events) = key::Key::new_pressed_key(key, &(), keymap_index);
+                let (pressed_key, events) = key::Key::new_pressed_key(key, (), keymap_index);
                 (pressed_key.into(), events.into_events())
             }
             Key::Layered { key, .. } => {
@@ -142,17 +142,15 @@ impl<L: layered::LayerImpl> key::Context for Context<DefaultNestableKey, L> {
 }
 
 /// simple::Context from composite::Context
-impl<L: layered::LayerImpl> From<&Context<DefaultNestableKey, L>> for &() {
-    fn from(_: &Context<DefaultNestableKey, L>) -> Self {
-        &()
+impl<L: layered::LayerImpl> From<Context<DefaultNestableKey, L>> for () {
+    fn from(_: Context<DefaultNestableKey, L>) -> Self {
+        ()
     }
 }
 
-impl<'c, L: layered::LayerImpl> From<&'c Context<DefaultNestableKey, L>>
-    for &'c layered::Context<(), L>
-{
-    fn from(ctx: &'c Context<DefaultNestableKey, L>) -> Self {
-        &ctx.layer_context
+impl<L: layered::LayerImpl> From<Context<DefaultNestableKey, L>> for layered::Context<(), L> {
+    fn from(ctx: Context<DefaultNestableKey, L>) -> Self {
+        ctx.layer_context
     }
 }
 
@@ -396,7 +394,7 @@ mod tests {
         let keymap_index: u16 = 0;
         let key = K::layer_modifier(layered::ModifierKey::Hold(0));
         let context = Ctx::new();
-        let (mut pressed_lmod_key, _) = key.new_pressed_key(&context, keymap_index);
+        let (mut pressed_lmod_key, _) = key.new_pressed_key(context, keymap_index);
 
         // Act
         let events = pressed_lmod_key
@@ -429,7 +427,7 @@ mod tests {
             )),
         ];
         let mut context = Ctx::new();
-        let (_pressed_key, pressed_key_events) = keys[0].new_pressed_key(&context, 0);
+        let (_pressed_key, pressed_key_events) = keys[0].new_pressed_key(context, 0);
         let maybe_ev = pressed_key_events.into_iter().next();
 
         // Act
@@ -465,7 +463,7 @@ mod tests {
             )),
         ];
         let mut context = Ctx::new();
-        let (mut pressed_lmod_key, _) = keys[0].new_pressed_key(&context, 0);
+        let (mut pressed_lmod_key, _) = keys[0].new_pressed_key(context, 0);
         context.layer_context.activate_layer(0);
         let events = pressed_lmod_key
             .handle_event(key::Event::Input(input::Event::Release { keymap_index: 0 }));
@@ -503,7 +501,7 @@ mod tests {
 
         // Act
         let keymap_index: u16 = 2;
-        let (pressed_key, _) = keys[keymap_index as usize].new_pressed_key(&context, keymap_index);
+        let (pressed_key, _) = keys[keymap_index as usize].new_pressed_key(context, keymap_index);
         let actual_keycode = pressed_key.key_output();
 
         // Assert
@@ -531,7 +529,7 @@ mod tests {
 
         // Act
         let keymap_index: u16 = 1;
-        let (pressed_key, _) = keys[keymap_index as usize].new_pressed_key(&context, keymap_index);
+        let (pressed_key, _) = keys[keymap_index as usize].new_pressed_key(context, keymap_index);
         let actual_keycode = pressed_key.key_output();
 
         // Assert

--- a/src/key/dynamic.rs
+++ b/src/key/dynamic.rs
@@ -21,7 +21,7 @@ where
     /// - a pressed key will receive all kinds of [input::Event].
     fn handle_event(
         &mut self,
-        context: &Self::Context,
+        context: Self::Context,
         event: key::Event<Ev>,
     ) -> heapless::Vec<key::ScheduledEvent<Ev>, M>;
 
@@ -70,13 +70,13 @@ impl<
 where
     key::Event<K::Event>: TryFrom<key::Event<Ev>>,
     key::Event<Ev>: From<key::Event<K::Event>>,
-    for<'c> &'c K::Context: From<&'c Ctx>,
+    K::Context: From<Ctx>,
 {
     type Context = Ctx;
 
     fn handle_event(
         &mut self,
-        context: &Self::Context,
+        context: Self::Context,
         event: key::Event<Ev>,
     ) -> heapless::Vec<key::ScheduledEvent<Ev>, M> {
         let mut scheduled_events: heapless::Vec<key::ScheduledEvent<Ev>, M> = heapless::Vec::new();
@@ -138,11 +138,11 @@ mod tests {
         // Act
         let keymap_index: u16 = 5; // arbitrary
         let _ = dyn_key.handle_event(
-            &context,
+            context,
             key::Event::Input(input::Event::Press { keymap_index }),
         );
         let _ = dyn_key.handle_event(
-            &context,
+            context,
             key::Event::Input(input::Event::Release { keymap_index }),
         );
 

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -72,7 +72,7 @@ impl key::Key for ModifierKey {
 
     fn new_pressed_key(
         &self,
-        _context: &Self::Context,
+        _context: Self::Context,
         keymap_index: u16,
     ) -> (
         input::PressedKey<Self, Self::PressedKeyState>,
@@ -240,7 +240,7 @@ impl<L: LayerImpl, K: key::Key> key::Key for LayeredKey<K, L> {
 
     fn new_pressed_key(
         &self,
-        context: &Self::Context,
+        context: Self::Context,
         keymap_index: u16,
     ) -> (
         input::PressedKey<Self, Self::PressedKeyState>,
@@ -252,7 +252,7 @@ impl<L: LayerImpl, K: key::Key> key::Key for LayeredKey<K, L> {
             .unwrap_or(self.base);
 
         let (passthru_pk, passthru_events) =
-            passthru_key.new_pressed_key(&context.inner_context, keymap_index);
+            passthru_key.new_pressed_key(context.inner_context, keymap_index);
 
         let pressed_key_state = PressedLayeredKeyState::new(passthru_pk);
         (
@@ -449,12 +449,10 @@ mod tests {
 
         // Act: without activating a layer, press the layered key
         let keymap_index = 9; // arbitrary
-        let (actual_pressed_key, actual_event) =
-            layered_key.new_pressed_key(&context, keymap_index);
+        let (actual_pressed_key, actual_event) = layered_key.new_pressed_key(context, keymap_index);
 
         // Assert
-        let (expected_pressed_key, expected_event) =
-            expected_key.new_pressed_key(&(), keymap_index);
+        let (expected_pressed_key, expected_event) = expected_key.new_pressed_key((), keymap_index);
         assert_eq!(
             actual_pressed_key.pressed_key_state.passthru_pk,
             expected_pressed_key
@@ -479,12 +477,12 @@ mod tests {
 
         // Act: without activating a layer, press the layered key
         let keymap_index = 9; // arbitrary
-        let (actual_pressed_key, _event) = layered_key.new_pressed_key(&context, keymap_index);
+        let (actual_pressed_key, _event) = layered_key.new_pressed_key(context, keymap_index);
 
         let actual_key_output = actual_pressed_key.key_output();
 
         // Assert
-        let (expected_pressed_key, _event) = expected_key.new_pressed_key(&(), keymap_index);
+        let (expected_pressed_key, _event) = expected_key.new_pressed_key((), keymap_index);
         let expected_key_output = expected_pressed_key.key_output();
         assert_eq!(actual_key_output, expected_key_output);
         assert_eq!(actual_key_output, Some(KeyOutput::from_key_code(0x04)));
@@ -510,12 +508,10 @@ mod tests {
         context.handle_event(LayerEvent::LayerActivated(1));
         context.handle_event(LayerEvent::LayerActivated(2));
         let keymap_index = 9; // arbitrary
-        let (actual_pressed_key, actual_event) =
-            layered_key.new_pressed_key(&context, keymap_index);
+        let (actual_pressed_key, actual_event) = layered_key.new_pressed_key(context, keymap_index);
 
         // Assert
-        let (expected_pressed_key, expected_event) =
-            expected_key.new_pressed_key(&(), keymap_index);
+        let (expected_pressed_key, expected_event) = expected_key.new_pressed_key((), keymap_index);
         assert_eq!(
             actual_pressed_key.pressed_key_state.passthru_pk,
             expected_pressed_key
@@ -543,12 +539,10 @@ mod tests {
         context.handle_event(LayerEvent::LayerActivated(1));
         context.handle_event(LayerEvent::LayerActivated(2));
         let keymap_index = 9; // arbitrary
-        let (actual_pressed_key, actual_event) =
-            layered_key.new_pressed_key(&context, keymap_index);
+        let (actual_pressed_key, actual_event) = layered_key.new_pressed_key(context, keymap_index);
 
         // Assert
-        let (expected_pressed_key, expected_event) =
-            expected_key.new_pressed_key(&(), keymap_index);
+        let (expected_pressed_key, expected_event) = expected_key.new_pressed_key((), keymap_index);
         assert_eq!(
             actual_pressed_key.pressed_key_state.passthru_pk,
             expected_pressed_key
@@ -571,12 +565,10 @@ mod tests {
         context.handle_event(LayerEvent::LayerActivated(0));
         context.handle_event(LayerEvent::LayerActivated(2));
         let keymap_index = 9; // arbitrary
-        let (actual_pressed_key, actual_event) =
-            layered_key.new_pressed_key(&context, keymap_index);
+        let (actual_pressed_key, actual_event) = layered_key.new_pressed_key(context, keymap_index);
 
         // Assert
-        let (expected_pressed_key, expected_event) =
-            expected_key.new_pressed_key(&(), keymap_index);
+        let (expected_pressed_key, expected_event) = expected_key.new_pressed_key((), keymap_index);
         assert_eq!(
             actual_pressed_key.pressed_key_state.passthru_pk,
             expected_pressed_key

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -111,7 +111,7 @@ pub trait Key: Copy + Debug + PartialEq {
     ///  so that holding the key resolves as a hold).
     fn new_pressed_key(
         &self,
-        context: &Self::Context,
+        context: Self::Context,
         keymap_index: u16,
     ) -> (
         input::PressedKey<Self, Self::PressedKeyState>,
@@ -123,7 +123,7 @@ pub trait Key: Copy + Debug + PartialEq {
 ///
 /// e.g. the behaviour of [layered::LayeredKey] depends on which
 ///  layers are active in [layered::Context].
-pub trait Context {
+pub trait Context: Clone + Copy {
     /// The type of `Event` the context handles.
     type Event;
 

--- a/src/key/simple.rs
+++ b/src/key/simple.rs
@@ -23,7 +23,7 @@ impl key::Key for Key {
 
     fn new_pressed_key(
         &self,
-        _context: &Self::Context,
+        _context: Self::Context,
         keymap_index: u16,
     ) -> (
         input::PressedKey<Self, Self::PressedKeyState>,

--- a/src/key/tap_hold.rs
+++ b/src/key/tap_hold.rs
@@ -26,7 +26,7 @@ impl key::Key for Key {
 
     fn new_pressed_key(
         &self,
-        _context: &Self::Context,
+        _context: Self::Context,
         keymap_index: u16,
     ) -> (
         input::PressedKey<Self, Self::PressedKeyState>,

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -166,7 +166,7 @@ impl<
         self.pressed_inputs.iter_mut().for_each(|pi| {
             if let input::PressedInput::Key { keymap_index, .. } = pi {
                 let key = &mut self.key_definitions[*keymap_index as usize];
-                key.handle_event(&self.context, ev.into())
+                key.handle_event(self.context, ev.into())
                     .into_iter()
                     .for_each(|sch_ev| self.event_scheduler.schedule_event(sch_ev));
             }
@@ -178,7 +178,7 @@ impl<
             input::Event::Press { keymap_index } => {
                 let key = &mut self.key_definitions[keymap_index as usize];
 
-                key.handle_event(&self.context, ev.into())
+                key.handle_event(self.context, ev.into())
                     .into_iter()
                     .for_each(|sch_ev| self.event_scheduler.schedule_event(sch_ev));
 
@@ -224,7 +224,7 @@ impl<
             self.pressed_inputs.iter_mut().for_each(|pi| {
                 if let input::PressedInput::Key { keymap_index, .. } = pi {
                     let key = &mut self.key_definitions[*keymap_index as usize];
-                    key.handle_event(&self.context, ev)
+                    key.handle_event(self.context, ev)
                         .into_iter()
                         .for_each(|sch_ev| self.event_scheduler.schedule_event(sch_ev));
                 }

--- a/src/tuples.rs
+++ b/src/tuples.rs
@@ -42,7 +42,7 @@ impl<
 where
     key::Event<<K0 as key::Key>::Event>: TryFrom<key::Event<Ev>>,
     key::Event<Ev>: From<key::Event<<K0 as key::Key>::Event>>,
-    for<'c> &'c <K0 as key::Key>::Context: From<&'c Ctx>,
+    <K0 as key::Key>::Context: From<Ctx>,
 {
     type Output = dyn dynamic::Key<Ev, M, Context = Ctx>;
 
@@ -63,7 +63,7 @@ impl<
 where
     crate::key::Event<<K0 as crate::key::Key>::Event>: TryFrom<crate::key::Event<Ev>>,
     crate::key::Event<Ev>: From<crate::key::Event<<K0 as crate::key::Key>::Event>>,
-    for<'c> &'c <K0 as crate::key::Key>::Context: From<&'c Ctx>,
+    <K0 as crate::key::Key>::Context: From<Ctx>,
 {
     fn index_mut(&mut self, idx: usize) -> &mut Self::Output {
         match idx {
@@ -82,7 +82,7 @@ impl<
 where
     crate::key::Event<<K0 as crate::key::Key>::Event>: TryFrom<crate::key::Event<Ev>>,
     crate::key::Event<Ev>: From<crate::key::Event<<K0 as crate::key::Key>::Event>>,
-    for<'c> &'c <K0 as crate::key::Key>::Context: From<&'c Ctx>,
+    <K0 as crate::key::Key>::Context: From<Ctx>,
 {
     fn reset(&mut self) {
         <dynamic::DynamicKey<K0, Ctx, Ev> as dynamic::Key<Ev, M>>::reset(&mut self.0)
@@ -151,7 +151,7 @@ macro_rules! define_keys {
                     #(
                     crate::key::Event<<K~I as crate::key::Key>::Event>: TryFrom<crate::key::Event<Ev>>,
                     crate::key::Event<Ev>: From<crate::key::Event<<K~I as crate::key::Key>::Event>>,
-                    for<'c> &'c <K~I as crate::key::Key>::Context: From<&'c Ctx>,
+                    <K~I as crate::key::Key>::Context: From<Ctx>,
                 )*
                 {
                     type Output = dyn crate::key::dynamic::Key<Ev, M, Context = Ctx>;
@@ -181,7 +181,7 @@ macro_rules! define_keys {
                     #(
                     crate::key::Event<<K~I as crate::key::Key>::Event>: TryFrom<crate::key::Event<Ev>>,
                     crate::key::Event<Ev>: From<crate::key::Event<<K~I as crate::key::Key>::Event>>,
-                    for<'c> &'c <K~I as crate::key::Key>::Context: From<&'c Ctx>,
+                    <K~I as crate::key::Key>::Context: From<Ctx>,
                 )*
                 {
                     fn index_mut(&mut self, idx: usize) -> &mut Self::Output {
@@ -209,7 +209,7 @@ macro_rules! define_keys {
                     #(
                     crate::key::Event<<K~I as crate::key::Key>::Event>: TryFrom<crate::key::Event<Ev>>,
                     crate::key::Event<Ev>: From<crate::key::Event<<K~I as crate::key::Key>::Event>>,
-                    for<'c> &'c <K~I as crate::key::Key>::Context: From<&'c Ctx>,
+                    <K~I as crate::key::Key>::Context: From<Ctx>,
                 )*
                 {
                     fn reset(&mut self) {


### PR DESCRIPTION
I wanted to keep `Context` to be passed as refs.

However, Rust lifetime constraints mean it's difficult to implement changes I want.

Keys can be thought of as either 'base keys' (like `key::simple::Key`), or 'modifier keys' that behave depending on other keys. -- e.g. TapHold is a key modifier; the key either acts as the 'tap' (like a normal key would when tapped), or TapHold allows the key acting as a 'hold'.

Modifier keys must be able to call `new_pressed_key` with the `K::Context` for the inner `K`.

Hence, I want to be able to construct a value like `Pair(Context, K::Context)` from `composite::Context { context1, context2, context3, .. }`. -- With refs, this might be more like `Pair(&Context, &K::Context)`.

In particular, constraints are:

- `key::dynamic::Key` must be an object-safe / `dyn`-compatible trait. In particular, this means the trait's methods aren't generic. (e.g. the `new_pressed_key` can't be generic on some kind of `K::Ctx`).
- Using `&Context` means that `Context` can't contain refs (to anything that lives less than `'static`).
  - Rationale for this constraint is the bounds on `dynamic::DynamicKey`'s `impl` of `dynamic::Key`. We need to be able to make e.g. `simple::Context` (or some other key context) from an aggregate `composite::Context`. Hence, we need something like `&simple::Context: From<&composite::Context>`. -- This bound can't be expressed on the method, because `dynamic::Key` doesn't know about `<K>`. `dynamic::Key` can't know about `<K>`, because the idea is to have an aggregate dynamic type e.g. `DynamicKey<simple::Key>: dynamic::Key<composite::Event>` and `DynamicKey<tap_hold::Key>: dynamic::Key<composite::Event>`. The bound can be expressed on the impl; but, then the LT on the bound is not related to the method. Expressing the LT bound outside the method then requires `for<'c>`, which requires `: + 'static`.
- So `Pair(&Ctx, &K::Ctx)` can't be used as a Context (it's got references).

I considered a few different solutions to try and keep the references in. -- If I can't come up with something, this will have to do.