### PR TITLE
CI: limit jobs to relevant paths

### DIFF
--- a/.github/workflows/nickel.yaml
+++ b/.github/workflows/nickel.yaml
@@ -4,9 +4,15 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'ncl/**'
+      - 'src/**'
   pull_request:
     branches:
       - '*'
+    paths:
+      - 'ncl/**'
+      - 'src/**'
 
 jobs:
   cargo-build:

--- a/.github/workflows/rust-thumbv6m-none-eabi.yaml
+++ b/.github/workflows/rust-thumbv6m-none-eabi.yaml
@@ -1,0 +1,59 @@
+name: Rust Checks (thumbv6m-none-eabi)
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.cargo/cargo.toml'
+      - 'Cargo.*'
+      - 'ld/rp2040/*'
+      - 'ncl/**/*.ncl'
+      - 'rp2040-rtic-smart-keyboard/**'
+      - 'src/**/*.rs'
+      - 'smart-keymap-nickel-helper/**'
+      - 'usbd-smart-keyboard/**'
+  pull_request:
+    branches:
+      - '*'
+    paths:
+      - '.cargo/cargo.toml'
+      - 'Cargo.*'
+      - 'ld/rp2040/*'
+      - 'ncl/**/*.ncl'
+      - 'rp2040-rtic-smart-keyboard/**'
+      - 'src/**/*.rs'
+      - 'smart-keymap-nickel-helper/**'
+      - 'usbd-smart-keyboard/**'
+
+jobs:
+  cargo-build-target-thumbv6m-none-eabi:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install nickel
+        run: |
+          wget https://github.com/tweag/nickel/releases/download/1.9.1/nickel-x86_64-linux
+          chmod +x ./nickel-x86_64-linux
+          sudo cp ./nickel-x86_64-linux /usr/bin/nickel
+
+      - name: Rust Add Target
+        run: rustup target add thumbv6m-none-eabi
+
+      - name: Run Cargo Build
+        run: cargo build --target=thumbv6m-none-eabi --no-default-features
+
+      - name: Run Cargo Build (usbd-smart-keymap)
+        run: cargo build --target=thumbv6m-none-eabi --package=usbd-smart-keyboard
+
+      - name: Run Cargo Build (rp2040-rtic-smart-keyboard)
+        run: cargo build --target=thumbv6m-none-eabi --package=rp2040-rtic-smart-keyboard

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -4,9 +4,25 @@ on:
   push:
     branches:
       - master
+    paths:
+      - '.cargo/cargo.toml'
+      - 'Cargo.*'
+      - 'features/**/*.feature'
+      - 'ncl/**/*.ncl'
+      - 'src/**/*.rs'
+      - 'smart-keymap-nickel-helper/**'
+      - 'tests/**/*.rs'
   pull_request:
     branches:
       - '*'
+    paths:
+      - '.cargo/cargo.toml'
+      - 'Cargo.*'
+      - 'features/**/*.feature'
+      - 'ncl/**/*.ncl'
+      - 'src/**/*.rs'
+      - 'smart-keymap-nickel-helper/**'
+      - 'tests/**/*.rs'
 
 jobs:
   cargo-build:
@@ -36,34 +52,3 @@ jobs:
 
       - name: Run Cargo Doc
         run: cargo doc
-
-  cargo-build-target-thumbv6m-none-eabi:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Install nickel
-        run: |
-          wget https://github.com/tweag/nickel/releases/download/1.9.1/nickel-x86_64-linux
-          chmod +x ./nickel-x86_64-linux
-          sudo cp ./nickel-x86_64-linux /usr/bin/nickel
-
-      - name: Rust Add Target
-        run: rustup target add thumbv6m-none-eabi
-
-      - name: Run Cargo Build
-        run: cargo build --target=thumbv6m-none-eabi --no-default-features
-
-      - name: Run Cargo Build (usbd-smart-keymap)
-        run: cargo build --target=thumbv6m-none-eabi --package=usbd-smart-keyboard
-
-      - name: Run Cargo Build (rp2040-rtic-smart-keyboard)
-        run: cargo build --target=thumbv6m-none-eabi --package=rp2040-rtic-smart-keyboard

--- a/.github/workflows/test-ceedling.yaml
+++ b/.github/workflows/test-ceedling.yaml
@@ -4,9 +4,17 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'src/**'
+      - 'smart_keymap/**'
+      - 'tests/ceedling/**'
   pull_request:
     branches:
       - '*'
+    paths:
+      - 'src/**'
+      - 'smart_keymap/**'
+      - 'tests/ceedling/**'
 
 jobs:
   unity-test:


### PR DESCRIPTION
GitHub Actions provides a generous but finite number of minutes of Actions runners per month.

I checked the usage, and the Ceedling tests have taken up about a third of my usage.

This PR addresses some of that.

- Limit the CI jobs to only run if paths changed.
  - e.g. changes to the `smart-keymap` `src/` are still going to run pretty much everything. But, that's the point.
  - Whereas, e.g. changes to the RP2040 code won't require running ceedling tests.

It might make sense to further restrict the Ceedling tests to run only after the Rust tests pass. I'll keep it in mind to see if it's an issue.