### PR TITLE
firmware/rp2040: board.rs codegen

### DIFF
--- a/firmware/rp2040-rtic-pico42-rust/Cargo.lock
+++ b/firmware/rp2040-rtic-pico42-rust/Cargo.lock
@@ -622,6 +622,7 @@ dependencies = [
  "rp2040-monotonic",
  "rtt-target 0.4.0",
  "smart-keymap",
+ "smart-keymap-nickel-helper",
  "usb-device",
  "usbd-human-interface-device",
  "usbd-serial",

--- a/firmware/rp2040-rtic-pico42-rust/README.MD
+++ b/firmware/rp2040-rtic-pico42-rust/README.MD
@@ -42,3 +42,17 @@ The firmware can be deployed to an RP2040 board (in bootloader mode)
  by using `cargo run` instead of `cargo build`.
  
 The `pico42` example can be built / run by adding `--example pico42`.
+
+A custom `board.ncl` file can be built by setting the `SMART_KEYBOARD_CUSTOM_BOARD`
+variable to its path, and building the `rp2040-rtic-smart-keyboard` package's binary. e.g.:
+
+```
+env \
+  SMART_KEYMAP_CUSTOM_KEYMAP="$(pwd)/../../tests/ncl/keymap-42key-dvorak-simple-with-tap_hold/keymap.ncl" \
+  SMART_KEYBOARD_CUSTOM_BOARD="$(pwd)/rp2040/examples/board-pico42.ncl" \
+    cargo build \
+      --release \
+      --target=thumbv6m-none-eabi \
+      --package=rp2040-rtic-smart-keyboard
+```
+

--- a/firmware/rp2040-rtic-pico42-rust/rp2040/Cargo.toml
+++ b/firmware/rp2040-rtic-pico42-rust/rp2040/Cargo.toml
@@ -31,3 +31,6 @@ usbd-human-interface-device = { workspace = true }
 usbd-serial = { workspace = true }
 
 smart-keymap = { workspace = true }
+
+[build-dependencies]
+smart-keymap-nickel-helper = { path = "../../../smart-keymap-nickel-helper" }

--- a/firmware/rp2040-rtic-pico42-rust/rp2040/build.rs
+++ b/firmware/rp2040-rtic-pico42-rust/rp2040/build.rs
@@ -1,0 +1,46 @@
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+use smart_keymap_nickel_helper::{nickel_board_rs_for_board_path, rustfmt, NickelError};
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=SMART_KEYBOARD_CUSTOM_BOARD");
+    println!("cargo::rustc-check-cfg=cfg(custom_board)");
+    if let Ok(custom_board_path) = env::var("SMART_KEYBOARD_CUSTOM_BOARD") {
+        let out_dir = env::var("OUT_DIR").unwrap();
+        let dest_path = Path::new(&out_dir).join("board.rs");
+        println!("cargo:rerun-if-changed={}", dest_path.to_str().unwrap());
+
+        if custom_board_path.ends_with(".rs") {
+            println!("cargo:rustc-cfg=custom_board");
+
+            // Copy the custom keymap file to the output directory
+            fs::copy(custom_board_path, &dest_path).unwrap();
+        } else if custom_board_path.ends_with(".ncl") {
+            println!("cargo:rustc-cfg=custom_board");
+
+            // Evaluate the custom keymap file with Nickel
+            let keymap_path = Path::new(&custom_board_path);
+            match nickel_board_rs_for_board_path(
+                format!("{}/ncl", env!("CARGO_MANIFEST_DIR")),
+                keymap_path,
+            ) {
+                Ok(board_rs) => {
+                    let mut file = fs::File::create(&dest_path).unwrap();
+                    let formatted = rustfmt(board_rs);
+                    file.write_all(formatted.as_bytes()).unwrap();
+                }
+                Err(NickelError::NickelNotFound) => {
+                    panic!("`nickel` not found in PATH");
+                }
+                Err(NickelError::EvalError(e)) => {
+                    panic!("Nickel evaluation failed: {}", e);
+                }
+            }
+        } else {
+            panic!("Unsupported custom board path: {}", custom_board_path);
+        }
+    }
+}

