### PR TITLE
Features: Tap Hold Configuration

### DIFF
--- a/features/keymap/key/tap_hold-config-interrupt-ignore.feature
+++ b/features/keymap/key/tap_hold-config-interrupt-ignore.feature
@@ -1,0 +1,68 @@
+Feature: TapHold Key (configure interrupt response: ignore)
+
+  The tap hold key's response to interruptions can be configured.
+
+  "Interrupts ignored" can be configured by setting `config.tap_hold.interrupt_response`
+   to `"Ignore"` in `keymap.ncl`.
+
+  "Ignore interrupts" just means the key only acts as hold by holding the key
+   for longer than the tap-hold timeout duration.
+
+  Background:
+
+    Let's demonstrate tap-hold "ignore interrupt" behaviour
+    using a keymap with a tap-hold key, and a keyboard key:
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        config.tap_hold.interrupt_response = "Ignore",
+        keys = [
+          K.A & K.hold K.LeftCtrl,
+          K.B
+        ]
+      }
+      """
+
+  Example: rolling key presses (press TH(A), press B, release TH(A)
+
+    Rolling the tap-hold key with another key
+    (i.e. interrupting the tap-hold key with another key press),
+     releasing the tap-hold key with `interrupt_response = "Ignore"`
+     resolves the key as tap.
+
+    When the keymap registers the following input
+      """
+      [
+        Press(keymap_index: 0),
+        Press(keymap_index: 1),
+        Release(keymap_index: 0),
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      let K = import "hid-usage-keyboard.ncl" in
+      { key_codes = [K.A, K.B] }
+      """
+
+  Example: interrupting tap (press TH(A), press B, release B, release TH(A))
+
+    After interrupting the tap-hold key with another key tap (press & release),
+     releasing the tap-hold key with `interrupt_response = "Ignore"`
+     resolves the key as tap.
+
+    When the keymap registers the following input
+      """
+      [
+        Press(keymap_index: 0),
+        Press(keymap_index: 1),
+        Release(keymap_index: 1),
+        Release(keymap_index: 0),
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      let K = import "hid-usage-keyboard.ncl" in
+      { key_codes = [K.A] }
+      """

--- a/features/keymap/key/tap_hold-config-interrupt-presses.feature
+++ b/features/keymap/key/tap_hold-config-interrupt-presses.feature
@@ -1,0 +1,65 @@
+Feature: TapHold Key (configure interrupt response: hold on key press)
+
+  The tap hold key's response to interruptions can be configured.
+
+  "Resolves as 'Hold' when interrupted by key press" can be configured
+   by setting `config.tap_hold.interrupt_response`
+   to `"HoldOnKeyPress"` in `keymap.ncl`.
+
+  Background:
+
+    Let's demonstrate tap-hold "hold on interrupting key press" behaviour
+    using a keymap with a tap-hold key, and a keyboard key:
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        config.tap_hold.interrupt_response = "HoldOnKeyPress",
+        keys = [
+          K.A & K.hold K.LeftCtrl,
+          K.B
+        ]
+      }
+      """
+
+  Example: rolling key presses (press TH(A), press B)
+
+    Rolling the tap-hold key
+    with another key
+    (i.e. interrupting the tap-hold key with another key press),
+     for a tap-hold key configured with `interrupt_response = "HoldOnKeyPress"`
+     resolves the tap-hold key as 'hold'.
+
+    When the keymap registers the following input
+      """
+      [
+        Press(keymap_index: 0),
+        Press(keymap_index: 1),
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      let K = import "hid-usage-keyboard.ncl" in
+      { modifiers = { left_ctrl = true }, key_codes = [K.B] }
+      """
+
+  Example: interrupting tap (press TH(A), press B, release B, release TH(A))
+
+    Interrupting the tap-hold key with another key tap (press & release),
+     for a tap-hold key configured with `interrupt_response = "HoldOnKeyPress"`
+     resolves the key as "hold".
+
+    When the keymap registers the following input
+      """
+      [
+        Press(keymap_index: 0),
+        Press(keymap_index: 1),
+        Release(keymap_index: 1),
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      let K = import "hid-usage-keyboard.ncl" in
+      { modifiers = { left_ctrl = true } }
+      """

--- a/features/keymap/key/tap_hold-config-timeout.feature
+++ b/features/keymap/key/tap_hold-config-timeout.feature
@@ -1,0 +1,54 @@
+Feature: TapHold Key (configure resolve-as-hold timeout)
+
+  The "timeout" before a tap-hold is considered as held
+  can be configured by the field `config.tap_hold.timeout`
+   in `keymap.ncl`.
+
+  Example: timeout configured to a low value
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        config.tap_hold.timeout = 50,
+        keys = [ K.A & K.hold K.LeftCtrl ],
+      }
+      """
+    When the keymap registers the following input
+      """
+      [
+        Press(keymap_index: 0)
+      ]
+      """
+    And the keymap ticks 60 times
+    Then the HID keyboard report should equal
+      """
+      let K = import "hid-usage-keyboard.ncl" in
+      { modifiers = { left_ctrl = true } }
+      """
+
+
+  Example: timeout configured to a high value
+
+    e.g. by setting the timeout to a very high value,
+     the key still won't resolve as "held" until that
+     the timeout has been reached.
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        config.tap_hold.timeout = 30000,
+        keys = [ K.A & K.hold K.LeftCtrl ],
+      }
+      """
+    When the keymap registers the following input
+      """
+      [
+        Press(keymap_index: 0)
+      ]
+      """
+    And the keymap ticks 10000 times
+    Then the HID keyboard report should equal
+      """
+      { modifiers = {}, key_codes = [] }
+      """

--- a/features/keymap/key/tap_hold.feature
+++ b/features/keymap/key/tap_hold.feature
@@ -20,7 +20,7 @@ Feature: TapHold Key
 
   Background:
 
-    Let's use a keymap a tap-hold key, and a keyboard key.
+    Let's use a keymap with a tap-hold key, and a keyboard key.
 
     Given a keymap.ncl:
       """

--- a/features/pandoc.css
+++ b/features/pandoc.css
@@ -1,0 +1,330 @@
+:root {
+  --text-color: #444;
+  --bg-color: #fefefe;
+  --heading-color: #11;
+  --link-color: #0645ad;
+  --link-visited: #0b0080;
+  --link-hover: #06e;
+  --link-active: #faa700;
+  --code-bg: #f5f5f5;
+  --blockquote-border: #EEE;
+  --blockquote-text: #666666;
+  --table-border: #ddd;
+  --table-header-bg: #eee;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --text-color: #e0e0e0;
+    --bg-color: #282828;
+    --heading-color: #fff;
+    --link-color: #8cb4ff;
+    --link-visited: #b4c6ef;
+    --link-hover: #74a5ff;
+    --link-active: #ffc266;
+    --code-bg: #2d2d2d;
+    --blockquote-border: #404040;
+    --blockquote-text: #a0a0a0;
+    --table-border: #404040;
+    --table-header-bg: #333;
+  }
+}
+
+html {
+  font-size: 100%;
+  overflow-y: scroll;
+  scroll-behavior: smooth;
+}
+
+body {
+  color: var(--text-color);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, 
+    "Helvetica Neue", Arial, Georgia, serif;
+  font-size: 12px;
+  line-height: 1.7;
+  padding: 1em;
+  margin: auto;
+  max-width: 42em;
+  background: var(--bg-color);
+}
+
+a {
+  color: var(--link-color);
+  text-decoration: none;
+}
+
+a:visited {
+  color: var(--link-visited);
+}
+
+a:hover {
+  color: var(--link-hover);
+}
+
+a:active {
+  color: var(--link-active);
+}
+
+:focus {
+  outline: 3px solid var(--link-color);
+  outline-offset: 2px;
+}
+
+:focus:not(:focus-visible) {
+  outline: none;
+}
+
+*::selection {
+  background: rgba(255, 255, 0, 0.3);
+  color: currentColor;
+}
+
+p {
+  margin: 1em 0;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: var(--heading-color);
+  line-height: 1.25;
+  margin-top: 2em;
+  font-weight: normal;
+}
+
+h4, h5, h6 {
+  font-weight: bold;
+}
+
+h1 { font-size: 2.5em; }
+h2 { font-size: 2em; }
+h3 { font-size: 1.5em; }
+h4 { font-size: 1.2em; }
+h5 { font-size: 1em; }
+h6 { font-size: 0.9em; }
+
+blockquote {
+  color: var(--blockquote-text);
+  margin: 0;
+  padding-left: 3em;
+  border-left: 0.5em solid var(--blockquote-border);
+}
+
+hr {
+  display: block;
+  height: 2px;
+  border: 0;
+  border-top: 1px solid var(--blockquote-border);
+  border-bottom: 1px solid transparent;
+  margin: 1em 0;
+  padding: 0;
+}
+
+pre, code, kbd, samp {
+  color: currentColor;
+  font-family: ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas, "DejaVu Sans Mono", monospace;
+  font-size: 0.98em;
+}
+
+pre {
+  white-space: pre;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  background-color: var(--code-bg);
+  padding: 1em;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+b, strong {
+  font-weight: bold;
+}
+
+dfn {
+  font-style: italic;
+}
+
+ins {
+  background: #ff9;
+  color: currentColor;
+  text-decoration: none;
+}
+
+mark {
+  background: #ff0;
+  color: currentColor;
+  font-style: italic;
+  font-weight: bold;
+}
+
+sub, sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sup {
+  top: -0.5em;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+ul, ol {
+  margin: 1em 0;
+  padding: 0 0 0 2em;
+}
+
+li p:last-child {
+  margin-bottom: 0;
+}
+
+ul ul, ol ol {
+  margin: .3em 0;
+}
+
+dl {
+  margin-bottom: 1em;
+}
+
+dt {
+  font-weight: bold;
+  margin-bottom: .8em;
+}
+
+dd {
+  margin: 0 0 .8em 2em;
+}
+
+dd:last-child {
+  margin-bottom: 0;
+}
+
+figure {
+  display: block;
+  text-align: center;
+  margin: 1em 0;
+}
+
+figure img {
+  border: none;
+  margin: 0 auto;
+}
+
+figcaption {
+  font-size: 0.8em;
+  font-style: italic;
+  margin: 0 0 .8em;
+}
+
+table {
+  margin-bottom: 2em;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+table th {
+  padding: .5em;
+  background-color: var(--table-header-bg);
+  border: 1px solid var(--table-border);
+}
+
+table td {
+  padding: .5em;
+  border: 1px solid var(--table-border);
+  vertical-align: top;
+}
+
+.author {
+  font-size: 1.2em;
+  text-align: center;
+}
+
+/* Responsive typography */
+@media only screen and (min-width: 480px) {
+  body {
+    font-size: 14px;
+  }
+}
+@media only screen and (min-width: 768px) {
+  body {
+    font-size: 16px;
+  }
+}
+
+/* Print styles */
+@media print {
+  * {
+    background: transparent !important;
+    color: black !important;
+    filter: none !important;
+  }
+
+  body {
+    font-size: 12pt;
+    max-width: 100%;
+  }
+
+  a, a:visited {
+    text-decoration: underline;
+  }
+
+  hr {
+    height: 1px;
+    border: 0;
+    border-bottom: 1px solid black;
+  }
+
+  a[href]:after {
+    content: " (" attr(href) ")";
+  }
+
+  abbr[title]:after {
+    content: " (" attr(title) ")";
+  }
+
+  pre, blockquote {
+    border: 1px solid #999;
+    padding-right: 1em;
+    page-break-inside: avoid;
+  }
+
+  tr, img {
+    page-break-inside: avoid;
+  }
+
+  img {
+    max-width: 100% !important;
+  }
+
+  @page :left {
+    margin: 15mm 20mm 15mm 10mm;
+  }
+
+  @page :right {
+    margin: 15mm 10mm 15mm 20mm;
+  }
+
+  p, h2, h3 {
+    orphans: 3;
+    widows: 3;
+  }
+
+  h2, h3 {
+    page-break-after: avoid;
+  }
+}
+
+/* Reduced motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}

--- a/features/scripts/generate-doc.sh
+++ b/features/scripts/generate-doc.sh
@@ -47,6 +47,8 @@ done
 pandoc \
   --standalone \
   --table-of-contents \
+  --embed-resources \
+  --css="${FEATURES_DIR}/pandoc.css" \
   --toc-depth=4 \
   --metadata=title="Smart Keymap Features" \
   ${KEYMAP_FEATURE_MD} \

--- a/features/scripts/gherkin2md.awk
+++ b/features/scripts/gherkin2md.awk
@@ -90,8 +90,7 @@ function strip_indent(str, indent) {
 # All other output in .feature files is Markdown prose.
 {
     if (in_docstring) {
-        # Indent the markdown code an extra two spaces.
-        print "  " strip_indent($0, docstring_indent)
+        print strip_indent($0, docstring_indent)
     } else {
         print trim($0)
     }


### PR DESCRIPTION
This PR adds `.feature` cucumber files, specifying tap hold configuration. Including:

- timeout
- "Ignore" interrupt response.
- "HoldOnKeyPress" interrupt response.

This PR also adds a pandoc.css file, which improves the theming of the generated HTML file.

Admittedly, the features are quite 'fragile' to write: the behaviour around the output needs to be *precisely* defined when considering tap-hold releases.

Ideally, these features could be described like "same key presses / releases observed as 'press A' 'press B'".