### PR TITLE
Add keyboard modifiers to smart keymap library

### DIFF
--- a/src/key/keyboard.rs
+++ b/src/key/keyboard.rs
@@ -22,6 +22,22 @@ impl Key {
         }
     }
 
+    /// Constructs a key with the given key_code and modifiers.
+    pub const fn new_with_modifiers(key_code: u8, modifiers: key::KeyboardModifiers) -> Self {
+        Key {
+            key_code,
+            modifiers,
+        }
+    }
+
+    /// Constructs a key with the given modifiers.
+    pub const fn from_modifiers(modifiers: key::KeyboardModifiers) -> Self {
+        Key {
+            key_code: 0x00,
+            modifiers,
+        }
+    }
+
     /// Gets the key code from [Key].
     pub fn key_code(&self) -> u8 {
         self.key_code

--- a/src/key/keyboard.rs
+++ b/src/key/keyboard.rs
@@ -100,6 +100,7 @@ impl key::PressedKeyState<Key> for PressedKeyState {
 
     /// Keyboard key always has a key_output.
     fn key_output(&self, key: &Key) -> Option<key::KeyOutput> {
-        Some(key::KeyOutput::from_key_code(key.key_code()))
+        let key_output = key::KeyOutput::from_key_code_with_modifiers(key.key_code, key.modifiers);
+        Some(key_output)
     }
 }

--- a/src/key/keyboard.rs
+++ b/src/key/keyboard.rs
@@ -8,12 +8,18 @@ use crate::{input, key};
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct Key {
     key_code: u8,
+    #[serde(default)]
+    modifiers: key::KeyboardModifiers,
 }
 
 impl Key {
     /// Constructs a key with the given key_code.
     pub const fn new(key_code: u8) -> Self {
-        Key { key_code }
+        let modifiers = key::KeyboardModifiers::new();
+        Key {
+            key_code,
+            modifiers,
+        }
     }
 
     /// Gets the key code from [Key].

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -193,6 +193,38 @@ impl KeyboardModifiers {
             right_gui: false,
         }
     }
+
+    /// Constructs a Vec of key codes from the modifiers.
+    pub fn as_key_codes(&self) -> heapless::Vec<u8, 8> {
+        let mut key_codes = heapless::Vec::new();
+
+        if self.left_ctrl {
+            key_codes.push(0xE0).unwrap();
+        }
+        if self.left_shift {
+            key_codes.push(0xE1).unwrap();
+        }
+        if self.left_alt {
+            key_codes.push(0xE2).unwrap();
+        }
+        if self.left_gui {
+            key_codes.push(0xE3).unwrap();
+        }
+        if self.right_ctrl {
+            key_codes.push(0xE4).unwrap();
+        }
+        if self.right_shift {
+            key_codes.push(0xE5).unwrap();
+        }
+        if self.right_alt {
+            key_codes.push(0xE6).unwrap();
+        }
+        if self.right_gui {
+            key_codes.push(0xE7).unwrap();
+        }
+
+        key_codes
+    }
 }
 
 /// Struct for the output from [PressedKey].

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -212,9 +212,30 @@ impl KeyOutput {
         }
     }
 
+    /// Constructs a [KeyOutput] from a key code with the given keyboard modifiers.
+    pub fn from_key_code_with_modifiers(key_code: u8, key_modifiers: KeyboardModifiers) -> Self {
+        KeyOutput {
+            key_code,
+            key_modifiers,
+        }
+    }
+
+    /// Constructs a [KeyOutput] for just the given keyboard modifiers.
+    pub fn from_key_modifiers(key_modifiers: KeyboardModifiers) -> Self {
+        KeyOutput {
+            key_code: 0x00,
+            key_modifiers,
+        }
+    }
+
     /// Returns the key code value.
     pub fn key_code(&self) -> u8 {
         self.key_code
+    }
+
+    /// Returns the keyboard modifiers of the key output.
+    pub fn key_modifiers(&self) -> KeyboardModifiers {
+        self.key_modifiers
     }
 }
 

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -194,6 +194,14 @@ impl KeyboardModifiers {
         }
     }
 
