### PR TITLE
Refactor nickel ncl-to-json to_json_serialized_key into key modules

### DIFF
--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -10,7 +10,7 @@
   },
 
   keyboard
-    | doc "Generates type declaration and value expression for smart_keymap::key::keyboard::Key."
+    | doc "for key::keyboard::Key."
     = {
       # c.f. doc_de_keyboard.md.
       # JSON serialization of key::keyboard::Key is just a number.
@@ -30,7 +30,7 @@
   },
 
   layer_modifier
-    | doc "Generates type declaration and value expression for smart_keymap::key::layered::ModifierKey."
+    | doc "for key::layered::ModifierKey."
     = {
       # c.f. doc_de_layered.md.
       # JSON serialization of key::layered::ModifierKey has variants: Hold(layer).
@@ -55,7 +55,7 @@
   },
 
   layered
-    | doc "Generates type declaration and value expression for smart_keymap::key::layered::LayeredKey."
+    | doc "for key::layered::LayeredKey."
     = {
       # c.f. doc_de_layered.md.
       # e.g.:
@@ -112,7 +112,7 @@
   },
 
   tap_hold
-    | doc "Generates type declaration and value expression for smart_keymap::key::tap_hold::Key."
+    | doc "for key::tap_hold::Key."
     = {
       # c.f. doc_de_tap_hold.md.
       # JSON serialization of key::tap_hold::Key is { tap: number, hold: number }

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -10,69 +10,10 @@
     | doc "The layers of the keymap that gets rendered to JSON"
     = [keys],
 
-  checks.check_to_json_serialized_key =
-    let K = import "keys.ncl" in
-    {
-      keyboard = {
-        keymap_example_key_code = {
-          actual = K.A,
-          expected = { key_code = 0x04 },
-        },
-        check_serialized_key_code = {
-          actual = K.A |> to_json_serialized_key,
-          expected = { key_code = 0x04 },
-        },
-      },
-
-      layered = {
-        keymap_example_layered_keyboard = {
-          actual = K.A & { layered = [null, K.C] },
-          expected = {
-            key_code = 0x04,
-            layered = [
-              null,
-              { key_code = 0x06 },
-            ],
-          },
-        },
-        check_serialized_layered_keyboard = {
-          actual = K.A & { layered = [null, K.C] } |> to_json_serialized_key,
-          expected = {
-            base = { key_code = 0x04 },
-            layered = [
-              null,
-              { key_code = 0x06 },
-            ],
-          },
-        },
-      },
-
-      layer_modifier = {
-        keymap_example_hold = {
-          actual = K.layer_mod.hold 0,
-          expected = { layer_modifier.hold = 0 },
-        },
-        check_serialized_hold = {
-          actual = K.layer_mod.hold 0 |> to_json_serialized_key,
-          expected = { Hold = 0 },
-        },
-      },
-
-      tap_hold = {
-        keymap_example_tap_keyboard_hold_keyboard = {
-          actual = K.A & K.hold K.LeftCtrl,
-          expected = { key_code = 0x04, hold = 0xE0 },
-        },
-        check_serialized_tap_keyboard_hold_keyboard = {
-          actual = K.A & K.hold K.LeftCtrl |> to_json_serialized_key,
-          expected = { tap = { key_code = 0x04 }, hold = { key_code = 0xE0 }  },
-        },
-      },
-    },
-
   checks.nestable = {
     check_nestable_is_key_keyboard =
       nestable.is_key { key_code = 0x04 },
+
     check_nestable_to_json_serialized_keyboard = {
       actual = { key_code = 0x04 } |> nestable.to_json_serialized,
       expected = { key_code = 0x04 },
@@ -82,10 +23,25 @@
   nestable = {
     is_key
       = keyboard.is_key,
+
     to_json_serialized = match {
       k if keyboard.is_key k => keyboard.to_json_serialized k,
     }
   },
+
+  checks.keyboard =
+    let K = import "keys.ncl" in
+    {
+      keymap_example_key_code = {
+        actual = K.A,
+        expected = { key_code = 0x04 },
+      },
+
+      check_serialized_key_code = {
+        actual = K.A |> to_json_serialized_key,
+        expected = { key_code = 0x04 },
+      },
+    },
 
   keyboard = {
     is_key
@@ -93,27 +49,65 @@
         { key_code } => true,
         _ => false,
       },
+
     to_json_serialized = fun { key_code = kc } => { key_code = kc },
   },
+
+  checks.layer_modifier =
+    let K = import "keys.ncl" in {
+      keymap_example_hold = {
+        actual = K.layer_mod.hold 0,
+        expected = { layer_modifier.hold = 0 },
+      },
+
+      check_serialized_hold = {
+        actual = K.layer_mod.hold 0 |> to_json_serialized_key,
+        expected = { Hold = 0 },
+      },
+    },
 
   layer_modifier = {
     is_key = match {
       { layer_modifier = { hold } } => true,
       _ => false,
     },
+
     to_json_serialized = fun { layer_modifier = { hold = hold_layer } } =>
       { Hold = hold_layer },
   },
 
   checks.layered =
     let K = import "keys.ncl" in {
+      keymap_example_layered_keyboard = {
+        actual = K.A & { layered = [null, K.C] },
+        expected = {
+          key_code = 0x04,
+          layered = [
+            null,
+            { key_code = 0x06 },
+          ],
+        },
+      },
+
       check_layered_base_keyboard_base_is_nestable_key =
         let key = K.A & { layered = [null, K.C] } in
         let { layered, ..base_key } = key in
         nestable.is_key base_key,
+
       check_layered_base_keyboard_is_key =
         let key = K.A & { layered = [null, K.C] } in
         layered.is_key key,
+
+      check_serialized_layered_keyboard = {
+        actual = K.A & { layered = [null, K.C] } |> to_json_serialized_key,
+        expected = {
+          base = { key_code = 0x04 },
+          layered = [
+            null,
+            { key_code = 0x06 },
+          ],
+        },
+      },
     },
 
   layered = {
@@ -123,6 +117,7 @@
         std.array.all (fun k => nestable.is_key k || k == null) layered,
       _ => false,
     },
+
     to_json_serialized = fun { layered = layered_keys, ..base_key } =>
       {
         base = to_json_serialized_key base_key,
@@ -132,15 +127,27 @@
 
   checks.tap_hold =
     let K = import "keys.ncl" in {
+      keymap_example_tap_keyboard_hold_keyboard = {
+        actual = K.A & K.hold K.LeftCtrl,
+        expected = { key_code = 0x04, hold = 0xE0 },
+      },
+
       check_tap_hold_tap_keyboard_is_nestable_key =
         let key = K.A & K.hold K.LeftCtrl  in
         let { hold, ..tap_key } = key in
         nestable.is_key tap_key,
+
       check_tap_keyboard_hold_keyboard_is_key =
         let key = K.A & K.hold K.LeftCtrl  in
         tap_hold.is_key key,
+
       check_tap_keyboard_hold_keyboard_to_json_serialized_keyboard = {
         actual = K.A & K.hold K.LeftCtrl |> tap_hold.to_json_serialized,
+        expected = { tap = { key_code = 0x04 }, hold = { key_code = 0xE0 }  },
+      },
+
+      check_serialized_tap_keyboard_hold_keyboard = {
+        actual = K.A & K.hold K.LeftCtrl |> to_json_serialized_key,
         expected = { tap = { key_code = 0x04 }, hold = { key_code = 0xE0 }  },
       },
     },
@@ -150,6 +157,7 @@
       { hold = hold_kc, ..tap_key } => nestable.is_key tap_key,
       _ => false,
     },
+
     to_json_serialized = fun { hold = hold_kc, ..tap_key } =>
       {
         hold = { key_code = hold_kc },

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -20,14 +20,16 @@
     },
   },
 
-  nestable = {
-    is_key
-      = keyboard.is_key,
+  nestable
+    | doc "for key::composite::NestableKey implementors."
+    = {
+      is_key
+        = keyboard.is_key,
 
-    to_json_serialized = match {
-      k if keyboard.is_key k => keyboard.to_json_serialized k,
-    }
-  },
+      to_json_serialized = match {
+        k if keyboard.is_key k => keyboard.to_json_serialized k,
+      }
+    },
 
   checks.keyboard =
     let K = import "keys.ncl" in
@@ -43,15 +45,17 @@
       },
     },
 
