### PR TITLE
ModifierKeyContext::from_context

### DIFF
--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -149,12 +149,11 @@ impl<T: CompositeTypes> key::Key for Key<T> {
                 (pressed_key.into(), events.into_events())
             }
             Key::TapHold { key, .. } => {
-                let taphold_context = context.into();
-                let inner_context = T::NK::pluck_context(context);
-                let modifier_key_context = key::ModifierKeyContext {
-                    context: taphold_context,
-                    inner_context,
-                };
+                let modifier_key_context = key::ModifierKeyContext::from_context(
+                    context,
+                    |c| c.into(),
+                    T::NK::pluck_context,
+                );
                 let (pressed_key, events) = key.new_pressed_key(modifier_key_context, keymap_index);
                 (
                     pressed_key.into(),
@@ -168,12 +167,11 @@ impl<T: CompositeTypes> key::Key for Key<T> {
                 (pressed_key.into(), events.into_events())
             }
             Key::Layered { key, .. } => {
-                let layered_context = context.into();
-                let inner_context = T::NK::pluck_context(context);
-                let modifier_key_context = key::ModifierKeyContext {
-                    context: layered_context,
-                    inner_context,
-                };
+                let modifier_key_context = key::ModifierKeyContext::from_context(
+                    context,
+                    |c| c.into(),
+                    T::NK::pluck_context,
+                );
                 let (pressed_key, events) = key.new_pressed_key(modifier_key_context, keymap_index);
                 (pressed_key.into(), events.map_events(T::NK::into_event))
             }
@@ -323,12 +321,11 @@ impl<T: CompositeTypes> key::PressedKeyState<Key<T>> for PressedKeyState<T> {
                 if let Ok(ev) = event.try_into_key_event(|event| {
                     key::ModifierKeyEvent::try_from(event, |e| e.try_into(), T::NK::try_event_from)
                 }) {
-                    let tap_hold_context = context.into();
-                    let inner_context = T::NK::pluck_context(context);
-                    let modifier_key_context = key::ModifierKeyContext {
-                        context: tap_hold_context,
-                        inner_context,
-                    };
+                    let modifier_key_context = key::ModifierKeyContext::from_context(
+                        context,
+                        |c| c.into(),
+                        T::NK::pluck_context,
+                    );
                     let events = pks.handle_event_for(modifier_key_context, keymap_index, key, ev);
                     events.map_events(|mke| mke.map_events(|th_e| th_e.into(), T::NK::into_event))
                 } else {
@@ -345,12 +342,11 @@ impl<T: CompositeTypes> key::PressedKeyState<Key<T>> for PressedKeyState<T> {
             }
             (Key::Layered { key, .. }, PressedKeyState::Layered(pks)) => {
                 if let Ok(ev) = event.try_into_key_event(T::NK::try_event_from) {
-                    let layered_context = context.into();
-                    let inner_context = T::NK::pluck_context(context);
-                    let modifier_key_context = key::ModifierKeyContext {
-                        context: layered_context,
-                        inner_context,
-                    };
+                    let modifier_key_context = key::ModifierKeyContext::from_context(
+                        context,
+                        |c| c.into(),
+                        T::NK::pluck_context,
+                    );
                     let events = pks.handle_event_for(modifier_key_context, keymap_index, key, ev);
                     events.map_events(T::NK::into_event)
                 } else {

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -150,6 +150,20 @@ pub struct ModifierKeyContext<Ctx, NCtx> {
     pub inner_context: NCtx,
 }
 
+impl<MC, IC> ModifierKeyContext<MC, IC> {
+    /// Constructs a ModifierKeyContext from the given context, using the provided functions for context/inner_context.
+    pub fn from_context<FC: Copy>(
+        fc: FC,
+        f: fn(FC) -> MC,
+        g: fn(FC) -> IC,
+    ) -> ModifierKeyContext<MC, IC> {
+        ModifierKeyContext {
+            context: f(fc),
+            inner_context: g(fc),
+        }
+    }
+}
+
 /// Struct for the output from [PressedKey].
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
 pub struct KeyOutput(u8);


### PR DESCRIPTION
Quick refactoring. (Uses one `let` instead of three).