### PR TITLE
Add checks.ncl for keymap-codegen, and keymap-ncl-to-json

### DIFF
--- a/features/keymap/layered.feature
+++ b/features/keymap/layered.feature
@@ -25,7 +25,7 @@ Feature: Layers
       {
         layers = [
           [
-            { layer_modifier = { hold = 0 } },
+            K.layer_mod.hold 0,
             K.A,
           ],
           [

--- a/ncl/checks.ncl
+++ b/ncl/checks.ncl
@@ -1,0 +1,51 @@
+{
+  Check
+    | doc "a Check is either a Bool, or a record with 'expected' and 'actual' fields."
+    = std.contract.any_of [
+      Bool,
+      { expected | Dyn, actual | Dyn, message | String | optional },
+    ],
+
+  is_check
+    | doc "predicate for if the given value is a Check."
+    = fun c =>
+      std.is_bool c ||
+      std.is_record c && std.record.has_field "expected" c && std.record.has_field "actual" c,
+
+  evaluate_check
+    = fun c =>
+      if std.is_bool c then
+        c == true || std.fail_with "check failed"
+      else
+        (c.expected == c.actual) ||
+          std.fail_with "expected equal: %{std.serialize 'Json c}",
+
+  NamedChecks
+    | doc "a record, with Check values. e.g. { check_add = { expected = 4, actual = add 2 2 } }"
+    = { _ | Check },
+
+  CheckOrChecks
+    = std.contract.any_of [
+      Check,
+      Checks
+    ],
+
+  Checks
+    | doc "a record, with Check values"
+    = { _ | CheckOrChecks },
+
+  evaluate_check_or_checks
+    = fun c =>
+     if is_check c then
+        evaluate_check c
+      else
+        std.record.map_values evaluate_check_or_checks c,
+
+  evaluate_checks
+    = fun c => std.record.map_values evaluate_check_or_checks c,
+
+  checks | Checks | default = {},
+
+  evaluated_checks
+    = evaluate_checks checks,
+}

--- a/ncl/checks.ncl
+++ b/ncl/checks.ncl
@@ -13,12 +13,12 @@
       std.is_record c && std.record.has_field "expected" c && std.record.has_field "actual" c,
 
   evaluate_check
-    = fun c =>
+    = fun c id =>
       if std.is_bool c then
-        c == true || std.fail_with "check failed"
+        c == true || std.fail_with "%{id}: check failed"
       else
         (c.expected == c.actual) ||
-          std.fail_with "expected equal: %{std.serialize 'Json c}",
+          std.fail_with "%{id}: expected != actual:\n\n%{std.serialize 'Json c}",
 
   NamedChecks
     | doc "a record, with Check values. e.g. { check_add = { expected = 4, actual = add 2 2 } }"
@@ -35,14 +35,15 @@
     = { _ | CheckOrChecks },
 
   evaluate_check_or_checks
-    = fun c =>
+    = fun c id =>
      if is_check c then
-        evaluate_check c
+        evaluate_check c id
       else
-        std.record.map_values evaluate_check_or_checks c,
+        std.record.map (fun k v => evaluate_check_or_checks v "%{id}.%{k}") c,
 
   evaluate_checks
-    = fun c => std.record.map_values evaluate_check_or_checks c,
+    = fun c =>
+        std.record.map (fun k v => evaluate_check_or_checks v k) c,
 
   checks | Checks | default = {},
 

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -145,7 +145,7 @@
       key if layer_modifier.is key => layer_modifier.key_type,
       key if layered.is key => layered.key_type key,
       key if tap_hold.is key => tap_hold.key_type,
-      _ => "unknown_key_type"
+      _ => 'unknown_key_type
     },
 
   rust_expr_of_key
@@ -155,7 +155,7 @@
       key if layer_modifier.is key => layer_modifier.rust_expr key,
       key if layered.is key => layered.rust_expr key,
       key if tap_hold.is key => tap_hold.rust_expr key,
-      _ => "unknown_key_type"
+      _ => 'unknown_key_type
     },
 
   keymap_rs

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -2,6 +2,14 @@
   serialized_json_keymap
     | doc "The 'JSON serialized' value of the keymap. e.g. imported from keymap.json.",
 
+
+  checks.layer_modifier_is = {
+    # Use a serialized value to check the "is" predicate.
+    check_serialized_is =
+      let serialized_value = { Hold = 0 } in
+      layer_modifier.is serialized_value
+  },
+
   layer_modifier
     | doc "Generates type declaration and value expression for smart_keymap::key::layered::ModifierKey."
     = {
@@ -13,6 +21,19 @@
       key_type = "crate::key::layered::ModifierKey",
       rust_expr = fun { Hold = layer_index } => "crate::key::layered::ModifierKey::Hold(%{std.to_string layer_index})",
     },
+
+  checks.layered_is = {
+    # Use a serialized value to check the "is" predicate.
+    check_serialized_base_keyboard_layered_keyboard_is =
+      let serialized_value = {
+        base = { key_code = 0x04 },
+        layered = [
+          null,
+          { key_code = 0x06 },
+        ]
+      } in
+      layered.is serialized_value
+  },
 
   layered
     | doc "Generates type declaration and value expression for smart_keymap::key::layered::LayeredKey."
@@ -61,6 +82,13 @@
         "%,
     },
 