-  keyboard = {
-    is_key
-      = match {
-        { key_code } => true,
-        _ => false,
-      },
+  keyboard
+    | doc "for key::keyboard::Key."
+    = {
+      is_key
+        = match {
+          { key_code } => true,
+          _ => false,
+        },
 
-    to_json_serialized = fun { key_code = kc } => { key_code = kc },
-  },
+      to_json_serialized = fun { key_code = kc } => { key_code = kc },
+    },
 
   checks.layer_modifier =
     let K = import "keys.ncl" in {
@@ -66,15 +70,17 @@
       },
     },
 
-  layer_modifier = {
-    is_key = match {
-      { layer_modifier = { hold } } => true,
-      _ => false,
-    },
+  layer_modifier
+    | doc "for key::layered::ModifierKey."
+    = {
+      is_key = match {
+        { layer_modifier = { hold } } => true,
+        _ => false,
+      },
 
-    to_json_serialized = fun { layer_modifier = { hold = hold_layer } } =>
-      { Hold = hold_layer },
-  },
+      to_json_serialized = fun { layer_modifier = { hold = hold_layer } } =>
+        { Hold = hold_layer },
+    },
 
   checks.layered =
     let K = import "keys.ncl" in {
@@ -110,20 +116,22 @@
       },
     },
 
