### PR TITLE
Fix Tap-Told rolling presses (for InterruptResolution::Ignore)

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,7 @@
 use serde::Deserialize;
 
+use crate::key;
+
 /// Input events for [crate::keymap::Keymap].
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
 pub enum Event {
@@ -17,6 +19,8 @@ pub enum Event {
     VirtualKeyPress {
         /// The virtual key code.
         key_code: u8,
+        /// Inserts the virtual key before the pressed key with this keymap index.
+        pressed_keymap_index: u16,
     },
     /// A virtual key release for a given `key_code`.
     VirtualKeyRelease {
@@ -51,7 +55,7 @@ impl<K: crate::key::Key, S: crate::key::PressedKeyState<K, Event = K::Event>> cr
             .handle_event_for(context, self.keymap_index, &self.key, event)
     }
 
-    fn key_output(&self) -> Option<crate::key::KeyOutput> {
+    fn key_output(&self) -> key::KeyOutputState {
         self.pressed_key_state.key_output(&self.key)
     }
 }

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -350,13 +350,13 @@ impl<T: CompositeTypes> key::PressedKeyState<Key<T>> for PressedKeyState<T> {
         }
     }
 
-    fn key_output(&self, key: &Key<T>) -> Option<key::KeyOutput> {
+    fn key_output(&self, key: &Key<T>) -> key::KeyOutputState {
         match (key, self) {
             (Key::LayerModifier(key), PressedKeyState::LayerModifier(pk)) => pk.key_output(key),
             (Key::Layered(key), PressedKeyState::Layered(pk)) => pk.key_output(key),
             (Key::Keyboard(key), PressedKeyState::Keyboard(pk)) => pk.key_output(key),
             (Key::TapHold(key), PressedKeyState::TapHold(pk)) => pk.key_output(key),
-            _ => None,
+            _ => key::KeyOutputState::no_output(),
         }
     }
 }
@@ -614,7 +614,7 @@ mod tests {
 
         // Assert
         let expected_keycode = Some(key::KeyOutput::from_key_code(0x06));
-        assert_eq!(actual_keycode, expected_keycode);
+        assert_eq!(actual_keycode.to_option(), expected_keycode);
     }
 
     #[test]
@@ -649,6 +649,6 @@ mod tests {
 
         // Assert
         let expected_keycode = Some(key::KeyOutput::from_key_code(0x04));
-        assert_eq!(actual_keycode, expected_keycode);
+        assert_eq!(actual_keycode.to_option(), expected_keycode);
     }
 }

--- a/src/key/dynamic.rs
+++ b/src/key/dynamic.rs
@@ -26,7 +26,7 @@ where
     ) -> heapless::Vec<key::ScheduledEvent<Ev>, M>;
 
     /// Output HID keyboard code for the [Key].
-    fn key_output(&self) -> Option<key::KeyOutput>;
+    fn key_output(&self) -> key::KeyOutputState;
 
     /// Resets the [Key] to its initial state.
     fn reset(&mut self);
@@ -110,11 +110,11 @@ where
         scheduled_events
     }
 
-    fn key_output(&self) -> Option<key::KeyOutput> {
+    fn key_output(&self) -> key::KeyOutputState {
         if let Some(pressed_key) = &self.pressed_key {
             pressed_key.key_output()
         } else {
-            None
+            key::KeyOutputState::no_output()
         }
     }
 
@@ -154,6 +154,6 @@ mod tests {
         // Assert
         let actual_key_code = dyn_key.key_output();
         let expected_key_code = None;
-        assert_eq!(actual_key_code, expected_key_code);
+        assert_eq!(actual_key_code.to_option(), expected_key_code);
     }
 }

--- a/src/key/keyboard.rs
+++ b/src/key/keyboard.rs
@@ -100,8 +100,8 @@ impl key::PressedKeyState<Key> for PressedKeyState {
     }
 
     /// Keyboard key always has a key_output.
-    fn key_output(&self, key: &Key) -> Option<key::KeyOutput> {
+    fn key_output(&self, key: &Key) -> key::KeyOutputState {
         let key_output = key::KeyOutput::from_key_code_with_modifiers(key.key_code, key.modifiers);
-        Some(key_output)
+        key::KeyOutputState::resolved(key_output)
     }
 }

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -320,8 +320,8 @@ impl key::PressedKeyState<ModifierKey> for PressedModifierKeyState {
         }
     }
 
-    fn key_output(&self, _key: &ModifierKey) -> Option<key::KeyOutput> {
-        None
+    fn key_output(&self, _key: &ModifierKey) -> key::KeyOutputState {
+        key::KeyOutputState::no_output()
     }
 }
 
@@ -366,7 +366,7 @@ impl<K: key::Key, L: LayerImpl> key::PressedKeyState<LayeredKey<K, L>>
             .handle_event(context.inner_context, event)
     }
 