+  checks.keyboard_is = {
+    # Use a serialized value to check the "is" predicate.
+    check_serialized_is =
+      let serialized_value = { key_code = 0x04 } in
+      keyboard.is serialized_value
+  },
+
   keyboard
     | doc "Generates type declaration and value expression for smart_keymap::key::keyboard::Key."
     = {
@@ -73,6 +101,16 @@
       key_type = "crate::key::keyboard::Key",
       rust_expr = fun { key_code } => "crate::key::keyboard::Key::new(%{std.to_string key_code})",
     },
+
+  checks.tap_hold_is = {
+    # Use a serialized value to check the "is" predicate.
+    check_serialized_tap_keyboard_hold_keyboard_is =
+      let serialized_value = {
+        hold = { key_code = 0xE0 },
+        tap = { key_code = 0x04 },
+      } in
+      tap_hold.is serialized_value
+  },
 
   tap_hold
     | doc "Generates type declaration and value expression for smart_keymap::key::tap_hold::Key."

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -18,6 +18,10 @@
           actual = K.A,
           expected = { key_code = 0x04 },
         },
+        check_serialized_key_code = {
+          actual = K.A |> to_json_serialized_key,
+          expected = { key_code = 0x04 },
+        },
       },
 
       layered = {
@@ -31,12 +35,26 @@
             ],
           },
         },
+        check_serialized_layered_keyboard = {
+          actual = K.A & { layered = [null, K.C] } |> to_json_serialized_key,
+          expected = {
+            base = { key_code = 0x04 },
+            layered = [
+              null,
+              { key_code = 0x06 },
+            ],
+          },
+        },
       },
 
       layer_modifier = {
         keymap_example_hold = {
           actual = K.layer_mod.hold 0,
           expected = { layer_modifier.hold = 0 },
+        },
+        check_serialized_hold = {
+          actual = K.layer_mod.hold 0 |> to_json_serialized_key,
+          expected = { Hold = 0 },
         },
       },
 

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -10,6 +10,44 @@
     | doc "The layers of the keymap that gets rendered to JSON"
     = [keys],
 
+  checks.check_to_json_serialized_key =
+    let K = import "keys.ncl" in
+    {
+      keyboard = {
+        keymap_example_key_code = {
+          actual = K.A,
+          expected = { key_code = 0x04 },
+        },
+      },
+
+      layered = {
+        keymap_example_layered_keyboard = {
+          actual = K.A & { layered = [null, K.C] },
+          expected = {
+            key_code = 0x04,
+            layered = [
+              null,
+              { key_code = 0x06 },
+            ],
+          },
+        },
+      },
+
+      layer_modifier = {
+        keymap_example_hold = {
+          actual = K.layer_mod.hold 0,
+          expected = { layer_modifier.hold = 0 },
+        },
+      },
+
+      tap_hold = {
+        keymap_example_tap_keyboard_hold_keyboard = {
+          actual = K.A & { hold = K.LeftCtrl },
+          expected = { key_code = 0x04, hold = { key_code = 0xE0 }  },
+        },
+      },
+    },
+
   to_json_serialized_key
     | doc "Constructs a JSON-representable key value from the given value from keymap.ncl."
     = match {

--- a/ncl/scripts/run-ncl-checks.sh
+++ b/ncl/scripts/run-ncl-checks.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Tests the Nickel keymaps under tests/ncl,
+#  checking the generated output matches expected snapshots,
+#  and that the generated keymap builds.
+
+set -ex
+
+SCRIPTS_DIR="$(dirname "$0")"
+REPOSITORY_DIR="${SCRIPTS_DIR}/../.."
+
+nickel \
+  eval \
+  --import-path="${REPOSITORY_DIR}/ncl" \
+  --field="evaluated_checks" \
+  checks.ncl \
+  keymap-ncl-to-json.ncl \
+  keymap-codegen.ncl

--- a/ncl/scripts/run-tests.sh
+++ b/ncl/scripts/run-tests.sh
@@ -8,6 +8,12 @@ set -ex
 
 SCRIPTS_DIR="$(dirname "$0")"
 
+# Run the nickel checks first.
+"${SCRIPTS_DIR}/run-ncl-checks.sh"
+
+# Then with each of the listed `tests/ncl`, check its generated keymap.rs:
+#  - matches the expected snapshot,
+#  - can be compiled.
 ncl_tests=(
     "keymap-1key-simple"
     "keymap-1key-tap_hold"


### PR DESCRIPTION
This PR adds `checks.ncl`, and also adds some `checks` to the `keymap-ncl-to-json`, and `keymap-codegen`.

- Checking the codegen works is already covered by checking generated `keymap.rs` against snapshots & that they build.

- But, it'd be useful to have these checks to provide (automatically verified) examples of inputs & outputs that the Nickle code is using.