-  layered = {
-    is_key = match {
-      { layered, ..base_key } if std.is_array layered =>
-        nestable.is_key base_key &&
-        std.array.all (fun k => nestable.is_key k || k == null) layered,
-      _ => false,
-    },
-
-    to_json_serialized = fun { layered = layered_keys, ..base_key } =>
-      {
-        base = to_json_serialized_key base_key,
-        layered = std.array.map to_json_serialized_key layered_keys,
+  layered
+    | doc "for key::layered::LayeredKey."
+    = {
+      is_key = match {
+        { layered, ..base_key } if std.is_array layered =>
+          nestable.is_key base_key &&
+          std.array.all (fun k => nestable.is_key k || k == null) layered,
+        _ => false,
       },
-  },
+
+      to_json_serialized = fun { layered = layered_keys, ..base_key } =>
+        {
+          base = to_json_serialized_key base_key,
+          layered = std.array.map to_json_serialized_key layered_keys,
+        },
+    },
 
   checks.tap_hold =
     let K = import "keys.ncl" in {
@@ -152,18 +160,20 @@
       },
     },
 
-  tap_hold = {
-    is_key = match {
-      { hold = hold_kc, ..tap_key } => nestable.is_key tap_key,
-      _ => false,
-    },
-
-    to_json_serialized = fun { hold = hold_kc, ..tap_key } =>
-      {
-        hold = { key_code = hold_kc },
-        tap = to_json_serialized_key tap_key,
+  tap_hold
+    | doc "for key::tap_hold::Key."
+    = {
+      is_key = match {
+        { hold = hold_kc, ..tap_key } => nestable.is_key tap_key,
+        _ => false,
       },
-  },
+
+      to_json_serialized = fun { hold = hold_kc, ..tap_key } =>
+        {
+          hold = { key_code = hold_kc },
+          tap = to_json_serialized_key tap_key,
+        },
+    },
 
   to_json_serialized_key
     | doc "Constructs a JSON-representable key value from the given value from keymap.ncl."

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -185,16 +185,16 @@
     | doc "Constructs a JSON-representable composite::Key value from the given value from keymap.ncl."
     = match {
       # Make key::layered::LayeredKey
-      k@{ key_code = base_key, layered = layered_keys } =>
+      k if layered.is_key k =>
         { Layered = { key = to_json_serialized_key k } },
       # Make key::tap_hold::Key from keys with a "hold" modifier.
-      k@{ hold = hold_kc, key_code = tap_kc } =>
+      k if tap_hold.is_key k =>
         { TapHold = { key = to_json_serialized_key k } },
       # Otherwise, keys with just a base key_code are key::keyboard keys.
-      k@{ key_code = kc } =>
+      k if keyboard.is_key k =>
         { Keyboard = { key = to_json_serialized_key k } },
       # Make key::layered::ModifierKey
-      k@{ layer_modifier = { hold = hold_layer } } =>
+      k if layer_modifier.is_key k =>
         { LayerModifier = { key = to_json_serialized_key k } },
       # Null values (None) stay null
       null => null,

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -70,25 +70,104 @@
       },
     },
 
