### PR TITLE
rust: add test covering TapHold Timeout behaviour

### DIFF
--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -378,11 +378,10 @@ impl TryFrom<key::Event<Event>> for key::Event<layered::LayerEvent> {
     type Error = key::EventError;
 
     fn try_from(ev: key::Event<Event>) -> Result<Self, Self::Error> {
-        match ev {
-            key::Event::Input(ev) => Ok(key::Event::Input(ev)),
-            key::Event::Key(Event::LayerModification(ev)) => Ok(key::Event::Key(ev)),
-            key::Event::Key(_) => Err(key::EventError::UnmappableEvent),
-        }
+        ev.try_map_key_event(|ev| match ev {
+            Event::LayerModification(ev) => Ok(ev),
+            _ => Err(key::EventError::UnmappableEvent),
+        })
     }
 }
 
@@ -390,10 +389,7 @@ impl TryFrom<key::Event<Event>> for key::Event<simple::Event> {
     type Error = key::EventError;
 
     fn try_from(ev: key::Event<Event>) -> Result<Self, Self::Error> {
-        match ev {
-            key::Event::Input(ev) => Ok(key::Event::Input(ev)),
-            key::Event::Key(_) => Err(key::EventError::UnmappableEvent),
-        }
+        ev.try_map_key_event(|_| Err(key::EventError::UnmappableEvent))
     }
 }
 
