### PR TITLE
rust: use tuple variants for key::composite::Key

### DIFF
--- a/features/deserialization/key_deserialization.feature
+++ b/features/deserialization/key_deserialization.feature
@@ -23,9 +23,9 @@ Feature: Key Deserialization
   Example: Deserialize a composite::Key (TapHold variant)
     When a composite::Key is deserialized from the RON string
       """
-      TapHold(key: Key(tap: Key(key_code: 0x04), hold: Key(key_code: 0xE0)))
+      TapHold(Key(tap: Key(key_code: 0x04), hold: Key(key_code: 0xE0)))
       """
     Then the result is same value as deserializing the JSON string
       """
-      { "TapHold": { "key": { "tap": { "key_code": 4 }, "hold": { "key_code": 224 } } } }
+      { "TapHold": { "tap": { "key_code": 4 }, "hold": { "key_code": 224 } } }
       """

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -270,16 +270,16 @@ let validators = import "validators.ncl" in
     = match {
         # Make key::layered::LayeredKey
         k if layered.is_key k =>
-          { Layered = { key = to_json_serialized_key k } },
+          { Layered = to_json_serialized_key k },
         # Make key::tap_hold::Key from keys with a "hold" modifier.
         k if tap_hold.is_key k =>
-          { TapHold = { key = to_json_serialized_key k } },
+          { TapHold = to_json_serialized_key k },
         # Otherwise, keys with just a base key_code are key::keyboard keys.
         k if keyboard.is_key k =>
-          { Keyboard = { key = to_json_serialized_key k } },
+          { Keyboard = to_json_serialized_key k },
         # Make key::layered::ModifierKey
         k if layer_modifier.is_key k =>
-          { LayerModifier = { key = to_json_serialized_key k } },
+          { LayerModifier = to_json_serialized_key k },
         # Null values (None) stay null
         null => null,
         _ => std.fail_with "unsupported item in keymap.ncl",

--- a/src/key/doc_de_composite.md
+++ b/src/key/doc_de_composite.md
@@ -16,9 +16,9 @@ type Ctx = composite::Context<T>;
 type Key = composite::Key<T>;
 
 let json = r#"
-  { "Keyboard": { "key": { "key_code": 4 } } }
+  { "Keyboard": { "key_code": 4 } }
 "#;
-let expected_key: Key = composite::Key::Keyboard { key: keyboard::Key::new(0x04) };
+let expected_key: Key = composite::Key::Keyboard(keyboard::Key::new(0x04));
 let actual_key: Key = serde_json::from_str(json).unwrap();
 assert_eq!(actual_key, expected_key);
 ```
@@ -41,14 +41,12 @@ type Ctx = composite::Context<T>;
 type Key = composite::Key<T>;
 
 let json = r#"
-  { "TapHold": { "key": { "hold": { "key_code": 224 }, "tap": { "key_code": 4 } } } }
+  { "TapHold": { "hold": { "key_code": 224 }, "tap": { "key_code": 4 } } }
 "#;
-let expected_key: Key = composite::Key::TapHold {
-  key: tap_hold::Key {
+let expected_key: Key = composite::Key::TapHold(tap_hold::Key {
     tap: keyboard::Key::new(4),
     hold: keyboard::Key::new(224),
-  },
-};
+  });
 let actual_key: Key = serde_json::from_str(json).unwrap();
 assert_eq!(actual_key, expected_key);
 ```
@@ -71,9 +69,9 @@ type Ctx = composite::Context<T>;
 type Key = composite::Key<T>;
 
 let json = r#"
-  { "LayerModifier": { "key": { "Hold": 2 } } }
+  { "LayerModifier": { "Hold": 2 } }
 "#;
-let expected_key: Key = composite::Key::LayerModifier { key: layered::ModifierKey::Hold(2) };
+let expected_key: Key = composite::Key::LayerModifier(layered::ModifierKey::Hold(2));
 let actual_key: Key = serde_json::from_str(json).unwrap();
 assert_eq!(actual_key, expected_key);
 ```
@@ -98,19 +96,15 @@ type Key = composite::Key<T>;
 let json = r#"
   {
     "Layered": {
-      "key": {
-        "base": { "key_code": 4 },
-        "layered": [{ "key_code": 5 }, null, { "key_code": 7 }]
-      }
+      "base": { "key_code": 4 },
+      "layered": [{ "key_code": 5 }, null, { "key_code": 7 }]
     }
   }
 "#;
-let expected_key: Key = composite::Key::Layered {
-  key: layered::LayeredKey {
+let expected_key: Key = composite::Key::Layered(layered::LayeredKey {
     base: keyboard::Key::new(0x04),
     layered: [Some(keyboard::Key::new(0x05)), None, Some(keyboard::Key::new(0x07))],
-  }
-};
+  });
 let actual_key: Key = serde_json::from_str(json).unwrap();
 assert_eq!(actual_key, expected_key);
 ```


### PR DESCRIPTION
`key::composite::Key` used struct enum variants, to allow for the possibility that keys might need some `PhantomData`.

However, this makes the Nickel implementation more difficult (e.g. can't write `{ "key" = key.f ... }` in Nickel; whereas what I'd want is "set the property `key` to be a result of `key.f ...`).

If some phantom data is needed, then perhaps it can just be included in the tuple variant.