--- a/firmware/rp2040-rtic-pico42-rust/rp2040/examples/board-pico42.ncl
+++ b/firmware/rp2040-rtic-pico42-rust/rp2040/examples/board-pico42.ncl
@@ -1,0 +1,53 @@
+{
+  gpio_pins,
+
+  usb
+    = {
+      vid = 0xCAFE,
+      pid = 0x0005,
+      manufacturer = "rgoulter keyboard-labs",
+      product = "Pico42"
+    },
+
+  matrix
+    =
+      let p = gpio_pins in
+      {
+        cols = [
+          p.GP0,
+          p.GP1,
+          p.GP2,
+          p.GP3,
+          p.GP4,
+          p.GP5,
+          p.GP6,
+          p.GP7,
+          p.GP8,
+          p.GP9,
+          p.GP10,
+          p.GP11,
+        ],
+        rows = [
+          p.GP14,
+          p.GP15,
+          p.GP16,
+          p.GP17,
+        ],
+        key_count = 42,
+      },
+
+  keymap_index_for_key = fun { column_index, row_index } =>
+    let NO = null in
+    let keymap_indices = [
+      [ 0,  1,  2,  3,  4, NO, NO,  5,  6,  7,  8,  9],
+      [10, 11, 12, 13, 14, NO, NO, 15, 16, 17, 18, 19],
+      [20, 21, 22, 23, 24, NO, NO, 25, 26, 27, 28, 29],
+      [30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41],
+    ]
+    in
+    let row = std.array.at row_index keymap_indices in
+    std.array.at column_index row |> match {
+        idx if idx != null => 'Key idx,
+        _ => 'NoKey,
+    },
+}