+    /// Predicate for whether the key code is a modifier key code.
+    pub const fn is_modifier_key_code(key_code: u8) -> bool {
+        match key_code {
+            0xE0..=0xE7 => true,
+            _ => false,
+        }
+    }
+
     /// Constructs a Vec of key codes from the modifiers.
     pub fn as_key_codes(&self) -> heapless::Vec<u8, 8> {
         let mut key_codes = heapless::Vec::new();

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -196,18 +196,25 @@ impl KeyboardModifiers {
 }
 
 /// Struct for the output from [PressedKey].
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
-pub struct KeyOutput(u8);
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KeyOutput {
+    key_code: u8,
+    key_modifiers: KeyboardModifiers,
+}
 
 impl KeyOutput {
     /// Constructs a [KeyOutput] from a key code.
     pub fn from_key_code(key_code: u8) -> Self {
-        KeyOutput(key_code)
+        let key_modifiers = KeyboardModifiers::new();
+        KeyOutput {
+            key_code,
+            key_modifiers,
+        }
     }
 
     /// Returns the key code value.
     pub fn key_code(&self) -> u8 {
-        self.0
+        self.key_code
     }
 }
 

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -234,6 +234,13 @@ impl KeyboardModifiers {
         key_codes
     }
 
+    /// Constructs the byte for the modifiers of an HID keyboard report.
+    pub fn as_byte(&self) -> u8 {
+        self.as_key_codes()
+            .iter()
+            .fold(0u8, |acc, &kc| acc | (1 << (kc - 0xE0)))
+    }
+
     /// Union of two KeyboardModifiers, taking "or" of each modifier.
     pub const fn union(&self, other: &KeyboardModifiers) -> KeyboardModifiers {
         KeyboardModifiers {

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -1,5 +1,7 @@
 use core::fmt::Debug;
 
+use serde::Deserialize;
+
 use crate::input;
 
 /// HID Keyboard keys.
@@ -160,6 +162,35 @@ impl<MC, IC> ModifierKeyContext<MC, IC> {
         ModifierKeyContext {
             context: f(fc),
             inner_context: g(fc),
+        }
+    }
+}
+
+/// Bool flags for each of the modifier keys (left ctrl, etc.).
+#[derive(Deserialize, Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct KeyboardModifiers {
+    left_ctrl: bool,
+    left_shift: bool,
+    left_alt: bool,
+    left_gui: bool,
+    right_ctrl: bool,
+    right_shift: bool,
+    right_alt: bool,
+    right_gui: bool,
+}
+
+impl KeyboardModifiers {
+    /// Constructs with modifiers defaulting to false.
+    pub const fn new() -> Self {
+        KeyboardModifiers {
+            left_ctrl: false,
+            left_shift: false,
+            left_alt: false,
+            left_gui: false,
+            right_ctrl: false,
+            right_shift: false,
+            right_alt: false,
+            right_gui: false,
         }
     }
 }

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -307,18 +307,28 @@ pub struct KeyOutput {
 impl KeyOutput {
     /// Constructs a [KeyOutput] from a key code.
     pub fn from_key_code(key_code: u8) -> Self {
-        let key_modifiers = KeyboardModifiers::new();
-        KeyOutput {
-            key_code,
-            key_modifiers,
+        if let Some(key_modifiers) = KeyboardModifiers::from_key_code(key_code) {
+            KeyOutput {
+                key_code: 0x00,
+                key_modifiers,
+            }
+        } else {
+            KeyOutput {
+                key_code,
+                key_modifiers: KeyboardModifiers::new(),
+            }
         }
     }
 
     /// Constructs a [KeyOutput] from a key code with the given keyboard modifiers.
     pub fn from_key_code_with_modifiers(key_code: u8, key_modifiers: KeyboardModifiers) -> Self {
+        let KeyOutput {
+            key_code,
+            key_modifiers: km,
+        } = Self::from_key_code(key_code);
         KeyOutput {
             key_code,
-            key_modifiers,
+            key_modifiers: km.union(&key_modifiers),
         }
     }
 

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -194,6 +194,47 @@ impl KeyboardModifiers {
         }
     }
 
+    /// Constructs with the given key_code.
+    ///
+    /// Returns None if the key_code is not a modifier key code.
+    pub const fn from_key_code(key_code: u8) -> Option<Self> {
+        match key_code {
+            0xE0 => Some(KeyboardModifiers {
+                left_ctrl: true,
+                ..KeyboardModifiers::new()
+            }),
+            0xE1 => Some(KeyboardModifiers {
+                left_shift: true,
+                ..KeyboardModifiers::new()
+            }),
+            0xE2 => Some(KeyboardModifiers {
+                left_alt: true,
+                ..KeyboardModifiers::new()
+            }),
+            0xE3 => Some(KeyboardModifiers {
+                left_gui: true,
+                ..KeyboardModifiers::new()
+            }),
+            0xE4 => Some(KeyboardModifiers {
+                right_ctrl: true,
+                ..KeyboardModifiers::new()
+            }),
+            0xE5 => Some(KeyboardModifiers {
+                right_shift: true,
+                ..KeyboardModifiers::new()
+            }),
+            0xE6 => Some(KeyboardModifiers {
+                right_alt: true,
+                ..KeyboardModifiers::new()
+            }),
+            0xE7 => Some(KeyboardModifiers {
+                right_gui: true,
+                ..KeyboardModifiers::new()
+            }),
+            _ => None,
+        }
+    }
+
     /// Predicate for whether the key code is a modifier key code.
     pub const fn is_modifier_key_code(key_code: u8) -> bool {
         match key_code {

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -233,6 +233,20 @@ impl KeyboardModifiers {
 
         key_codes
     }
+
+    /// Union of two KeyboardModifiers, taking "or" of each modifier.
+    pub const fn union(&self, other: &KeyboardModifiers) -> KeyboardModifiers {
+        KeyboardModifiers {
+            left_ctrl: self.left_ctrl || other.left_ctrl,
+            left_shift: self.left_shift || other.left_shift,
+            left_alt: self.left_alt || other.left_alt,
+            left_gui: self.left_gui || other.left_gui,
+            right_ctrl: self.right_ctrl || other.right_ctrl,
+            right_shift: self.right_shift || other.right_shift,
+            right_alt: self.right_alt || other.right_alt,
+            right_gui: self.right_gui || other.right_gui,
+        }
+    }
 }
 
 /// Struct for the output from [PressedKey].


### PR DESCRIPTION
This PR adds support for keyboard modifiers to keys for keymap library. -- e.g. "A & Ctrl" as a single key, rather than needing "A" and "Ctrl" to be two different keys.

`key::KeyOutput` and `key::keyboard::Key` are incidentally similar structures for now; but the intention is for `KeyOutput` to also support HID consumer codes (e.g. media keys), and HID mouse codes.