### PR TITLE
Brushup Makefile & justfile scripts

### DIFF
--- a/.github/workflows/test-ceedling.yaml
+++ b/.github/workflows/test-ceedling.yaml
@@ -36,8 +36,7 @@ jobs:
           bundle install
           cargo install --force cbindgen
 
-      - name: Run Tests
+      - name: Run Ceedling Tests
         run: |
           export PATH=$(gem environment user_gemhome)/bin:$PATH
-          make
-          make test
+          make test-ceedling

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,18 +88,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "bstr"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,7 +141,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn",
 ]
 
 [[package]]
@@ -247,7 +235,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.91",
+ "syn",
  "synthez",
 ]
 
@@ -273,7 +261,7 @@ checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn",
 ]
 
 [[package]]
@@ -303,60 +291,6 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
-
-[[package]]
-name = "frunk"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874b6a17738fc273ec753618bac60ddaeac48cb1d7684c3e7bd472e57a28b817"
-dependencies = [
- "frunk_core",
- "frunk_derives",
-]
-
-[[package]]
-name = "frunk_core"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3529a07095650187788833d585c219761114005d5976185760cf794d265b6a5c"
-
-[[package]]
-name = "frunk_derives"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e99b8b3c28ae0e84b604c75f721c21dc77afb3706076af5e8216d15fd1deaae3"
-dependencies = [
- "frunk_proc_macro_helpers",
- "quote",
- "syn 2.0.91",
-]
-
-[[package]]
-name = "frunk_proc_macro_helpers"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a956ef36c377977e512e227dcad20f68c2786ac7a54dacece3746046fea5ce"
-dependencies = [
- "frunk_core",
- "proc-macro2",
- "quote",
- "syn 2.0.91",
-]
-
-[[package]]
-name = "fugit"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17186ad64927d5ac8f02c1e77ccefa08ccd9eaa314d5a4772278aa204a22f7e7"
-dependencies = [
- "gcd",
-]
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -414,7 +348,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn",
 ]
 
 [[package]]
@@ -448,12 +382,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gcd"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
-
-[[package]]
 name = "gherkin"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,7 +392,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.91",
+ "syn",
  "textwrap",
  "thiserror",
  "typed-builder",
@@ -604,7 +532,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.91",
+ "syn",
 ]
 
 [[package]]
@@ -665,57 +593,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
-dependencies = [
- "num_enum_derive",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.91",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
-
-[[package]]
-name = "option-block"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f2c5d345596a14d7c8b032a68f437955f0059f2eb9a5972371c84f7eef3227"
-
-[[package]]
-name = "packed_struct"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b29691432cc9eff8b282278473b63df73bea49bc3ec5e67f31a3ae9c3ec190"
-dependencies = [
- "bitvec",
- "packed_struct_codegen",
-]
-
-[[package]]
-name = "packed_struct_codegen"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd6706dfe50d53e0f6aa09e12c034c44faacd23e966ae5a209e8bdb8f179f98"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "paste"
@@ -767,7 +648,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn",
 ]
 
 [[package]]
@@ -781,12 +662,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "portable-atomic"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "proc-macro2"
@@ -805,12 +680,6 @@ checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "regex"
@@ -902,7 +771,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn",
 ]
 
 [[package]]
@@ -928,7 +797,7 @@ checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn",
 ]
 
 [[package]]
@@ -960,7 +829,7 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn",
 ]
 
 [[package]]
@@ -976,7 +845,6 @@ dependencies = [
  "seq-macro",
  "serde",
  "serde_json",
- "usbd-human-interface-device",
 ]
 
 [[package]]
@@ -999,17 +867,6 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53cbcb5a243bd33b7858b1d7f4aca2153490815872d86d955d6ea29f743c035"
@@ -1025,7 +882,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3d2c2202510a1e186e63e596d9318c91a8cbe85cd1a56a7be0c333e5f59ec8d"
 dependencies = [
- "syn 2.0.91",
+ "syn",
  "synthez-codegen",
  "synthez-core",
 ]
