### PR TITLE
Rewrite Nickel predicates as validators

### DIFF
--- a/ncl/checks.ncl
+++ b/ncl/checks.ncl
@@ -18,7 +18,12 @@
         c == true || std.fail_with "%{id}: check failed"
       else
         (c.expected == c.actual) ||
-          std.fail_with "%{id}: expected != actual:\n\n%{std.serialize 'Json c}",
+          (let ser = fun v =>
+            v |> std.typeof |> match {
+              'Enum => v |> std.enum.to_tag_and_arg |> std.serialize 'Json,
+              _ => v |> std.serialize 'Json,
+            } in
+            std.fail_with "%{id}: expected != actual:\n\nexpected:\n%{ser c.expected}\n\nactual:\n%{ser c.actual}"),
 
   NamedChecks
     | doc "a record, with Check values. e.g. { check_add = { expected = 4, actual = add 2 2 } }"

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -5,6 +5,23 @@
   serialized_json_keymap
     | doc "The 'JSON serialized' value of the keymap. e.g. imported from keymap.json.",
 
+  nestable
+    | doc "for key::composite::NestableKey implementors."
+    = {
+      serialized_json_validator
+        = keyboard.serialized_json_validator,
+
+      is_serialized_json
+        = keyboard.is_serialized_json,
+
+      key_type
+        = keyboard.key_type,
+
+      rust_expr
+        = keyboard.rust_expr,
+    },
+
+
   checks.keyboard_is = {
     # Use a serialized value to check the "is" predicate.
     check_serialized_is =
@@ -55,8 +72,8 @@
             },
           },
 
-      is_serialized_json = fun k =>
-        'Ok == serialized_json_validator k,
+      is_serialized_json
+        = fun k => 'Ok == serialized_json_validator k,
 
       key_type = "crate::key::keyboard::Key",
 
@@ -104,10 +121,19 @@
     = {
       # c.f. doc_de_layered.md.
       # JSON serialization of key::layered::ModifierKey has variants: Hold(layer).
-      is_serialized_json = fun k => std.is_record k
-        && std.record.has_field "Hold" k
-        && std.is_number (std.record.get "Hold" k),
+      serialized_json_validator
+        = validators.record.validator {
+          fields_validator = validators.record.has_exact_fields ["Hold"],
+          field_validators = {
+            Hold = validators.is_number,
+          },
+        },
+
+      is_serialized_json
+        = fun k => 'Ok == serialized_json_validator k,
+
       key_type = "crate::key::layered::ModifierKey",
+
       rust_expr = fun { Hold = layer_index } => "crate::key::layered::ModifierKey::Hold(%{std.to_string layer_index})",
     },
 
@@ -136,18 +162,21 @@
       #   }
       # ```
       # JSON serialization of key::layered::Layered has variants: { base, layered }
-      is_serialized_json = fun k =>
-        let is_nested_key = keyboard.is_serialized_json in
-        std.is_record k
-        && std.record.has_field "base" k
-        && is_nested_key (std.record.get "base" k)
-        && std.record.has_field "layered" k
-        && std.is_array (std.record.get "layered" k)
-        && std.array.all
-           (fun lk =>
-              lk == null ||
-              is_nested_key lk)
-           (std.record.get "layered" k),
+      serialized_json_validator
+        = validators.record.validator {
+          fields_validator = validators.record.has_exact_fields ["base", "layered"],
+          field_validators = {
+            base = keyboard.serialized_json_validator,
+            layered = validators.array.validator
+              (validators.any_of [
+                validators.is_null,
+                nestable.serialized_json_validator,
+              ]),
+          },
+        },
+
+      is_serialized_json
+        = fun k => 'Ok == serialized_json_validator k,
 
       # c.f. doc_de_layered.md.
       # ```
