### PR TITLE
nickel: contracts from validators

### DIFF
--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -1,7 +1,8 @@
 let validators = import "validators.ncl" in
 {
   serialized_json_keymap
-    | doc "The 'JSON serialized' value of the keymap. e.g. imported from keymap.json.",
+    | doc "The 'JSON serialized' value of the keymap. e.g. imported from keymap.json."
+    | { keys | Array key.SerializedJson, .. },
 
   checks.keyboard_is
     = {
@@ -20,6 +21,8 @@ let validators = import "validators.ncl" in
   keyboard
     | doc "for key::keyboard::Key."
     = {
+        SerializedJson = std.contract.from_validator serialized_json_validator,
+
         # c.f. doc_de_keyboard.md.
         serialized_json_validator
           = validators.record.validator {
@@ -106,6 +109,8 @@ let validators = import "validators.ncl" in
   layer_modifier
     | doc "for key::layered::ModifierKey."
     = {
+        SerializedJson = std.contract.from_validator serialized_json_validator,
+
         # c.f. doc_de_layered.md.
         # JSON serialization of key::layered::ModifierKey has variants: Hold(layer).
         serialized_json_validator
@@ -147,6 +152,8 @@ let validators = import "validators.ncl" in
   layered
     | doc "for key::layered::LayeredKey."
     = {
+        SerializedJson = std.contract.from_validator serialized_json_validator,
+
         # c.f. doc_de_layered.md.
         # e.g.:
         # ```
@@ -221,6 +228,8 @@ let validators = import "validators.ncl" in
   tap_hold
     | doc "for key::tap_hold::Key."
     = {
+        SerializedJson = std.contract.from_validator serialized_json_validator,
+
         # c.f. doc_de_tap_hold.md.
         # JSON serialization of key::tap_hold::Key is { tap: key, hold: key }
         serialized_json_validator
@@ -269,6 +278,8 @@ let validators = import "validators.ncl" in
     = {
         base_key
           = {
+              SerializedJson = std.contract.from_validator serialized_json_validator,
+
               serialized_json_validator
                 = validators.any_of
                     [
@@ -308,6 +319,8 @@ let validators = import "validators.ncl" in
 
         tap_hold_key
           = {
+              SerializedJson = std.contract.from_validator serialized_json_validator,
+
               serialized_json_validator
                 = validators.any_of
                     [
@@ -349,6 +362,8 @@ let validators = import "validators.ncl" in
 
         layered_key
           = {
+              SerializedJson = std.contract.from_validator serialized_json_validator,
+
               serialized_json_validator
                 = validators.any_of
                     [
@@ -408,6 +423,8 @@ let validators = import "validators.ncl" in
 
   key
     = {
+        SerializedJson = std.contract.from_validator serialized_json_validator,
+
         serialized_json_validator
           = validators.any_of
               [

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -1,6 +1,14 @@
 let validators = import "validators.ncl" in
 {
-  KeymapKey = Dyn,
+  KeymapKey
+    = std.contract.any_of
+        [
+          keyboard.Key,
+          layer_modifier.Key,
+          layered.Key,
+          tap_hold.Key,
+          std.contract.from_validator validators.is_null,
+        ],
 
   KeymapLayer = std.contract.any_of [Array KeymapKey, String],
 
@@ -37,6 +45,8 @@ let validators = import "validators.ncl" in
   keyboard
     | doc "for key::keyboard::Key."
     = {
+        Key = std.contract.from_validator key_validator,
+
         key_validator
           = validators.record.validator {
               fields_validator = validators.all_of [
@@ -93,6 +103,8 @@ let validators = import "validators.ncl" in
   layer_modifier
     | doc "for key::layered::ModifierKey."
     = {
+        Key = std.contract.from_validator key_validator,
+
         key_validator
           = fun k => k |>
               match {
@@ -146,6 +158,8 @@ let validators = import "validators.ncl" in
   layered
     | doc "for key::layered::LayeredKey."
     = {
+        Key = std.contract.from_validator key_validator,
+
         key_validator
           = fun k => k |> match {
               { layered, ..base_key } =>
@@ -208,6 +222,8 @@ let validators = import "validators.ncl" in
   tap_hold
     | doc "for key::tap_hold::Key."
     = {
+        Key = std.contract.from_validator key_validator,
+
         key_validator
           = fun k => k |>
               match {
@@ -235,6 +251,8 @@ let validators = import "validators.ncl" in
 
   key
     = {
+        Key = std.contract.from_validator key_validator,
+
         key_validator
           = fun k => k |>
               validators.any_of [


### PR DESCRIPTION
One of the things which elevates Nickel more than "JSON plus functions" would suggest is its contracts.

https://nickel-lang.org/user-manual/correctness/

Roughly, in Nickel, types are things like "string", "array", "record".

Contracts provide a mechanism for checking that something is true about some value. -- e.g. that it has a particular shape, or particular range of values. The contract is checked once the value is known. This hopefully saves running into a problem in the middle of a function.

e.g. one example where FAK used Nickel contracts was in ensuring that layer-modifier always pointed to a valid layer index.

I'm not sure how useful the contracts this PR adds will be; I think to be more usable, I'd want the failing validators to output better errors. -- e.g. atm, since keys can be any-of a number of contracts, the error is quite opaque.