### PR TITLE
Cucumber Keymap use Vec<DynamicKey>

### DIFF
--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -225,15 +225,7 @@ impl HIDKeyboardReporter {
 
 /// State for a keymap that handles input, and outputs HID keyboard reports.
 #[derive(Debug)]
-pub struct Keymap<
-    I: IndexMut<
-            usize,
-            Output = dyn key::dynamic::Key<
-                key::composite::Event,
-                Context = key::composite::Context,
-            >,
-        > + crate::tuples::KeysReset,
-> {
+pub struct Keymap<I> {
     key_definitions: I,
     context: composite::Context,
     pressed_inputs: heapless::Vec<input::PressedInput, 16>,
@@ -242,13 +234,8 @@ pub struct Keymap<
 }
 
 impl<
-        I: IndexMut<
-                usize,
-                Output = dyn key::dynamic::Key<
-                    key::composite::Event,
-                    Context = key::composite::Context,
-                >,
-            > + crate::tuples::KeysReset,
+        K: key::dynamic::Key<key::composite::Event, Context = key::composite::Context> + ?Sized,
+        I: IndexMut<usize, Output = K> + crate::tuples::KeysReset,
     > Keymap<I>
 {
     /// Constructs a new keymap with the given key definitions and context.

--- a/src/tuples.rs
+++ b/src/tuples.rs
@@ -11,6 +11,20 @@ pub trait KeysReset {
     fn reset(&mut self);
 }
 
+#[cfg(feature = "std")]
+impl<K: key::Key, Ctx: key::Context<Event = Ev> + Debug + 'static, Ev: Copy + Debug> KeysReset
+    for Vec<dynamic::DynamicKey<K, Ctx, Ev>>
+where
+    K::Event: TryFrom<Ev>,
+    Ev: From<K::Event>,
+    K::Context: From<Ctx>,
+{
+    fn reset(&mut self) {
+        self.iter_mut()
+            .for_each(|k| <dynamic::DynamicKey<K, Ctx, Ev> as dynamic::Key<Ev>>::reset(k));
+    }
+}
+
 /// A tuple struct for 1 key.
 #[derive(Debug)]
 pub struct Keys1<


### PR DESCRIPTION
The tests were previously limited to Keys1 or Keys2.

While I'd rather not write Cucumber features for *keys* with large keymaps, it's an unnecessary technical constraint.