### PR TITLE
rust: use CompositeTypes trait to describe key::composite generics

### DIFF
--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -147,8 +147,11 @@ pub mod init {
     /// Alias for the NestedKey used for the [Context].
     pub type NestedKey = crate::key::composite::DefaultNestableKey;
 
+    /// Types used in Composite keys.
+    pub type CompositeImpl = crate::key::composite::CompositeImpl<NestedKey, LayersImpl>;
+
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
-    pub type Context = crate::key::composite::Context<LayersImpl>;
+    pub type Context = crate::key::composite::Context<CompositeImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
     pub type Event = crate::key::composite::Event;

--- a/src/key/doc_de_composite.md
+++ b/src/key/doc_de_composite.md
@@ -9,9 +9,11 @@ use key::{composite, layered, simple};
 
 use composite::DefaultNestableKey;
 
+type NK = composite::DefaultNestableKey;
 type L = layered::ArrayImpl<1>;
-type Ctx = composite::Context<L>;
-type Key = composite::Key<DefaultNestableKey, L>;
+type T = composite::CompositeImpl<NK, L>;
+type Ctx = composite::Context<T>;
+type Key = composite::Key<T>;
 
 let json = r#"
   { "Simple": { "key": 4 } }
@@ -32,9 +34,11 @@ use key::{composite, layered, tap_hold};
 
 use composite::DefaultNestableKey;
 
+type NK = composite::DefaultNestableKey;
 type L = layered::ArrayImpl<1>;
-type Ctx = composite::Context<L>;
-type Key = composite::Key<DefaultNestableKey, L>;
+type T = composite::CompositeImpl<NK, L>;
+type Ctx = composite::Context<T>;
+type Key = composite::Key<T>;
 
 let json = r#"
   { "TapHold": { "key": { "hold": 224, "tap": 4 } } }
@@ -55,9 +59,11 @@ use key::{composite, layered};
 
 use composite::DefaultNestableKey;
 
+type NK = composite::DefaultNestableKey;
 type L = layered::ArrayImpl<1>;
-type Ctx = composite::Context<L>;
-type Key = composite::Key<DefaultNestableKey, L>;
+type T = composite::CompositeImpl<NK, L>;
+type Ctx = composite::Context<T>;
+type Key = composite::Key<T>;
 
 let json = r#"
   { "LayerModifier": { "key": { "Hold": 2 } } }
@@ -78,9 +84,11 @@ use key::{composite, layered, simple};
 
 use composite::DefaultNestableKey;
 
+type NK = composite::DefaultNestableKey;
 type L = layered::ArrayImpl<3>;
-type Ctx = composite::Context<L>;
-type Key = composite::Key<DefaultNestableKey, L>;
+type T = composite::CompositeImpl<NK, L>;
+type Ctx = composite::Context<T>;
+type Key = composite::Key<T>;
 
 let json = r#"
   {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -134,13 +134,13 @@ pub struct Keymap<
             usize,
             Output = dyn key::dynamic::Key<
                 key::composite::Event,
-                Context = key::composite::Context<L>,
+                Context = key::composite::Context<T>,
             >,
         > + crate::tuples::KeysReset,
-    L: key::layered::LayerImpl = key::layered::ArrayImpl<0>,
+    T: key::composite::CompositeTypes = key::composite::CompositeImpl,
 > {
     key_definitions: I,
-    context: composite::Context<L>,
+    context: composite::Context<T>,
     pressed_inputs: heapless::Vec<input::PressedInput, 16>,
     event_scheduler: EventScheduler,
 }
@@ -150,14 +150,14 @@ impl<
                 usize,
                 Output = dyn key::dynamic::Key<
                     key::composite::Event,
-                    Context = key::composite::Context<L>,
+                    Context = key::composite::Context<T>,
                 >,
             > + crate::tuples::KeysReset,
-        L: key::layered::LayerImpl,
-    > Keymap<I, L>
+        T: key::composite::CompositeTypes,
+    > Keymap<I, T>
 {
     /// Constructs a new keymap with the given key definitions and context.
-    pub const fn new(key_definitions: I, context: composite::Context<L>) -> Self {
+    pub const fn new(key_definitions: I, context: composite::Context<T>) -> Self {
         Self {
             key_definitions,
             context,
@@ -402,13 +402,15 @@ mod tests {
         use key::{composite, layered, simple};
         use tuples::Keys2;
 
-        use composite::{DefaultNestableKey, Event};
+        use composite::Event;
 
         // Assemble
+        type NK = composite::DefaultNestableKey;
         type L = layered::ArrayImpl<1>;
-        type Ctx = composite::Context<L>;
+        type T = composite::CompositeImpl<NK, L>;
+        type Ctx = composite::Context<T>;
         type MK = layered::ModifierKey;
-        type LK = layered::LayeredKey<DefaultNestableKey, L>;
+        type LK = layered::LayeredKey<NK, L>;
         let keys: Keys2<MK, LK, Ctx, Event> = tuples::Keys2::new((
             layered::ModifierKey::Hold(0),
             layered::LayeredKey::new(simple::Key(0x04), [Some(simple::Key(0x05))]),
@@ -432,12 +434,14 @@ mod tests {
         use key::{composite, layered, simple};
         use tuples::Keys2;
 
-        use composite::{DefaultNestableKey, Event};
+        use composite::Event;
 
         // Assemble
+        type NK = composite::DefaultNestableKey;
         type L = layered::ArrayImpl<1>;
-        type Ctx = composite::Context<L>;
-        type K = composite::Key<DefaultNestableKey, L>;
+        type T = composite::CompositeImpl<NK, L>;
+        type Ctx = composite::Context<T>;
+        type K = composite::Key<T>;
         let keys: Keys2<K, K, Ctx, Event> = tuples::Keys2::new((
             K::layer_modifier(layered::ModifierKey::Hold(0)),
             K::layered(layered::LayeredKey::new(
@@ -462,12 +466,14 @@ mod tests {
         use key::{composite, layered, simple};
         use tuples::Keys2;
 
-        use composite::{DefaultNestableKey, Event};
+        use composite::Event;
 
         // Assemble
+        type NK = composite::DefaultNestableKey;
         type L = layered::ArrayImpl<1>;
-        type Ctx = composite::Context<L>;
-        type K = composite::Key<DefaultNestableKey, L>;
+        type T = composite::CompositeImpl<NK, L>;
+        type Ctx = composite::Context<T>;
+        type K = composite::Key<T>;
         let keys: Keys2<K, K, Ctx, Event> = tuples::Keys2::new((
             K::layer_modifier(layered::ModifierKey::Hold(0)),
             K::layered(layered::LayeredKey::new(
@@ -494,12 +500,14 @@ mod tests {
         use key::{composite, layered, simple};
         use tuples::Keys2;
 
-        use composite::{DefaultNestableKey, Event};
+        use composite::Event;
 
         // Assemble
+        type NK = composite::DefaultNestableKey;
         type L = layered::ArrayImpl<1>;
-        type Ctx = composite::Context<L>;
-        type K = composite::Key<DefaultNestableKey, L>;
+        type T = composite::CompositeImpl<NK, L>;
+        type Ctx = composite::Context<T>;
+        type K = composite::Key<T>;
         let keys: Keys2<K, K, Ctx, Event> = tuples::Keys2::new((
             K::layer_modifier(layered::ModifierKey::Hold(0)),
             K::layered(layered::LayeredKey::new(
@@ -526,12 +534,14 @@ mod tests {
         use key::{composite, layered, simple};
         use tuples::Keys2;
 
-        use composite::{DefaultNestableKey, Event};
+        use composite::Event;
 
         // Assemble
+        type NK = composite::DefaultNestableKey;
         type L = layered::ArrayImpl<1>;
-        type Ctx = composite::Context<L>;
-        type K = composite::Key<DefaultNestableKey, L>;
+        type T = composite::CompositeImpl<NK, L>;
+        type Ctx = composite::Context<T>;
+        type K = composite::Key<T>;
         let keys: Keys2<K, K, Ctx, Event> = tuples::Keys2::new((
             K::layer_modifier(layered::ModifierKey::Hold(0)),
             K::layered(layered::LayeredKey::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,14 +73,17 @@ pub mod init {
     /// Alias for the NestedKey used for the [Context].
     pub type NestedKey = composite::DefaultNestableKey;
 
+    /// Types used in Composite keys.
+    pub type CompositeImpl = composite::CompositeImpl<NestedKey, LayersImpl>;
+
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
-    pub type Context = composite::Context<LayersImpl>;
+    pub type Context = composite::Context<CompositeImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
     pub type Event = composite::Event;
 
     /// Alias for keys.
-    pub type Key = composite::Key<NestedKey, LayersImpl>;
+    pub type Key = composite::Key<CompositeImpl>;
 
     /// Initial [Context] value.
     pub const CONTEXT: Context = composite::Context {
@@ -99,7 +102,7 @@ pub mod init {
 #[cfg(custom_keymap)]
 include!(env!("SMART_KEYMAP_CUSTOM_KEYMAP"));
 
-static mut KEYMAP: keymap::Keymap<init::KeyDefinitionsType, init::LayersImpl> =
+static mut KEYMAP: keymap::Keymap<init::KeyDefinitionsType, init::CompositeImpl> =
     keymap::Keymap::new(init::KEY_DEFINITIONS, init::CONTEXT);
 
 /// Initialize the global keymap instance.

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -59,15 +59,16 @@ fn nickel_to_json_for_hid_report(keymap_ncl: &str) -> io::Result<String> {
 
 type NestedKey = key::composite::DefaultNestableKey;
 type LayersImpl = key::layered::ArrayImpl<16>;
-type Key = key::composite::Key<NestedKey, LayersImpl>;
-type Context = key::composite::Context<LayersImpl>;
+type CompositeImpl = key::composite::CompositeImpl<NestedKey, LayersImpl>;
+type Key = key::composite::Key<CompositeImpl>;
+type Context = key::composite::Context<CompositeImpl>;
 type Event = key::composite::Event;
 
 #[derive(Debug)]
 enum LoadedKeymap {
     NoKeymap,
-    Keymap1(Keymap<tuples::Keys1<Key, Context, Event>, LayersImpl>),
-    Keymap2(Keymap<tuples::Keys2<Key, Key, Context, Event>, LayersImpl>),
+    Keymap1(Keymap<tuples::Keys1<Key, Context, Event>, CompositeImpl>),
+    Keymap2(Keymap<tuples::Keys2<Key, Key, Context, Event>, CompositeImpl>),
 }
 
 impl LoadedKeymap {

--- a/tests/ncl/keymap-1key-simple/expected.rs
+++ b/tests/ncl/keymap-1key-simple/expected.rs
@@ -8,8 +8,11 @@ pub mod init {
     /// Alias for the NestedKey used for the [Context].
     pub type NestedKey = crate::key::composite::DefaultNestableKey;
 
+    /// Types used in Composite keys.
+    pub type CompositeImpl = crate::key::composite::CompositeImpl<NestedKey, LayersImpl>;
+
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
-    pub type Context = crate::key::composite::Context<LayersImpl>;
+    pub type Context = crate::key::composite::Context<CompositeImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
     pub type Event = crate::key::composite::Event;

--- a/tests/ncl/keymap-1key-tap_hold/expected.rs
+++ b/tests/ncl/keymap-1key-tap_hold/expected.rs
@@ -8,8 +8,11 @@ pub mod init {
     /// Alias for the NestedKey used for the [Context].
     pub type NestedKey = crate::key::composite::DefaultNestableKey;
 
+    /// Types used in Composite keys.
+    pub type CompositeImpl = crate::key::composite::CompositeImpl<NestedKey, LayersImpl>;
+
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
-    pub type Context = crate::key::composite::Context<LayersImpl>;
+    pub type Context = crate::key::composite::Context<CompositeImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
     pub type Event = crate::key::composite::Event;

--- a/tests/ncl/keymap-2key-2layer-simple/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-simple/expected.rs
@@ -8,8 +8,11 @@ pub mod init {
     /// Alias for the NestedKey used for the [Context].
     pub type NestedKey = crate::key::composite::DefaultNestableKey;
 
+    /// Types used in Composite keys.
+    pub type CompositeImpl = crate::key::composite::CompositeImpl<NestedKey, LayersImpl>;
+
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
-    pub type Context = crate::key::composite::Context<LayersImpl>;
+    pub type Context = crate::key::composite::Context<CompositeImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
     pub type Event = crate::key::composite::Event;

--- a/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
@@ -8,8 +8,11 @@ pub mod init {
     /// Alias for the NestedKey used for the [Context].
     pub type NestedKey = crate::key::composite::DefaultNestableKey;
 
+    /// Types used in Composite keys.
+    pub type CompositeImpl = crate::key::composite::CompositeImpl<NestedKey, LayersImpl>;
+
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
-    pub type Context = crate::key::composite::Context<LayersImpl>;
+    pub type Context = crate::key::composite::Context<CompositeImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
     pub type Event = crate::key::composite::Event;

--- a/tests/ncl/keymap-60key-dvorak-simple/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple/expected.rs
@@ -8,8 +8,11 @@ pub mod init {
     /// Alias for the NestedKey used for the [Context].
     pub type NestedKey = crate::key::composite::DefaultNestableKey;
 
+    /// Types used in Composite keys.
+    pub type CompositeImpl = crate::key::composite::CompositeImpl<NestedKey, LayersImpl>;
+
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
-    pub type Context = crate::key::composite::Context<LayersImpl>;
+    pub type Context = crate::key::composite::Context<CompositeImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
     pub type Event = crate::key::composite::Event;


### PR DESCRIPTION
This was done in support of #99.