### PR TITLE
Remove Ord constraint from Event

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 
 /// Input events for [crate::keymap::Keymap].
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
 pub enum Event {
     /// A physical key press for a given `keymap_index`.
     Press {

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -349,7 +349,7 @@ where
 }
 
 /// Aggregates the [key::Event] types.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum Event {
     /// A tap-hold event.
     TapHold(tap_hold::Event),

--- a/src/key/dynamic.rs
+++ b/src/key/dynamic.rs
@@ -8,7 +8,7 @@ use key::PressedKey as _;
 /// A dyn-compatible Key trait.
 pub trait Key<Ev, const M: usize = 2>: Debug
 where
-    Ev: Copy + Debug + Ord,
+    Ev: Copy + Debug,
 {
     /// The context type for the key.
     type Context: key::Context<Event = Ev>;
@@ -62,7 +62,7 @@ impl<K: key::Key, Ctx, Ev> DynamicKey<K, Ctx, Ev> {
 impl<
         K: key::Key,
         Ctx: key::Context<Event = Ev> + Debug + 'static,
-        Ev: Copy + Debug + Ord,
+        Ev: Copy + Debug,
         const M: usize,
     > Key<Ev, M> for DynamicKey<K, Ctx, Ev>
 where

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -278,7 +278,7 @@ impl<L: LayerImpl, K: key::Key> key::Key for LayeredKey<K, L> {
 }
 
 /// Events from [ModifierKey] which affect [Context].
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum LayerEvent {
     /// Activates the given layer.
     LayerActivated(LayerIndex),

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -16,7 +16,7 @@ pub mod composite;
 pub mod dynamic;
 
 /// Events emitted when a [Key] is pressed.
-#[derive(Debug, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct PressedKeyEvents<E, const M: usize = 2>(heapless::Vec<ScheduledEvent<E>, M>);
 
 impl<E: Copy + Debug> PressedKeyEvents<E> {
@@ -215,7 +215,7 @@ type EventResult<T> = Result<T, EventError>;
 ///
 /// It's useful for [Key] implementations to use [Event] with [Key::Event],
 ///  and map [Key::Event] to and partially from [composite::Event].
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Event<T> {
     /// Keymap input events, such as physical key presses.
     Input(input::Event),
@@ -283,7 +283,7 @@ pub enum Schedule {
 }
 
 /// Schedules a given `T` with [Event], for some [Schedule].
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ScheduledEvent<T> {
     /// Whether to handle the event immediately, or after some delay.
     pub schedule: Schedule,

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -103,7 +103,7 @@ pub trait Key: Copy + Debug + PartialEq {
     type ContextEvent;
     /// The associated `Event` is to be handled by the associated [Context],
     ///  and any active [PressedKeyState]s.
-    type Event: Copy + Debug + Ord;
+    type Event: Copy + Debug;
     /// The associated [PressedKeyState] implements functionality
     ///  for the pressed key.
     /// (e.g. [tap_hold::PressedKeyState] implements behaviour resolving

--- a/src/key/simple.rs
+++ b/src/key/simple.rs
@@ -41,7 +41,7 @@ impl key::Key for Key {
 }
 
 /// Unit-like struct for event. (crate::key::simple doesn't use events).
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct Event();
 
 /// Unit-like struct for [crate::key::PressedKeyState]. (crate::key::simple pressed keys don't have state).

--- a/src/key/tap_hold.rs
+++ b/src/key/tap_hold.rs
@@ -60,7 +60,7 @@ pub enum TapHoldState {
 }
 
 /// Events emitted by a tap-hold key.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum Event {
     /// Event indicating the key has been held long enough to resolve as hold.
     TapHoldTimeout {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -6,7 +6,7 @@ use crate::key;
 
 use key::{composite, Context, Event};
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 struct ScheduledEvent<E> {
     time: u32,
     event: Event<E>,

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -15,8 +15,7 @@ struct ScheduledEvent<E> {
 #[derive(Debug)]
 struct EventScheduler {
     pending_events: heapless::spsc::Queue<Event<composite::Event>, 256>,
-    scheduled_events:
-        heapless::BinaryHeap<ScheduledEvent<composite::Event>, heapless::binary_heap::Min, 16>,
+    scheduled_events: heapless::Vec<ScheduledEvent<composite::Event>, 16>,
     schedule_counter: u32,
 }
 
@@ -24,7 +23,7 @@ impl EventScheduler {
     pub const fn new() -> Self {
         Self {
             pending_events: heapless::spsc::Queue::new(),
-            scheduled_events: heapless::BinaryHeap::new(),
+            scheduled_events: heapless::Vec::new(),
             schedule_counter: 0,
         }
     }
@@ -48,29 +47,32 @@ impl EventScheduler {
 
     pub fn schedule_after(&mut self, delay: u32, event: Event<composite::Event>) {
         let time = self.schedule_counter + delay;
+        // binary sort insertion;
+        //  smallest at *end* (quick to pop off),
+        //  highest at *start*.
+        let pos = self
+            .scheduled_events
+            .binary_search_by(|&sch_item| sch_item.time.cmp(&delay).reverse())
+            .unwrap_or_else(|e| e);
         self.scheduled_events
-            .push(ScheduledEvent { time, event })
+            .insert(pos, ScheduledEvent { time, event })
             .unwrap();
     }
 
     pub fn cancel_events_for_keymap_index(&mut self, keymap_index: u16) {
-        let old_scheduled_events_heap = core::mem::take(&mut self.scheduled_events);
-        let mut old_events = old_scheduled_events_heap.into_vec();
-        old_events.retain(|ScheduledEvent { event, .. }| match event {
-            Event::Key {
-                keymap_index: ki, ..
-            } => *ki != keymap_index,
-            _ => true,
-        });
-        for scheduled_event in old_events {
-            self.scheduled_events.push(scheduled_event).unwrap();
-        }
+        self.scheduled_events
+            .retain(|ScheduledEvent { event, .. }| match event {
+                Event::Key {
+                    keymap_index: ki, ..
+                } => *ki != keymap_index,
+                _ => true,
+            });
     }
 
     pub fn tick(&mut self) {
         self.schedule_counter += 1;
         let scheduled_ready =
-            if let Some(ScheduledEvent { time, .. }) = self.scheduled_events.peek() {
+            if let Some(ScheduledEvent { time, .. }) = self.scheduled_events.last() {
                 *time <= self.schedule_counter
             } else {
                 false

--- a/src/tuples.rs
+++ b/src/tuples.rs
@@ -16,16 +16,12 @@ pub trait KeysReset {
 pub struct Keys1<
     K0: key::Key,
     Ctx: key::Context<Event = Ev> + Debug = composite::Context,
-    Ev: Copy + Debug + Ord = composite::Event,
+    Ev: Copy + Debug = composite::Event,
     const M: usize = 2,
 >(dynamic::DynamicKey<K0, Ctx, Ev>);
 
-impl<
-        K0: key::Key,
-        Ctx: key::Context<Event = Ev> + Debug,
-        Ev: Copy + Debug + Ord,
-        const M: usize,
-    > Keys1<K0, Ctx, Ev, M>
+impl<K0: key::Key, Ctx: key::Context<Event = Ev> + Debug, Ev: Copy + Debug, const M: usize>
+    Keys1<K0, Ctx, Ev, M>
 {
     /// Constructs a KeysN for the given tuple.
     pub const fn new((k0,): (K0,)) -> Self {
@@ -36,7 +32,7 @@ impl<
 impl<
         K0: key::Key + 'static,
         Ctx: key::Context<Event = Ev> + Debug + 'static,
-        Ev: Copy + Debug + Ord + 'static,
+        Ev: Copy + Debug + 'static,
         const M: usize,
     > Index<usize> for Keys1<K0, Ctx, Ev, M>
 where
@@ -57,7 +53,7 @@ where
 impl<
         K0: crate::key::Key + 'static,
         Ctx: crate::key::Context<Event = Ev> + Debug + 'static,
-        Ev: Copy + Debug + Ord + 'static,
+        Ev: Copy + Debug + 'static,
         const M: usize,
     > IndexMut<usize> for Keys1<K0, Ctx, Ev, M>
 where
@@ -76,7 +72,7 @@ where
 impl<
         K0: crate::key::Key + 'static,
         Ctx: crate::key::Context<Event = Ev> + Debug + 'static,
-        Ev: Copy + Debug + Ord + 'static,
+        Ev: Copy + Debug + 'static,
         const M: usize,
     > KeysReset for Keys1<K0, Ctx, Ev, M>
 where
@@ -102,7 +98,7 @@ macro_rules! define_keys {
                         K~I: crate::key::Key,
                     )*
                 Ctx: crate::key::Context<Event = Ev> + core::fmt::Debug = crate::key::composite::Context,
-                Ev: Copy + core::fmt::Debug + Ord = crate::key::composite::Event,
+                Ev: Copy + core::fmt::Debug = crate::key::composite::Event,
                 const M: usize = 2,
                 >(
                     #(
@@ -115,7 +111,7 @@ macro_rules! define_keys {
                         K~I: crate::key::Key,
                     )*
                 Ctx: crate::key::Context<Event = Ev> + core::fmt::Debug,
-                Ev: Copy + core::fmt::Debug + Ord,
+                Ev: Copy + core::fmt::Debug,
                 const M: usize,
                 > [<Keys $n>]<
                     #(K~I,)*
@@ -141,7 +137,7 @@ macro_rules! define_keys {
                         K~I: crate::key::Key + 'static,
                     )*
                 Ctx: crate::key::Context<Event = Ev> + core::fmt::Debug + 'static,
-                Ev: Copy + core::fmt::Debug + Ord + 'static,
+                Ev: Copy + core::fmt::Debug + 'static,
                 const M: usize,
                 > core::ops::Index<usize> for [<Keys $n>]<
                     #(K~I,)*
@@ -171,7 +167,7 @@ macro_rules! define_keys {
                         K~I: crate::key::Key + 'static,
                     )*
                 Ctx: crate::key::Context<Event = Ev> + core::fmt::Debug + 'static,
-                Ev: Copy + core::fmt::Debug + Ord + 'static,
+                Ev: Copy + core::fmt::Debug + 'static,
                 const M: usize,
                 > core::ops::IndexMut<usize> for [<Keys $n>]<
                     #(K~I,)*
@@ -199,7 +195,7 @@ macro_rules! define_keys {
                         K~I: crate::key::Key + 'static,
                     )*
                 Ctx: crate::key::Context<Event = Ev> + core::fmt::Debug + 'static,
-                Ev: Copy + core::fmt::Debug + Ord + 'static,
+                Ev: Copy + core::fmt::Debug + 'static,
                 const M: usize,
                 > crate::tuples::KeysReset for [<Keys $n>]<
                     #(K~I,)*


### PR DESCRIPTION
This PR achieves two things:

- replaces the somewhat awkward PQ use in the `keymap::EventScheduler` with a Vec. -- This ought to be much more efficient for the (frequently called) "remove events for keymap index", even not as quick for the (less frequently called) "schedule_at".

- Removes the `Ord` requirement from `Event`s. -- It was convenient to just add `#[derive(Ord)]` for the `EventScheduler`. However, this caused some friction when trying to add generics to `key::composite::Event`; I didn't see a compelling need to keep `Ord` on `Event`. (Whereas, say, `priority` might make more sense as something to add to `EventScheduler`).