### PR TITLE
Add Nickel validators

### DIFF
--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -1,4 +1,7 @@
 {
+  validators
+    = (import "validators.ncl"),
+
   serialized_json_keymap
     | doc "The 'JSON serialized' value of the keymap. e.g. imported from keymap.json.",
 
@@ -6,19 +9,29 @@
     # Use a serialized value to check the "is" predicate.
     check_serialized_is =
       let serialized_value = { key_code = 0x04 } in
-      keyboard.is_serialized_json serialized_value
+      keyboard.is_serialized_json serialized_value,
   },
 
   keyboard
     | doc "for key::keyboard::Key."
     = {
       # c.f. doc_de_keyboard.md.
-      # JSON serialization of key::keyboard::Key is just a number.
+      serialized_json_validator
+        = validators.record.validator {
+            fields_validator = validators.all_of [
+              validators.record.has_any_field_of ["key_code"],
+              validators.record.has_only_fields ["key_code"],
+            ],
+            field_validators = {
+              key_code = validators.is_number
+            },
+          },
+
       is_serialized_json = fun k =>
-          std.is_record k &&
-          std.record.has_field "key_code" k &&
-          std.is_number (std.record.get "key_code" k),
+        'Ok == serialized_json_validator k,
+
       key_type = "crate::key::keyboard::Key",
+
       rust_expr = fun { key_code } => "crate::key::keyboard::Key::new(%{std.to_string key_code})",
     },
 

--- a/ncl/validators.ncl
+++ b/ncl/validators.ncl
@@ -12,6 +12,13 @@
   fail
     = std.function.const ('Error {}),
 
+  is_bool
+    = fun v =>
+      if std.is_bool v then
+        'Ok
+      else
+        'Error { message = "Expected bool" },
+
   is_number
     = fun v =>
       if std.is_number v then

--- a/ncl/validators.ncl
+++ b/ncl/validators.ncl
@@ -46,6 +46,18 @@
 
     check_has_only_fields
       = 'Ok == record.has_only_fields ["x", "y"] { x = 3 },
+
+    check_validate
+      = 'Ok
+        ==
+        record.validate
+          {
+            fields_validator = record.has_only_fields ["x", "y"],
+            field_validators = {
+              x = is_number,
+            },
+          }
+          { x = 3 },
   },
 
   record = {
@@ -76,5 +88,28 @@
               "Found: %{r |> std.record.fields}"
             ],
           },
+
+    validator
+      = fun { fields_validator, field_validators } r =>
+        r |> fields_validator |> match {
+          'Ok =>
+            let rec validate_fields = fun fields =>
+              fields |> match {
+                [] => 'Ok,
+                [field, ..fields] =>
+                  (if std.record.has_field field field_validators then
+                     let v = std.record.get field r in
+                     let validator = std.record.get field field_validators in
+                     validator v
+                   else
+                     'Ok) |> match {
+                    'Ok => validate_fields fields,
+                    err => err,
+                  }
+              } in
+              r |> std.record.fields |> validate_fields,
+
+          err => err,
+        },
   },
 }

--- a/ncl/validators.ncl
+++ b/ncl/validators.ncl
@@ -34,11 +34,29 @@
     },
 
   checks.check_record_validators = {
+    check_has_any_field_of
+      = 'Ok == record.has_any_field_of ["x", "y"] { x = 3, z = 5 },
+
     check_has_only_fields
       = 'Ok == record.has_only_fields ["x", "y"] { x = 3 },
   },
 
   record = {
+    has_any_field_of
+      = fun fields r =>
+        if r |> std.record.fields |> std.array.length == 0 then
+          'Error { message = "record has no fields" }
+        else if r |> std.record.fields |> std.array.any (fun f => std.array.elem f fields) then
+          'Ok
+        else
+          'Error {
+            message = "Unexpected fields",
+            notes = [
+              "Expected any of: %{fields |> std.serialize},",
+              "Found: %{r |> std.record.fields}"
+            ],
+          },
+
     has_only_fields
       = fun fields r =>
         if r |> std.record.fields |> std.array.all (fun f => std.array.elem f fields) then

--- a/ncl/validators.ncl
+++ b/ncl/validators.ncl
@@ -1,0 +1,35 @@
+{
+  Validator
+    = Dyn ->
+      [|
+        'Ok,
+        'Error { message | String | optional, notes | Array String | optional, }
+      |],
+
+  ok
+    = std.function.const 'Ok,
+
+  fail
+    = std.function.const ('Error {}),
+
+  checks.all_of = {
+    all_ok_is_ok = {
+      expected = 'Ok,
+      actual = all_of [ok, ok, ok] {},
+    },
+    any_fail_is_error = {
+      expected = 'Error {},
+      actual = all_of [ok, fail, ok] {},
+    },
+  },
+
+  all_of = fun validators v =>
+    validators |> match {
+      [] => 'Ok,
+      [validator, ..validators] =>
+        validator v |> match {
+          'Ok => all_of validators v,
+          err => err,
+        },
+    }
+}

--- a/ncl/validators.ncl
+++ b/ncl/validators.ncl
@@ -31,5 +31,25 @@
           'Ok => all_of validators v,
           err => err,
         },
-    }
+    },
+
+  checks.check_record_validators = {
+    check_has_only_fields
+      = 'Ok == record.has_only_fields ["x", "y"] { x = 3 },
+  },
+
+  record = {
+    has_only_fields
+      = fun fields r =>
+        if r |> std.record.fields |> std.array.all (fun f => std.array.elem f fields) then
+          'Ok
+        else
+          'Error {
+            message = "Unexpected fields",
+            notes = [
+              "Expected only: %{fields |> std.serialize},",
+              "Found: %{r |> std.record.fields}"
+            ],
+          },
+  },
 }

--- a/ncl/validators.ncl
+++ b/ncl/validators.ncl
@@ -12,6 +12,13 @@
   fail
     = std.function.const ('Error {}),
 
+  is_number
+    = fun v =>
+      if std.is_number v then
+        'Ok
+      else
+        'Error { message = "Expected number" },
+
   checks.all_of = {
     all_ok_is_ok = {
       expected = 'Ok,


### PR DESCRIPTION
`is_serialized_json` has been written as a predicate; but, Nickel validators are a more expressive tool, especially for Nickel contracts.

But also, it's a bit tedious to write out a non-trivial predicate directly. -- It's much nicer to have abstractions like `all_of`. And if adding abstractions, they might as well be validators not predicates.