### PR TITLE
Limit HID reports to 1 new pressed key per report

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -24,6 +24,7 @@
 
   packages = [
     pkgs.cmake-language-server
+    pkgs.cargo-nextest
     pkgs.just
     pkgs.nickel
     pkgs.rust-cbindgen

--- a/firmware/rp2040-rtic-pico42-rust/src/input/smart_keymap.rs
+++ b/firmware/rp2040-rtic-pico42-rust/src/input/smart_keymap.rs
@@ -37,7 +37,7 @@ impl KeyboardBackend {
     pub fn tick(&mut self) {
         self.keymap.tick();
 
-        let keymap_output = self.keymap.pressed_keys();
+        let keymap_output = smart_keymap::keymap::KeymapOutput::new(self.keymap.pressed_keys());
         let pressed_keycodes = keymap_output.pressed_key_codes();
         self.pressed_key_codes = pressed_keycodes.iter().map(|&key| key.into()).collect();
     }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -89,7 +89,7 @@ impl<E: Debug> EventScheduler<E> {
     }
 }
 
-/// Output from the keymap, used to build HID reports.
+/// Constructs an HID report or a sequence of key codes from the given sequence of [key::KeyOutput].
 #[derive(Debug)]
 pub struct KeymapOutput {
     pressed_key_codes: heapless::Vec<key::KeyOutput, 16>,

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -409,6 +409,26 @@ mod tests {
     }
 
     #[test]
+    fn test_hid_keyboard_reporter_reports_single_keypress() {
+        // Assemble
+        let mut input: heapless::Vec<key::KeyOutput, 16> = heapless::Vec::new();
+        input.push(key::KeyOutput::from_key_code(0x04)).unwrap();
+
+        let mut reporter = HIDKeyboardReporter::new();
+
+        // Act
+        reporter.update(input);
+        let actual_outputs = reporter.reportable_key_outputs();
+
+        // Assert
+        let expected_outputs: heapless::Vec<key::KeyOutput, 16> = [0x04]
+            .iter()
+            .map(|kc| key::KeyOutput::from_key_code(*kc))
+            .collect();
+        assert_eq!(actual_outputs, expected_outputs);
+    }
+
+    #[test]
     fn test_keymap_with_keyboard_key_with_composite_context() {
         use key::composite::{Context, Event};
         use key::keyboard;

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -339,8 +339,8 @@ impl<
         self.handle_all_pending_events();
     }
 
-    /// Returns the the pressed key codes.
-    pub fn pressed_keys(&self) -> KeymapOutput {
+    /// Returns the the pressed key outputs.
+    pub fn pressed_keys(&self) -> heapless::Vec<key::KeyOutput, 16> {
         let pressed_key_codes = self
             .pressed_inputs
             .iter()
@@ -361,12 +361,12 @@ impl<
                 }
             });
 
-        KeymapOutput::new(pressed_key_codes.collect())
+        pressed_key_codes.collect()
     }
 
     /// Returns the current HID keyboard report.
     pub fn boot_keyboard_report(&self) -> [u8; 8] {
-        self.pressed_keys().as_hid_boot_keyboard_report()
+        KeymapOutput::new(self.pressed_keys()).as_hid_boot_keyboard_report()
     }
 }
 

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -239,6 +239,7 @@ pub struct Keymap<
     context: composite::Context<L>,
     pressed_inputs: heapless::Vec<input::PressedInput, 16>,
     event_scheduler: EventScheduler<composite::Event>,
+    hid_reporter: HIDKeyboardReporter,
 }
 
 impl<
@@ -259,6 +260,7 @@ impl<
             context,
             pressed_inputs: heapless::Vec::new(),
             event_scheduler: EventScheduler::new(),
+            hid_reporter: HIDKeyboardReporter::new(),
         }
     }
 
@@ -267,6 +269,7 @@ impl<
         self.pressed_inputs.clear();
         self.event_scheduler.init();
         self.key_definitions.reset();
+        self.hid_reporter.init();
     }
 
     /// Handles input events.
@@ -398,6 +401,14 @@ impl<
             });
 
         pressed_key_codes.collect()
+    }
+
+    /// Updates the keymap indicating a report is sent; returns the reportable keymap output.
+    pub fn report_output(&mut self) -> KeymapOutput {
+        self.hid_reporter.update(self.pressed_keys());
+        let output = KeymapOutput::new(self.hid_reporter.reportable_key_outputs());
+        self.hid_reporter.report_sent();
+        output
     }
 
     /// Returns the current HID keyboard report.

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -365,6 +365,7 @@ impl<
     }
 
     /// Returns the current HID keyboard report.
+    #[doc(hidden)]
     pub fn boot_keyboard_report(&self) -> [u8; 8] {
         KeymapOutput::new(self.pressed_keys()).as_hid_boot_keyboard_report()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ pub unsafe extern "C" fn keymap_tick(buf: *mut u8) {
     unsafe {
         KEYMAP.tick();
 
-        let report = keymap::KeymapOutput::new(KEYMAP.pressed_keys()).as_hid_boot_keyboard_report();
+        let report = KEYMAP.report_output().as_hid_boot_keyboard_report();
         core::ptr::copy_nonoverlapping(report.as_ptr(), buf, report.len());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ pub unsafe extern "C" fn keymap_tick(buf: *mut u8) {
     unsafe {
         KEYMAP.tick();
 
-        let report = KEYMAP.boot_keyboard_report();
+        let report = keymap::KeymapOutput::new(KEYMAP.pressed_keys()).as_hid_boot_keyboard_report();
         core::ptr::copy_nonoverlapping(report.as_ptr(), buf, report.len());
     }
 }
@@ -175,7 +175,7 @@ pub unsafe extern "C" fn copy_hid_boot_keyboard_report(buf: *mut u8) {
     }
 
     unsafe {
-        let report = KEYMAP.boot_keyboard_report();
+        let report = keymap::KeymapOutput::new(KEYMAP.pressed_keys()).as_hid_boot_keyboard_report();
         core::ptr::copy_nonoverlapping(report.as_ptr(), buf, report.len());
     }
 }

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -123,8 +123,14 @@ impl LoadedKeymap {
     }
     pub fn boot_keyboard_report(&self) -> [u8; 8] {
         match self {
-            LoadedKeymap::Keymap1(keymap) => keymap.boot_keyboard_report(),
-            LoadedKeymap::Keymap2(keymap) => keymap.boot_keyboard_report(),
+            LoadedKeymap::Keymap1(keymap) => {
+                smart_keymap::keymap::KeymapOutput::new(keymap.pressed_keys())
+                    .as_hid_boot_keyboard_report()
+            }
+            LoadedKeymap::Keymap2(keymap) => {
+                smart_keymap::keymap::KeymapOutput::new(keymap.pressed_keys())
+                    .as_hid_boot_keyboard_report()
+            }
             _ => panic!("No keymap loaded"),
         }
     }


### PR DESCRIPTION
If an HID report at tick `t` reports key codes `[0, 0, 0, ...]`, and at `t+1` reports codes `[0x12, 0x04]`, then the OS interprets this as `0x04, 0x12` pressed.

This affects how tap-hold keys report "tap" keys in rolling keypress sequences.

The implemented solution adds a "HID Keyboard Reporter" filter, which filters pressed keys to only report 1 new pressed key for each report sent.