@@ -1036,7 +893,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f724aa6d44b7162f3158a57bccd871a77b39a4aef737e01bcdff41f4772c7746"
 dependencies = [
- "syn 2.0.91",
+ "syn",
  "synthez-core",
 ]
 
@@ -1049,14 +906,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sealed",
- "syn 2.0.91",
+ "syn",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "terminal_size"
@@ -1096,7 +947,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn",
 ]
 
 [[package]]
@@ -1116,7 +967,7 @@ checksum = "29a3151c41d0b13e3d011f98adc24434560ef06673a155a6c7f66b9879eecce2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn",
 ]
 
 [[package]]
@@ -1142,31 +993,6 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
-
-[[package]]
-name = "usb-device"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98816b1accafbb09085168b90f27e93d790b4bfa19d883466b5e53315b5f06a6"
-dependencies = [
- "heapless",
- "portable-atomic",
-]
-
-[[package]]
-name = "usbd-human-interface-device"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f549646a39027f191f865a222f20b1886e4c16848d67a43191f63c1a9d59c07"
-dependencies = [
- "frunk",
- "fugit",
- "heapless",
- "num_enum",
- "option-block",
- "packed_struct",
- "usb-device",
-]
 
 [[package]]
 name = "utf8parse"
@@ -1265,12 +1091,3 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 default = ["std", "staticlib"]
 std = []
 staticlib = []
-usbd-human-interface-device = ["dep:usbd-human-interface-device"]
 
 [lib]
 name = "smart_keymap"
@@ -29,7 +28,6 @@ libc = "0.2"
 paste = "1.0"
 seq-macro = "0.3"
 serde = { version = "1.0", features = ["derive"], default-features = false }
-usbd-human-interface-device = { version = "0.5.0", optional = true }
 
 [dev-dependencies]
 cucumber = "0.21"

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ all: include/smart_keymap.h
 	$(CARGO) build
 
 .PHONY: test
-test: include/smart_keymap.h
+test: include/smart_keymap.h test-ncl
 
 .PHONY: clean
-clean:
+clean: clean-generated-keymaps
 	rm -f include/smart_keymap.h
 	$(CARGO) clean
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 CARGO = cargo
 CBINDGEN = cbindgen
 
+ifndef VERBOSE
+MAKEFLAGS += --no-print-directory
+endif
+
 include ncl/ncl.mk
 include tests/ceedling/ceedling.mk
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,11 @@ all: include/smart_keymap.h
 	$(CARGO) build
 
 .PHONY: test
-test: include/smart_keymap.h test-ncl
+test: test-rust test-ncl test-ceedling
+
+.PHONY: test-rust
+test-rust:
+	$(CARGO) test
 
 .PHONY: clean
 clean: clean-generated-keymaps

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,14 @@
 CARGO = cargo
 CBINDGEN = cbindgen
 
+include tests/ceedling/ceedling.mk
+
 .PHONY: all
 all: include/smart_keymap.h
 	$(CARGO) build
 
 .PHONY: test
 test: include/smart_keymap.h
-	$(CARGO) test
-	env SMART_KEYMAP_CUSTOM_KEYMAP="$(shell pwd)/tests/ncl/keymap-4key-simple/keymap.ncl" \
-	  $(CARGO) rustc --crate-type "staticlib"
-	cd tests/ceedling && ceedling
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 CARGO = cargo
 CBINDGEN = cbindgen
 
+include ncl/ncl.mk
 include tests/ceedling/ceedling.mk
 
 .PHONY: all
@@ -14,12 +15,6 @@ test: include/smart_keymap.h
 clean:
 	rm -f include/smart_keymap.h
 	$(CARGO) clean
-
-%/keymap.json:
-	ncl/scripts/keymap-ncl-to-json.sh $(shell dirname $@)
-
-%/keymap.rs: %/keymap.json
-	ncl/scripts/keymap-codegen.sh $(shell dirname $@)
 
 include/smart_keymap.h: src/lib.rs
 	$(CBINDGEN) -c cbindgen.toml -o include/smart_keymap.h

