### PR TITLE
rust: refactor layered::LayeredKey Context to ModifierContext

### DIFF
--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -146,7 +146,7 @@ pub mod init {
     pub type NestedKey = crate::key::composite::DefaultNestableKey;
 
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
-    pub type Context = crate::key::composite::Context<NestedKey, LayersImpl>;
+    pub type Context = crate::key::composite::Context<LayersImpl>;
 
     /// Initial [Context] value.
     pub const CONTEXT: Context = crate::key::composite::Context::new();

--- a/src/key/doc_de_composite.md
+++ b/src/key/doc_de_composite.md
@@ -10,7 +10,7 @@ use key::{composite, layered, simple};
 use composite::DefaultNestableKey;
 
 type L = layered::ArrayImpl<1>;
-type Ctx = composite::Context<DefaultNestableKey, L>;
+type Ctx = composite::Context<L>;
 type Key = composite::Key<DefaultNestableKey, L>;
 
 let json = r#"
@@ -33,7 +33,7 @@ use key::{composite, layered, tap_hold};
 use composite::DefaultNestableKey;
 
 type L = layered::ArrayImpl<1>;
-type Ctx = composite::Context<DefaultNestableKey, L>;
+type Ctx = composite::Context<L>;
 type Key = composite::Key<DefaultNestableKey, L>;
 
 let json = r#"
@@ -56,7 +56,7 @@ use key::{composite, layered};
 use composite::DefaultNestableKey;
 
 type L = layered::ArrayImpl<1>;
-type Ctx = composite::Context<DefaultNestableKey, L>;
+type Ctx = composite::Context<L>;
 type Key = composite::Key<DefaultNestableKey, L>;
 
 let json = r#"
@@ -79,7 +79,7 @@ use key::{composite, layered, simple};
 use composite::DefaultNestableKey;
 
 type L = layered::ArrayImpl<3>;
-type Ctx = composite::Context<DefaultNestableKey, L>;
+type Ctx = composite::Context<L>;
 type Key = composite::Key<DefaultNestableKey, L>;
 
 let json = r#"

--- a/src/key/dynamic.rs
+++ b/src/key/dynamic.rs
@@ -33,10 +33,8 @@ where
 }
 
 /// Convenience type alias for [Key] which uses [crate::key::composite::Event] and [crate::key::composite::Context].
-pub type CompositeKey<const L: key::layered::LayerIndex = 0> = dyn Key<
-    key::composite::Event,
-    Context = key::composite::Context<key::composite::DefaultNestableKey, [bool; L]>,
->;
+pub type CompositeKey<const L: key::layered::LayerIndex = 0> =
+    dyn Key<key::composite::Event, Context = key::composite::Context<[bool; L]>>;
 
 /// Generic implementation of [Key] for a [key::Key] and some `Ctx`/`Ev`.
 #[derive(Debug)]