-    fn key_output(&self, _key: &LayeredKey<K, L>) -> Option<key::KeyOutput> {
+    fn key_output(&self, _key: &LayeredKey<K, L>) -> key::KeyOutputState {
         use crate::key::PressedKey as _;
 
         self.passthrough_pk.key_output()
@@ -515,7 +515,10 @@ mod tests {
         let (expected_pressed_key, _event) = expected_key.new_pressed_key((), keymap_index);
         let expected_key_output = expected_pressed_key.key_output();
         assert_eq!(actual_key_output, expected_key_output);
-        assert_eq!(actual_key_output, Some(KeyOutput::from_key_code(0x04)));
+        assert_eq!(
+            actual_key_output.to_option(),
+            Some(KeyOutput::from_key_code(0x04))
+        );
     }
 
     // Terminology:

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -384,6 +384,45 @@ impl KeyOutput {
     }
 }
 
+/// Whether the key output is pending or resolved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyOutputState {
+    /// The key state is pending.
+    Pending,
+    /// The key has output.
+    Resolved(Option<KeyOutput>),
+}
+
+impl KeyOutputState {
+    /// Constructs a [KeyOutputState] with a resolved key output.
+    pub fn resolved(key_output: KeyOutput) -> Self {
+        KeyOutputState::Resolved(Some(key_output))
+    }
+
+    /// Constructs a [KeyOutputState] indicating the key is resolved with no output.
+    pub fn no_output() -> Self {
+        KeyOutputState::Resolved(None)
+    }
+
+    /// Constructs a [KeyOutputState] indicating the key state is pending.
+    pub fn pending() -> Self {
+        KeyOutputState::Pending
+    }
+
+    /// Predicate for whether the key output is resolved.
+    pub fn is_resolved(&self) -> bool {
+        matches!(self, KeyOutputState::Resolved(_))
+    }
+
+    /// Returns the key output as an Option.
+    pub fn to_option(&self) -> Option<KeyOutput> {
+        match self {
+            KeyOutputState::Resolved(key_output) => *key_output,
+            _ => None,
+        }
+    }
+}
+
 /// [PressedKeyState] for a stateful pressed key value.
 pub trait PressedKey {
     /// The type of `Context` the pressed key handles.
@@ -399,7 +438,7 @@ pub trait PressedKey {
     ) -> PressedKeyEvents<Self::Event>;
 
     /// Output for the pressed key.
-    fn key_output(&self) -> Option<KeyOutput>;
+    fn key_output(&self) -> KeyOutputState;
 }
 
 /// Implements functionality for the pressed key.
@@ -420,7 +459,7 @@ pub trait PressedKeyState<K: Key>: Debug {
     ) -> PressedKeyEvents<Self::Event>;
 
     /// Output for the pressed key state.
-    fn key_output(&self, key: &K) -> Option<KeyOutput>;
+    fn key_output(&self, key: &K) -> KeyOutputState;
 }
 
 /// Errors for [TryFrom] implementations.

--- a/src/key/tap_hold.rs
+++ b/src/key/tap_hold.rs
@@ -227,9 +227,12 @@ impl<K: key::Key> key::PressedKeyState<Key<K>> for PressedKeyState<K> {
                     //  so, we send virtual key tap (press, scheduled release) with the
                     //  pressed key's output.
                     (TapHoldState::Tap, Some(pk)) => {
-                        if let Some(key_output) = pk.key_output() {
+                        if let Some(key_output) = pk.key_output().to_option() {
                             let key_code = key_output.key_code();
-                            let press_ev = input::Event::VirtualKeyPress { key_code };
+                            let press_ev = input::Event::VirtualKeyPress {
+                                key_code,
+                                pressed_keymap_index: keymap_index,
+                            };
                             let release_ev = input::Event::VirtualKeyRelease { key_code };
                             let mut events: key::PressedKeyEvents<Self::Event> =
                                 key::PressedKeyEvents::event(press_ev.into());
@@ -246,7 +249,10 @@ impl<K: key::Key> key::PressedKeyState<Key<K>> for PressedKeyState<K> {
         }
     }
 
-    fn key_output(&self, _key: &Key<K>) -> Option<key::KeyOutput> {
-        self.pressed_key.as_ref().and_then(|pk| pk.key_output())
+    fn key_output(&self, _key: &Key<K>) -> key::KeyOutputState {
+        match &self.pressed_key {
+            Some(pk) => pk.key_output(),
+            None => key::KeyOutputState::pending(),
+        }
     }
 }


### PR DESCRIPTION
I noticed that tap-hold doesn't behave the way I like. When rolling key presses (& ignoring key interrupts), I was observing keys in the wrong order.

This PR adds a unit tests demonstrating this, and fixes this.

Sadly, the fix is in one commit, not three, but it:

- Replaces `key_output` return value with `KeyOutputState`.
- This allows `tap_hold::PressedKeyState` to indicate it's "pending".
  - The `Keymap` only takes pressed outputs from non-pending keys.
- Further, the VirtualKey emitted by the "tap"-resolved tap hold needs to be considered as pressed *before* the rolling input -- But, since the tap is only resolved as tap when the TH key releases, we need a way of inserting the VirtKey at this position. -- Adding `pressed_keymap_index` to `VirtualKeyPress` was the neatest way of expressing this that I could think of.