### PR TITLE
Improve Cucumber DX for unhappy code

### DIFF
--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -174,8 +174,19 @@ fn setup_nickel_keymap(world: &mut KeymapWorld, step: &Step) {
     let keymap_ncl = step.docstring().unwrap();
     match nickel_json_serialization_for_keymap(keymap_ncl) {
         Ok(json) => {
-            let keys_vec: Vec<Key> = Deserializer::JSON.from_str(&json).unwrap();
-            world.keymap = keys_vec.into();
+            let keys_vec_result: serde_json::Result<Vec<Key>> = serde_json::from_str(&json);
+            match keys_vec_result {
+                Ok(keys_vec) => {
+                    world.keymap = keys_vec.into();
+                }
+                Err(e) => {
+                    panic!(
+                        "\n\nerror deserailizing JSON:\n\nDeserialization Error:\n\n{}\n\nJSON:\n{}",
+                        e,
+                        json,
+                    )
+                }
+            }
         }
         Err(e) => match e {
             NickelError::NickelNotFound => panic!("`nickel` not found on PATH. Please install it."),


### PR DESCRIPTION
This improves the `keymap.rs` Cucumber test implementation with some checks & more specific panics for:

- if `nickel` not on PATH.
  - The user-facing half of this project is in `nickel`. It's a fairly hard dependency.

- Cases where the `nickel eval` fails. (Typically, because the step doc string has invalid Nickel code).
  - When troubleshooting, this narrows down what to check. -- e.g. can write nickel `checks` to see what's not lining up.

- Cases where the JSON from `nickel eval` fails to deserialize.
  - When troubleshooting, this narrows it down. -- e.g. can add unit test for a particular deserialization.