@@ -131,7 +129,7 @@ mod tests {
     #[test]
     fn test_composite_dynamic_simple_key_has_no_key_code_when_released() {
         // Assemble
-        let dyn_key: &mut dyn Key<composite::Event, Context = composite::Context<simple::Key>> =
+        let dyn_key: &mut dyn Key<composite::Event, Context = composite::Context> =
             &mut DynamicKey::new(simple::Key(0x04));
         let context = composite::Context::new();
 

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -93,7 +93,7 @@ pub trait Key: Copy + Debug + PartialEq {
     ///  may affect behaviour when pressing the key.
     /// (e.g. the behaviour of [layered::LayeredKey] depends on which
     ///  layers are active in [layered::Context]).
-    type Context: Context<Event = Self::ContextEvent>;
+    type Context;
     /// The event used by the [Key]'s associated [Context].
     type ContextEvent;
     /// The associated `Event` is to be handled by the associated [Context],
@@ -134,6 +134,16 @@ pub trait Context: Clone + Copy {
 impl Context for () {
     type Event = ();
     fn handle_event(&mut self, _event: Self::Event) {}
+}
+
+/// Context struct for use by "modifier" keys.
+/// (Keys which modify the behaviour of some key,
+///  e.g. [key::layered::LayeredKey]).
+pub struct ModifierKeyContext<Ctx, NCtx> {
+    /// The [Context] for the modifier key.
+    pub context: Ctx,
+    /// The [Context] for the modified key.
+    pub inner_context: NCtx,
 }
 
 /// Struct for the output from [PressedKey].

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -118,13 +118,13 @@ pub struct Keymap<
             usize,
             Output = dyn key::dynamic::Key<
                 key::composite::Event,
-                Context = key::composite::Context<key::composite::DefaultNestableKey, L>,
+                Context = key::composite::Context<L>,
             >,
         > + crate::tuples::KeysReset,
     L: key::layered::LayerImpl = key::layered::ArrayImpl<0>,
 > {
     key_definitions: I,
-    context: composite::Context<composite::DefaultNestableKey, L>,
+    context: composite::Context<L>,
     pressed_inputs: heapless::Vec<input::PressedInput, 16>,
     event_scheduler: EventScheduler,
 }
@@ -134,17 +134,14 @@ impl<
                 usize,
                 Output = dyn key::dynamic::Key<
                     key::composite::Event,
-                    Context = key::composite::Context<key::composite::DefaultNestableKey, L>,
+                    Context = key::composite::Context<L>,
                 >,
             > + crate::tuples::KeysReset,
         L: key::layered::LayerImpl,
     > Keymap<I, L>
 {
     /// Constructs a new keymap with the given key definitions and context.
-    pub const fn new(
-        key_definitions: I,
-        context: composite::Context<composite::DefaultNestableKey, L>,
-    ) -> Self {
+    pub const fn new(key_definitions: I, context: composite::Context<L>) -> Self {
         Self {
             key_definitions,
             context,
@@ -275,13 +272,12 @@ mod tests {
 
     #[test]
     fn test_keymap_with_simple_key_with_composite_context() {
-        use key::composite::{Context, DefaultNestableKey, Event};
+        use key::composite::{Context, Event};
         use key::simple;
         use tuples::Keys1;
 
         // Assemble
-        let keys: Keys1<simple::Key, Context<DefaultNestableKey>, Event> =
-            Keys1::new((simple::Key(0x04),));
+        let keys: Keys1<simple::Key, Context, Event> = Keys1::new((simple::Key(0x04),));
         let context = composite::Context::new();
         let mut keymap = Keymap::new(keys, context);
 
@@ -299,10 +295,10 @@ mod tests {
         use key::{composite, simple};
         use tuples::Keys1;
 
-        use composite::{Context, DefaultNestableKey, Event};
+        use composite::{Context, Event};
 
         // Assemble
-        let keys: Keys1<composite::Key, Context<DefaultNestableKey>, Event> =
+        let keys: Keys1<composite::Key, Context, Event> =
             Keys1::new((composite::Key::simple(simple::Key(0x04)),));
         let context = composite::Context::new();
         let mut keymap = Keymap::new(keys, context);
@@ -325,7 +321,7 @@ mod tests {
 
         // Assemble
         type L = layered::ArrayImpl<1>;
-        type Ctx = composite::Context<DefaultNestableKey, L>;
+        type Ctx = composite::Context<L>;
         type MK = layered::ModifierKey;
         type LK = layered::LayeredKey<DefaultNestableKey, L>;
         let keys: Keys2<MK, LK, Ctx, Event> = tuples::Keys2::new((
@@ -355,7 +351,7 @@ mod tests {
 
         // Assemble
         type L = layered::ArrayImpl<1>;
-        type Ctx = composite::Context<DefaultNestableKey, L>;
+        type Ctx = composite::Context<L>;
         type K = composite::Key<DefaultNestableKey, L>;
         let keys: Keys2<K, K, Ctx, Event> = tuples::Keys2::new((
             K::layer_modifier(layered::ModifierKey::Hold(0)),
@@ -385,7 +381,7 @@ mod tests {
 
         // Assemble
         type L = layered::ArrayImpl<1>;
-        type Ctx = composite::Context<DefaultNestableKey, L>;
+        type Ctx = composite::Context<L>;
         type K = composite::Key<DefaultNestableKey, L>;
         let keys: Keys2<K, K, Ctx, Event> = tuples::Keys2::new((
             K::layer_modifier(layered::ModifierKey::Hold(0)),
@@ -417,7 +413,7 @@ mod tests {
 
         // Assemble
         type L = layered::ArrayImpl<1>;
-        type Ctx = composite::Context<DefaultNestableKey, L>;
+        type Ctx = composite::Context<L>;
         type K = composite::Key<DefaultNestableKey, L>;
         let keys: Keys2<K, K, Ctx, Event> = tuples::Keys2::new((
             K::layer_modifier(layered::ModifierKey::Hold(0)),
@@ -449,7 +445,7 @@ mod tests {
 
         // Assemble
         type L = layered::ArrayImpl<1>;
-        type Ctx = composite::Context<DefaultNestableKey, L>;
+        type Ctx = composite::Context<L>;
         type K = composite::Key<DefaultNestableKey, L>;
         let keys: Keys2<K, K, Ctx, Event> = tuples::Keys2::new((
             K::layer_modifier(layered::ModifierKey::Hold(0)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ pub mod init {
     pub type NestedKey = composite::DefaultNestableKey;
 
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
-    pub type Context = composite::Context<NestedKey, LayersImpl>;
+    pub type Context = composite::Context<LayersImpl>;
 
     /// Alias for keys.
     pub type Key = composite::Key<NestedKey, LayersImpl>;

--- a/src/tuples.rs
+++ b/src/tuples.rs
@@ -15,7 +15,7 @@ pub trait KeysReset {
 #[derive(Debug)]
 pub struct Keys1<
     K0: key::Key,
-    Ctx: key::Context<Event = Ev> + Debug = composite::Context<composite::DefaultNestableKey>,
+    Ctx: key::Context<Event = Ev> + Debug = composite::Context,
     Ev: Copy + Debug + Ord = composite::Event,
     const M: usize = 2,
 >(dynamic::DynamicKey<K0, Ctx, Ev>);
@@ -101,7 +101,7 @@ macro_rules! define_keys {
                     #(
                         K~I: crate::key::Key,
                     )*
-                Ctx: crate::key::Context<Event = Ev> + core::fmt::Debug = crate::key::composite::Context<crate::key::composite::DefaultNestableKey>,
+                Ctx: crate::key::Context<Event = Ev> + core::fmt::Debug = crate::key::composite::Context,
                 Ev: Copy + core::fmt::Debug + Ord = crate::key::composite::Event,
                 const M: usize = 2,
                 >(

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -60,7 +60,7 @@ fn nickel_to_json_for_hid_report(keymap_ncl: &str) -> io::Result<String> {
 type NestedKey = key::composite::DefaultNestableKey;
 type LayersImpl = key::layered::ArrayImpl<16>;
 type Key = key::composite::Key<NestedKey, LayersImpl>;
-type Context = key::composite::Context<NestedKey, LayersImpl>;
+type Context = key::composite::Context<LayersImpl>;
 
 #[derive(Debug)]
 enum LoadedKeymap {

--- a/tests/ncl/keymap-1key-simple/expected.rs
+++ b/tests/ncl/keymap-1key-simple/expected.rs
@@ -7,7 +7,7 @@ pub mod init {
     pub type NestedKey = crate::key::composite::DefaultNestableKey;
 
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
-    pub type Context = crate::key::composite::Context<NestedKey, LayersImpl>;
+    pub type Context = crate::key::composite::Context<LayersImpl>;
 
     /// Initial [Context] value.
     pub const CONTEXT: Context = crate::key::composite::Context::new();

--- a/tests/ncl/keymap-1key-tap_hold/expected.rs
+++ b/tests/ncl/keymap-1key-tap_hold/expected.rs
@@ -7,7 +7,7 @@ pub mod init {
     pub type NestedKey = crate::key::composite::DefaultNestableKey;
 
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
-    pub type Context = crate::key::composite::Context<NestedKey, LayersImpl>;
+    pub type Context = crate::key::composite::Context<LayersImpl>;
 
     /// Initial [Context] value.
     pub const CONTEXT: Context = crate::key::composite::Context::new();

--- a/tests/ncl/keymap-2key-2layer-simple/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-simple/expected.rs
@@ -7,7 +7,7 @@ pub mod init {
     pub type NestedKey = crate::key::composite::DefaultNestableKey;
 
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
-    pub type Context = crate::key::composite::Context<NestedKey, LayersImpl>;
+    pub type Context = crate::key::composite::Context<LayersImpl>;
 
     /// Initial [Context] value.
     pub const CONTEXT: Context = crate::key::composite::Context::new();

--- a/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
@@ -7,7 +7,7 @@ pub mod init {
     pub type NestedKey = crate::key::composite::DefaultNestableKey;
 
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
-    pub type Context = crate::key::composite::Context<NestedKey, LayersImpl>;
+    pub type Context = crate::key::composite::Context<LayersImpl>;
 
     /// Initial [Context] value.
     pub const CONTEXT: Context = crate::key::composite::Context::new();

--- a/tests/ncl/keymap-60key-dvorak-simple/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple/expected.rs
@@ -7,7 +7,7 @@ pub mod init {
     pub type NestedKey = crate::key::composite::DefaultNestableKey;
 
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
-    pub type Context = crate::key::composite::Context<NestedKey, LayersImpl>;
+    pub type Context = crate::key::composite::Context<LayersImpl>;
 
     /// Initial [Context] value.
     pub const CONTEXT: Context = crate::key::composite::Context::new();


### PR DESCRIPTION
`layered::Context` "having" `inner_context` felt awkward. (A layered key might have a context-manipulating key; but that context-manipulating key might also be in non-layered keys; so the context it manipulates ... would be mut ref'd from multiple places, or something?).

After #89 adjusted use of Context to be values (not references), this was relatively straightforward.