### PR TITLE
Composite nested key

### DIFF
--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -294,7 +294,7 @@ pub mod init {
     pub type NestedKey = crate::key::composite::DefaultNestableKey;
 
     /// Types used in Composite keys.
-    pub type CompositeImpl = crate::key::composite::CompositeImpl<NestedKey, LayersImpl>;
+    pub type CompositeImpl = crate::key::composite::CompositeImpl<LayersImpl, NestedKey>;
 
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
     pub type Context = crate::key::composite::Context<LayersImpl>;

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -440,17 +440,17 @@ impl TryFrom<Event> for tap_hold::Event {
 
 impl<ME: Copy, IE: Copy> TryFrom<Event> for key::ModifierKeyEvent<ME, IE>
 where
-    ME: TryFrom<Event, Error = key::EventError>,
-    IE: TryFrom<Event, Error = key::EventError>,
+    ME: TryFrom<Event>,
+    IE: TryFrom<Event>,
 {
     type Error = key::EventError;
 
     fn try_from(ev: Event) -> Result<Self, Self::Error> {
-        let res: Result<ME, key::EventError> = ev.try_into();
+        let res: Result<ME, _> = ev.try_into();
         if let Ok(key_event) = res {
             Ok(key::ModifierKeyEvent::Modifier(key_event))
         } else {
-            let res: Result<IE, key::EventError> = ev.try_into();
+            let res: Result<IE, _> = ev.try_into();
             if let Ok(key_event) = res {
                 Ok(key::ModifierKeyEvent::Inner(key_event))
             } else {

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -45,6 +45,25 @@ impl_nestable_key!(keyboard::Key);
 impl_nestable_key!(tap_hold::Key<keyboard::Key>);
 impl_nestable_key!(layered::ModifierKey);
 
+impl<L: layered::LayerImpl> NestableKey<L> for Key<CompositeImpl<L, keyboard::Key>>
+where
+    <L as layered::LayerImpl>::Layers<keyboard::Key>: serde::de::DeserializeOwned,
+{
+    fn pluck_context(context: Context<L>) -> <Self as key::Key>::Context {
+        context
+    }
+
+    fn into_event(event: <Self as crate::key::Key>::Event) -> Event {
+        event.into()
+    }
+
+    fn try_event_from(
+        event: Event,
+    ) -> Result<<Self as crate::key::Key>::Event, crate::key::EventError> {
+        Ok(event)
+    }
+}
+
 /// Related types used by [Key], [Context] and [Event].
 pub trait CompositeTypes: Copy + Debug + PartialEq
 where

--- a/src/key/doc_de_composite.md
+++ b/src/key/doc_de_composite.md
@@ -11,7 +11,7 @@ use composite::DefaultNestableKey;
 
 type NK = composite::DefaultNestableKey;
 type L = layered::ArrayImpl<1>;
-type T = composite::CompositeImpl<NK, L>;
+type T = composite::CompositeImpl<L, NK>;
 type Ctx = composite::Context<T>;
 type Key = composite::Key<T>;
 
@@ -36,7 +36,7 @@ use composite::DefaultNestableKey;
 
 type NK = composite::DefaultNestableKey;
 type L = layered::ArrayImpl<1>;
-type T = composite::CompositeImpl<NK, L>;
+type T = composite::CompositeImpl<L, NK>;
 type Ctx = composite::Context<T>;
 type Key = composite::Key<T>;
 
@@ -66,7 +66,7 @@ use composite::DefaultNestableKey;
 
 type NK = composite::DefaultNestableKey;
 type L = layered::ArrayImpl<1>;
-type T = composite::CompositeImpl<NK, L>;
+type T = composite::CompositeImpl<L, NK>;
 type Ctx = composite::Context<T>;
 type Key = composite::Key<T>;
 
@@ -91,7 +91,7 @@ use composite::DefaultNestableKey;
 
 type NK = composite::DefaultNestableKey;
 type L = layered::ArrayImpl<3>;
-type T = composite::CompositeImpl<NK, L>;
+type T = composite::CompositeImpl<L, NK>;
 type Ctx = composite::Context<T>;
 type Key = composite::Key<T>;
 

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -514,7 +514,7 @@ mod tests {
         const NUM_LAYERS: usize = 1;
         type NK = composite::DefaultNestableKey;
         type L = layered::ArrayImpl<NUM_LAYERS>;
-        type T = composite::CompositeImpl<NK, L>;
+        type T = composite::CompositeImpl<L, NK>;
         type Ctx = composite::Context<L>;
         type Ev = composite::Event;
         type K = composite::Key<T>;
@@ -550,7 +550,7 @@ mod tests {
         const NUM_LAYERS: usize = 1;
         type NK = composite::DefaultNestableKey;
         type L = layered::ArrayImpl<NUM_LAYERS>;
-        type T = composite::CompositeImpl<NK, L>;
+        type T = composite::CompositeImpl<L, NK>;
         type Ctx = composite::Context<L>;
         type Ev = composite::Event;
         type K = composite::Key<T>;
@@ -588,7 +588,7 @@ mod tests {
         const NUM_LAYERS: usize = 1;
         type NK = composite::DefaultNestableKey;
         type L = layered::ArrayImpl<NUM_LAYERS>;
-        type T = composite::CompositeImpl<NK, L>;
+        type T = composite::CompositeImpl<L, NK>;
         type Ctx = composite::Context<L>;
         type Ev = composite::Event;
         type K = composite::Key<T>;
@@ -626,7 +626,7 @@ mod tests {
         const NUM_LAYERS: usize = 1;
         type NK = composite::DefaultNestableKey;
         type L = layered::ArrayImpl<NUM_LAYERS>;
-        type T = composite::CompositeImpl<NK, L>;
+        type T = composite::CompositeImpl<L, NK>;
         type Ctx = composite::Context<L>;
         type Ev = composite::Event;
         type K = composite::Key<T>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub mod init {
     pub type NestedKey = composite::DefaultNestableKey;
 
     /// Types used in Composite keys.
-    pub type CompositeImpl = composite::CompositeImpl<NestedKey, LayersImpl>;
+    pub type CompositeImpl = composite::CompositeImpl<LayersImpl, NestedKey>;
 
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
     pub type Context = composite::Context<LayersImpl>;

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -94,7 +94,7 @@ fn nickel_to_json_for_hid_report(keymap_ncl: &str) -> io::Result<String> {
 const NUM_LAYERS: usize = 16;
 type NestedKey = key::composite::DefaultNestableKey;
 type LayersImpl = key::layered::ArrayImpl<NUM_LAYERS>;
-type CompositeImpl = key::composite::CompositeImpl<NestedKey, LayersImpl>;
+type CompositeImpl = key::composite::CompositeImpl<LayersImpl, NestedKey>;
 type Key = key::composite::Key<CompositeImpl>;
 type Context = key::composite::Context<LayersImpl>;
 type Event = key::composite::Event;

--- a/tests/ncl/keymap-1key-simple/expected.rs
+++ b/tests/ncl/keymap-1key-simple/expected.rs
@@ -9,7 +9,7 @@ pub mod init {
     pub type NestedKey = crate::key::composite::DefaultNestableKey;
 
     /// Types used in Composite keys.
-    pub type CompositeImpl = crate::key::composite::CompositeImpl<NestedKey, LayersImpl>;
+    pub type CompositeImpl = crate::key::composite::CompositeImpl<LayersImpl, NestedKey>;
 
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
     pub type Context = crate::key::composite::Context<LayersImpl>;

--- a/tests/ncl/keymap-1key-tap_hold/expected.rs
+++ b/tests/ncl/keymap-1key-tap_hold/expected.rs
@@ -9,7 +9,7 @@ pub mod init {
     pub type NestedKey = crate::key::composite::DefaultNestableKey;
 
     /// Types used in Composite keys.
-    pub type CompositeImpl = crate::key::composite::CompositeImpl<NestedKey, LayersImpl>;
+    pub type CompositeImpl = crate::key::composite::CompositeImpl<LayersImpl, NestedKey>;
 
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
     pub type Context = crate::key::composite::Context<LayersImpl>;

--- a/tests/ncl/keymap-2key-2layer-simple/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-simple/expected.rs
@@ -9,7 +9,7 @@ pub mod init {
     pub type NestedKey = crate::key::composite::DefaultNestableKey;
 
     /// Types used in Composite keys.
-    pub type CompositeImpl = crate::key::composite::CompositeImpl<NestedKey, LayersImpl>;
+    pub type CompositeImpl = crate::key::composite::CompositeImpl<LayersImpl, NestedKey>;
 
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
     pub type Context = crate::key::composite::Context<LayersImpl>;

--- a/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
@@ -9,7 +9,7 @@ pub mod init {
     pub type NestedKey = crate::key::composite::DefaultNestableKey;
 
     /// Types used in Composite keys.
-    pub type CompositeImpl = crate::key::composite::CompositeImpl<NestedKey, LayersImpl>;
+    pub type CompositeImpl = crate::key::composite::CompositeImpl<LayersImpl, NestedKey>;
 
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
     pub type Context = crate::key::composite::Context<LayersImpl>;

--- a/tests/ncl/keymap-60key-dvorak-simple/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple/expected.rs
@@ -9,7 +9,7 @@ pub mod init {
     pub type NestedKey = crate::key::composite::DefaultNestableKey;
 
     /// Types used in Composite keys.
-    pub type CompositeImpl = crate::key::composite::CompositeImpl<NestedKey, LayersImpl>;
+    pub type CompositeImpl = crate::key::composite::CompositeImpl<LayersImpl, NestedKey>;
 
     /// Alias for Context type; i.e. [crate::key::context::Context] with generics.
     pub type Context = crate::key::composite::Context<LayersImpl>;


### PR DESCRIPTION
The bulk of this had been done in #103.

It looks small; but this FINALLY enables e.g. tap-hold, layered to use more keys than just the trivial `keyboard::Key`.

This had been blocking some smart keymap implementations:

- e.g. Miryoku-style tap-hold thumb keys require both tap-hold of composite key types (both "Esc", a keyboard::Key, and "hold layer", a layermod), as well as layering (e.g. `0` is on the thumb).
  - (i.e. tap-hold's nested keys both need to be the same type; so, to have both layer mod and "esc", a `composite::Key` is used).

- similarly, home-row mods on layered keymap would then require that a layered key could consist of composite key types (tap-hold and other non-tap-hold keys).

There were basically two things to resolve before being able to impl `composite::NestableKey` for `composite::Key`:

- needing to convert `composite::Context<L>` into `composite::Context<L>`.
  - Rather, `NestableKey` has a function for 'plucking' the context for the nestable key from the aggregate `composite::Context<L>`. But the context for composite key is clearly just the same `Context<L>`.
      - I opted to lift the `<L>` generic to the `NestableKey` trait so as to clarify that these `L` are the same.
      - This re-shuffle meant it was more convenient to have `CompositeImpl<L, K>` than `CompositeImpl<K, L>`. (This mostly affects default generic values).

- the `TryFrom` impl. for `ModifierKeyEvent` assumed the bounds' `TryFrom` had `key::EventError`.
  - Point is, `composite::Event` (the assoc `Event` type for `composite::Key`) trivially implements `TryFrom` `composite::Event`, but with `Infallible` as the error.

Once those two things were resolved, I was able to add a unit test checking `TapHold(K.A, layer.Hold(0))`.

Now what blocks the "layered taphold layer-modifying thumb keys" (& home row mods) in `keymap.ncl` is:

- in the smart keymap: more impl. of `key::composite::NestableKey` for more `key::composite::Key<NK>`.
- Nickel keymap support.
  - in particular, Nickel will need to calculate the nested key type.