### PR TITLE
rust: refactor events to use key::ModifierKeyEvent

### DIFF
--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -155,7 +155,7 @@ pub mod init {
     pub type Context = crate::key::composite::Context<CompositeImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
-    pub type Event = crate::key::composite::Event<CompositeImpl>;
+    pub type Event = crate::key::composite::Event;
 
     /// Initial [Context] value.
     pub const CONTEXT: Context = crate::key::composite::Context {

--- a/src/key/dynamic.rs
+++ b/src/key/dynamic.rs
@@ -35,7 +35,7 @@ where
 /// Convenience type alias for [Key] which uses [crate::key::composite::Event] and [crate::key::composite::Context].
 #[allow(type_alias_bounds)]
 pub type CompositeKey<T: key::composite::CompositeTypes = key::composite::CompositeImpl> =
-    dyn Key<key::composite::Event<T>, Context = key::composite::Context<T>>;
+    dyn Key<key::composite::Event, Context = key::composite::Context<T>>;
 
 /// Generic implementation of [Key] for a [key::Key] and some `Ctx`/`Ev`.
 #[derive(Debug)]

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -284,6 +284,15 @@ impl<T> From<input::Event> for Event<T> {
     }
 }
 
+/// Sum type for events which modify other keys.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModifierKeyEvent<T, U> {
+    /// The modifier's event type.
+    Modifier(T),
+    /// The inner key's event type.
+    Inner(U),
+}
+
 /// Schedule for a [ScheduledEvent].
 #[allow(unused)]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -133,7 +133,7 @@ pub struct Keymap<
     I: IndexMut<
             usize,
             Output = dyn key::dynamic::Key<
-                key::composite::Event<T>,
+                key::composite::Event,
                 Context = key::composite::Context<T>,
             >,
         > + crate::tuples::KeysReset,
@@ -142,14 +142,14 @@ pub struct Keymap<
     key_definitions: I,
     context: composite::Context<T>,
     pressed_inputs: heapless::Vec<input::PressedInput, 16>,
-    event_scheduler: EventScheduler<composite::Event<T>>,
+    event_scheduler: EventScheduler<composite::Event>,
 }
 
 impl<
         I: IndexMut<
                 usize,
                 Output = dyn key::dynamic::Key<
-                    key::composite::Event<T>,
+                    key::composite::Event,
                     Context = key::composite::Context<T>,
                 >,
             > + crate::tuples::KeysReset,
