### PR TITLE
firmware: evt: enter bootloader on SW_1_1 for CH32X-48

### DIFF
--- a/firmware/ch32x035-usb-device-compositekm-c/User/usbd_compostie_km.c
+++ b/firmware/ch32x035-usb-device-compositekm-c/User/usbd_compostie_km.c
@@ -132,6 +132,14 @@ void KB_Scan_Init( void )
 {
     keyboard_matrix_init();
 
+    GPIO_ResetBits(GPIOB, GPIO_Pin_1); // col0
+    Delay_Us(5);
+    bool is_boot = GPIO_ReadInputDataBit(GPIOA, GPIO_Pin_4) != 1; // row0
+    if (is_boot) {
+        SystemReset_StartMode(Start_Mode_BOOT);
+        NVIC_SystemReset();
+    }
+
     keymap_init();
 
     // Init LED


### PR DESCRIPTION
Later, this can be refactored into the matrix scanning generation from NCL.

(And ideally, having some kind of BOOT callback from some keymap key).