--- a/firmware/rp2040-rtic-pico42-rust/rp2040/ncl/codegen.ncl
+++ b/firmware/rp2040-rtic-pico42-rust/rp2040/ncl/codegen.ncl
@@ -1,0 +1,126 @@
+{
+  GpioPin
+    = { id | String, type | String, },
+
+  gpio_pins
+    : { _ | GpioPin }
+    | doc "Record with GP0, GP1, .., GP29, mapped to { id, type } records."
+    =
+      let ports = ["GP"] in
+      let pins = std.array.range 0 30 in
+
+      std.array.flat_map
+        (fun port_name => # GP
+          std.array.map
+            (fun pin_num => # 0, 1, .. 29
+               {
+                 # GP0 = ...
+                 "%{port_name}%{std.to_string pin_num}" =
+                   {
+                     "id" = "gpio%{std.to_string pin_num}",
+                     "type" = "bank0::Gpio%{std.to_string pin_num}",
+                   },
+               })
+            pins)
+        ports
+      |> (std.array.fold_left (&) {}) | { _ : GpioPin },
+
+  matrix
+    | {
+      cols | Array GpioPin,
+      rows | Array GpioPin,
+      key_count | Number,
+    }
+    | doc "the cols/rows, and number of keys, used for generating the matrix scan code.",
+
+  keymap_index_for_key
+    | doc "Returns the keymap index for the key corresponding to the (0-based) digital column_index and row_index.",
+
+  usb
+   | {
+       vid | Number,
+       pid | Number,
+       manufacturer | String,
+       product | String,
+     },
+
+  board_rs =
+    let col_count = matrix.cols |> std.array.length in
+    let const_cols_expr = col_count |> std.to_string in
+    let row_count = matrix.rows |> std.array.length in
+    let const_rows_expr = row_count |> std.to_string in
+    let keymap_indices_expr =
+      let keymap_index_expr =
+        match {
+          'Key idx => "Some(%{std.to_string idx})",
+          'NoKey   => "None",
+        } in
+      let cols_expr = fun row_idx =>
+        std.array.generate
+          (fun col_idx =>
+             keymap_index_for_key
+               {
+                 row_index = row_idx,
+                 column_index = col_idx,
+               } |>
+             keymap_index_expr)
+          col_count in
+      let row_expr = fun row_idx =>
+        "[ %{std.string.join ", " (cols_expr row_idx)} ]" in
+      let row_exprs = std.array.generate row_expr row_count in
+      "[ %{std.string.join ", " row_exprs} ]" in
+    let macro_cols_expr =
+      let macro_col_expr = fun col_idx =>
+        let { id, .. } = std.array.at col_idx matrix.cols in
+        "$gpio_pins.%{id}.into_pull_up_input().into_dyn_pin()" in
+      let macro_col_exprs = std.array.generate macro_col_expr col_count in
+      "[%{std.string.join "," macro_col_exprs}]" in
+    let macro_rows_expr =
+      let macro_row_expr = fun row_idx =>
+        let { id, .. } = std.array.at row_idx matrix.rows in
+        "$gpio_pins.%{id}.into_push_pull_output().into_dyn_pin()" in
+      let macro_row_exprs = std.array.generate macro_row_expr row_count in
+      "[%{std.string.join "," macro_row_exprs}]" in
+
+    let vid_expr = usb.vid |> std.to_string in
+    let pid_expr = usb.pid |> std.to_string in
+    let manufacturer_expr = "\"%{usb.manufacturer}\"" in
+    let product_expr = "\"%{usb.product}\"" in
+    m%"
+mod board {
+    use rp2040_hal as hal;
+
+    use usbd_smart_keyboard::matrix::Matrix;
+
+    use rp2040_rtic_smart_keyboard::input::{Input, Output};
+
+    pub const COLS: usize = %{const_cols_expr};
+
+    pub const ROWS: usize = %{const_rows_expr};
+
+    pub const KEYMAP_INDICES: [[Option<u16>; COLS]; ROWS] = %{keymap_indices_expr};
+
+    pub const VID: u16 = %{vid_expr};
+    pub const PID: u16 = %{pid_expr};
+    pub const MANUFACTURER: &str = %{manufacturer_expr};
+    pub const PRODUCT: &str = %{product_expr};
+
+    pub type Keyboard = usbd_smart_keyboard::input::Keyboard<
+        COLS,
+        ROWS,
+        Matrix<Input, Output, COLS, ROWS, hal::Timer>,
+    >;
+
+    pub type PressedKeys = usbd_smart_keyboard::input::PressedKeys<COLS, ROWS>;
+
+    macro_rules! rows_and_cols {
+        ($gpio_pins:expr, $cols:ident, $rows:ident) => {
+            let $cols = %{macro_cols_expr};
+            let $rows = %{macro_rows_expr};
+        };
+    }
+
+    pub(crate) use rows_and_cols;
+}
+"%,
+}

--- a/firmware/rp2040-rtic-pico42-rust/rp2040/src/main.rs
+++ b/firmware/rp2040-rtic-pico42-rust/rp2040/src/main.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+#[cfg(not(custom_board))]
 mod board {
     use rp2040_hal as hal;
 
@@ -46,6 +47,9 @@ mod board {
 
     pub(crate) use rows_and_cols;
 }
+
+#[cfg(custom_board)]
+include!(concat!(env!("OUT_DIR"), "/board.rs"));
 
 #[rtic::app(
     device = rp_pico::hal::pac,


### PR DESCRIPTION
Since the `rp2040`'s `main.rs` and example `pico42.rs` example isolate the board-specific code to `mod board`, it's possible to use code generation from Nickel files from a board definition.

This is similar to the `smart-keymap`'s `lib.rs` using code generation for a custom `keymap.ncl`, or the firmware/evt/ch32x code generation which was written earlier.

This hopefully makes it quicker/easier for someone to get started using the smart-keymap for RP2040-based boards.