@@ -407,7 +407,7 @@ mod tests {
         type L = layered::ArrayImpl<1>;
         type T = composite::CompositeImpl<NK, L>;
         type Ctx = composite::Context<T>;
-        type Ev = composite::Event<T>;
+        type Ev = composite::Event;
         type MK = layered::ModifierKey;
         type LK = layered::LayeredKey<NK, L>;
         let keys: Keys2<MK, LK, Ctx, Ev> = tuples::Keys2::new((
@@ -438,7 +438,7 @@ mod tests {
         type L = layered::ArrayImpl<1>;
         type T = composite::CompositeImpl<NK, L>;
         type Ctx = composite::Context<T>;
-        type Ev = composite::Event<T>;
+        type Ev = composite::Event;
         type K = composite::Key<T>;
         let keys: Keys2<K, K, Ctx, Ev> = tuples::Keys2::new((
             K::layer_modifier(layered::ModifierKey::Hold(0)),
@@ -469,7 +469,7 @@ mod tests {
         type L = layered::ArrayImpl<1>;
         type T = composite::CompositeImpl<NK, L>;
         type Ctx = composite::Context<T>;
-        type Ev = composite::Event<T>;
+        type Ev = composite::Event;
         type K = composite::Key<T>;
         let keys: Keys2<K, K, Ctx, Ev> = tuples::Keys2::new((
             K::layer_modifier(layered::ModifierKey::Hold(0)),
@@ -502,7 +502,7 @@ mod tests {
         type L = layered::ArrayImpl<1>;
         type T = composite::CompositeImpl<NK, L>;
         type Ctx = composite::Context<T>;
-        type Ev = composite::Event<T>;
+        type Ev = composite::Event;
         type K = composite::Key<T>;
         let keys: Keys2<K, K, Ctx, Ev> = tuples::Keys2::new((
             K::layer_modifier(layered::ModifierKey::Hold(0)),
@@ -535,7 +535,7 @@ mod tests {
         type L = layered::ArrayImpl<1>;
         type T = composite::CompositeImpl<NK, L>;
         type Ctx = composite::Context<T>;
-        type Ev = composite::Event<T>;
+        type Ev = composite::Event;
         type K = composite::Key<T>;
         let keys: Keys2<K, K, Ctx, Ev> = tuples::Keys2::new((
             K::layer_modifier(layered::ModifierKey::Hold(0)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ pub mod init {
     pub type Context = composite::Context<CompositeImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
-    pub type Event = composite::Event<CompositeImpl>;
+    pub type Event = composite::Event;
 
     /// Alias for keys.
     pub type Key = composite::Key<CompositeImpl>;

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -62,7 +62,7 @@ type LayersImpl = key::layered::ArrayImpl<16>;
 type CompositeImpl = key::composite::CompositeImpl<NestedKey, LayersImpl>;
 type Key = key::composite::Key<CompositeImpl>;
 type Context = key::composite::Context<CompositeImpl>;
-type Event = key::composite::Event<CompositeImpl>;
+type Event = key::composite::Event;
 
 #[derive(Debug)]
 enum LoadedKeymap {

--- a/tests/ncl/keymap-1key-simple/expected.rs
+++ b/tests/ncl/keymap-1key-simple/expected.rs
@@ -15,7 +15,7 @@ pub mod init {
     pub type Context = crate::key::composite::Context<CompositeImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
-    pub type Event = crate::key::composite::Event<CompositeImpl>;
+    pub type Event = crate::key::composite::Event;
 
     /// Initial [Context] value.
     pub const CONTEXT: Context = crate::key::composite::Context {

--- a/tests/ncl/keymap-1key-tap_hold/expected.rs
+++ b/tests/ncl/keymap-1key-tap_hold/expected.rs
@@ -15,7 +15,7 @@ pub mod init {
     pub type Context = crate::key::composite::Context<CompositeImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
-    pub type Event = crate::key::composite::Event<CompositeImpl>;
+    pub type Event = crate::key::composite::Event;
 
     /// Initial [Context] value.
     pub const CONTEXT: Context = crate::key::composite::Context {

--- a/tests/ncl/keymap-2key-2layer-simple/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-simple/expected.rs
@@ -15,7 +15,7 @@ pub mod init {
     pub type Context = crate::key::composite::Context<CompositeImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
-    pub type Event = crate::key::composite::Event<CompositeImpl>;
+    pub type Event = crate::key::composite::Event;
 
     /// Initial [Context] value.
     pub const CONTEXT: Context = crate::key::composite::Context {

--- a/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
@@ -15,7 +15,7 @@ pub mod init {
     pub type Context = crate::key::composite::Context<CompositeImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
-    pub type Event = crate::key::composite::Event<CompositeImpl>;
+    pub type Event = crate::key::composite::Event;
 
     /// Initial [Context] value.
     pub const CONTEXT: Context = crate::key::composite::Context {

--- a/tests/ncl/keymap-60key-dvorak-simple/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple/expected.rs
@@ -15,7 +15,7 @@ pub mod init {
     pub type Context = crate::key::composite::Context<CompositeImpl>;
 
     /// Alias for Event type; i.e. [crate::key::context::Event].
-    pub type Event = crate::key::composite::Event<CompositeImpl>;
+    pub type Event = crate::key::composite::Event;
 
     /// Initial [Context] value.
     pub const CONTEXT: Context = crate::key::composite::Context {


### PR DESCRIPTION
This was implemented working towards #102, implementing NestableKey for more types.

- The first problem was `tap_hold::Event`'s `Passthrough` variant, which is generic over some event. The design of "key handles event with context" requires passing these events down through (and back up from) keys that the modifier keys modify. -- For contexts, the ModifierKeyContext, and composite::Context are products of the contexts. -- For events, the composite::Context is a sum. Hence, it makes sense to similarly have a ModifierKeyEvent which is a sum.

- I noticed the impl. of ModifierKeyEvent is isomorphic to Either, sure.
