### PR TITLE
Impl more NestableKeys

### DIFF
--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -152,7 +152,7 @@ pub mod init {
     pub type CompositeImpl = crate::key::composite::CompositeImpl<NestedKey, LayersImpl>;
 
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
-    pub type Context = crate::key::composite::Context<CompositeImpl>;
+    pub type Context = crate::key::composite::Context<LayersImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
     pub type Event = crate::key::composite::Event;

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -155,7 +155,7 @@ pub mod init {
     pub type Context = crate::key::composite::Context<CompositeImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
-    pub type Event = crate::key::composite::Event<CompositeImpl>;
+    pub type Event = crate::key::composite::Event;
 
     /// Initial [Context] value.
     pub const CONTEXT: Context = crate::key::composite::Context {

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -21,19 +21,28 @@ pub trait NestableKey: key::Key + Sized {
     ) -> Result<key::Event<<Self as key::Key>::Event>, key::EventError>;
 }
 
-impl NestableKey for crate::key::simple::Key {
-    fn into_event(
-        event: crate::key::Event<<Self as crate::key::Key>::Event>,
-    ) -> crate::key::Event<Event> {
-        event.into()
-    }
+macro_rules! impl_nestable_key {
+    ($key_type:path) => {
+        impl NestableKey for $key_type {
+            fn into_event(
+                event: crate::key::Event<<Self as crate::key::Key>::Event>,
+            ) -> crate::key::Event<Event> {
+                event.into()
+            }
 
-    fn try_event_from(
-        event: crate::key::Event<Event>,
-    ) -> Result<crate::key::Event<<Self as crate::key::Key>::Event>, crate::key::EventError> {
-        event.try_into()
-    }
+            fn try_event_from(
+                event: crate::key::Event<Event>,
+            ) -> Result<crate::key::Event<<Self as crate::key::Key>::Event>, crate::key::EventError>
+            {
+                event.try_into()
+            }
+        }
+    };
 }
+
+impl_nestable_key!(simple::Key);
+impl_nestable_key!(tap_hold::Key<simple::Key>);
+impl_nestable_key!(layered::ModifierKey);
 
 /// Related types used by [Key], [Context] and [Event].
 pub trait CompositeTypes: Copy + Debug + PartialEq

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -21,16 +21,17 @@ pub trait NestableKey: key::Key + Sized {
     ) -> Result<key::Event<<Self as key::Key>::Event>, key::EventError>;
 }
 
-impl NestableKey for simple::Key {
-    fn into_event(event: key::Event<<Self as key::Key>::Event>) -> key::Event<Event> {
+impl NestableKey for crate::key::simple::Key {
+    fn into_event(
+        event: crate::key::Event<<Self as crate::key::Key>::Event>,
+    ) -> crate::key::Event<Event> {
         event.into()
     }
 
     fn try_event_from(
-        event: key::Event<Event>,
-    ) -> Result<key::Event<simple::Event>, key::EventError> {
-        let res: key::EventResult<key::Event<simple::Event>> = event.try_into();
-        res
+        event: crate::key::Event<Event>,
+    ) -> Result<crate::key::Event<<Self as crate::key::Key>::Event>, crate::key::EventError> {
+        event.try_into()
     }
 }
 

--- a/src/key/dynamic.rs
+++ b/src/key/dynamic.rs
@@ -125,14 +125,18 @@ where
 mod tests {
     use super::*;
 
-    use key::{composite, simple};
+    use key::{composite, layered, simple};
 
     #[test]
     fn test_composite_dynamic_simple_key_has_no_key_code_when_released() {
         // Assemble
         let dyn_key: &mut dyn Key<composite::Event, Context = composite::Context> =
             &mut DynamicKey::new(simple::Key(0x04));
-        let context = composite::Context::default();
+        let context: composite::Context = composite::Context {
+            layer_context: layered::Context {
+                active_layers: [false; 0],
+            },
+        };
 
         // Act
         let keymap_index: u16 = 5; // arbitrary

--- a/src/key/dynamic.rs
+++ b/src/key/dynamic.rs
@@ -35,7 +35,7 @@ where
 /// Convenience type alias for [Key] which uses [crate::key::composite::Event] and [crate::key::composite::Context].
 #[allow(type_alias_bounds)]
 pub type CompositeKey<T: key::composite::CompositeTypes = key::composite::CompositeImpl> =
-    dyn Key<key::composite::Event<T>, Context = key::composite::Context<T>>;
+    dyn Key<key::composite::Event, Context = key::composite::Context<T>>;
 
 /// Generic implementation of [Key] for a [key::Key] and some `Ctx`/`Ev`.
 #[derive(Debug)]

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -55,10 +55,7 @@ impl<E: Copy + Debug> PressedKeyEvents<E> {
             self.0
                 .as_slice()
                 .iter()
-                .map(|scheduled_event| ScheduledEvent {
-                    schedule: scheduled_event.schedule,
-                    event: f(scheduled_event.event),
-                })
+                .map(|sch_ev| sch_ev.map_scheduled_event(f))
                 .collect(),
         )
     }
@@ -330,14 +327,19 @@ impl<T: Copy> ScheduledEvent<T> {
         }
     }
 
+    /// Maps the Event of the ScheduledEvent into a new type.
+    pub fn map_scheduled_event<U>(&self, f: fn(Event<T>) -> Event<U>) -> ScheduledEvent<U> {
+        ScheduledEvent {
+            event: f(self.event),
+            schedule: self.schedule,
+        }
+    }
+
     /// Maps the ScheduledEvent into a new type.
     pub fn into_scheduled_event<U>(&self) -> ScheduledEvent<U>
     where
         Event<U>: From<Event<T>>,
     {
-        ScheduledEvent {
-            event: self.event.into(),
-            schedule: self.schedule,
-        }
+        self.map_scheduled_event(|e| e.into())
     }
 }

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -284,6 +284,15 @@ impl<T> From<input::Event> for Event<T> {
     }
 }
 
+/// Sum type for events which modify other keys.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModifierKeyEvent<T, U> {
+    /// The modifier's event type.
+    Modifier(T),
+    /// The inner key's event type.
+    Inner(U),
+}
+
 /// Schedule for a [ScheduledEvent].
 #[allow(unused)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -303,6 +303,21 @@ impl<T: Copy, U: Copy> ModifierKeyEvent<T, U> {
             ModifierKeyEvent::Inner(u) => g(u),
         }
     }