+  checks.nestable = {
+    check_nestable_is_key_keyboard =
+      nestable.is_key { key_code = 0x04 },
+    check_nestable_to_json_serialized_keyboard = {
+      actual = { key_code = 0x04 } |> nestable.to_json_serialized,
+      expected = { key_code = 0x04 },
+    },
+  },
+
+  nestable = {
+    is_key
+      = keyboard.is_key,
+    to_json_serialized = match {
+      k if keyboard.is_key k => keyboard.to_json_serialized k,
+    }
+  },
+
+  keyboard = {
+    is_key
+      = match {
+        { key_code } => true,
+        _ => false,
+      },
+    to_json_serialized = fun { key_code = kc } => { key_code = kc },
+  },
+
+  layer_modifier = {
+    is_key = match {
+      { layer_modifier = { hold } } => true,
+      _ => false,
+    },
+    to_json_serialized = fun { layer_modifier = { hold = hold_layer } } =>
+      { Hold = hold_layer },
+  },
+
+  checks.layered =
+    let K = import "keys.ncl" in {
+      check_layered_base_keyboard_base_is_nestable_key =
+        let key = K.A & { layered = [null, K.C] } in
+        let { layered, ..base_key } = key in
+        nestable.is_key base_key,
+      check_layered_base_keyboard_is_key =
+        let key = K.A & { layered = [null, K.C] } in
+        layered.is_key key,
+    },
+
+  layered = {
+    is_key = match {
+      { layered, ..base_key } if std.is_array layered =>
+        nestable.is_key base_key &&
+        std.array.all (fun k => nestable.is_key k || k == null) layered,
+      _ => false,
+    },
+    to_json_serialized = fun { layered = layered_keys, ..base_key } =>
+      {
+        base = to_json_serialized_key base_key,
+        layered = std.array.map to_json_serialized_key layered_keys,
+      },
+  },
+
+  checks.tap_hold =
+    let K = import "keys.ncl" in {
+      check_tap_hold_tap_keyboard_is_nestable_key =
+        let key = K.A & K.hold K.LeftCtrl  in
+        let { hold, ..tap_key } = key in
+        nestable.is_key tap_key,
+      check_tap_keyboard_hold_keyboard_is_key =
+        let key = K.A & K.hold K.LeftCtrl  in
+        tap_hold.is_key key,
+      check_tap_keyboard_hold_keyboard_to_json_serialized_keyboard = {
+        actual = K.A & K.hold K.LeftCtrl |> tap_hold.to_json_serialized,
+        expected = { tap = { key_code = 0x04 }, hold = { key_code = 0xE0 }  },
+      },
+    },
+
+  tap_hold = {
+    is_key = match {
+      { hold = hold_kc, ..tap_key } => nestable.is_key tap_key,
+      _ => false,
+    },
+    to_json_serialized = fun { hold = hold_kc, ..tap_key } =>
+      {
+        hold = { key_code = hold_kc },
+        tap = to_json_serialized_key tap_key,
+      },
+  },
+
   to_json_serialized_key
     | doc "Constructs a JSON-representable key value from the given value from keymap.ncl."
     = match {
       # Make key::layered::LayeredKey
-      { key_code = base_key, layered = layered_keys } =>
-        {
-          base = { key_code = base_key },
-          layered = std.array.map to_json_serialized_key layered_keys
-        },
+      k if layered.is_key k => layered.to_json_serialized k,
       # Make key::tap_hold::Key from keys with a "hold" modifier.
-      { hold = hold_kc, key_code = tap_kc } =>
-        {
-          hold = { key_code = hold_kc },
-          tap = { key_code = tap_kc },
-        },
+      k if tap_hold.is_key k => tap_hold.to_json_serialized k,
       # Otherwise, keys with just a base key_code are key::keyboard keys.
-      { key_code = kc } => { key_code = kc },
+      k if keyboard.is_key k => keyboard.to_json_serialized k,
       # Make key::layered::ModifierKey
-      { layer_modifier = { hold = hold_layer } } => { Hold = hold_layer },
+      k if layer_modifier.is_key k => layer_modifier.to_json_serialized k,
       # Null values (None) stay null
       null => null,
       _ => std.fail_with "unsupported item in keymap.ncl",


### PR DESCRIPTION
This PR refactors `to_json_serialized_key`, factoring its implementation into `nestable`, `keyboard`, `layered`, `tap_hold`, etc. records with `is_key` predicates, and `to_json_serialized`.

This will make it easier to deal with multiple `NestableKey` implemantations, as well as making it clearer where the current code is assuming "key code" instead of "key".