### PR TITLE
Key tap hold, change to ignore interrupts

### DIFF
--- a/features/keymap/key/tap_hold.feature
+++ b/features/keymap/key/tap_hold.feature
@@ -61,17 +61,3 @@ Feature: TapHold Key
       let K = import "hid-usage-keyboard.ncl" in
       { modifiers = { left_ctrl = true } }
       """
-
-  Example: acts as 'hold' when interrupted
-    When the keymap registers the following input
-      """
-      [
-        Press(keymap_index: 0),
-        Press(keymap_index: 1)
-      ]
-      """
-    Then the HID keyboard report should equal
-      """
-      let K = import "hid-usage-keyboard.ncl" in
-      { modifiers = { left_ctrl = true }, key_codes = [K.B] }
-      """

--- a/src/key/tap_hold.rs
+++ b/src/key/tap_hold.rs
@@ -30,7 +30,7 @@ pub struct Config {
 /// Default tap hold config.
 pub const CONFIG: Config = Config {
     timeout: 200,
-    interrupt_response: InterruptResponse::HoldOnKeyPress,
+    interrupt_response: InterruptResponse::Ignore,
 };
 
 /// A key with tap-hold functionality.

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -692,8 +692,18 @@ mod tests {
 
         // Act
         // - Press the tap-hold key.
+        // - Resolve the tap-hold as hold (Time the tap-hold key out)
         // - Press the layered key.
         keymap.handle_input(input::Event::Press { keymap_index: 0 });
+        keymap
+            .event_scheduler
+            .schedule_event(key::ScheduledEvent::immediate(key::Event::Key {
+                keymap_index: 0,
+                key_event: key::ModifierKeyEvent::<tap_hold::Event, composite::Event>::Modifier(
+                    tap_hold::Event::TapHoldTimeout,
+                )
+                .into(),
+            }));
         keymap.handle_input(input::Event::Press { keymap_index: 1 });
         let actual_report = keymap.boot_keyboard_report();
 
@@ -735,9 +745,17 @@ mod tests {
 
         // 1. Press the tap-hold key
         keymap.handle_input(input::Event::Press { keymap_index: 0 });
-        // 2. Resolve tap-hold to 'hold', by tapping another key.
-        keymap.handle_input(input::Event::Press { keymap_index: 1 });
-        keymap.handle_input(input::Event::Release { keymap_index: 1 });
+        // 2. Resolve the tap-hold as hold (Time the tap-hold key out)
+        keymap
+            .event_scheduler
+            .schedule_event(key::ScheduledEvent::immediate(key::Event::Key {
+                keymap_index: 0,
+                key_event: key::ModifierKeyEvent::<tap_hold::Event, composite::Event>::Modifier(
+                    tap_hold::Event::TapHoldTimeout,
+                )
+                .into(),
+            }));
+        keymap.tick();
         // 3. Release the tap-hold key (release layered::LayerModifier::Hold)
         keymap.handle_input(input::Event::Release { keymap_index: 0 });
 

--- a/tests/ceedling/test/test_keydef_taphold.c
+++ b/tests/ceedling/test/test_keydef_taphold.c
@@ -16,23 +16,6 @@ void setUp(void) {
 void tearDown(void) {
 }
 
-void test_taphold_interrupted_is_hold(void) {
-    // Interrupting a taphold results in the 'hold' key.
-    //
-    // Pressing T.H., then A, is same as "Hold key + A"
-
-    uint8_t expected_report[8] = {MOD_LCTL, 0, KC_A, 0, 0, 0, 0, 0};
-    uint8_t actual_report[8] = {0, 0, 0, 0, 0, 0, 0, 0};
-
-    keymap_init();
-
-    keymap_register_input_keypress(0); // First key in keymap is TapHold(_, Ctrl)
-    keymap_register_input_keypress(2); // Third key in the keymap is A
-
-    copy_hid_boot_keyboard_report(actual_report);
-    TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report, 8);
-}
-
 void test_taphold_dth_uth_is_tap(void) {
     // Pressing T.H., then releasing T.H., is same as tapping the tap key.
     // (Check the tap key gets pressed).


### PR DESCRIPTION
Obviously changing config from `keymap.ncl` (and `keymap.json`) would be better. But, until then, I apparently prefer ignore interrupts.