### PR TITLE
rust: key::Key::Event assoc type must be PartialEq

### DIFF
--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -103,7 +103,7 @@ pub trait Key: Copy + Debug + PartialEq {
     type ContextEvent;
     /// The associated `Event` is to be handled by the associated [Context],
     ///  and any active [PressedKeyState]s.
-    type Event: Copy + Debug;
+    type Event: Copy + Debug + PartialEq;
     /// The associated [PressedKeyState] implements functionality
     ///  for the pressed key.
     /// (e.g. [tap_hold::PressedKeyState] implements behaviour resolving


### PR DESCRIPTION
#98 was a little too aggressive. `Ord` is unnecessary. `PartialEq` is useful to have.