### PR TITLE
lift DefaultNestableKey to generic in key::composite

### DIFF
--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -53,6 +53,20 @@ impl<E: Copy + Debug> PressedKeyEvents<E> {
         self.0.push(ScheduledEvent::after(delay, event)).unwrap();
     }
 
+    /// Maps over the PressedKeyEvents.
+    pub fn map_events<F>(&self, f: fn(Event<E>) -> Event<F>) -> PressedKeyEvents<F> {
+        PressedKeyEvents(
+            self.0
+                .as_slice()
+                .iter()
+                .map(|scheduled_event| ScheduledEvent {
+                    schedule: scheduled_event.schedule,
+                    event: f(scheduled_event.event),
+                })
+                .collect(),
+        )
+    }
+
     /// Maps the PressedKeyEvents to a new type.
     pub fn into_events<F>(&self) -> PressedKeyEvents<F>
     where


### PR DESCRIPTION
`key::composite` has been using `DefaultNestableKey` throughout its implementation.

This restricts the implementation. It should be a generic `NestableKey` that gets used.

Rust-wise ... afaict, the bounds for various `From` and `TryFrom` can get a bit messy. -- In one attempt, the type inference on the compiler was giving me funky results. -- It seems that `key::composite`'s use of `From` bounds is a bit absurd.