+
+    /// Tries to construct either variant.
+    pub fn try_from<V: Copy>(
+        v: V,
+        f: fn(V) -> EventResult<T>,
+        g: fn(V) -> EventResult<U>,
+    ) -> EventResult<ModifierKeyEvent<T, U>> {
+        if let Ok(t) = f(v) {
+            Ok(ModifierKeyEvent::Modifier(t))
+        } else if let Ok(u) = g(v) {
+            Ok(ModifierKeyEvent::Inner(u))
+        } else {
+            Err(EventError::UnmappableEvent)
+        }
+    }
 }
 
 /// Schedule for a [ScheduledEvent].

--- a/src/key/tap_hold.rs
+++ b/src/key/tap_hold.rs
@@ -107,9 +107,7 @@ impl<K: key::Key> key::PressedKeyState<Key<K>> for PressedKeyState<K> {
                 // TapHold: any interruption resolves pending TapHold as Hold.
                 let (hold_pk, hold_pke) = key.hold.new_pressed_key(inner_context, keymap_index);
                 self.resolve(TapHoldState::Hold(hold_pk));
-                hold_pke.map_events(|sch_ev| {
-                    sch_ev.map_key_event(|ev| key::ModifierKeyEvent::Inner(ev))
-                })
+                hold_pke.map_events(|ev| key::ModifierKeyEvent::Inner(ev))
             }
             key::Event::Input(input::Event::Release { keymap_index: ki }) => {
                 let mut pke = key::PressedKeyEvents::no_events();
@@ -117,9 +115,7 @@ impl<K: key::Key> key::PressedKeyState<Key<K>> for PressedKeyState<K> {
                     // TapHold: resolved as tap.
                     let (tap_pk, tap_pke) = key.tap.new_pressed_key(inner_context, keymap_index);
                     self.resolve(TapHoldState::Tap(tap_pk));
-                    pke.extend(tap_pke.map_events(|sch_ev| {
-                        sch_ev.map_key_event(|ev| key::ModifierKeyEvent::Inner(ev))
-                    }));
+                    pke.extend(tap_pke.map_events(|ev| key::ModifierKeyEvent::Inner(ev)));
                 }
 
                 match &self {
@@ -146,9 +142,7 @@ impl<K: key::Key> key::PressedKeyState<Key<K>> for PressedKeyState<K> {
                 // Key held long enough to resolve as hold.
                 let (hold_pk, hold_pke) = key.hold.new_pressed_key(inner_context, keymap_index);
                 self.resolve(TapHoldState::Hold(hold_pk));
-                hold_pke.map_events(|sch_ev| {
-                    sch_ev.map_key_event(|ev| key::ModifierKeyEvent::Inner(ev))
-                })
+                hold_pke.map_events(|ev| key::ModifierKeyEvent::Inner(ev))
             }
             _ => key::PressedKeyEvents::no_events(),
         }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -133,7 +133,7 @@ pub struct Keymap<
     I: IndexMut<
             usize,
             Output = dyn key::dynamic::Key<
-                key::composite::Event<T>,
+                key::composite::Event,
                 Context = key::composite::Context<T>,
             >,
         > + crate::tuples::KeysReset,
@@ -142,14 +142,14 @@ pub struct Keymap<
     key_definitions: I,
     context: composite::Context<T>,
     pressed_inputs: heapless::Vec<input::PressedInput, 16>,
-    event_scheduler: EventScheduler<composite::Event<T>>,
+    event_scheduler: EventScheduler<composite::Event>,
 }
 
 impl<
         I: IndexMut<
                 usize,
                 Output = dyn key::dynamic::Key<
