### PR TITLE
Nickel: annotate serialized_json_keymap as default

### DIFF
--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -73,6 +73,7 @@
         (std.array.length base_keys),
 
   serialized_json_keymap
+    | default
     | doc "The keymap.json output value."
     =
       layered_keys |> std.array.map to_json_serialized_key,


### PR DESCRIPTION
The benefit of this is e.g. allows going from `keymap.ncl` to `keymap.rs` by importing both `keymap-codegen.ncl` and `keymap-ncl-to-json.ncl` (or e.g. invoking `nickel` with both files).

I'd considered the idea of merging the two NCL files into one.. but, this seems against the spirit of modularity; and the two files have clear separate purposes: `ncl-to-json` takes the keymap from a Nickel model and compiles these values to the "JSON serializable" values. `codegen` takes JSON serializable values (e.g. from a `keymap.json`), and compiles this to a `keymap.rs`.