@@ -185,15 +214,19 @@
     | doc "for key::tap_hold::Key."
     = {
       # c.f. doc_de_tap_hold.md.
-      # JSON serialization of key::tap_hold::Key is { tap: number, hold: number }
-      is_serialized_json =
-        fun k =>
-          let is_nested_key = keyboard.is_serialized_json in
-          std.is_record k &&
-          std.record.has_field "tap" k &&
-          is_nested_key (std.record.get "tap" k) &&
-          std.record.has_field "hold" k &&
-          is_nested_key (std.record.get "hold" k),
+      # JSON serialization of key::tap_hold::Key is { tap: key, hold: key }
+      serialized_json_validator
+        = validators.record.validator {
+          fields_validator = validators.record.has_exact_fields ["tap", "hold"],
+          field_validators = {
+            tap = nestable.serialized_json_validator,
+            hold = nestable.serialized_json_validator,
+          },
+        },
+
+      is_serialized_json
+        = fun k => 'Ok == serialized_json_validator k,
+
       # kludge: support tap_hold::Key<K> in Rust first, then impl. NCL support later.
       key_type = "crate::key::tap_hold::Key<crate::key::keyboard::Key>",
       rust_expr = fun { hold, tap, } =>

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -1,7 +1,5 @@
+let validators = import "validators.ncl" in
 {
-  validators
-    = (import "validators.ncl"),
-
   serialized_json_keymap
     | doc "The 'JSON serialized' value of the keymap. e.g. imported from keymap.json.",
 

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -1,3 +1,4 @@
+let validators = import "validators.ncl" in
 {
   KeymapKey = Dyn,
 
@@ -23,6 +24,9 @@
   nestable
     | doc "for key::composite::NestableKey implementors."
     = {
+      key_validator
+        = keyboard.key_validator,
+
       is_key
         = keyboard.is_key,
 
@@ -48,13 +52,41 @@
   keyboard
     | doc "for key::keyboard::Key."
     = {
+      key_validator
+        = validators.record.validator {
+            fields_validator = validators.all_of [
+              validators.record.has_any_field_of ["key_code", "modifiers"],
+              validators.record.has_only_fields ["key_code", "modifiers"],
+            ],
+            field_validators = {
+              key_code = validators.is_number,
+              modifiers = validators.record.validator {
+                fields_validator = validators.record.has_only_fields [
+                  "left_ctrl",
+                  "left_shift",
+                  "left_alt",
+                  "left_gui",
+                  "right_ctrl",
+                  "right_shift",
+                  "right_alt",
+                  "right_gui",
+                ],
+                field_validators = {
+                  left_ctrl = validators.is_bool,
+                  left_shift = validators.is_bool,
+                  left_alt = validators.is_bool,
+                  left_gui = validators.is_bool,
+                  right_ctrl = validators.is_bool,
+                  right_shift = validators.is_bool,
+                  right_alt = validators.is_bool,
+                  right_gui = validators.is_bool,
+                },
+              },
+            },
+          },
+
       is_key
-        = match {
-          { key_code } => true,
-          { modifiers } => true,
-          { key_code, modifiers } => true,
-          _ => false,
-        },
+        = fun k => 'Ok == key_validator k,
 
       to_json_serialized
         = fun key => key,
@@ -76,10 +108,14 @@
   layer_modifier
     | doc "for key::layered::ModifierKey."
     = {
-      is_key = match {
-        { layer_modifier = { hold } } => true,
-        _ => false,
-      },
+      key_validator
+        = fun k => k |> match {
+          { layer_modifier = { hold } } => validators.is_number hold,
+          _ => 'Error { message = "expected { layer_modifier = { hold } }" },
+        },
+
+      is_key
+        = fun k => 'Ok == key_validator k,
 
       to_json_serialized = fun { layer_modifier = { hold = hold_layer } } =>
         { Hold = hold_layer },
@@ -122,12 +158,25 @@
   layered
     | doc "for key::layered::LayeredKey."
     = {
-      is_key = match {
-        { layered, ..base_key } if std.is_array layered =>
-          nestable.is_key base_key &&
-          std.array.all (fun k => nestable.is_key k || k == null) layered,
-        _ => false,
-      },
+      key_validator
+        = fun k => k |> match {
+          { layered, ..base_key } =>
+            let valid_layered =
+              layered |>
+                validators.array.validator (
+                  validators.any_of [validators.is_null, nestable.key_validator]
+                ) in
+            let valid_base_key = nestable.key_validator base_key in
+            [valid_layered, valid_base_key] |> match {
+              ['Ok, 'Ok] => 'Ok,
+              [err, _] => err,
+              [_, err] => err,
+            },
+          _ => 'Error { message = "expected { layered = Array NestableKey, ..base_key }" },
+        },
+
+      is_key
+        = fun k => 'Ok == key_validator k,
 
       to_json_serialized = fun { layered = layered_keys, ..base_key } =>
         {
@@ -166,10 +215,21 @@
   tap_hold
     | doc "for key::tap_hold::Key."
     = {
-      is_key = match {
-        { hold = hold_key, ..tap_key } => nestable.is_key hold_key &&  nestable.is_key tap_key,
-        _ => false,
-      },
+      key_validator
+        = fun k => k |> match {
+          { hold = hold_key, ..tap_key } =>
+            let valid_hold_key = nestable.key_validator hold_key in
+            let valid_tap_key = nestable.key_validator tap_key in
+            [valid_hold_key, valid_tap_key] |> match {
+              ['Ok, 'Ok] => 'Ok,
+              [err, _] => err,
+              [_, err] => err,
+            },
+          _ => 'Error { message = "expected { hold = NestableKey, ..tap_key }" },
+        },
+
+      is_key
+        = fun k => 'Ok == key_validator k,
 
       to_json_serialized = fun { hold = hold_key, ..tap_key } =>
         {

--- a/ncl/validators.ncl
+++ b/ncl/validators.ncl
@@ -6,6 +6,13 @@
         'Error { message | String | optional, notes | Array String | optional, }
       |],
 
+  check_is_error
+    = fun c =>
+      c |> match {
+        'Error _ => true,
+        _ => false,
+      },
+
   ok
     = std.function.const 'Ok,
 

--- a/ncl/validators.ncl
+++ b/ncl/validators.ncl
@@ -82,6 +82,25 @@
         },
     },
 
+  checks.check_any_of = {
+    any_ok_is_ok = {
+      expected = 'Ok,
+      actual = any_of [fail, fail, ok] {},
+    },
+    empty_is_error =
+       any_of [] {} |> check_is_error,
+  },
+
+  any_of = fun validators v =>
+    validators |> match {
+      [] => 'Error { message = "No validators satisfied" },
+      [validator, ..validators] =>
+        validator v |> match {
+          'Ok => 'Ok,
+          err => any_of validators v,
+        },
+    },
+
   checks.check_record_validators = {
     check_has_any_field_of
       = 'Ok == record.has_any_field_of ["x", "y"] { x = 3, z = 5 },

--- a/ncl/validators.ncl
+++ b/ncl/validators.ncl
@@ -122,6 +122,19 @@
   },
 
   record = {
+    has_all_fields
+      = fun fields r =>
+        if fields |> std.array.all (fun f => std.array.elem f (std.record.fields r)) then
+          'Ok
+        else
+          'Error {
+            message = "Missing fields",
+            notes = [
+              "Expected all of: %{fields |> std.serialize},",
+              "Found: %{r |> std.record.fields}"
+            ],
+          },
+
     has_any_field_of
       = fun fields r =>
         if r |> std.record.fields |> std.array.length == 0 then

--- a/ncl/validators.ncl
+++ b/ncl/validators.ncl
@@ -12,6 +12,13 @@
   fail
     = std.function.const ('Error {}),
 
+  is_array
+    = fun v =>
+      if std.is_array v then
+        'Ok
+      else
+        'Error { message = "Expected array" },
+
   is_bool
     = fun v =>
       if std.is_bool v then
@@ -19,12 +26,33 @@
       else
         'Error { message = "Expected bool" },
 
+  is_null
+    = fun v =>
+      if v == null then
+        'Ok
+      else
+        'Error { message = "Expected null" },
+
   is_number
     = fun v =>
       if std.is_number v then
         'Ok
       else
         'Error { message = "Expected number" },
+
+  is_record
+    = fun v =>
+      if std.is_record v then
+        'Ok
+      else
+        'Error { message = "Expected record" },
+
+  is_string
+    = fun v =>
+      if std.is_string v then
+        'Ok
+      else
+        'Error { message = "Expected string" },
 
   checks.all_of = {
     all_ok_is_ok = {

--- a/ncl/validators.ncl
+++ b/ncl/validators.ncl
@@ -205,25 +205,29 @@
 
     validator
       = fun { fields_validator, field_validators } r =>
-        r |> fields_validator |> match {
+        r |> is_record |> match {
           'Ok =>
-            let rec validate_fields = fun fields =>
-              fields |> match {
-                [] => 'Ok,
-                [field, ..fields] =>
-                  (if std.record.has_field field field_validators then
-                     let v = std.record.get field r in
-                     let validator = std.record.get field field_validators in
-                     validator v
-                   else
-                     'Ok) |> match {
-                    'Ok => validate_fields fields,
-                    err => err,
-                  }
-              } in
-              r |> std.record.fields |> validate_fields,
+            r |> fields_validator |> match {
+              'Ok =>
+                let rec validate_fields = fun fields =>
+                  fields |> match {
+                    [] => 'Ok,
+                    [field, ..fields] =>
+                      (if std.record.has_field field field_validators then
+                        let v = std.record.get field r in
+                        let validator = std.record.get field field_validators in
+                        validator v
+                      else
+                        'Ok) |> match {
+                        'Ok => validate_fields fields,
+                        err => err,
+                      }
+                  } in
+                  r |> std.record.fields |> validate_fields,
 
+              err => err,
+            },
           err => err,
-        },
+        }
   },
 }

--- a/ncl/validators.ncl
+++ b/ncl/validators.ncl
@@ -133,6 +133,15 @@
     check_has_only_fields
       = 'Ok == record.has_only_fields ["x", "y"] { x = 3 },
 
+    check_has_exact_fields
+      = 'Ok == record.has_exact_fields ["x"] { x = 3 },
+
+    check_has_exact_fields_missing_err
+      = record.has_exact_fields ["x", "y"] { x = 3 } |> check_is_error,
+
+    check_has_exact_fields_extra_err
+      = record.has_exact_fields ["x"] { x = 3, y = 4 } |> check_is_error,
+
     check_validator
       = 'Ok
         ==
@@ -174,6 +183,12 @@
               "Found: %{r |> std.record.fields}"
             ],
           },
+
+    has_exact_fields = fun fields r =>
+      all_of [
+        has_all_fields fields,
+        has_only_fields fields,
+      ] r,
 
     has_only_fields
       = fun fields r =>

--- a/ncl/validators.ncl
+++ b/ncl/validators.ncl
@@ -54,10 +54,10 @@
     check_has_only_fields
       = 'Ok == record.has_only_fields ["x", "y"] { x = 3 },
 
-    check_validate
+    check_validator
       = 'Ok
         ==
-        record.validate
+        record.validator
           {
             fields_validator = record.has_only_fields ["x", "y"],
             field_validators = {

--- a/ncl/validators.ncl
+++ b/ncl/validators.ncl
@@ -101,6 +101,31 @@
         },
     },
 
+  checks.check_array_validators = {
+    check_validator
+      = 'Ok == array.validator is_number [1, 2, 3],
+  },
+
+  array = {
+    validator
+      = fun elements_validator a =>
+        a |> is_array |> match {
+          'Ok =>
+            let rec validate_elements = fun elements =>
+              elements |> match {
+                [] => 'Ok,
+                [element, ..elements] =>
+                  elements_validator element |> match {
+                    'Ok => validate_elements elements,
+                    err => err,
+                  }
+              } in
+              a |> validate_elements,
+
+          err => err,
+        },
+  },
+
   checks.check_record_validators = {
     check_has_any_field_of
       = 'Ok == record.has_any_field_of ["x", "y"] { x = 3, z = 5 },


### PR DESCRIPTION
This PR follows up earlier NCL changes which introduced validators.

- checks can now handle serializing `'Error { .. }` values (i.e. Nickel enums), which simplifies troubleshooting validator checks.

- some basic validators have been added.

- the predicates (T -> bool) for `keymap-codegen` have been rewritten in terms of validators (T -> 'Ok | 'Error { .. }).

- the predicates in `keymap-ncl-to-json` have been rewritten in terms of validators.