-                    key::composite::Event<T>,
+                    key::composite::Event,
                     Context = key::composite::Context<T>,
                 >,
             > + crate::tuples::KeysReset,
@@ -407,7 +407,7 @@ mod tests {
         type L = layered::ArrayImpl<1>;
         type T = composite::CompositeImpl<NK, L>;
         type Ctx = composite::Context<T>;
-        type Ev = composite::Event<T>;
+        type Ev = composite::Event;
         type MK = layered::ModifierKey;
         type LK = layered::LayeredKey<NK, L>;
         let keys: Keys2<MK, LK, Ctx, Ev> = tuples::Keys2::new((
@@ -438,7 +438,7 @@ mod tests {
         type L = layered::ArrayImpl<1>;
         type T = composite::CompositeImpl<NK, L>;
         type Ctx = composite::Context<T>;
-        type Ev = composite::Event<T>;
+        type Ev = composite::Event;
         type K = composite::Key<T>;
         let keys: Keys2<K, K, Ctx, Ev> = tuples::Keys2::new((
             K::layer_modifier(layered::ModifierKey::Hold(0)),
@@ -469,7 +469,7 @@ mod tests {
         type L = layered::ArrayImpl<1>;
         type T = composite::CompositeImpl<NK, L>;
         type Ctx = composite::Context<T>;
-        type Ev = composite::Event<T>;
+        type Ev = composite::Event;
         type K = composite::Key<T>;
         let keys: Keys2<K, K, Ctx, Ev> = tuples::Keys2::new((
             K::layer_modifier(layered::ModifierKey::Hold(0)),
@@ -502,7 +502,7 @@ mod tests {
         type L = layered::ArrayImpl<1>;
         type T = composite::CompositeImpl<NK, L>;
         type Ctx = composite::Context<T>;
-        type Ev = composite::Event<T>;
+        type Ev = composite::Event;
         type K = composite::Key<T>;
         let keys: Keys2<K, K, Ctx, Ev> = tuples::Keys2::new((
             K::layer_modifier(layered::ModifierKey::Hold(0)),
@@ -535,7 +535,7 @@ mod tests {
         type L = layered::ArrayImpl<1>;
         type T = composite::CompositeImpl<NK, L>;
         type Ctx = composite::Context<T>;
-        type Ev = composite::Event<T>;
+        type Ev = composite::Event;
         type K = composite::Key<T>;
         let keys: Keys2<K, K, Ctx, Ev> = tuples::Keys2::new((
             K::layer_modifier(layered::ModifierKey::Hold(0)),

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -134,13 +134,13 @@ pub struct Keymap<
             usize,
             Output = dyn key::dynamic::Key<
                 key::composite::Event,
-                Context = key::composite::Context<T>,
+                Context = key::composite::Context<L>,
             >,
         > + crate::tuples::KeysReset,
-    T: key::composite::CompositeTypes = key::composite::CompositeImpl,
+    L: key::layered::LayerImpl = key::layered::ArrayImpl<0>,
 > {
     key_definitions: I,
-    context: composite::Context<T>,
+    context: composite::Context<L>,
     pressed_inputs: heapless::Vec<input::PressedInput, 16>,
     event_scheduler: EventScheduler<composite::Event>,
 }
@@ -150,14 +150,14 @@ impl<
                 usize,
                 Output = dyn key::dynamic::Key<
                     key::composite::Event,
-                    Context = key::composite::Context<T>,
+                    Context = key::composite::Context<L>,
                 >,
             > + crate::tuples::KeysReset,
-        T: key::composite::CompositeTypes,
-    > Keymap<I, T>
+        L: key::layered::LayerImpl,
+    > Keymap<I, L>
 {
     /// Constructs a new keymap with the given key definitions and context.
-    pub const fn new(key_definitions: I, context: composite::Context<T>) -> Self {
+    pub const fn new(key_definitions: I, context: composite::Context<L>) -> Self {
         Self {
             key_definitions,
             context,
@@ -296,8 +296,15 @@ mod tests {
         use tuples::Keys1;
 
         // Assemble
+        const NUM_LAYERS: usize = 0;
+        type L = crate::key::layered::ArrayImpl<NUM_LAYERS>;
+        type Ctx = Context<L>;
         let keys: Keys1<simple::Key, Context, Event> = Keys1::new((simple::Key(0x04),));
-        let context = composite::Context::default();
+        let context: Ctx = Ctx {
+            layer_context: crate::key::layered::Context {
+                active_layers: [false; NUM_LAYERS],
+            },
+        };
         let mut keymap = Keymap::new(keys, context);
 
         // Act
@@ -320,7 +327,11 @@ mod tests {
             tap: simple::Key(0x04),
             hold: simple::Key(0xE0),
         },));
-        let context = composite::Context::default();
+        let context: Context = Context {
+            layer_context: crate::key::layered::Context {
+                active_layers: [false; 0],
+            },
+        };
         let mut keymap = Keymap::new(keys, context);
 
         // Act
@@ -349,7 +360,11 @@ mod tests {
             tap: simple::Key(0x04),
             hold: simple::Key(0xE0),
         },));
-        let context = composite::Context::default();
+        let context: Context = Context {
+            layer_context: crate::key::layered::Context {
+                active_layers: [false; 0],
+            },
+        };
         let mut keymap = Keymap::new(keys, context);
 
         // Act
@@ -385,7 +400,11 @@ mod tests {
         // Assemble
         let keys: Keys1<composite::Key, Context, Event> =
             Keys1::new((composite::Key::simple(simple::Key(0x04)),));
-        let context = composite::Context::default();
+        let context: Context = Context {
+            layer_context: crate::key::layered::Context {
+                active_layers: [false; 0],
+            },
+        };
         let mut keymap = Keymap::new(keys, context);
 
         // Act
@@ -403,10 +422,10 @@ mod tests {
         use tuples::Keys2;
 
         // Assemble
+        const NUM_LAYERS: usize = 1;
         type NK = composite::DefaultNestableKey;
-        type L = layered::ArrayImpl<1>;
-        type T = composite::CompositeImpl<NK, L>;
-        type Ctx = composite::Context<T>;
+        type L = layered::ArrayImpl<NUM_LAYERS>;
+        type Ctx = composite::Context<L>;
         type Ev = composite::Event;
         type MK = layered::ModifierKey;
         type LK = layered::LayeredKey<NK, L>;
@@ -414,7 +433,11 @@ mod tests {
             layered::ModifierKey::Hold(0),
             layered::LayeredKey::new(simple::Key(0x04), [Some(simple::Key(0x05))]),
         ));
-        let context = Ctx::default();
+        let context: Ctx = Ctx {
+            layer_context: layered::Context {
+                active_layers: [false; NUM_LAYERS],
+            },
+        };
 
         let mut keymap = Keymap::new(keys, context);
 
@@ -434,10 +457,11 @@ mod tests {
         use tuples::Keys2;
 
         // Assemble
+        const NUM_LAYERS: usize = 1;
         type NK = composite::DefaultNestableKey;
-        type L = layered::ArrayImpl<1>;
+        type L = layered::ArrayImpl<NUM_LAYERS>;
         type T = composite::CompositeImpl<NK, L>;
-        type Ctx = composite::Context<T>;
+        type Ctx = composite::Context<L>;
         type Ev = composite::Event;
         type K = composite::Key<T>;
         let keys: Keys2<K, K, Ctx, Ev> = tuples::Keys2::new((
@@ -447,7 +471,11 @@ mod tests {
                 [Some(simple::Key(0x05))],
             )),
         ));
-        let context = Ctx::default();
+        let context: Ctx = Ctx {
+            layer_context: layered::Context {
+                active_layers: [false; NUM_LAYERS],
+            },
+        };
         let mut keymap = Keymap::new(keys, context);
 
         // Act
@@ -465,10 +493,11 @@ mod tests {
         use tuples::Keys2;
 
         // Assemble
+        const NUM_LAYERS: usize = 1;
         type NK = composite::DefaultNestableKey;
-        type L = layered::ArrayImpl<1>;
+        type L = layered::ArrayImpl<NUM_LAYERS>;
         type T = composite::CompositeImpl<NK, L>;
-        type Ctx = composite::Context<T>;
+        type Ctx = composite::Context<L>;
         type Ev = composite::Event;
         type K = composite::Key<T>;
         let keys: Keys2<K, K, Ctx, Ev> = tuples::Keys2::new((
@@ -478,7 +507,11 @@ mod tests {
                 [Some(simple::Key(0x05))],
             )),
         ));
-        let context = Ctx::default();
+        let context: Ctx = Ctx {
+            layer_context: layered::Context {
+                active_layers: [false; NUM_LAYERS],
+            },
+        };
 
         let mut keymap = Keymap::new(keys, context);
 
@@ -498,10 +531,11 @@ mod tests {
         use tuples::Keys2;
 
         // Assemble
+        const NUM_LAYERS: usize = 1;
         type NK = composite::DefaultNestableKey;
-        type L = layered::ArrayImpl<1>;
+        type L = layered::ArrayImpl<NUM_LAYERS>;
         type T = composite::CompositeImpl<NK, L>;
-        type Ctx = composite::Context<T>;
+        type Ctx = composite::Context<L>;
         type Ev = composite::Event;
         type K = composite::Key<T>;
         let keys: Keys2<K, K, Ctx, Ev> = tuples::Keys2::new((
@@ -511,7 +545,11 @@ mod tests {
                 [Some(simple::Key(0x05))],
             )),
         ));
-        let context = Ctx::default();
+        let context: Ctx = Ctx {
+            layer_context: layered::Context {
+                active_layers: [false; NUM_LAYERS],
+            },
+        };
         let mut keymap = Keymap::new(keys, context);
 
         // Act
@@ -531,10 +569,11 @@ mod tests {
         use tuples::Keys2;
 
         // Assemble
+        const NUM_LAYERS: usize = 1;
         type NK = composite::DefaultNestableKey;
-        type L = layered::ArrayImpl<1>;
+        type L = layered::ArrayImpl<NUM_LAYERS>;
         type T = composite::CompositeImpl<NK, L>;
-        type Ctx = composite::Context<T>;
+        type Ctx = composite::Context<L>;
         type Ev = composite::Event;
         type K = composite::Key<T>;
         let keys: Keys2<K, K, Ctx, Ev> = tuples::Keys2::new((
@@ -544,7 +583,11 @@ mod tests {
                 [Some(simple::Key(0x05))],
             )),
         ));
-        let context = Ctx::default();
+        let context: Ctx = Ctx {
+            layer_context: layered::Context {
+                active_layers: [false; NUM_LAYERS],
+            },
+        };
         let mut keymap = Keymap::new(keys, context);
 
         // Act

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ pub mod init {
     pub type Context = composite::Context<CompositeImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
-    pub type Event = composite::Event<CompositeImpl>;
+    pub type Event = composite::Event;
 
     /// Alias for keys.
     pub type Key = composite::Key<CompositeImpl>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ pub mod init {
     pub type CompositeImpl = composite::CompositeImpl<NestedKey, LayersImpl>;
 
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
-    pub type Context = composite::Context<CompositeImpl>;
+    pub type Context = composite::Context<LayersImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
     pub type Event = composite::Event;
@@ -102,7 +102,7 @@ pub mod init {
 #[cfg(custom_keymap)]
 include!(env!("SMART_KEYMAP_CUSTOM_KEYMAP"));
 
-static mut KEYMAP: keymap::Keymap<init::KeyDefinitionsType, init::CompositeImpl> =
+static mut KEYMAP: keymap::Keymap<init::KeyDefinitionsType, init::LayersImpl> =
     keymap::Keymap::new(init::KEY_DEFINITIONS, init::CONTEXT);
 
 /// Initialize the global keymap instance.

--- a/src/tuples.rs
+++ b/src/tuples.rs
@@ -36,8 +36,8 @@ impl<
         const M: usize,
     > Index<usize> for Keys1<K0, Ctx, Ev, M>
 where
-    key::Event<<K0 as key::Key>::Event>: TryFrom<key::Event<Ev>>,
-    key::Event<Ev>: From<key::Event<<K0 as key::Key>::Event>>,
+    <K0 as key::Key>::Event: TryFrom<Ev>,
+    Ev: From<<K0 as key::Key>::Event>,
     <K0 as key::Key>::Context: From<Ctx>,
 {
     type Output = dyn dynamic::Key<Ev, M, Context = Ctx>;
@@ -57,8 +57,8 @@ impl<
         const M: usize,
     > IndexMut<usize> for Keys1<K0, Ctx, Ev, M>
 where
-    crate::key::Event<<K0 as crate::key::Key>::Event>: TryFrom<crate::key::Event<Ev>>,
-    crate::key::Event<Ev>: From<crate::key::Event<<K0 as crate::key::Key>::Event>>,
+    <K0 as crate::key::Key>::Event: TryFrom<Ev>,
+    Ev: From<<K0 as crate::key::Key>::Event>,
     <K0 as crate::key::Key>::Context: From<Ctx>,
 {
     fn index_mut(&mut self, idx: usize) -> &mut Self::Output {
@@ -76,8 +76,8 @@ impl<
         const M: usize,
     > KeysReset for Keys1<K0, Ctx, Ev, M>
 where
-    crate::key::Event<<K0 as crate::key::Key>::Event>: TryFrom<crate::key::Event<Ev>>,
-    crate::key::Event<Ev>: From<crate::key::Event<<K0 as crate::key::Key>::Event>>,
+    <K0 as crate::key::Key>::Event: TryFrom<Ev>,
+    Ev: From<<K0 as crate::key::Key>::Event>,
     <K0 as crate::key::Key>::Context: From<Ctx>,
 {
     fn reset(&mut self) {
@@ -145,8 +145,8 @@ macro_rules! define_keys {
                     >
                 where
                     #(
-                    crate::key::Event<<K~I as crate::key::Key>::Event>: TryFrom<crate::key::Event<Ev>>,
-                    crate::key::Event<Ev>: From<crate::key::Event<<K~I as crate::key::Key>::Event>>,
+                    <K~I as crate::key::Key>::Event: TryFrom<Ev>,
+                    Ev: From<<K~I as crate::key::Key>::Event>,
                     <K~I as crate::key::Key>::Context: From<Ctx>,
                 )*
                 {
@@ -175,8 +175,8 @@ macro_rules! define_keys {
                     >
                 where
                     #(
-                    crate::key::Event<<K~I as crate::key::Key>::Event>: TryFrom<crate::key::Event<Ev>>,
-                    crate::key::Event<Ev>: From<crate::key::Event<<K~I as crate::key::Key>::Event>>,
+                    <K~I as crate::key::Key>::Event: TryFrom<Ev>,
+                    Ev: From<<K~I as crate::key::Key>::Event>,
                     <K~I as crate::key::Key>::Context: From<Ctx>,
                 )*
                 {
@@ -203,8 +203,8 @@ macro_rules! define_keys {
                     >
                 where
                     #(
-                    crate::key::Event<<K~I as crate::key::Key>::Event>: TryFrom<crate::key::Event<Ev>>,
-                    crate::key::Event<Ev>: From<crate::key::Event<<K~I as crate::key::Key>::Event>>,
+                    <K~I as crate::key::Key>::Event: TryFrom<Ev>,
+                    Ev: From<<K~I as crate::key::Key>::Event>,
                     <K~I as crate::key::Key>::Context: From<Ctx>,
                 )*
                 {

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -62,7 +62,7 @@ type LayersImpl = key::layered::ArrayImpl<16>;
 type CompositeImpl = key::composite::CompositeImpl<NestedKey, LayersImpl>;
 type Key = key::composite::Key<CompositeImpl>;
 type Context = key::composite::Context<CompositeImpl>;
-type Event = key::composite::Event<CompositeImpl>;
+type Event = key::composite::Event;
 
 #[derive(Debug)]
 enum LoadedKeymap {

--- a/tests/ncl/keymap-1key-simple/expected.rs
+++ b/tests/ncl/keymap-1key-simple/expected.rs
@@ -12,7 +12,7 @@ pub mod init {
     pub type CompositeImpl = crate::key::composite::CompositeImpl<NestedKey, LayersImpl>;
 
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
-    pub type Context = crate::key::composite::Context<CompositeImpl>;
+    pub type Context = crate::key::composite::Context<LayersImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
     pub type Event = crate::key::composite::Event;

--- a/tests/ncl/keymap-1key-simple/expected.rs
+++ b/tests/ncl/keymap-1key-simple/expected.rs
@@ -15,7 +15,7 @@ pub mod init {
     pub type Context = crate::key::composite::Context<CompositeImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
-    pub type Event = crate::key::composite::Event<CompositeImpl>;
+    pub type Event = crate::key::composite::Event;
 
     /// Initial [Context] value.
     pub const CONTEXT: Context = crate::key::composite::Context {

--- a/tests/ncl/keymap-1key-tap_hold/expected.rs
+++ b/tests/ncl/keymap-1key-tap_hold/expected.rs
@@ -12,7 +12,7 @@ pub mod init {
     pub type CompositeImpl = crate::key::composite::CompositeImpl<NestedKey, LayersImpl>;
 
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
-    pub type Context = crate::key::composite::Context<CompositeImpl>;
+    pub type Context = crate::key::composite::Context<LayersImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
     pub type Event = crate::key::composite::Event;

--- a/tests/ncl/keymap-1key-tap_hold/expected.rs
+++ b/tests/ncl/keymap-1key-tap_hold/expected.rs
@@ -15,7 +15,7 @@ pub mod init {
     pub type Context = crate::key::composite::Context<CompositeImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
-    pub type Event = crate::key::composite::Event<CompositeImpl>;
+    pub type Event = crate::key::composite::Event;
 
     /// Initial [Context] value.
     pub const CONTEXT: Context = crate::key::composite::Context {

--- a/tests/ncl/keymap-2key-2layer-simple/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-simple/expected.rs
@@ -12,7 +12,7 @@ pub mod init {
     pub type CompositeImpl = crate::key::composite::CompositeImpl<NestedKey, LayersImpl>;
 
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
-    pub type Context = crate::key::composite::Context<CompositeImpl>;
+    pub type Context = crate::key::composite::Context<LayersImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
     pub type Event = crate::key::composite::Event;

--- a/tests/ncl/keymap-2key-2layer-simple/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-simple/expected.rs
@@ -15,7 +15,7 @@ pub mod init {
     pub type Context = crate::key::composite::Context<CompositeImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
-    pub type Event = crate::key::composite::Event<CompositeImpl>;
+    pub type Event = crate::key::composite::Event;
 
     /// Initial [Context] value.
     pub const CONTEXT: Context = crate::key::composite::Context {

--- a/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
@@ -12,7 +12,7 @@ pub mod init {
     pub type CompositeImpl = crate::key::composite::CompositeImpl<NestedKey, LayersImpl>;
 
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
-    pub type Context = crate::key::composite::Context<CompositeImpl>;
+    pub type Context = crate::key::composite::Context<LayersImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
     pub type Event = crate::key::composite::Event;

--- a/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
@@ -15,7 +15,7 @@ pub mod init {
     pub type Context = crate::key::composite::Context<CompositeImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
-    pub type Event = crate::key::composite::Event<CompositeImpl>;
+    pub type Event = crate::key::composite::Event;
 
     /// Initial [Context] value.
     pub const CONTEXT: Context = crate::key::composite::Context {

--- a/tests/ncl/keymap-60key-dvorak-simple/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple/expected.rs
@@ -12,7 +12,7 @@ pub mod init {
     pub type CompositeImpl = crate::key::composite::CompositeImpl<NestedKey, LayersImpl>;
 
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
-    pub type Context = crate::key::composite::Context<CompositeImpl>;
+    pub type Context = crate::key::composite::Context<LayersImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
     pub type Event = crate::key::composite::Event;

--- a/tests/ncl/keymap-60key-dvorak-simple/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple/expected.rs
@@ -15,7 +15,7 @@ pub mod init {
     pub type Context = crate::key::composite::Context<CompositeImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
-    pub type Event = crate::key::composite::Event<CompositeImpl>;
+    pub type Event = crate::key::composite::Event;
 
     /// Initial [Context] value.
     pub const CONTEXT: Context = crate::key::composite::Context {


### PR DESCRIPTION
After updating `key::tap_hold::Key` to `tap_hold::Key<K>`, I realised that for Nickel keymaps to support tap-hold of keys, there need to be more nestable keys.

Implementing Nestable keys for `composite::Event<K>` was high friction. -- I think some refactoring needs to be done before implementing deeply nested keys.

* * *

What I want to see from this PR is unit tests with composite keys with nested keys, for the kinds of keymaps I want.

e.g. For a miryoku-style keymap, the thumb key is layered, but is also used as a tap-hold key with a layer modifier and a simple key.