@@ -401,11 +397,10 @@ impl TryFrom<key::Event<Event>> for key::Event<tap_hold::Event> {
     type Error = key::EventError;
 
     fn try_from(ev: key::Event<Event>) -> Result<Self, Self::Error> {
-        match ev {
-            key::Event::Input(ev) => Ok(key::Event::Input(ev)),
-            key::Event::Key(Event::TapHold(ev)) => Ok(key::Event::Key(ev)),
-            key::Event::Key(_) => Err(key::EventError::UnmappableEvent),
-        }
+        ev.try_map_key_event(|ev| match ev {
+            Event::TapHold(ev) => Ok(ev),
+            _ => Err(key::EventError::UnmappableEvent),
+        })
     }
 }
 

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -428,9 +428,10 @@ mod tests {
 
         // Assert
         let _key_ev = match events.into_iter().next().map(|sch_ev| sch_ev.event) {
-            Some(key::Event::Key(Event::LayerModification(
-                layered::LayerEvent::LayerDeactivated(layer),
-            ))) => {
+            Some(key::Event::Key {
+                key_event: Event::LayerModification(layered::LayerEvent::LayerDeactivated(layer)),
+                ..
+            }) => {
                 assert_eq!(layer, 0);
             }
             _ => panic!("Expected an Event::Key(LayerModification(LayerDeactivated(layer)))"),
@@ -459,9 +460,9 @@ mod tests {
         // Act
         let event = match maybe_ev {
             Some(key::ScheduledEvent {
-                event: key::Event::Key(ev),
+                event: key::Event::Key { key_event, .. },
                 ..
-            }) => ev,
+            }) => key_event,
             _ => panic!("Expected Some(ScheduledEvent(Event::Key(_)))"),
         };
         context.handle_event(event);
@@ -494,7 +495,7 @@ mod tests {
         let events = pressed_lmod_key
             .handle_event(key::Event::Input(input::Event::Release { keymap_index: 0 }));
         let key_ev = match events.into_iter().next().map(|sch_ev| sch_ev.event) {
-            Some(key::Event::Key(ev)) => ev,
+            Some(key::Event::Key { key_event, .. }) => key_event,
             _ => panic!("Expected an Event::Key(_)"),
         };
 

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -358,28 +358,19 @@ pub enum Event {
 
 impl From<key::Event<layered::LayerEvent>> for key::Event<Event> {
     fn from(ev: key::Event<layered::LayerEvent>) -> Self {
-        match ev {
-            key::Event::Input(ev) => key::Event::Input(ev),
-            key::Event::Key(ev) => key::Event::Key(Event::LayerModification(ev)),
-        }
+        ev.map_key_event(Event::LayerModification)
     }
 }
 
 impl From<key::Event<simple::Event>> for key::Event<Event> {
     fn from(ev: key::Event<simple::Event>) -> Self {
-        match ev {
-            key::Event::Input(ev) => key::Event::Input(ev),
-            key::Event::Key(_) => panic!("key::simple never emits events"),
-        }
+        ev.map_key_event(|_| panic!("key::simple never emits events"))
     }
 }
 
 impl From<key::Event<tap_hold::Event>> for key::Event<Event> {
     fn from(ev: key::Event<tap_hold::Event>) -> Self {
-        match ev {
-            key::Event::Input(ev) => key::Event::Input(ev),
-            key::Event::Key(ev) => key::Event::Key(Event::TapHold(ev)),
-        }
+        ev.map_key_event(Event::TapHold)
     }
 }
 

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -79,7 +79,10 @@ impl key::Key for ModifierKey {
         key::PressedKeyEvents<Self::Event>,
     ) {
         let (pk, ev) = ModifierKey::new_pressed_key(self, keymap_index);
-        (pk, key::PressedKeyEvents::event(key::Event::key_event(ev)))
+        (
+            pk,
+            key::PressedKeyEvents::event(key::Event::key_event(keymap_index, ev)),
+        )
     }
 }
 
@@ -297,6 +300,7 @@ impl key::PressedKeyState<ModifierKey> for PressedModifierKeyState {
                 key::Event::Input(input::Event::Release { keymap_index: ki }) => {
                     if keymap_index == ki {
                         key::PressedKeyEvents::event(key::Event::key_event(
+                            keymap_index,
                             LayerEvent::LayerDeactivated(*layer),
                         ))
                     } else {

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -390,7 +390,11 @@ mod tests {
 
         // Assert: the pressed key should have emitted a layer deactivation event
         let first_ev = actual_events.into_iter().next().map(|sch_ev| sch_ev.event);
-        if let Some(key::Event::Key(actual_layer_event)) = first_ev {
+        if let Some(key::Event::Key {
+            key_event: actual_layer_event,
+            ..
+        }) = first_ev
+        {
             let expected_layer_event = LayerEvent::LayerDeactivated(layer);
             assert_eq!(actual_layer_event, expected_layer_event);
         } else {

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -79,7 +79,7 @@ impl key::Key for ModifierKey {
         key::PressedKeyEvents<Self::Event>,
     ) {
         let (pk, ev) = ModifierKey::new_pressed_key(self, keymap_index);
-        (pk, key::PressedKeyEvents::key_event(ev))
+        (pk, key::PressedKeyEvents::event(key::Event::key_event(ev)))
     }
 }
 
@@ -296,7 +296,9 @@ impl key::PressedKeyState<ModifierKey> for PressedModifierKeyState {
             ModifierKey::Hold(layer) => match event {
                 key::Event::Input(input::Event::Release { keymap_index: ki }) => {
                     if keymap_index == ki {
-                        key::PressedKeyEvents::key_event(LayerEvent::LayerDeactivated(*layer))
+                        key::PressedKeyEvents::event(key::Event::key_event(
+                            LayerEvent::LayerDeactivated(*layer),
+                        ))
                     } else {
                         key::PressedKeyEvents::no_events()
                     }

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -217,6 +217,9 @@ pub enum EventError {
     UnmappableEvent,
 }
 
+/// Convenience alias for a [Result] with an [EventError].
+type EventResult<T> = Result<T, EventError>;
+
 /// Events which are either input, or for a particular [Key::Event].
 ///
 /// It's useful for [Key] implementations to use [Event] with [Key::Event],
@@ -235,6 +238,14 @@ impl<T: Copy> Event<T> {
         match self {
             Event::Input(event) => Event::Input(*event),
             Event::Key(key_event) => Event::Key(f(*key_event)),
+        }
+    }
+
+    /// Maps the Event into a new type.
+    pub fn try_map_key_event<U>(&self, f: fn(T) -> EventResult<U>) -> EventResult<Event<U>> {
+        match self {
+            Event::Input(event) => Ok(Event::Input(*event)),
+            Event::Key(key_event) => f(*key_event).map(Event::Key),
         }
     }
 }

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -229,6 +229,16 @@ pub enum Event<T> {
     Key(T),
 }
 
+impl<T: Copy> Event<T> {
+    /// Maps the Event into a new type.
+    pub fn map_key_event<U>(&self, f: fn(T) -> U) -> Event<U> {
+        match self {
+            Event::Input(event) => Event::Input(*event),
+            Event::Key(key_event) => Event::Key(f(*key_event)),
+        }
+    }
+}
+
 impl<T> From<input::Event> for Event<T> {
     fn from(event: input::Event) -> Self {
         Event::Input(event)

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -33,7 +33,7 @@ impl<E: Copy + Debug> PressedKeyEvents<E> {
     /// Constructs a [PressedKeyEvents] with an immediate [Event].
     pub fn key_event(key_event: E) -> Self {
         PressedKeyEvents(
-            Some(ScheduledEvent::immediate(Event::Key(key_event)))
+            Some(ScheduledEvent::immediate(Event::Key { key_event }))
                 .into_iter()
                 .collect(),
         )
@@ -42,7 +42,7 @@ impl<E: Copy + Debug> PressedKeyEvents<E> {
     /// Constructs a [PressedKeyEvents] with an [Event] scheduled after a delay.
     pub fn scheduled_key_event(delay: u16, key_event: E) -> Self {
         PressedKeyEvents(
-            Some(ScheduledEvent::after(delay, Event::Key(key_event)))
+            Some(ScheduledEvent::after(delay, Event::Key { key_event }))
                 .into_iter()
                 .collect(),
         )
@@ -229,7 +229,10 @@ pub enum Event<T> {
     /// Keymap input events, such as physical key presses.
     Input(input::Event),
     /// [Key] implementation specific events.
-    Key(T),
+    Key {
+        /// A [Key::Event] event.
+        key_event: T,
+    },
 }
 
 impl<T: Copy> Event<T> {
@@ -237,7 +240,9 @@ impl<T: Copy> Event<T> {
     pub fn map_key_event<U>(&self, f: fn(T) -> U) -> Event<U> {
         match self {
             Event::Input(event) => Event::Input(*event),
-            Event::Key(key_event) => Event::Key(f(*key_event)),
+            Event::Key { key_event } => Event::Key {
+                key_event: f(*key_event),
+            },
         }
     }
 
@@ -245,7 +250,7 @@ impl<T: Copy> Event<T> {
     pub fn try_map_key_event<U>(&self, f: fn(T) -> EventResult<U>) -> EventResult<Event<U>> {
         match self {
             Event::Input(event) => Ok(Event::Input(*event)),
-            Event::Key(key_event) => f(*key_event).map(Event::Key),
+            Event::Key { key_event } => f(*key_event).map(|key_event| Event::Key { key_event }),
         }
     }
 }

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -30,19 +30,10 @@ impl<E: Copy + Debug> PressedKeyEvents<E> {
         PressedKeyEvents(Some(ScheduledEvent::immediate(event)).into_iter().collect())
     }
 
-    /// Constructs a [PressedKeyEvents] with an immediate [Event].
-    pub fn key_event(key_event: E) -> Self {
-        PressedKeyEvents(
-            Some(ScheduledEvent::immediate(Event::Key { key_event }))
-                .into_iter()
-                .collect(),
-        )
-    }
-
     /// Constructs a [PressedKeyEvents] with an [Event] scheduled after a delay.
-    pub fn scheduled_key_event(delay: u16, key_event: E) -> Self {
+    pub fn scheduled_event(delay: u16, event: Event<E>) -> Self {
         PressedKeyEvents(
-            Some(ScheduledEvent::after(delay, Event::Key { key_event }))
+            Some(ScheduledEvent::after(delay, event))
                 .into_iter()
                 .collect(),
         )
@@ -236,6 +227,11 @@ pub enum Event<T> {
 }
 
 impl<T: Copy> Event<T> {
+    /// Constructs an [Event] from an [Key::Event].
+    pub fn key_event(key_event: T) -> Self {
+        Event::Key { key_event }
+    }
+
     /// Maps the Event into a new type.
     pub fn map_key_event<U>(&self, f: fn(T) -> U) -> Event<U> {
         match self {

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -221,6 +221,8 @@ pub enum Event<T> {
     Input(input::Event),
     /// [Key] implementation specific events.
     Key {
+        /// The keymap index the event was generated from.
+        keymap_index: u16,
         /// A [Key::Event] event.
         key_event: T,
     },
@@ -228,16 +230,23 @@ pub enum Event<T> {
 
 impl<T: Copy> Event<T> {
     /// Constructs an [Event] from an [Key::Event].
-    pub fn key_event(key_event: T) -> Self {
-        Event::Key { key_event }
+    pub fn key_event(keymap_index: u16, key_event: T) -> Self {
+        Event::Key {
+            keymap_index,
+            key_event,
+        }
     }
 
     /// Maps the Event into a new type.
     pub fn map_key_event<U>(&self, f: fn(T) -> U) -> Event<U> {
         match self {
             Event::Input(event) => Event::Input(*event),
-            Event::Key { key_event } => Event::Key {
+            Event::Key {
+                key_event,
+                keymap_index,
+            } => Event::Key {
                 key_event: f(*key_event),
+                keymap_index: *keymap_index,
             },
         }
     }
@@ -246,7 +255,13 @@ impl<T: Copy> Event<T> {
     pub fn try_map_key_event<U>(&self, f: fn(T) -> EventResult<U>) -> EventResult<Event<U>> {
         match self {
             Event::Input(event) => Ok(Event::Input(*event)),
-            Event::Key { key_event } => f(*key_event).map(|key_event| Event::Key { key_event }),
+            Event::Key {
+                key_event,
+                keymap_index,
+            } => f(*key_event).map(|key_event| Event::Key {
+                key_event,
+                keymap_index: *keymap_index,
+            }),
         }
     }
 }

--- a/src/key/tap_hold.rs
+++ b/src/key/tap_hold.rs
@@ -119,7 +119,10 @@ impl key::PressedKeyState<Key> for PressedKeyState {
                     _ => key::PressedKeyEvents::no_events(),
                 }
             }
-            key::Event::Key(Event::TapHoldTimeout { .. }) => {
+            key::Event::Key {
+                key_event: Event::TapHoldTimeout { .. },
+                ..
+            } => {
                 // Key held long enough to resolve as hold.
                 self.resolve(TapHoldState::Hold);
                 key::PressedKeyEvents::no_events()

--- a/src/key/tap_hold.rs
+++ b/src/key/tap_hold.rs
@@ -66,12 +66,6 @@ pub enum Event {
     },
 }
 
-impl From<Event> for key::Event<Event> {
-    fn from(event: Event) -> Self {
-        key::Event::Key(event)
-    }
-}
-
 /// The state of a pressed tap-hold key.
 #[derive(Debug, Clone, Copy)]
 pub struct PressedKeyState {

--- a/src/key/tap_hold.rs
+++ b/src/key/tap_hold.rs
@@ -42,7 +42,7 @@ impl key::Key for Key {
             },
             key::PressedKeyEvents::scheduled_event(
                 200,
-                key::Event::key_event(Event::TapHoldTimeout { keymap_index }),
+                key::Event::key_event(keymap_index, Event::TapHoldTimeout { keymap_index }),
             ),
         )
     }

--- a/src/key/tap_hold.rs
+++ b/src/key/tap_hold.rs
@@ -40,7 +40,10 @@ impl key::Key for Key {
                     state: TapHoldState::Pending,
                 },
             },
-            key::PressedKeyEvents::scheduled_key_event(200, Event::TapHoldTimeout { keymap_index }),
+            key::PressedKeyEvents::scheduled_event(
+                200,
+                key::Event::key_event(Event::TapHoldTimeout { keymap_index }),
+            ),
         )
     }
 }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -16,7 +16,7 @@ struct ScheduledEvent<E> {
 struct EventScheduler {
     pending_events: heapless::spsc::Queue<Event<composite::Event>, 256>,
     scheduled_events:
-        heapless::BinaryHeap<ScheduledEvent<composite::Event>, heapless::binary_heap::Min, 256>,
+        heapless::BinaryHeap<ScheduledEvent<composite::Event>, heapless::binary_heap::Min, 16>,
     schedule_counter: u32,
 }
 

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -53,6 +53,20 @@ impl EventScheduler {
             .unwrap();
     }
 
+    pub fn cancel_events_for_keymap_index(&mut self, keymap_index: u16) {
+        let old_scheduled_events_heap = core::mem::take(&mut self.scheduled_events);
+        let mut old_events = old_scheduled_events_heap.into_vec();
+        old_events.retain(|ScheduledEvent { event, .. }| match event {
+            Event::Key {
+                keymap_index: ki, ..
+            } => *ki != keymap_index,
+            _ => true,
+        });
+        for scheduled_event in old_events {
+            self.scheduled_events.push(scheduled_event).unwrap();
+        }
+    }
+
     pub fn tick(&mut self) {
         self.schedule_counter += 1;
         let scheduled_ready =

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -228,8 +228,8 @@ impl<
             });
 
             // Update context with the event
-            if let key::Event::Key(ev) = ev {
-                self.context.handle_event(ev);
+            if let key::Event::Key { key_event, .. } = ev {
+                self.context.handle_event(key_event);
             }
 
             if let Event::Input(input_ev) = ev {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -207,6 +207,9 @@ impl<
                         _ => false,
                     })
                     .map(|i| self.pressed_inputs.remove(i));
+
+                self.event_scheduler
+                    .cancel_events_for_keymap_index(keymap_index);
             }
             input::Event::VirtualKeyPress { key_code } => {
                 // Add to pressed keys.


### PR DESCRIPTION
Ha! I thought this was weird behaviour. -- The timeouts from a TapHold press were affecting the following TapHold presses.

- Captured this with a unit test.

This PR then follows that test up with some refactoring around `key::Event`, adding `keymap_index` to `key::Event::Key`, and then adding a method to `EventScheduler` to remove that event.

(Implementation-wise... using a BinaryHeap becomes the wrong abstraction to use; it'd be better to use a Vec, and maintain the vec as sorted using binary searches to insert scheduled events. -- This can be done in a different PR).