--- a/features/scripts/generate-doc.sh
+++ b/features/scripts/generate-doc.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
 SCRIPTS_DIR="$(dirname "$0")"
 REPOSITORY_DIR="${SCRIPTS_DIR}/../.."

--- a/firmware/ch32x035-usb-device-compositekm-c/Makefile
+++ b/firmware/ch32x035-usb-device-compositekm-c/Makefile
@@ -1,3 +1,5 @@
+BOARD=ncl/weact-ch32x-core-board.ncl
+
 .PHONY: all
 all: generated/matrix.c libsmartkeymap
 
@@ -14,22 +16,18 @@ test:
 	  ncl/test-expected-ch32x-48.ncl \
 	  ncl/test-actual-ch32x-48.ncl
 
+.PHONY: generated/matrix.c
 generated/matrix.c:
 	nickel export \
 	  --format=raw \
 	  --field=output \
-	  ncl/weact-ch32x-core-board.ncl \
+	  $(BOARD) \
 	  ncl/matrix_scan.ncl \
 	  > generated/matrix.c
 
 .PHONY: generated-ch32x-48
-generated-ch32x-48:
-	nickel export \
-	  --format=raw \
-	  --field=output \
-	  ncl/ch32x-48.ncl \
-	  ncl/matrix_scan.ncl \
-	  > generated/matrix.c
+generated-ch32x-48: BOARD=ncl/ch32x-48.ncl
+generated-ch32x-48: generated/matrix.c
 
 .PHONY: libsmartkeymap
 libsmartkeymap: libsmartkeymap/smart_keymap.h libsmartkeymap/libsmart_keymap.a;

--- a/firmware/ch32x035-usb-device-compositekm-c/Makefile
+++ b/firmware/ch32x035-usb-device-compositekm-c/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all: generated/matrix.c
+all: generated/matrix.c libsmartkeymap
 
 .PHONY: clean
 clean:
@@ -30,3 +30,12 @@ generated-ch32x-48:
 	  ncl/ch32x-48.ncl \
 	  ncl/matrix_scan.ncl \
 	  > generated/matrix.c
+
+.PHONY: libsmartkeymap
+libsmartkeymap: libsmartkeymap/smart_keymap.h libsmartkeymap/libsmart_keymap.a;
+
+libsmartkeymap/smart_keymap.h:
+	echo "ERROR: smart_keymap.h not installed. Please copy from the smart-keymap project."
+
+libsmartkeymap/libsmart_keymap.a:
+	echo "ERROR: libsmart_keymap.a not installed. Please copy from the smart-keymap project."

--- a/firmware/ch32x035-usb-device-compositekm-c/README.MD
+++ b/firmware/ch32x035-usb-device-compositekm-c/README.MD
@@ -15,52 +15,33 @@ The firmware has been modified to use `libsmart_keymap`.
 
 ## Building
 
-The firmware should be linked using a `libsmart_keymap.a`
- built with a suitable keymap
- for the `riscv32imac-unknown-none-elf` target.
+The task-runner [just](https://just.systems/man/en/) is used
+ for convenient invocation of build tasks.
 
-e.g. from the repository's root directory, run:
+The `smart-keymap`'s justfile provides an `install` recipe
+ for conveniently building & installing the `libsmart_keymap.a`.
 
-```
-just build-keymap-rv-48key-checkkeys
-```
+This directory's `justfile` provides a `flash` recipe for conveniently
+ building & flashing the HID keyboard firmware.
 
+From the `smart-keymap` root directory,
+the firmware can be flashed with the keymap `tests/ncl/{test_keymap}/keymap.ncl`
+by running e.g.:
 
-The `include/smart_keymap.h` and
-`target/riscv32imac-unknown-none-elf/release/libsmart_keymap.a`
-files should be copied into the `libsmartkeymap/` directory.
-
-Matrix key scanning is generated from files under `ncl/`.
-
-To generate the `generated/matrix.c` for the CH32X-048, run:
-
-```
-make generated-ch32x-48
+``` sh
+just \
+  test_keymap=keymap-48key-checkkeys \
+  dest_dir="firmware/ch32x035-usb-device-compositekm-c/libsmartkeymap/" \
+  install && \
+just firmware/ch32x035-usb-device-compositekm-c/flash
 ```
 
-Or to generate the `generated/matrix.c` for the WeAct CH32X core board:
+### Flashing the CH32X
 
-```
-make
-```
+If the CH32X does not have code protection enabled, `wchisp` can be used to flash
+the MCU by shorting DOWNLOAD and plugging in the USB connector.
 
-An appropriate toolchain should be on `PATH`. e.g. using the package from the
-Nix flake from <https://github.com/rgoulter/ch32>:
-
-```
-nix shell github:rgoulter/ch32#mrs-riscv-embedded-gcc12
-```
-
-Then the firmware can be built with:
-
-```
-cmake --toolchain=../../toolchains/riscv-none-elf.cmake ..
-make
-```
-
-The WeAct core board, for some reason, has code protect enabled, and so requires `wlink` and a
+The WeAct core board, for some reason, has code protection enabled. This requires `wlink` and a
 and a WCH link compatible with the CH32X035, such as WCH-LinkE.
 (SEE: https://github.com/ch32-rs/wchisp/issues/68#issuecomment-2558167356).
 
-If the CH32X hasn't had code protection enabled, `wchisp` can be used to flash
-the MCU by shorting DOWNLOAD and plugging in the USB connector.

--- a/firmware/ch32x035-usb-device-compositekm-c/justfile
+++ b/firmware/ch32x035-usb-device-compositekm-c/justfile
@@ -1,0 +1,24 @@
+board := "ncl/ch32x-48.ncl"
+
+default: build
+
+_libsmartkeymap:
+  make libsmartkeymap
+
+generate-matrix:
+  make generated/matrix.c BOARD={{board}}
+
+cmake-generate: _libsmartkeymap generate-matrix
+  mkdir -p build
+  cd build && \
+    cmake --toolchain=../../toolchains/riscv-none-elf.cmake ..
+
+build: cmake-generate
+  cd build && \
+    make
+
+await-bootloader:
+  timeout 30 ./scripts/wchisp-await-bootloader.sh
+
+flash: build await-bootloader
+  wchisp flash build/usb-device-compositekm.hex

--- a/firmware/ch32x035-usb-device-compositekm-c/ncl/weact-ch32x-core-board.ncl
+++ b/firmware/ch32x035-usb-device-compositekm-c/ncl/weact-ch32x-core-board.ncl
@@ -19,5 +19,5 @@
   keymap_index_for_key
     | doc "Returns the keymap index for the key corresponding to the (0-based) digital column_index and row_index."
     = fun { column_index | Number, row_index | Number, .. } =>
-      column_index + row_index * (std.array.length board.cols),
+      'Ok (column_index + row_index * (std.array.length board.cols)),
 }

--- a/firmware/ch32x035-usb-device-compositekm-c/scripts/wchisp-await-bootloader.sh
+++ b/firmware/ch32x035-usb-device-compositekm-c/scripts/wchisp-await-bootloader.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+
+which wchisp >/dev/null 2>&1 || {
+    echo "ERROR: 'wchisp' not found on PATH."
+    exit 1
+}
+
+wchisp_available () {
+  wchisp info >/dev/null 2>&1
+  return $?
+}
+
+if ! wchisp_available; then
+  echo "Waiting for WCH ISP bootloader..."
+  while ! wchisp_available
+  do
+    sleep 1
+  done
+fi

--- a/justfile
+++ b/justfile
@@ -1,3 +1,9 @@
+test_keymap := "keymap-4key-simple"
+
+dest_dir := "firmware/ch32x035-usb-device-compositekm-c/libsmartkeymap/"
+
+target := "riscv32imac-unknown-none-elf"
+
 default: test
 
 bindgen:
@@ -9,20 +15,18 @@ clean:
 test:
     make test
 
-build-keymap-rv-48key-checkkeys: && (build-keymap-rv `pwd`/"tests/ncl/keymap-48key-checkkeys/keymap.rs")
-    make tests/ncl/keymap-48key-checkkeys/keymap.rs
-
-build-test-keymap-rv-ncl_60key_dvorak: && (build-keymap-rv `pwd`/"tests/ncl/keymap-60key-dvorak-simple/keymap.rs")
-    make tests/ncl/keymap-60key-dvorak-simple/keymap.rs
-
-build-test-keymap-rv-checkkeys_60key: (build-keymap-rv `pwd`/"tests/keymaps/checkkeys_60key_keymap.rs")
-
-build-keymap-rv $SMART_KEYMAP_CUSTOM_KEYMAP: (build-keymap-target SMART_KEYMAP_CUSTOM_KEYMAP "riscv32imac-unknown-none-elf")
-
-build-keymap-target $SMART_KEYMAP_CUSTOM_KEYMAP target:
-    cargo rustc \
+build-keymap:
+    env \
+      SMART_KEYMAP_CUSTOM_KEYMAP={{env("SMART_KEYMAP_CUSTOM_KEYMAP", "tests/ncl/" + test_keymap + "/keymap.ncl")}} \
+        cargo rustc \
         --crate-type "staticlib" \
-        --target riscv32imac-unknown-none-elf \
         --release \
+        --target "{{target}}" \
         --no-default-features \
         --features "staticlib"
+
+_install:
+    cp include/smart_keymap.h {{dest_dir}}
+    cp target/{{target}}/release/libsmart_keymap.a {{dest_dir}}
+
+install: bindgen build-keymap _install

--- a/justfile
+++ b/justfile
@@ -25,5 +25,4 @@ build-keymap-target $SMART_KEYMAP_CUSTOM_KEYMAP target:
         --target riscv32imac-unknown-none-elf \
         --release \
         --no-default-features \
-        --features "staticlib" \
-        --features "usbd-human-interface-device"
+        --features "staticlib"

--- a/ncl/ncl.mk
+++ b/ncl/ncl.mk
@@ -1,3 +1,15 @@
+.PHONY: clean-generated-keymaps
+clean-generated-keymaps:
+	ncl/scripts/clean-generated-keymaps.sh
+
+.PHONY: test-ncl
+test-ncl: test-ncl-checks
+	ncl/scripts/run-tests.sh
+
+.PHONY: test-ncl-checks
+test-ncl-checks:
+	ncl/scripts/run-ncl-checks.sh
+
 %/keymap.json:
 	ncl/scripts/keymap-ncl-to-json.sh $(shell dirname $@)
 

--- a/ncl/ncl.mk
+++ b/ncl/ncl.mk
@@ -1,0 +1,5 @@
+%/keymap.json:
+	ncl/scripts/keymap-ncl-to-json.sh $(shell dirname $@)
+
+%/keymap.rs: %/keymap.json
+	ncl/scripts/keymap-codegen.sh $(shell dirname $@)

--- a/ncl/scripts/clean-generated-keymaps.sh
+++ b/ncl/scripts/clean-generated-keymaps.sh
@@ -5,7 +5,7 @@
 # Runs cargo build with the keymap.rs generated from the keymap.json
 #  for the given ncl snapshot test.
 
-set -ex
+set -e
 
 SCRIPTS_DIR="$(dirname "$0")"
 REPOSITORY_DIR="${SCRIPTS_DIR}/../.."

--- a/ncl/scripts/keymap-codegen.sh
+++ b/ncl/scripts/keymap-codegen.sh
@@ -5,7 +5,7 @@
 # Generates a formatted Rust keymap.rs file for the keymap.json
 #  in the given directory.
 
-set -ex
+set -e
 
 SCRIPTS_DIR="$(dirname "$0")"
 REPOSITORY_DIR="${SCRIPTS_DIR}/../.."

--- a/ncl/scripts/keymap-ncl-to-json.sh
+++ b/ncl/scripts/keymap-ncl-to-json.sh
@@ -5,7 +5,7 @@
 # Generates a keymap.json file for the keymap.ncl
 #  in the given directory.
 
-set -ex
+set -e
 
 SCRIPTS_DIR="$(dirname "$0")"
 REPOSITORY_DIR="${SCRIPTS_DIR}/../.."

--- a/ncl/scripts/run-ncl-checks.sh
+++ b/ncl/scripts/run-ncl-checks.sh
@@ -4,7 +4,7 @@
 #  checking the generated output matches expected snapshots,
 #  and that the generated keymap builds.
 
-set -ex
+set -e
 
 SCRIPTS_DIR="$(dirname "$0")"
 REPOSITORY_DIR="${SCRIPTS_DIR}/../.."

--- a/ncl/scripts/run-tests.sh
+++ b/ncl/scripts/run-tests.sh
@@ -4,7 +4,7 @@
 #  checking the generated output matches expected snapshots,
 #  and that the generated keymap builds.
 
-set -ex
+set -e
 
 SCRIPTS_DIR="$(dirname "$0")"
 

--- a/ncl/scripts/save-keymap-rs-snapshot.sh
+++ b/ncl/scripts/save-keymap-rs-snapshot.sh
@@ -6,7 +6,7 @@
 #  against the expected.rs in the directory for
 #  the given ncl snapshot test.
 
-set -ex
+set -e
 
 SCRIPTS_DIR="$(dirname "$0")"
 REPOSITORY_DIR="${SCRIPTS_DIR}/../.."

--- a/ncl/scripts/save-test-snapshots.sh
+++ b/ncl/scripts/save-test-snapshots.sh
@@ -4,7 +4,7 @@
 #  checking the generated output matches expected snapshots,
 #  and that the generated keymap builds.
 
-set -ex
+set -e
 
 SCRIPTS_DIR="$(dirname "$0")"
 

--- a/ncl/scripts/test-ncl-builds.sh
+++ b/ncl/scripts/test-ncl-builds.sh
@@ -5,7 +5,7 @@
 # Runs cargo build with the keymap.rs generated from the keymap.json
 #  for the given ncl snapshot test.
 
-set -ex
+set -e
 
 SCRIPTS_DIR="$(dirname "$0")"
 REPOSITORY_DIR="${SCRIPTS_DIR}/../.."

--- a/ncl/scripts/test-ncl-diff.sh
+++ b/ncl/scripts/test-ncl-diff.sh
@@ -6,7 +6,7 @@
 #  against the expected.rs in the directory for
 #  the given ncl snapshot test.
 
-set -ex
+set -e
 
 SCRIPTS_DIR="$(dirname "$0")"
 REPOSITORY_DIR="${SCRIPTS_DIR}/../.."

--- a/tests/ceedling/ceedling.mk
+++ b/tests/ceedling/ceedling.mk
@@ -1,0 +1,9 @@
+CEEDLING = ceedling
+
+TEST_KEYMAP = keymap-4key-simple
+
+.PHONY: test-ceedling
+test-ceedling: include/smart_keymap.h
+	env SMART_KEYMAP_CUSTOM_KEYMAP="$(shell pwd)/tests/ncl/$(TEST_KEYMAP)/keymap.ncl" \
+	  $(CARGO) rustc --crate-type "staticlib"
+	cd tests/ceedling && $(CEEDLING)


### PR DESCRIPTION
A bunch of changes to `Makefile` and `justfile`, including the CH32X EVT firmware example.

(Excluding the RP2040 and the CH58x EVT firmware examples).

In particular, allows for running the "build the static lib, copy it to the evt dir, build & flash" in one command:

```
just test_keymap=keymap-48key-checkkeys install && just firmware/ch32x035-usb-device-compositekm-c/flash
```

(It's a bit more verbose if using a different evt dir).

Some limitations I ran into with `just`:

- It has interpolation `{{ }}` in recipes, but not in strings.
- It doesn't handle `SIGINT` in a way I'd expect (to my understanding, doesn't wait for the child process to exit), which makes it inconvenient to Ctrl+c on "await bootloader".

Some further effort:
- It might make more sense to use ENV variables rather than `just` ones; since e.g. direnv or dotenv files could be used instead of command line args.
- https://just.systems/man/en/modules1190.html
- https://just.systems/man/en/fallback-to-parent-justfiles.html