### PR TITLE
nickel format

### DIFF
--- a/ncl/checks.ncl
+++ b/ncl/checks.ncl
@@ -1,7 +1,8 @@
 {
   Check
     | doc "a Check is either a Bool, or a record with 'expected' and 'actual' fields."
-    = std.contract.any_of [
+    =
+      std.contract.any_of [
         Bool,
         { expected | Dyn, actual | Dyn, message | String | optional },
       ],
@@ -9,46 +10,50 @@
   is_check
     | doc "predicate for if the given value is a Check."
     = fun c =>
-        std.is_bool c ||
-        std.is_record c && std.record.has_field "expected" c && std.record.has_field "actual" c,
+      std.is_bool c
+      || std.is_record c
+      && std.record.has_field "expected" c
+      && std.record.has_field "actual" c,
 
-  evaluate_check
-    = fun c id =>
-        if std.is_bool c then
-          c == true || std.fail_with "%{id}: check failed"
-        else
-          (c.expected == c.actual) ||
-            (let ser = fun v =>
-              v |> std.typeof |> match {
-                'Enum => v |> std.enum.to_tag_and_arg |> std.serialize 'Json,
-                _ => v |> std.serialize 'Json,
-              } in
-              std.fail_with "%{id}: expected != actual:\n\nexpected:\n%{ser c.expected}\n\nactual:\n%{ser c.actual}"),
+  evaluate_check = fun c id =>
+    if std.is_bool c then
+      c == true || std.fail_with "%{id}: check failed"
+    else
+      (c.expected == c.actual)
+      || (
+        let ser = fun v =>
+          v
+          |> std.typeof
+          |> match {
+            'Enum => v |> std.enum.to_tag_and_arg |> std.serialize 'Json,
+            _ => v |> std.serialize 'Json,
+          }
+        in
+        std.fail_with "%{id}: expected != actual:\n\nexpected:\n%{ser c.expected}\n\nactual:\n%{ser c.actual}"
+      ),
 
   NamedChecks
     | doc "a record, with Check values. e.g. { check_add = { expected = 4, actual = add 2 2 } }"
     = { _ | Check },
 
-  CheckOrChecks
-    = std.contract.any_of [
-        Check,
-        Checks
-      ],
+  CheckOrChecks =
+    std.contract.any_of [
+      Check,
+      Checks
+    ],
 
   Checks
     | doc "a record, with Check values"
     = { _ | CheckOrChecks },
 
-  evaluate_check_or_checks
-    = fun c id =>
-        if is_check c then
-           evaluate_check c id
-         else
-           std.record.map (fun k v => evaluate_check_or_checks v "%{id}.%{k}") c,
+  evaluate_check_or_checks = fun c id =>
+    if is_check c then
+      evaluate_check c id
+    else
+      std.record.map (fun k v => evaluate_check_or_checks v "%{id}.%{k}") c,
 
-  evaluate_checks
-    = fun c =>
-        std.record.map (fun k v => evaluate_check_or_checks v k) c,
+  evaluate_checks = fun c =>
+    std.record.map (fun k v => evaluate_check_or_checks v k) c,
 
   checks | Checks | default = {},
 

--- a/ncl/hid-report.ncl
+++ b/ncl/hid-report.ncl
@@ -9,14 +9,14 @@
         modifiers |>
         std.record.map (fun mod is_pressed =>
           mod |> match {
-            "left_ctrl" if is_pressed => 0x01,
-            "left_shift" if is_pressed => 0x02,
-            "left_alt" if is_pressed => 0x04,
-            "left_gui" if is_pressed => 0x08,
-            "right_ctrl" if is_pressed => 0x10,
-            "right_shift" if is_pressed => 0x20,
-            "right_alt" if is_pressed => 0x40,
-            "right_gui" if is_pressed => 0x80,
+            "left_ctrl"   if is_pressed =>   1, # 0x01
+            "left_shift"  if is_pressed =>   2, # 0x02
+            "left_alt"    if is_pressed =>   4, # 0x04
+            "left_gui"    if is_pressed =>   8, # 0x08
+            "right_ctrl"  if is_pressed =>  16, # 0x10
+            "right_shift" if is_pressed =>  32, # 0x20
+            "right_alt"   if is_pressed =>  64, # 0x40
+            "right_gui"   if is_pressed => 128, # 0x80
             _ => 0,
           })
         |> std.record.values

--- a/ncl/hid-report.ncl
+++ b/ncl/hid-report.ncl
@@ -3,24 +3,26 @@
 
   key_codes | default = [],
 
-  as_bytes
-    =
-      let modifier =
-        modifiers |>
-        std.record.map (fun mod is_pressed =>
-          mod |> match {
-            "left_ctrl"   if is_pressed =>   1, # 0x01
-            "left_shift"  if is_pressed =>   2, # 0x02
-            "left_alt"    if is_pressed =>   4, # 0x04
-            "left_gui"    if is_pressed =>   8, # 0x08
-            "right_ctrl"  if is_pressed =>  16, # 0x10
-            "right_shift" if is_pressed =>  32, # 0x20
-            "right_alt"   if is_pressed =>  64, # 0x40
-            "right_gui"   if is_pressed => 128, # 0x80
-            _ => 0,
-          })
-        |> std.record.values
-        |> std.array.fold_left (+) 0 in
-      let key_codes_6 = std.array.generate (fun idx => std.array.at_or idx 0 key_codes) 6 in
-      std.array.concat [modifier, 0] key_codes_6
+  as_bytes =
+    let modifier =
+      modifiers
+      |> std.record.map (fun mod is_pressed =>
+        mod
+        |> match {
+          "left_ctrl" if is_pressed => 1, # 0x01
+          "left_shift" if is_pressed => 2, # 0x02
+          "left_alt" if is_pressed => 4, # 0x04
+          "left_gui" if is_pressed => 8, # 0x08
+          "right_ctrl" if is_pressed => 16, # 0x10
+          "right_shift" if is_pressed => 32, # 0x20
+          "right_alt" if is_pressed => 64, # 0x40
+          "right_gui" if is_pressed => 128, # 0x80
+          _ => 0,
+        }
+      )
+      |> std.record.values
+      |> std.array.fold_left (+) 0
+    in
+    let key_codes_6 = std.array.generate (fun idx => std.array.at_or idx 0 key_codes) 6 in
+    std.array.concat [modifier, 0] key_codes_6
 }

--- a/ncl/key-extensions.ncl
+++ b/ncl/key-extensions.ncl
@@ -1,249 +1,249 @@
 {
-  keyboard
-    = fun K =>
-        (import "hid-usage-keyboard.ncl")
-        |> std.record.map_values
-             (fun kc =>
-                kc |> match {
-                  # 0xE0 .. 0xE7
-                  _ if 224 <= kc && kc <= 231 => {
-                    modifiers = kc |> match {
-                      224 => { left_ctrl = true },
-                      225 => { left_shift = true },
-                      226 => { left_alt = true },
-                      227 => { left_gui = true },
-                      228 => { right_ctrl = true },
-                      229 => { right_shift = true },
-                      230 => { right_alt = true },
-                      231 => { right_gui = true },
-                    },
-                  },
+  keyboard = fun K =>
+    (import "hid-usage-keyboard.ncl")
+    |> std.record.map_values (fun kc =>
+      kc
+      |> match {
+        # 0xE0 .. 0xE7
+        _ if 224 <= kc && kc <= 231 =>
+          {
+            modifiers =
+              kc
+              |> match {
+                224 => { left_ctrl = true },
+                225 => { left_shift = true },
+                226 => { left_alt = true },
+                227 => { left_gui = true },
+                228 => { right_ctrl = true },
+                229 => { right_shift = true },
+                230 => { right_alt = true },
+                231 => { right_gui = true },
+              },
+          },
+        kc => { key_code = kc },
+      }
+    ),
 
-                  kc => { key_code = kc },
-                }),
-
-  tap_hold
-    = fun K => {
-        hold
+  tap_hold = fun K =>
+    {
+      hold
         | doc "creates a hold key modifier"
         = fun key => { hold = key },
 
-        H_LCtrl = hold K.LeftCtrl,
-        H_LShift = hold K.LeftShift,
-        H_LAlt = hold K.LeftAlt,
-        H_LGUI = hold K.LeftGUI,
-        H_RCtrl = hold K.RightCtrl,
-        H_RShift = hold K.RightShift,
-        H_RAlt = hold K.RightAlt,
-        H_RGUI = hold K.RightGUI,
-      },
+      H_LCtrl = hold K.LeftCtrl,
+      H_LShift = hold K.LeftShift,
+      H_LAlt = hold K.LeftAlt,
+      H_LGUI = hold K.LeftGUI,
+      H_RCtrl = hold K.RightCtrl,
+      H_RShift = hold K.RightShift,
+      H_RAlt = hold K.RightAlt,
+      H_RGUI = hold K.RightGUI,
+    },
 
-  layered
-    = fun K => {
-        layer_mod = {
-          hold = fun layer_num => {
+  layered = fun K =>
+    {
+      layer_mod = {
+        hold = fun layer_num =>
+          {
             layer_modifier = { hold = layer_num }
           },
-        },
-
-        # Layer Transparency
-        TTTT = null,
       },
 
-  shifted
-    = fun K =>
-        {
-          Exclaim = K.N1,
-          At = K.N2,
-          Hash = K.N3,
-          Dollar = K.N4,
-          Percent = K.N5,
-          Caret = K.N6, # ^
-          Ampersand = K.N7,
-          Asterisk = K.N8,
-          LeftParen = K.N9,
-          RightParen = K.N0,
+      # Layer Transparency
+      TTTT = null,
+    },
 
-          LeftCurlyBracket = K.LeftBracket,
-          RightCurlyBracket = K.RightBracket,
+  shifted = fun K =>
+    {
+      Exclaim = K.N1,
+      At = K.N2,
+      Hash = K.N3,
+      Dollar = K.N4,
+      Percent = K.N5,
+      Caret = K.N6, # ^
+      Ampersand = K.N7,
+      Asterisk = K.N8,
+      LeftParen = K.N9,
+      RightParen = K.N0,
 
-          Tilde = K.Grave, # ~
+      LeftCurlyBracket = K.LeftBracket,
+      RightCurlyBracket = K.RightBracket,
 
-          Plus = K.Equals,
-          Underscore = K.Minus,
+      Tilde = K.Grave, # ~
 
-          Question = K.Slash,
-          Pipe = K.Backslash,
+      Plus = K.Equals,
+      Underscore = K.Minus,
 
-          Colon = K.Semicolon,
-          DoubleQuote = K.Quote,
+      Question = K.Slash,
+      Pipe = K.Backslash,
 
-          LeftAngleBracket = K.Comma,
-          RightAngleBracket = K.Dot,
-        } |> std.record.map_values (fun k => k & K.LeftShift),
+      Colon = K.Semicolon,
+      DoubleQuote = K.Quote,
 
-  aliases
-    = fun K =>
-        {
-          Enter = K.Return,
-          Circumflex = K.Caret, # ^
-          LeftBrace = K.LeftCurlyBracket, # {
-          RightBrace = K.RightCurlyBracket,
-        },
+      LeftAngleBracket = K.Comma,
+      RightAngleBracket = K.Dot,
+    }
+    |> std.record.map_values (fun k => k & K.LeftShift),
 
-  abbreviations
-    = fun K =>
-        {
-          XXXX = K.NO,
+  aliases = fun K =>
+    {
+      Enter = K.Return,
+      Circumflex = K.Caret, # ^
+      LeftBrace = K.LeftCurlyBracket, # {
+      RightBrace = K.RightCurlyBracket,
+    },
 
-          RET  = K.Return,
-          ESC  = K.Escape,
-          BSPC = K.Backspace,
-          TAB  = K.Tab,
-          SPC  = K.Space,
+  abbreviations = fun K =>
+    {
+      XXXX = K.NO,
 
-          ENT  = K.Enter,
+      RET = K.Return,
+      ESC = K.Escape,
+      BSPC = K.Backspace,
+      TAB = K.Tab,
+      SPC = K.Space,
 
-          EXCL = K.Exclaim,
-          AT   = K.At,
-          HASH = K.Hash,
-          DLR  = K.Dollar,
-          PCT  = K.Percent,
-          CARE = K.Caret, # ^
-          AMP  = K.Ampersand,
-          ASTR = K.Asterisk,
-          LPRN = K.LeftParen,
-          RPRN = K.RightParen,
+      ENT = K.Enter,
 
-          PERC = K.Percent,
-          CIRC = K.Circumflex, # ^
+      EXCL = K.Exclaim,
+      AT = K.At,
+      HASH = K.Hash,
+      DLR = K.Dollar,
+      PCT = K.Percent,
+      CARE = K.Caret, # ^
+      AMP = K.Ampersand,
+      ASTR = K.Asterisk,
+      LPRN = K.LeftParen,
+      RPRN = K.RightParen,
 
-          LBRK = K.LeftBracket,  # [
-          LCBR = K.LeftCurlyBracket,  # {
-          LBRC = K.LeftBrace,  # {
-          RBRK = K.RightBracket,
-          RCBR = K.RightCurlyBracket,
-          RBRC = K.RightBrace,
+      PERC = K.Percent,
+      CIRC = K.Circumflex, # ^
 
-          GRV = K.Grave,   # `
-          TILD = K.Tilde,  # ~
+      LBRK = K.LeftBracket, # [
+      LCBR = K.LeftCurlyBracket, # {
+      LBRC = K.LeftBrace, # {
+      RBRK = K.RightBracket,
+      RCBR = K.RightCurlyBracket,
+      RBRC = K.RightBrace,
 
-          MINS = K.Minus,
-          UNDS = K.Underscore,
-          EQLS = K.Equals,
-          PLUS = K.Plus,
+      GRV = K.Grave, # `
+      TILD = K.Tilde, # ~
 
-          SLSH = K.Slash,
-          QUES = K.Question,
-          BSLS = K.Backslash,
-          PIPE = K.Pipe,
+      MINS = K.Minus,
+      UNDS = K.Underscore,
+      EQLS = K.Equals,
+      PLUS = K.Plus,
 
-          SCLN = K.Semicolon,
-          COLN = K.Colon,
-          QUOT = K.Quote,
-          DQUO = K.DoubleQuote,
+      SLSH = K.Slash,
+      QUES = K.Question,
+      BSLS = K.Backslash,
+      PIPE = K.Pipe,
 
-          COMM = K.Comma,
-          LABR = K.LeftAngleBracket,
-          DOT  = K.Dot,
-          RABR = K.RightAngleBracket,
+      SCLN = K.Semicolon,
+      COLN = K.Colon,
+      QUOT = K.Quote,
+      DQUO = K.DoubleQuote,
 
-          CAPS = K.CapsLock,
+      COMM = K.Comma,
+      LABR = K.LeftAngleBracket,
+      DOT = K.Dot,
+      RABR = K.RightAngleBracket,
 
-          PSCR = K.PrintScreen,
-          SCRL = K.ScrollLock,
-          PAUS = K.Pause,
+      CAPS = K.CapsLock,
 
-          SLCK = K.ScrollLock,
+      PSCR = K.PrintScreen,
+      SCRL = K.ScrollLock,
+      PAUS = K.Pause,
 
-          INS  = K.Insert,
-          HOME = K.Home,
-          PGUP = K.PageUp,
-          DEL  = K.Delete,
-          END  = K.End,
-          PGDN = K.PageDown,
+      SLCK = K.ScrollLock,
 
-          RGHT = K.Right,
-          LEFT = K.Left,
-          DOWN = K.Down,
-          UP   = K.Up,
+      INS = K.Insert,
+      HOME = K.Home,
+      PGUP = K.PageUp,
+      DEL = K.Delete,
+      END = K.End,
+      PGDN = K.PageDown,
 
-          NPNL = K.NumLock,
-          NPSL = K.NPSlash,
-          NPST = K.NPStar,
-          NPMN = K.NPMinus,
-          NPPL = K.NPPlus,
-          NPEN = K.NPEnter,
-          NPDT = K.NPDot,
+      RGHT = K.Right,
+      LEFT = K.Left,
+      DOWN = K.Down,
+      UP = K.Up,
 
-          LCTL = K.LeftCtrl,
-          LSFT = K.LeftShift,
-          LALT = K.LeftAlt,
-          LGUI = K.LeftGUI,
-          RCTL = K.RightCtrl,
-          RSFT = K.RightShift,
-          RALT = K.RightAlt,
-          RGUI = K.RightGUI,
+      NPNL = K.NumLock,
+      NPSL = K.NPSlash,
+      NPST = K.NPStar,
+      NPMN = K.NPMinus,
+      NPPL = K.NPPlus,
+      NPEN = K.NPEnter,
+      NPDT = K.NPDot,
 
-          APPN = K.Application,
+      LCTL = K.LeftCtrl,
+      LSFT = K.LeftShift,
+      LALT = K.LeftAlt,
+      LGUI = K.LeftGUI,
+      RCTL = K.RightCtrl,
+      RSFT = K.RightShift,
+      RALT = K.RightAlt,
+      RGUI = K.RightGUI,
 
-          NUSH = K.NonUSHash,
-          NUSB = K.NonUSBackslash,
-        },
+      APPN = K.Application,
 
-  literals
-    = fun K =>
-        {
-          "1" = K.N1,
-          "2" = K.N2,
-          "3" = K.N3,
-          "4" = K.N4,
-          "5" = K.N5,
-          "6" = K.N6,
-          "7" = K.N7,
-          "8" = K.N8,
-          "9" = K.N9,
-          "0" = K.N0,
+      NUSH = K.NonUSHash,
+      NUSB = K.NonUSBackslash,
+    },
 
-          "!" = K.Exclaim,
-          "@" = K.At,
-          "#" = K.Hash,
-          "$" = K.Dollar,
-          "%" = K.Percent,
-          "^" = K.Caret,
-          "&" = K.Ampersand,
-          "*" = K.Asterisk,
-          "(" = K.LeftParen,
-          ")" = K.RightParen,
+  literals = fun K =>
+    {
+      "1" = K.N1,
+      "2" = K.N2,
+      "3" = K.N3,
+      "4" = K.N4,
+      "5" = K.N5,
+      "6" = K.N6,
+      "7" = K.N7,
+      "8" = K.N8,
+      "9" = K.N9,
+      "0" = K.N0,
 
-          "["  = K.LeftBracket,
-          "{" = K.LeftCurlyBracket,
-          "]"  = K.RightBracket,
-          "}" = K.RightCurlyBracket,
+      "!" = K.Exclaim,
+      "@" = K.At,
+      "#" = K.Hash,
+      "$" = K.Dollar,
+      "%" = K.Percent,
+      "^" = K.Caret,
+      "&" = K.Ampersand,
+      "*" = K.Asterisk,
+      "(" = K.LeftParen,
+      ")" = K.RightParen,
 
-          "`" = K.Grave,
-          "~" = K.Tilde,
+      "[" = K.LeftBracket,
+      "{" = K.LeftCurlyBracket,
+      "]" = K.RightBracket,
+      "}" = K.RightCurlyBracket,
 
-          "-"  = K.Minus,
-          "_" = K.Underscore,
-          "="  = K.Equals,
-          "+" = K.Plus,
+      "`" = K.Grave,
+      "~" = K.Tilde,
 
-          "/"  = K.Slash,
-          "?" = K.Question,
-          "\\" = K.Backslash,
-          "|" = K.Pipe,
+      "-" = K.Minus,
+      "_" = K.Underscore,
+      "=" = K.Equals,
+      "+" = K.Plus,
 
-          ";"  = K.Semicolon,
-          ":"  = K.Colon,
-          "'"  = K.Quote,
-          "\""  = K.DoubleQuote,
+      "/" = K.Slash,
+      "?" = K.Question,
+      "\\" = K.Backslash,
+      "|" = K.Pipe,
 
-          ","  = K.Comma,
-          "<" = K.LeftAngleBracket,
-          "."  = K.Dot,
-          ">" = K.RightAngleBracket,
-        },
+      ";" = K.Semicolon,
+      ":" = K.Colon,
+      "'" = K.Quote,
+      "\"" = K.DoubleQuote,
+
+      "," = K.Comma,
+      "<" = K.LeftAngleBracket,
+      "." = K.Dot,
+      ">" = K.RightAngleBracket,
+    },
 
   extend_keys = fun K key_extension => K & key_extension K,
 }

--- a/ncl/key-extensions.ncl
+++ b/ncl/key-extensions.ncl
@@ -5,16 +5,17 @@
         |> std.record.map_values
              (fun kc =>
                 kc |> match {
-                  _ if 0xE0 <= kc && kc <= 0xE7 => {
+                  # 0xE0 .. 0xE7
+                  _ if 224 <= kc && kc <= 231 => {
                     modifiers = kc |> match {
-                      0xE0 => { left_ctrl = true },
-                      0xE1 => { left_shift = true },
-                      0xE2 => { left_alt = true },
-                      0xE3 => { left_gui = true },
-                      0xE4 => { right_ctrl = true },
-                      0xE5 => { right_shift = true },
-                      0xE6 => { right_alt = true },
-                      0xE7 => { right_gui = true },
+                      224 => { left_ctrl = true },
+                      225 => { left_shift = true },
+                      226 => { left_alt = true },
+                      227 => { left_gui = true },
+                      228 => { right_ctrl = true },
+                      229 => { right_shift = true },
+                      230 => { right_alt = true },
+                      231 => { right_gui = true },
                     },
                   },
 

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -8,10 +8,10 @@ let validators = import "validators.ncl" in
     = {
         # Use a serialized value to check the "is" predicate.
         check_serialized_is =
-          let serialized_value = { key_code = 0x04 } in
+          let serialized_value = { key_code = 4 } in
           keyboard.is_serialized_json serialized_value,
         check_serialized_with_modifier_is =
-          let serialized_value = { key_code = 0x04, modifiers = { left_ctrl = true} } in
+          let serialized_value = { key_code = 4, modifiers = { left_ctrl = true} } in
           keyboard.is_serialized_json serialized_value,
         check_serialized_modifiers_is =
           let serialized_value = { modifiers = { left_ctrl = true} } in
@@ -140,10 +140,10 @@ let validators = import "validators.ncl" in
         # Use a serialized value to check the "is" predicate.
         check_serialized_base_keyboard_layered_keyboard_is
           = let serialized_value = {
-              base = { key_code = 0x04 },
+              base = { key_code = 4 },
               layered = [
                 null,
-                { key_code = 0x06 },
+                { key_code = 6 },
               ]
             } in
             layered.is_serialized_json serialized_value
@@ -219,8 +219,8 @@ let validators = import "validators.ncl" in
     # Use a serialized value to check the "is" predicate.
     check_serialized_tap_keyboard_hold_keyboard_is
       = let serialized_value = {
-          hold = { key_code = 0xE0 },
-          tap = { key_code = 0x04 },
+          hold = { key_code = 224 },
+          tap = { key_code = 4 },
         } in
         tap_hold.is_serialized_json serialized_value,
   },

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -4,36 +4,38 @@ let validators = import "validators.ncl" in
     | doc "The 'JSON serialized' value of the keymap. e.g. imported from keymap.json."
     | { keys | Array key.SerializedJson, .. },
 
-  checks.keyboard_is
-    = {
-        # Use a serialized value to check the "is" predicate.
-        check_serialized_is =
-          let serialized_value = { key_code = 4 } in
-          keyboard.is_serialized_json serialized_value,
-        check_serialized_with_modifier_is =
-          let serialized_value = { key_code = 4, modifiers = { left_ctrl = true} } in
-          keyboard.is_serialized_json serialized_value,
-        check_serialized_modifiers_is =
-          let serialized_value = { modifiers = { left_ctrl = true} } in
-          keyboard.is_serialized_json serialized_value,
-      },
+  checks.keyboard_is = {
+    # Use a serialized value to check the "is" predicate.
+    check_serialized_is =
+      let serialized_value = { key_code = 4 } in
+      keyboard.is_serialized_json serialized_value,
+    check_serialized_with_modifier_is =
+      let serialized_value = { key_code = 4, modifiers = { left_ctrl = true } } in
+      keyboard.is_serialized_json serialized_value,
+    check_serialized_modifiers_is =
+      let serialized_value = { modifiers = { left_ctrl = true } } in
+      keyboard.is_serialized_json serialized_value,
+  },
 
   keyboard
     | doc "for key::keyboard::Key."
     = {
-        SerializedJson = std.contract.from_validator serialized_json_validator,
+      SerializedJson = std.contract.from_validator serialized_json_validator,
 
-        # c.f. doc_de_keyboard.md.
-        serialized_json_validator
-          = validators.record.validator {
-              fields_validator = validators.all_of [
-                validators.record.has_any_field_of ["key_code", "modifiers"],
-                validators.record.has_only_fields ["key_code", "modifiers"],
-              ],
-              field_validators = {
-                key_code = validators.is_number,
-                modifiers = validators.record.validator {
-                  fields_validator = validators.record.has_only_fields [
+      # c.f. doc_de_keyboard.md.
+      serialized_json_validator =
+        validators.record.validator {
+          fields_validator =
+            validators.all_of [
+              validators.record.has_any_field_of ["key_code", "modifiers"],
+              validators.record.has_only_fields ["key_code", "modifiers"],
+            ],
+          field_validators = {
+            key_code = validators.is_number,
+            modifiers =
+              validators.record.validator {
+                fields_validator =
+                  validators.record.has_only_fields [
                     "left_ctrl",
                     "left_shift",
                     "left_alt",
@@ -43,458 +45,446 @@ let validators = import "validators.ncl" in
                     "right_alt",
                     "right_gui",
                   ],
-                  field_validators = {
-                    left_ctrl = validators.is_bool,
-                    left_shift = validators.is_bool,
-                    left_alt = validators.is_bool,
-                    left_gui = validators.is_bool,
-                    right_ctrl = validators.is_bool,
-                    right_shift = validators.is_bool,
-                    right_alt = validators.is_bool,
-                    right_gui = validators.is_bool,
-                  },
+                field_validators = {
+                  left_ctrl = validators.is_bool,
+                  left_shift = validators.is_bool,
+                  left_alt = validators.is_bool,
+                  left_gui = validators.is_bool,
+                  right_ctrl = validators.is_bool,
+                  right_shift = validators.is_bool,
+                  right_alt = validators.is_bool,
+                  right_gui = validators.is_bool,
                 },
               },
-            },
+          },
+        },
 
-        is_serialized_json
-          = fun k => 'Ok == serialized_json_validator k,
+      is_serialized_json = fun k => 'Ok == serialized_json_validator k,
 
-        key_type
-          = {
-              key_type = "crate::key::keyboard::Key",
-              as_rust_type_path = key_type,
-            },
-
-        rust_expr
-          = fun key =>
-              let rec modifiers_expr = fun m =>
-                m |> match {
-                  {} => "crate::key::KeyboardModifiers::new()",
-                  { left_ctrl, ..modifiers } if left_ctrl =>
-                    "crate::key::KeyboardModifiers::LEFT_CTRL.union(&%{modifiers_expr modifiers})",
-                  { left_alt, ..modifiers } if left_alt =>
-                    "crate::key::KeyboardModifiers::LEFT_ALT.union(&%{modifiers_expr modifiers})",
-                  { left_shift, ..modifiers } if left_shift =>
-                    "crate::key::KeyboardModifiers::LEFT_SHIFT.union(&%{modifiers_expr modifiers})",
-                  { left_gui, ..modifiers } if left_gui =>
-                    "crate::key::KeyboardModifiers::LEFT_GUI.union(&%{modifiers_expr modifiers})",
-                  { right_ctrl, ..modifiers } if right_ctrl =>
-                    "crate::key::KeyboardModifiers::RIGHT_CTRL.union(&%{modifiers_expr modifiers})",
-                  { right_alt, ..modifiers } if right_alt =>
-                    "crate::key::KeyboardModifiers::RIGHT_ALT.union(&%{modifiers_expr modifiers})",
-                  { right_shift, ..modifiers } if right_shift =>
-                    "crate::key::KeyboardModifiers::RIGHT_SHIFT.union(&%{modifiers_expr modifiers})",
-                  { right_gui, ..modifiers } if right_gui =>
-                    "crate::key::KeyboardModifiers::RIGHT_GUI.union(&%{modifiers_expr modifiers})",
-                } in
-              key |> match {
-                { key_code } =>
-                  "crate::key::keyboard::Key::new(%{std.to_string key_code})",
-                { modifiers } =>
-                  "crate::key::keyboard::Key::from_modifiers(%{modifiers_expr modifiers})",
-                { key_code, modifiers } =>
-                  "crate::key::keyboard::Key::new_with_modifiers(%{std.to_string key_code}, %{modifiers_expr modifiers})",
-              },
+      key_type = {
+        key_type = "crate::key::keyboard::Key",
+        as_rust_type_path = key_type,
       },
 
-  checks.layer_modifier_is
-    = {
-        # Use a serialized value to check the "is" predicate.
-        check_serialized_is
-          = let serialized_value = { Hold = 0 } in
-            layer_modifier.is_serialized_json serialized_value
-      },
+      rust_expr = fun key =>
+        let rec modifiers_expr = fun m =>
+          m
+          |> match {
+            {} => "crate::key::KeyboardModifiers::new()",
+            { left_ctrl, ..modifiers } if left_ctrl =>
+              "crate::key::KeyboardModifiers::LEFT_CTRL.union(&%{modifiers_expr modifiers})",
+            { left_alt, ..modifiers } if left_alt =>
+              "crate::key::KeyboardModifiers::LEFT_ALT.union(&%{modifiers_expr modifiers})",
+            { left_shift, ..modifiers } if left_shift =>
+              "crate::key::KeyboardModifiers::LEFT_SHIFT.union(&%{modifiers_expr modifiers})",
+            { left_gui, ..modifiers } if left_gui =>
+              "crate::key::KeyboardModifiers::LEFT_GUI.union(&%{modifiers_expr modifiers})",
+            { right_ctrl, ..modifiers } if right_ctrl =>
+              "crate::key::KeyboardModifiers::RIGHT_CTRL.union(&%{modifiers_expr modifiers})",
+            { right_alt, ..modifiers } if right_alt =>
+              "crate::key::KeyboardModifiers::RIGHT_ALT.union(&%{modifiers_expr modifiers})",
+            { right_shift, ..modifiers } if right_shift =>
+              "crate::key::KeyboardModifiers::RIGHT_SHIFT.union(&%{modifiers_expr modifiers})",
+            { right_gui, ..modifiers } if right_gui =>
+              "crate::key::KeyboardModifiers::RIGHT_GUI.union(&%{modifiers_expr modifiers})",
+          }
+        in
+        key
+        |> match {
+          { key_code } =>
+            "crate::key::keyboard::Key::new(%{std.to_string key_code})",
+          { modifiers } =>
+            "crate::key::keyboard::Key::from_modifiers(%{modifiers_expr modifiers})",
+          { key_code, modifiers } =>
+            "crate::key::keyboard::Key::new_with_modifiers(%{std.to_string key_code}, %{modifiers_expr modifiers})",
+        },
+    },
+
+  checks.layer_modifier_is = {
+    # Use a serialized value to check the "is" predicate.
+    check_serialized_is =
+      let serialized_value = { Hold = 0 } in
+      layer_modifier.is_serialized_json serialized_value
+  },
 
   layer_modifier
     | doc "for key::layered::ModifierKey."
     = {
-        SerializedJson = std.contract.from_validator serialized_json_validator,
+      SerializedJson = std.contract.from_validator serialized_json_validator,
 
-        # c.f. doc_de_layered.md.
-        # JSON serialization of key::layered::ModifierKey has variants: Hold(layer).
-        serialized_json_validator
-          = validators.record.validator {
-              fields_validator = validators.record.has_exact_fields ["Hold"],
-              field_validators = {
-                Hold = validators.is_number,
-              },
-            },
+      # c.f. doc_de_layered.md.
+      # JSON serialization of key::layered::ModifierKey has variants: Hold(layer).
+      serialized_json_validator =
+        validators.record.validator {
+          fields_validator = validators.record.has_exact_fields ["Hold"],
+          field_validators = {
+            Hold = validators.is_number,
+          },
+        },
 
-        is_serialized_json
-          = fun k => 'Ok == serialized_json_validator k,
+      is_serialized_json = fun k => 'Ok == serialized_json_validator k,
 
-        key_type
-          = {
-              key_type = "crate::key::layered::ModifierKey",
-              as_rust_type_path = key_type,
-            },
-
-        rust_expr
-          = fun { Hold = layer_index } =>
-            "crate::key::layered::ModifierKey::Hold(%{std.to_string layer_index})",
+      key_type = {
+        key_type = "crate::key::layered::ModifierKey",
+        as_rust_type_path = key_type,
       },
 
-  checks.layered_is
-    = {
-        # Use a serialized value to check the "is" predicate.
-        check_serialized_base_keyboard_layered_keyboard_is
-          = let serialized_value = {
-              base = { key_code = 4 },
-              layered = [
-                null,
-                { key_code = 6 },
-              ]
-            } in
-            layered.is_serialized_json serialized_value
-      },
+      rust_expr = fun { Hold = layer_index } =>
+        "crate::key::layered::ModifierKey::Hold(%{std.to_string layer_index})",
+    },
+
+  checks.layered_is = {
+    # Use a serialized value to check the "is" predicate.
+    check_serialized_base_keyboard_layered_keyboard_is =
+      let serialized_value = {
+        base = { key_code = 4 },
+        layered = [
+          null,
+          { key_code = 6 },
+        ]
+      }
+      in
+      layered.is_serialized_json serialized_value
+  },
 
   layered
     | doc "for key::layered::LayeredKey."
     = {
-        SerializedJson = std.contract.from_validator serialized_json_validator,
+      SerializedJson = std.contract.from_validator serialized_json_validator,
 
-        # c.f. doc_de_layered.md.
-        # e.g.:
-        # ```
-        #   {
-        #     "base": 4,
-        #     "layered": [5, null, 7]
-        #   }
-        # ```
-        # JSON serialization of key::layered::Layered has fields: { base, layered }
-        serialized_json_validator
-          = validators.record.validator {
-              fields_validator = validators.record.has_exact_fields ["base", "layered"],
-              field_validators = {
-                base = key.serialized_json_validator,
-                layered = validators.array.validator
-                  (validators.any_of [
-                    validators.is_null,
-                    key.serialized_json_validator,
-                  ]),
-              },
-            },
+      # c.f. doc_de_layered.md.
+      # e.g.:
+      # ```
+      #   {
+      #     "base": 4,
+      #     "layered": [5, null, 7]
+      #   }
+      # ```
+      # JSON serialization of key::layered::Layered has fields: { base, layered }
+      serialized_json_validator =
+        validators.record.validator {
+          fields_validator = validators.record.has_exact_fields ["base", "layered"],
+          field_validators = {
+            base = key.serialized_json_validator,
+            layered =
+              validators.array.validator (
+                validators.any_of [
+                  validators.is_null,
+                  key.serialized_json_validator,
+                ]
+              ),
+          },
+        },
 
-        is_serialized_json
-          = fun k => 'Ok == serialized_json_validator k,
+      is_serialized_json = fun k => 'Ok == serialized_json_validator k,
 
-        # c.f. doc_de_layered.md.
-        # ```
-        #   type Key = layered::LayeredKey<keyboard::Key>;
-        # ```
-        key_type
-          = fun { base, layered } =>
-              let base_key_type = key.key_type base in
-              let non_null_layered = std.array.filter ((!=) null) layered in
-              let layered_key_types = std.array.map (fun nk => key.key_type nk) non_null_layered in
-              let nested_key_type =
-                if std.array.all (fun kt => kt == base_key_type) layered_key_types then
-                  base_key_type
-                else
-                  composite.tap_hold_key.key_type base in
-              {
-                key_type = "crate::key::layered::LayeredKey",
-                as_rust_type_path = "%{key_type}<%{nested_key_type.as_rust_type_path}>",
-              },
+      # c.f. doc_de_layered.md.
+      # ```
+      #   type Key = layered::LayeredKey<keyboard::Key>;
+      # ```
+      key_type = fun { base, layered } =>
+        let base_key_type = key.key_type base in
+        let non_null_layered = std.array.filter ((!=) null) layered in
+        let layered_key_types = std.array.map (fun nk => key.key_type nk) non_null_layered in
+        let nested_key_type =
+          if std.array.all (fun kt => kt == base_key_type) layered_key_types then
+            base_key_type
+          else
+            composite.tap_hold_key.key_type base
+        in
+        {
+          key_type = "crate::key::layered::LayeredKey",
+          as_rust_type_path = "%{key_type}<%{nested_key_type.as_rust_type_path}>",
+        },
 
-        rust_expr
-          = fun { base, layered } =>
-              let base_key_type = key.key_type base in
-              let non_null_layered = std.array.filter ((!=) null) layered in
-              let layered_key_types = std.array.map (fun nk => key.key_type nk) non_null_layered in
-              let nk_expr =
-                if std.array.all (fun kt => kt == base_key_type) layered_key_types then
-                  key.rust_expr
-                else
-                  composite.tap_hold_key.rust_expr in
-              let base_expr = nk_expr base in
-              let layered_exprs = layered
-                |> std.array.map (fun lk => if lk == null then "None" else "Some(%{nk_expr lk})")
-                |> std.string.join "," in
-              "crate::key::layered::LayeredKey::new(%{base_expr}, [%{layered_exprs}])",
-      },
+      rust_expr = fun { base, layered } =>
+        let base_key_type = key.key_type base in
+        let non_null_layered = std.array.filter ((!=) null) layered in
+        let layered_key_types = std.array.map (fun nk => key.key_type nk) non_null_layered in
+        let nk_expr =
+          if std.array.all (fun kt => kt == base_key_type) layered_key_types then
+            key.rust_expr
+          else
+            composite.tap_hold_key.rust_expr
+        in
+        let base_expr = nk_expr base in
+        let layered_exprs =
+          layered
+          |> std.array.map (fun lk => if lk == null then "None" else "Some(%{nk_expr lk})")
+          |> std.string.join ","
+        in
+        "crate::key::layered::LayeredKey::new(%{base_expr}, [%{layered_exprs}])",
+    },
 
   checks.check_tap_hold = {
     # Use a serialized value to check the "is" predicate.
-    check_serialized_tap_keyboard_hold_keyboard_is
-      = let serialized_value = {
-          hold = { key_code = 224 },
-          tap = { key_code = 4 },
-        } in
-        tap_hold.is_serialized_json serialized_value,
+    check_serialized_tap_keyboard_hold_keyboard_is =
+      let serialized_value = {
+        hold = { key_code = 224 },
+        tap = { key_code = 4 },
+      }
+      in
+      tap_hold.is_serialized_json serialized_value,
   },
 
   tap_hold
     | doc "for key::tap_hold::Key."
     = {
-        SerializedJson = std.contract.from_validator serialized_json_validator,
+      SerializedJson = std.contract.from_validator serialized_json_validator,
 
-        # c.f. doc_de_tap_hold.md.
-        # JSON serialization of key::tap_hold::Key is { tap: key, hold: key }
-        serialized_json_validator
-          = validators.record.validator {
-            fields_validator = validators.record.has_exact_fields ["tap", "hold"],
-            field_validators = {
-              tap = key.serialized_json_validator,
-              hold = key.serialized_json_validator,
-            },
+      # c.f. doc_de_tap_hold.md.
+      # JSON serialization of key::tap_hold::Key is { tap: key, hold: key }
+      serialized_json_validator =
+        validators.record.validator {
+          fields_validator = validators.record.has_exact_fields ["tap", "hold"],
+          field_validators = {
+            tap = key.serialized_json_validator,
+            hold = key.serialized_json_validator,
           },
+        },
 
-        is_serialized_json
-          = fun k => 'Ok == serialized_json_validator k,
+      is_serialized_json = fun k => 'Ok == serialized_json_validator k,
 
-        key_type
-          = fun { hold, tap } =>
-              let hold_key_type = key.key_type hold in
-              let tap_key_type = key.key_type tap in
-              # let nested_key_type =
-              #   if tap_key_type == hold_key_type then
-              #     tap_key_type
-              #   else
-              #     composite.base_key.key_type tap in
-              let nested_key_type = composite.base_key.key_type tap in
-              {
-                key_type = "crate::key::tap_hold::Key",
-                as_rust_type_path = "%{key_type}<%{nested_key_type.as_rust_type_path}>"
-              },
+      key_type = fun { hold, tap } =>
+        let hold_key_type = key.key_type hold in
+        let tap_key_type = key.key_type tap in
+        # let nested_key_type =
+        #   if tap_key_type == hold_key_type then
+        #     tap_key_type
+        #   else
+        #     composite.base_key.key_type tap in
+        let nested_key_type = composite.base_key.key_type tap in
+        {
+          key_type = "crate::key::tap_hold::Key",
+          as_rust_type_path = "%{key_type}<%{nested_key_type.as_rust_type_path}>"
+        },
 
-        rust_expr
-          = fun { hold, tap, } =>
-              let tap_kt = key.key_type tap in
-              let hold_kt = key.key_type hold in
-              # let nk_expr =
-              #   if tap_kt == hold_kt then
-              #     key.rust_expr
-              #   else
-              #     composite.base_key.rust_expr in
-              let nk_expr = composite.base_key.rust_expr in
-              let hold_expr = nk_expr hold in
-              let tap_expr = nk_expr tap in
-              "crate::key::tap_hold::Key::new(%{tap_expr}, %{hold_expr})",
+      rust_expr = fun { hold, tap, } =>
+        let tap_kt = key.key_type tap in
+        let hold_kt = key.key_type hold in
+        # let nk_expr =
+        #   if tap_kt == hold_kt then
+        #     key.rust_expr
+        #   else
+        #     composite.base_key.rust_expr in
+        let nk_expr = composite.base_key.rust_expr in
+        let hold_expr = nk_expr hold in
+        let tap_expr = nk_expr tap in
+        "crate::key::tap_hold::Key::new(%{tap_expr}, %{hold_expr})",
+    },
+
+  composite = {
+    base_key = {
+      SerializedJson = std.contract.from_validator serialized_json_validator,
+
+      serialized_json_validator =
+        validators.any_of [
+          layer_modifier.serialized_json_validator,
+          keyboard.serialized_json_validator,
+        ],
+
+      is_serialized_json = fun k => 'Ok == serialized_json_validator k,
+
+      key_type = match {
+        key if layer_modifier.is_serialized_json key =>
+          {
+            key_type = "crate::key::composite::BaseKey",
+            as_rust_type_path = key_type,
+          },
+        key if keyboard.is_serialized_json key =>
+          {
+            key_type = "crate::key::composite::BaseKey",
+            as_rust_type_path = key_type,
+          },
+        _ => 'unknown_key_type
       },
 
-  composite
-    = {
-        base_key
-          = {
-              SerializedJson = std.contract.from_validator serialized_json_validator,
+      rust_expr = match {
+        key if layer_modifier.is_serialized_json key =>
+          let expr = layer_modifier.rust_expr key in
+          "crate::key::composite::BaseKey::layer_modifier(%{expr})",
+        key if keyboard.is_serialized_json key =>
+          let expr = keyboard.rust_expr key in
+          "crate::key::composite::BaseKey::keyboard(%{expr})",
+        _ => 'unknown_key_type
+      },
+    },
 
-              serialized_json_validator
-                = validators.any_of
-                    [
-                      layer_modifier.serialized_json_validator,
-                      keyboard.serialized_json_validator,
-                    ],
+    tap_hold_key = {
+      SerializedJson = std.contract.from_validator serialized_json_validator,
 
-              is_serialized_json
-                = fun k => 'Ok == serialized_json_validator k,
+      serialized_json_validator =
+        validators.any_of [
+          tap_hold.serialized_json_validator,
+          composite.base_key.serialized_json_validator,
+        ],
 
-              key_type
-                = match {
-                    key if layer_modifier.is_serialized_json key =>
-                      {
-                        key_type = "crate::key::composite::BaseKey",
-                        as_rust_type_path = key_type,
-                      },
-                    key if keyboard.is_serialized_json key =>
-                      {
-                        key_type = "crate::key::composite::BaseKey",
-                        as_rust_type_path = key_type,
-                      },
-                    _ => 'unknown_key_type
-                  },
+      is_serialized_json = fun k => 'Ok == serialized_json_validator k,
 
-              rust_expr
-                = match {
-                    key if layer_modifier.is_serialized_json key =>
-                      let expr = layer_modifier.rust_expr key in
-                      "crate::key::composite::BaseKey::layer_modifier(%{expr})",
-                    key if keyboard.is_serialized_json key =>
-                      let expr = keyboard.rust_expr key in
-                      "crate::key::composite::BaseKey::keyboard(%{expr})",
-                    _ => 'unknown_key_type
-                  },
-            },
-
-        tap_hold_key
-          = {
-              SerializedJson = std.contract.from_validator serialized_json_validator,
-
-              serialized_json_validator
-                = validators.any_of
-                    [
-                      tap_hold.serialized_json_validator,
-                      composite.base_key.serialized_json_validator,
-                    ],
-
-              is_serialized_json
-                = fun k => 'Ok == serialized_json_validator k,
-
-              key_type
-                = match {
-                    key if tap_hold.is_serialized_json key =>
-                      {
-                        key_type = "crate::key::composite::TapHoldKey",
-                        nested_key_type = "crate::key::composite::BaseKey",
-                        as_rust_type_path = "%{key_type}<%{nested_key_type}>",
-                      },
-                    key if composite.base_key.is_serialized_json key =>
-                      {
-                        key_type = "crate::key::composite::TapHoldKey",
-                        nested_key_type = "crate::key::composite::BaseKey",
-                        as_rust_type_path = "%{key_type}<%{nested_key_type}>",
-                      },
-                    _ => 'unknown_key_type
-                  },
-
-              rust_expr
-                = match {
-                    key if tap_hold.is_serialized_json key =>
-                      let expr = tap_hold.rust_expr key in
-                      "crate::key::composite::TapHoldKey::tap_hold(%{expr})",
-                    key if composite.base_key.is_serialized_json key =>
-                      let expr = composite.base_key.rust_expr key in
-                      "crate::key::composite::TapHoldKey::Pass(%{expr})",
-                    _ => 'unknown_key_type
-                  },
-            },
-
-        layered_key
-          = {
-              SerializedJson = std.contract.from_validator serialized_json_validator,
-
-              serialized_json_validator
-                = validators.any_of
-                    [
-                      layered.serialized_json_validator,
-                      composite.tap_hold_key.serialized_json_validator,
-                    ],
-
-              is_serialized_json
-                = fun k => 'Ok == serialized_json_validator k,
-
-              key_type
-                = match {
-                    key if layered.is_serialized_json key =>
-                      {
-                        key_type = "crate::key::composite::LayeredKey",
-                        nested_key_type = "crate::key::composite::TapHoldKey",
-                        as_rust_type_path = "%{key_type}<%{nested_key_type}>",
-                      },
-                    key if composite.tap_hold_key.is_serialized_json key =>
-                      {
-                        key_type = "crate::key::composite::LayeredKey",
-                        nested_key_type = "crate::key::composite::TapHoldKey",
-                        as_rust_type_path = "%{key_type}<%{nested_key_type}>",
-                      },
-                    _ => 'unknown_key_type
-                  },
-
-              rust_expr
-                = match {
-                    key if layered.is_serialized_json key =>
-                      let expr = layered.rust_expr key in
-                      "crate::key::composite::LayeredKey::layered(%{expr})",
-                    key if composite.tap_hold_key.is_serialized_json key =>
-                      let expr = composite.tap_hold_key.rust_expr key in
-                      "crate::key::composite::LayeredKey::Pass(%{expr})",
-                    _ => 'unknown_key_type
-                  },
-            },
-
-        wrap_rust_expr
-          = match {
-              k if keyboard.is_serialized_json k =>
-                let k_expr = keyboard.rust_expr k in
-                "crate::key::composite::Key::keyboard(%{k_expr})",
-              k if layer_modifier.is_serialized_json k =>
-                let k_expr = layer_modifier.rust_expr k in
-                "crate::key::composite::Key::layer_modifier(%{k_expr})",
-              k if layered.is_serialized_json k =>
-                let k_expr = layered.key_expr k in
-                "crate::key::composite::Key::layered(%{k_expr})",
-              k if tap_hold.is_serialized_json k =>
-                let k_expr = tap_hold.rust_expr k in
-                "crate::key::composite::Key::tap_hold(%{k_expr})",
-              _ => 'Error { message = "unknown variant for key::composite::Key" },
-            },
+      key_type = match {
+        key if tap_hold.is_serialized_json key =>
+          {
+            key_type = "crate::key::composite::TapHoldKey",
+            nested_key_type = "crate::key::composite::BaseKey",
+            as_rust_type_path = "%{key_type}<%{nested_key_type}>",
+          },
+        key if composite.base_key.is_serialized_json key =>
+          {
+            key_type = "crate::key::composite::TapHoldKey",
+            nested_key_type = "crate::key::composite::BaseKey",
+            as_rust_type_path = "%{key_type}<%{nested_key_type}>",
+          },
+        _ => 'unknown_key_type
       },
 
-  key
-    = {
-        SerializedJson = std.contract.from_validator serialized_json_validator,
-
-        serialized_json_validator
-          = validators.any_of
-              [
-                keyboard.serialized_json_validator,
-                layer_modifier.serialized_json_validator,
-                layered.serialized_json_validator,
-                tap_hold.serialized_json_validator,
-              ],
-
-        is_serialized_json
-          = fun k => 'Ok == serialized_json_validator k,
-
-        key_type
-          = match {
-              key if keyboard.is_serialized_json key => keyboard.key_type,
-              key if layer_modifier.is_serialized_json key => layer_modifier.key_type,
-              key if layered.is_serialized_json key => layered.key_type key,
-              key if tap_hold.is_serialized_json key => tap_hold.key_type key,
-              _ => 'unknown_key_type
-            },
-
-        rust_expr
-          = match {
-              key if keyboard.is_serialized_json key => keyboard.rust_expr key,
-              key if layer_modifier.is_serialized_json key => layer_modifier.rust_expr key,
-              key if layered.is_serialized_json key => layered.rust_expr key,
-              key if tap_hold.is_serialized_json key => tap_hold.rust_expr key,
-              _ => 'unknown_key_type
-            },
+      rust_expr = match {
+        key if tap_hold.is_serialized_json key =>
+          let expr = tap_hold.rust_expr key in
+          "crate::key::composite::TapHoldKey::tap_hold(%{expr})",
+        key if composite.base_key.is_serialized_json key =>
+          let expr = composite.base_key.rust_expr key in
+          "crate::key::composite::TapHoldKey::Pass(%{expr})",
+        _ => 'unknown_key_type
       },
+    },
+
+    layered_key = {
+      SerializedJson = std.contract.from_validator serialized_json_validator,
+
+      serialized_json_validator =
+        validators.any_of [
+          layered.serialized_json_validator,
+          composite.tap_hold_key.serialized_json_validator,
+        ],
+
+      is_serialized_json = fun k => 'Ok == serialized_json_validator k,
+
+      key_type = match {
+        key if layered.is_serialized_json key =>
+          {
+            key_type = "crate::key::composite::LayeredKey",
+            nested_key_type = "crate::key::composite::TapHoldKey",
+            as_rust_type_path = "%{key_type}<%{nested_key_type}>",
+          },
+        key if composite.tap_hold_key.is_serialized_json key =>
+          {
+            key_type = "crate::key::composite::LayeredKey",
+            nested_key_type = "crate::key::composite::TapHoldKey",
+            as_rust_type_path = "%{key_type}<%{nested_key_type}>",
+          },
+        _ => 'unknown_key_type
+      },
+
+      rust_expr = match {
+        key if layered.is_serialized_json key =>
+          let expr = layered.rust_expr key in
+          "crate::key::composite::LayeredKey::layered(%{expr})",
+        key if composite.tap_hold_key.is_serialized_json key =>
+          let expr = composite.tap_hold_key.rust_expr key in
+          "crate::key::composite::LayeredKey::Pass(%{expr})",
+        _ => 'unknown_key_type
+      },
+    },
+
+    wrap_rust_expr = match {
+      k if keyboard.is_serialized_json k =>
+        let k_expr = keyboard.rust_expr k in
+        "crate::key::composite::Key::keyboard(%{k_expr})",
+      k if layer_modifier.is_serialized_json k =>
+        let k_expr = layer_modifier.rust_expr k in
+        "crate::key::composite::Key::layer_modifier(%{k_expr})",
+      k if layered.is_serialized_json k =>
+        let k_expr = layered.key_expr k in
+        "crate::key::composite::Key::layered(%{k_expr})",
+      k if tap_hold.is_serialized_json k =>
+        let k_expr = tap_hold.rust_expr k in
+        "crate::key::composite::Key::tap_hold(%{k_expr})",
+      _ => 'Error { message = "unknown variant for key::composite::Key" },
+    },
+  },
+
+  key = {
+    SerializedJson = std.contract.from_validator serialized_json_validator,
+
+    serialized_json_validator =
+      validators.any_of [
+        keyboard.serialized_json_validator,
+        layer_modifier.serialized_json_validator,
+        layered.serialized_json_validator,
+        tap_hold.serialized_json_validator,
+      ],
+
+    is_serialized_json = fun k => 'Ok == serialized_json_validator k,
+
+    key_type = match {
+      key if keyboard.is_serialized_json key => keyboard.key_type,
+      key if layer_modifier.is_serialized_json key => layer_modifier.key_type,
+      key if layered.is_serialized_json key => layered.key_type key,
+      key if tap_hold.is_serialized_json key => tap_hold.key_type key,
+      _ => 'unknown_key_type
+    },
+
+    rust_expr = match {
+      key if keyboard.is_serialized_json key => keyboard.rust_expr key,
+      key if layer_modifier.is_serialized_json key => layer_modifier.rust_expr key,
+      key if layered.is_serialized_json key => layered.rust_expr key,
+      key if tap_hold.is_serialized_json key => tap_hold.rust_expr key,
+      _ => 'unknown_key_type
+    },
+  },
 
   keymap_rs
     | doc "Text contents of the keymap.rs generated from the keymap.json"
-    = let { config, keys } = serialized_json_keymap &
-        {
+    =
+      let { config, keys } =
+        serialized_json_keymap
+        & {
           config = {
             tap_hold = {
               timeout | default = 200,
               interrupt_response | default = "Ignore",
             },
           },
-        } in
+        }
+      in
       let tap_hold_config_expr = m%"
         crate::key::tap_hold::Config {
             timeout: %{std.to_string config.tap_hold.timeout},
             interrupt_response: crate::key::tap_hold::InterruptResponse::%{config.tap_hold.interrupt_response},
         }
-      "% in
+      "%
+      in
       let keymap_len = std.array.length keys in
       let num_layers =
-        keys |>
-        std.array.fold_left
+        keys
+        |> std.array.fold_left
           (fun max_num_layers key =>
-            let num_layers = key |> match {
-              { layered, .. } => std.array.length layered,
-              _ => 0,
-            } in
+            let num_layers =
+              key
+              |> match {
+                { layered, .. } => std.array.length layered,
+                _ => 0,
+              }
+            in
             if num_layers > max_num_layers then
               num_layers
             else
-              max_num_layers)
-          0 in
+              max_num_layers
+          )
+          0
+      in
       let keys_id = "Keys%{std.to_string keymap_len}" in
-      let key_types = keys
+      let key_types =
+        keys
         |> std.array.map key.key_type
         |> std.array.map (fun key_type => key_type.as_rust_type_path)
-        |> std.string.join "," in
-      let key_exprs = keys
+        |> std.string.join ","
+      in
+      let key_exprs =
+        keys
         |> std.array.map (fun k => "%{key.rust_expr k},")
-        |> std.string.join "" in
+        |> std.string.join ""
+      in
       m%"
 /// Types and initial data used for constructing [KEYMAP].
 pub mod init {

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -33,12 +33,12 @@ let validators = import "validators.ncl" in
       {
         keymap_example_key_code = {
           actual = K.A,
-          expected = { key_code = 0x04 },
+          expected = { key_code = 4 },
         },
 
         check_serialized_key_code = {
           actual = K.A |> key.to_json_serialized,
-          expected = { key_code = 0x04 },
+          expected = { key_code = 4 },
         },
       },
 
@@ -126,10 +126,10 @@ let validators = import "validators.ncl" in
         keymap_example_layered_keyboard = {
           actual = K.A & { layered = [null, K.C] },
           expected = {
-            key_code = 0x04,
+            key_code = 4,
             layered = [
               null,
-              { key_code = 0x06 },
+              { key_code = 6 },
             ],
           },
         },
@@ -146,10 +146,10 @@ let validators = import "validators.ncl" in
         check_serialized_layered_keyboard = {
           actual = K.A & { layered = [null, K.C] } |> key.to_json_serialized,
           expected = {
-            base = { key_code = 0x04 },
+            base = { key_code = 4 },
             layered = [
               null,
-              { key_code = 0x06 },
+              { key_code = 6 },
             ],
           },
         },
@@ -196,7 +196,7 @@ let validators = import "validators.ncl" in
       {
         keymap_example_tap_keyboard_hold_keyboard = {
           actual = K.A & K.hold K.LeftCtrl,
-          expected = { key_code = 0x04, hold = { modifiers = { left_ctrl = true } } },
+          expected = { key_code = 4, hold = { modifiers = { left_ctrl = true } } },
         },
 
         check_tap_hold_tap_keyboard_is_key =
@@ -210,12 +210,12 @@ let validators = import "validators.ncl" in
 
         check_tap_keyboard_hold_keyboard_to_json_serialized_keyboard = {
           actual = K.A & K.hold K.LeftCtrl |> tap_hold.to_json_serialized,
-          expected = { tap = { key_code = 0x04 }, hold = { modifiers = { left_ctrl = true } } },
+          expected = { tap = { key_code = 4 }, hold = { modifiers = { left_ctrl = true } } },
         },
 
         check_serialized_tap_keyboard_hold_keyboard = {
           actual = K.A & K.hold K.LeftCtrl |> key.to_json_serialized,
-          expected = { tap = { key_code = 0x04 }, hold = { modifiers = { left_ctrl = true } } },
+          expected = { tap = { key_code = 4 }, hold = { modifiers = { left_ctrl = true } } },
         },
       },
 
@@ -313,7 +313,7 @@ let validators = import "validators.ncl" in
     = {
       check_layer_as_array_of_keys = {
         actual = layer_as_array_of_keys " A ",
-        expected = [{ key_code = 0x04 }],
+        expected = [{ key_code = 4 }],
       },
 
       check_layer_as_array_of_keys_tttt = {

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -1,16 +1,15 @@
 let validators = import "validators.ncl" in
 {
-  KeymapKey
-    = std.contract.any_of
-        [
-          keyboard.Key,
-          layer_modifier.Key,
-          layered.Key,
-          tap_hold.Key,
-          std.contract.from_validator validators.is_null,
-        ],
+  KeymapKey =
+    std.contract.any_of [
+      keyboard.Key,
+      layer_modifier.Key,
+      layered.Key,
+      tap_hold.Key,
+      std.contract.from_validator validators.is_null,
+    ],
 
-  KeymapLayer = std.contract.any_of [Array KeymapKey, String],
+  KeymapLayer = std.contract.any_of [ Array KeymapKey, String ],
 
   config = {},
 
@@ -28,35 +27,38 @@ let validators = import "validators.ncl" in
     | doc "Key extension which gets applied when using whitespace-delimited string keymap layers"
     = fun K => {},
 
-  checks.keyboard
-    = let K = import "keys.ncl" in
-      {
-        keymap_example_key_code = {
-          actual = K.A,
-          expected = { key_code = 4 },
-        },
-
-        check_serialized_key_code = {
-          actual = K.A |> key.to_json_serialized,
-          expected = { key_code = 4 },
-        },
+  checks.keyboard =
+    let K = import "keys.ncl" in
+    {
+      keymap_example_key_code = {
+        actual = K.A,
+        expected = { key_code = 4 },
       },
+
+      check_serialized_key_code = {
+        actual = K.A |> key.to_json_serialized,
+        expected = { key_code = 4 },
+      },
+    },
 
   keyboard
     | doc "for key::keyboard::Key."
     = {
-        Key = std.contract.from_validator key_validator,
+      Key = std.contract.from_validator key_validator,
 
-        key_validator
-          = validators.record.validator {
-              fields_validator = validators.all_of [
-                validators.record.has_any_field_of ["key_code", "modifiers"],
-                validators.record.has_only_fields ["key_code", "modifiers"],
-              ],
-              field_validators = {
-                key_code = validators.is_number,
-                modifiers = validators.record.validator {
-                  fields_validator = validators.record.has_only_fields [
+      key_validator =
+        validators.record.validator {
+          fields_validator =
+            validators.all_of [
+              validators.record.has_any_field_of ["key_code", "modifiers"],
+              validators.record.has_only_fields ["key_code", "modifiers"],
+            ],
+          field_validators = {
+            key_code = validators.is_number,
+            modifiers =
+              validators.record.validator {
+                fields_validator =
+                  validators.record.has_only_fields [
                     "left_ctrl",
                     "left_shift",
                     "left_alt",
@@ -66,283 +68,275 @@ let validators = import "validators.ncl" in
                     "right_alt",
                     "right_gui",
                   ],
-                  field_validators = {
-                    left_ctrl = validators.is_bool,
-                    left_shift = validators.is_bool,
-                    left_alt = validators.is_bool,
-                    left_gui = validators.is_bool,
-                    right_ctrl = validators.is_bool,
-                    right_shift = validators.is_bool,
-                    right_alt = validators.is_bool,
-                    right_gui = validators.is_bool,
-                  },
+                field_validators = {
+                  left_ctrl = validators.is_bool,
+                  left_shift = validators.is_bool,
+                  left_alt = validators.is_bool,
+                  left_gui = validators.is_bool,
+                  right_ctrl = validators.is_bool,
+                  right_shift = validators.is_bool,
+                  right_alt = validators.is_bool,
+                  right_gui = validators.is_bool,
                 },
               },
-            },
-
-        is_key
-          = fun k => 'Ok == key_validator k,
-
-        to_json_serialized
-          = fun key => key,
-      },
-
-  checks.layer_modifier
-    = let K = import "keys.ncl" in {
-        keymap_example_hold = {
-          actual = K.layer_mod.hold 0,
-          expected = { layer_modifier.hold = 0 },
+          },
         },
 
-        check_serialized_hold = {
-          actual = K.layer_mod.hold 0 |> key.to_json_serialized,
-          expected = { Hold = 0 },
-        },
+      is_key = fun k => 'Ok == key_validator k,
+
+      to_json_serialized = fun key => key,
+    },
+
+  checks.layer_modifier =
+    let K = import "keys.ncl" in
+    {
+      keymap_example_hold = {
+        actual = K.layer_mod.hold 0,
+        expected = { layer_modifier.hold = 0 },
       },
+
+      check_serialized_hold = {
+        actual = K.layer_mod.hold 0 |> key.to_json_serialized,
+        expected = { Hold = 0 },
+      },
+    },
 
   layer_modifier
     | doc "for key::layered::ModifierKey."
     = {
-        Key = std.contract.from_validator key_validator,
+      Key = std.contract.from_validator key_validator,
 
-        key_validator
-          = fun k => k |>
-              match {
-                { layer_modifier = { hold } } => validators.is_number hold,
-                _ => 'Error { message = "expected { layer_modifier = { hold } }" },
-              },
-
-        is_key
-          = fun k => 'Ok == key_validator k,
-
-        to_json_serialized
-          = fun { layer_modifier = { hold = hold_layer } } =>
-              { Hold = hold_layer },
-      },
-
-  checks.layered
-    = let K = import "keys.ncl" in
-      {
-        keymap_example_layered_keyboard = {
-          actual = K.A & { layered = [null, K.C] },
-          expected = {
-            key_code = 4,
-            layered = [
-              null,
-              { key_code = 6 },
-            ],
-          },
+      key_validator = fun k =>
+        k
+        |> match {
+          { layer_modifier = { hold } } => validators.is_number hold,
+          _ => 'Error { message = "expected { layer_modifier = { hold } }" },
         },
 
-        check_layered_base_keyboard_base_is_key =
-          let k = K.A & { layered = [null, K.C] } in
-          let { layered, ..base_key } = k in
-          key.is_key base_key,
+      is_key = fun k => 'Ok == key_validator k,
 
-        check_layered_base_keyboard_is_key =
-          let key = K.A & { layered = [null, K.C] } in
-          layered.is_key key,
+      to_json_serialized = fun { layer_modifier = { hold = hold_layer } } =>
+        { Hold = hold_layer },
+    },
 
-        check_serialized_layered_keyboard = {
-          actual = K.A & { layered = [null, K.C] } |> key.to_json_serialized,
-          expected = {
-            base = { key_code = 4 },
-            layered = [
-              null,
-              { key_code = 6 },
-            ],
-          },
+  checks.layered =
+    let K = import "keys.ncl" in
+    {
+      keymap_example_layered_keyboard = {
+        actual = K.A & { layered = [ null, K.C] },
+        expected = {
+          key_code = 4,
+          layered = [
+            null,
+            { key_code = 6 },
+          ],
         },
       },
+
+      check_layered_base_keyboard_base_is_key =
+        let k = K.A & { layered = [ null, K.C] } in
+        let { layered, ..base_key } = k in
+        key.is_key base_key,
+
+      check_layered_base_keyboard_is_key =
+        let key = K.A & { layered = [ null, K.C] } in
+        layered.is_key key,
+
+      check_serialized_layered_keyboard = {
+        actual = K.A & { layered = [ null, K.C] } |> key.to_json_serialized,
+        expected = {
+          base = { key_code = 4 },
+          layered = [
+            null,
+            { key_code = 6 },
+          ],
+        },
+      },
+    },
 
   layered
     | doc "for key::layered::LayeredKey."
     = {
-        Key = std.contract.from_validator key_validator,
+      Key = std.contract.from_validator key_validator,
 
-        key_validator
-          = fun k => k |> match {
-              { layered, ..base_key } =>
-                let valid_layered =
-                  layered |>
-                    validators.array.validator (
-                      validators.any_of [validators.is_null, key.key_validator]
-                    ) in
-                let valid_base_key = key.key_validator base_key in
-                [valid_layered, valid_base_key] |> match {
-                  ['Ok, 'Ok] => 'Ok,
-                  [err, _] => err,
-                  [_, err] => err,
-                },
-              _ => 'Error { message = "expected { layered = Array Key, ..base_key }" },
+      key_validator = fun k =>
+        k
+        |> match {
+          { layered, ..base_key } =>
+            let valid_layered =
+              layered
+              |> validators.array.validator (
+                validators.any_of [validators.is_null, key.key_validator]
+              )
+            in
+            let valid_base_key = key.key_validator base_key in
+            [valid_layered, valid_base_key]
+            |> match {
+              ['Ok, 'Ok] => 'Ok,
+              [err, _] => err,
+              [_, err] => err,
             },
+          _ => 'Error { message = "expected { layered = Array Key, ..base_key }" },
+        },
 
-        is_key
-          = fun k => 'Ok == key_validator k,
+      is_key = fun k => 'Ok == key_validator k,
 
-        to_json_serialized
-          = fun { layered = layered_keys, ..base_key } =>
-              {
-                base = key.to_json_serialized base_key,
-                layered =
-                  std.array.map
-                    (fun k => if k != null then key.to_json_serialized k else null)
-                    layered_keys,
-              },
+      to_json_serialized = fun { layered = layered_keys, ..base_key } =>
+        {
+          base = key.to_json_serialized base_key,
+          layered =
+            std.array.map
+              (fun k => if k != null then key.to_json_serialized k else null)
+              layered_keys,
+        },
+    },
+
+  checks.tap_hold =
+    let K = import "keys.ncl" in
+    {
+      keymap_example_tap_keyboard_hold_keyboard = {
+        actual = K.A & K.hold K.LeftCtrl,
+        expected = { key_code = 4, hold = { modifiers = { left_ctrl = true } } },
       },
 
-  checks.tap_hold
-    = let K = import "keys.ncl" in
-      {
-        keymap_example_tap_keyboard_hold_keyboard = {
-          actual = K.A & K.hold K.LeftCtrl,
-          expected = { key_code = 4, hold = { modifiers = { left_ctrl = true } } },
-        },
+      check_tap_hold_tap_keyboard_is_key =
+        let k = K.A & K.hold K.LeftCtrl in
+        let { hold, ..tap_key } = k in
+        key.is_key tap_key,
 
-        check_tap_hold_tap_keyboard_is_key =
-          let k = K.A & K.hold K.LeftCtrl  in
-          let { hold, ..tap_key } = k in
-          key.is_key tap_key,
+      check_tap_keyboard_hold_keyboard_is_key =
+        let key = K.A & K.hold K.LeftCtrl in
+        tap_hold.is_key key,
 
-        check_tap_keyboard_hold_keyboard_is_key =
-          let key = K.A & K.hold K.LeftCtrl  in
-          tap_hold.is_key key,
-
-        check_tap_keyboard_hold_keyboard_to_json_serialized_keyboard = {
-          actual = K.A & K.hold K.LeftCtrl |> tap_hold.to_json_serialized,
-          expected = { tap = { key_code = 4 }, hold = { modifiers = { left_ctrl = true } } },
-        },
-
-        check_serialized_tap_keyboard_hold_keyboard = {
-          actual = K.A & K.hold K.LeftCtrl |> key.to_json_serialized,
-          expected = { tap = { key_code = 4 }, hold = { modifiers = { left_ctrl = true } } },
-        },
+      check_tap_keyboard_hold_keyboard_to_json_serialized_keyboard = {
+        actual = K.A & K.hold K.LeftCtrl |> tap_hold.to_json_serialized,
+        expected = { tap = { key_code = 4 }, hold = { modifiers = { left_ctrl = true } } },
       },
+
+      check_serialized_tap_keyboard_hold_keyboard = {
+        actual = K.A & K.hold K.LeftCtrl |> key.to_json_serialized,
+        expected = { tap = { key_code = 4 }, hold = { modifiers = { left_ctrl = true } } },
+      },
+    },
 
   tap_hold
     | doc "for key::tap_hold::Key."
     = {
-        Key = std.contract.from_validator key_validator,
+      Key = std.contract.from_validator key_validator,
 
-        key_validator
-          = fun k => k |>
-              match {
-                { hold = hold_key, ..tap_key } =>
-                  let valid_hold_key = key.key_validator hold_key in
-                  let valid_tap_key = key.key_validator tap_key in
-                  [valid_hold_key, valid_tap_key] |> match {
-                    ['Ok, 'Ok] => 'Ok,
-                    [err, _] => err,
-                    [_, err] => err,
-                  },
-                _ => 'Error { message = "expected { hold = Key, ..tap_key }" },
-              },
-
-        is_key
-          = fun k => 'Ok == key_validator k,
-
-        to_json_serialized
-          = fun { hold = hold_key, ..tap_key } =>
-              {
-                hold = key.to_json_serialized hold_key,
-                tap = key.to_json_serialized tap_key,
-              },
-      },
-
-  key
-    = {
-        Key = std.contract.from_validator key_validator,
-
-        key_validator
-          = fun k => k |>
-              validators.any_of [
-                keyboard.key_validator,
-                layer_modifier.key_validator,
-                layered.key_validator,
-                tap_hold.key_validator,
-              ],
-
-        is_key
-          = fun k => 'Ok == key_validator k,
-
-        to_json_serialized
-          = match {
-              # Make key::layered::LayeredKey
-              k if layered.is_key k => layered.to_json_serialized k,
-              # Make key::tap_hold::Key from keys with a "hold" modifier.
-              k if tap_hold.is_key k => tap_hold.to_json_serialized k,
-              # Otherwise, keys with just a base key_code are key::keyboard keys.
-              k if keyboard.is_key k => keyboard.to_json_serialized k,
-              # Make key::layered::ModifierKey
-              k if layer_modifier.is_key k => layer_modifier.to_json_serialized k,
-              # Null values (None) stay null
-              null => null,
-              _ => std.fail_with "unsupported item in keymap.ncl",
+      key_validator = fun k =>
+        k
+        |> match {
+          { hold = hold_key, ..tap_key } =>
+            let valid_hold_key = key.key_validator hold_key in
+            let valid_tap_key = key.key_validator tap_key in
+            [valid_hold_key, valid_tap_key]
+            |> match {
+              ['Ok, 'Ok] => 'Ok,
+              [err, _] => err,
+              [_, err] => err,
             },
-      },
+          _ => 'Error { message = "expected { hold = Key, ..tap_key }" },
+        },
 
-  checks.check_words_from_whitespace_delimited_string
-    = {
-      check_words_from_whitespace_delimited_string = {
-        actual = words_from_whitespace_delimited_string "   a b  c ",
-        expected = ["a", "b", "c"],
-      },
+      is_key = fun k => 'Ok == key_validator k,
+
+      to_json_serialized = fun { hold = hold_key, ..tap_key } =>
+        {
+          hold = key.to_json_serialized hold_key,
+          tap = key.to_json_serialized tap_key,
+        },
     },
+
+  key = {
+    Key = std.contract.from_validator key_validator,
+
+    key_validator = fun k =>
+      k
+      |> validators.any_of [
+        keyboard.key_validator,
+        layer_modifier.key_validator,
+        layered.key_validator,
+        tap_hold.key_validator,
+      ],
+
+    is_key = fun k => 'Ok == key_validator k,
+
+    to_json_serialized = match {
+      # Make key::layered::LayeredKey
+      k if layered.is_key k => layered.to_json_serialized k,
+      # Make key::tap_hold::Key from keys with a "hold" modifier.
+      k if tap_hold.is_key k => tap_hold.to_json_serialized k,
+      # Otherwise, keys with just a base key_code are key::keyboard keys.
+      k if keyboard.is_key k => keyboard.to_json_serialized k,
+      # Make key::layered::ModifierKey
+      k if layer_modifier.is_key k => layer_modifier.to_json_serialized k,
+      # Null values (None) stay null
+      null => null,
+      _ => std.fail_with "unsupported item in keymap.ncl",
+    },
+  },
+
+  checks.check_words_from_whitespace_delimited_string = {
+    check_words_from_whitespace_delimited_string = {
+      actual = words_from_whitespace_delimited_string "   a b  c ",
+      expected = ["a", "b", "c"],
+    },
+  },
 
   words_from_whitespace_delimited_string
     | doc "Return array of fields from whitespace-delimited string."
     = fun s =>
-        s |> std.string.replace_regex "\\s+" " "
-          |> std.string.split " "
-          |> std.array.filter ((!=) ""),
+      s
+      |> std.string.replace_regex "\\s+" " "
+      |> std.string.split " "
+      |> std.array.filter ((!=) ""),
 
-  checks.check_map_fields_with_record
-    = {
-      check_map_fields_with_record = {
-        actual = map_fields_with_record { a = 1, b = 2, c = 3 } ["a", "c"],
-        expected = [1, 3],
-      },
+  checks.check_map_fields_with_record = {
+    check_map_fields_with_record = {
+      actual = map_fields_with_record { a = 1, b = 2, c = 3 } ["a", "c"],
+      expected = [1, 3],
     },
+  },
 
   map_fields_with_record
     | doc "Maps each field in an array to the value of the given record."
     = fun record fields =>
-        fields |> std.array.map (std.function.flip std.record.get record),
+      fields |> std.array.map (std.function.flip std.record.get record),
 
-  checks.check_layer_as_array_of_keys
-    = {
-      check_layer_as_array_of_keys = {
-        actual = layer_as_array_of_keys " A ",
-        expected = [{ key_code = 4 }],
-      },
-
-      check_layer_as_array_of_keys_tttt = {
-        actual = layer_as_array_of_keys " TTTT ",
-        expected = [null],
-      },
+  checks.check_layer_as_array_of_keys = {
+    check_layer_as_array_of_keys = {
+      actual = layer_as_array_of_keys " A ",
+      expected = [{ key_code = 4 }],
     },
+
+    check_layer_as_array_of_keys_tttt = {
+      actual = layer_as_array_of_keys " TTTT ",
+      expected = [ null ],
+    },
+  },
 
   # Return array-of-keys representation of layer.
   #
   # A KeymapLayer may be either:
   #   - Array Key
   #   - String
-  layer_as_array_of_keys
-    = fun l =>
-        if std.is_string l then
-          let { extend_keys, .. } = import "key-extensions.ncl" in
-          let K = extend_keys (import "keys.ncl") custom_keys in
-          l |> words_from_whitespace_delimited_string
-            |> map_fields_with_record K
-        else
-          l,
+  layer_as_array_of_keys = fun l =>
+    if std.is_string l then
+      let { extend_keys, .. } = import "key-extensions.ncl" in
+      let K = extend_keys (import "keys.ncl") custom_keys in
+      l
+      |> words_from_whitespace_delimited_string
+      |> map_fields_with_record K
+    else
+      l,
 
   layered_keys
     | doc "Constructs array of key::layered::LayeredKey values from layers."
-    = if std.array.length layers == 0 then
+    =
+      if std.array.length layers == 0 then
         std.fail_with "keys or layers must be provided"
-      else
-      if std.array.length layers <= 1 then
+      else if std.array.length layers <= 1 then
         std.array.at 0 layers
       else
         let layers = layers |> std.array.map layer_as_array_of_keys in
@@ -356,13 +350,15 @@ let validators = import "validators.ncl" in
             if no_layered then
               base_key
             else
-              base_key & { layered = layered_ })
+              base_key & { layered = layered_ }
+          )
           (std.array.length base_keys),
 
   serialized_json_keymap
     | default
     | doc "The keymap.json output value."
-    = let config_ = config in
+    =
+      let config_ = config in
       {
         keys = layered_keys |> std.array.map key.to_json_serialized,
         config = config_,

--- a/ncl/layouts/split_3x5+3.ncl
+++ b/ncl/layouts/split_3x5+3.ncl
@@ -1,13 +1,12 @@
 {
-  into_layout
-    = fun from_split_3x5_3 split_3x5_3_keymap =>
-        let split_3x5_3_layers =
-          let km_aug = import "keymap-ncl-to-json.ncl" in
-          split_3x5_3_keymap.layers
-            |> std.array.map (split_3x5_3_keymap & km_aug).layer_as_array_of_keys
-        in
-        (std.record.remove "layers" split_3x5_3_keymap) &
-        {
-          layers = std.array.map from_split_3x5_3 split_3x5_3_layers
-        },
+  into_layout = fun from_split_3x5_3 split_3x5_3_keymap =>
+    let split_3x5_3_layers =
+      let km_aug = import "keymap-ncl-to-json.ncl" in
+      split_3x5_3_keymap.layers
+      |> std.array.map (split_3x5_3_keymap & km_aug).layer_as_array_of_keys
+    in
+    (std.record.remove "layers" split_3x5_3_keymap)
+    & {
+      layers = std.array.map from_split_3x5_3 split_3x5_3_layers
+    },
 }

--- a/ncl/ncl.mk
+++ b/ncl/ncl.mk
@@ -15,3 +15,21 @@ test-ncl-checks:
 
 %/keymap.rs: %/keymap.json
 	ncl/scripts/keymap-codegen.sh $(shell dirname $@)
+
+# Some NCL code uses hexadecimal representation (0x00)
+#  which is not supported by `nickel format`.
+#
+# uses hex-formatted numbers:
+#   ncl/hid-usage-keyboard.ncl
+.PHONY: ncl-format
+ncl-format:
+	nickel format \
+	   ncl/layouts/split_3x5+3.ncl \
+	   ncl/checks.ncl \
+	   ncl/hid-report.ncl \
+	   ncl/import-keymap-json.ncl \
+       ncl/key-extensions.ncl  \
+       ncl/keymap-ncl-to-json.ncl \
+	   ncl/keymap-codegen.ncl \
+	   ncl/keys.ncl \
+	   ncl/validators.ncl

--- a/ncl/validators.ncl
+++ b/ncl/validators.ncl
@@ -1,245 +1,230 @@
 {
-  Validator
-    = Dyn ->
-      [|
-        'Ok,
-        'Error { message | String | optional, notes | Array String | optional, }
-      |],
+  Validator =
+    Dyn -> [|
+      'Ok,
+      'Error { message | String | optional, notes | Array String | optional, }
+    |],
 
-  check_is_error
-    = fun c =>
-        c |> match {
-          'Error _ => true,
-          _ => false,
-        },
+  check_is_error = fun c =>
+    c
+    |> match {
+      'Error _ => true,
+      _ => false,
+    },
 
-  ok
-    = std.function.const 'Ok,
+  ok = std.function.const 'Ok,
 
-  fail
-    = std.function.const ('Error {}),
+  fail = std.function.const ('Error {}),
 
-  is_array
-    = fun v =>
-        if std.is_array v then
-          'Ok
-        else
-          'Error { message = "Expected array" },
+  is_array = fun v =>
+    if std.is_array v then
+      'Ok
+    else
+      'Error { message = "Expected array" },
 
-  is_bool
-    = fun v =>
-        if std.is_bool v then
-          'Ok
-        else
-          'Error { message = "Expected bool" },
+  is_bool = fun v =>
+    if std.is_bool v then
+      'Ok
+    else
+      'Error { message = "Expected bool" },
 
-  is_null
-    = fun v =>
-        if v == null then
-          'Ok
-        else
-          'Error { message = "Expected null" },
+  is_null = fun v =>
+    if v == null then
+      'Ok
+    else
+      'Error { message = "Expected null" },
 
-  is_number
-    = fun v =>
-        if std.is_number v then
-          'Ok
-        else
-          'Error { message = "Expected number" },
+  is_number = fun v =>
+    if std.is_number v then
+      'Ok
+    else
+      'Error { message = "Expected number" },
 
-  is_record
-    = fun v =>
-        if std.is_record v then
-          'Ok
-        else
-          'Error { message = "Expected record" },
+  is_record = fun v =>
+    if std.is_record v then
+      'Ok
+    else
+      'Error { message = "Expected record" },
 
-  is_string
-    = fun v =>
-        if std.is_string v then
-          'Ok
-        else
-          'Error { message = "Expected string" },
+  is_string = fun v =>
+    if std.is_string v then
+      'Ok
+    else
+      'Error { message = "Expected string" },
 
-  checks.all_of
-    = {
-        all_ok_is_ok = {
-          expected = 'Ok,
-          actual = all_of [ok, ok, ok] {},
-        },
+  checks.all_of = {
+    all_ok_is_ok = {
+      expected = 'Ok,
+      actual = all_of [ok, ok, ok] {},
+    },
 
-        any_fail_is_error = {
-          expected = 'Error {},
-          actual = all_of [ok, fail, ok] {},
-        },
-      },
-
-  all_of
-    = fun validators v =>
-        validators |> match {
-          [] => 'Ok,
-          [validator, ..validators] =>
-            validator v |> match {
-              'Ok => all_of validators v,
-              err => err,
-            },
-        },
-
-  checks.check_any_of
-    = {
-        any_ok_is_ok = {
-          expected = 'Ok,
-          actual = any_of [fail, fail, ok] {},
-        },
-        empty_is_error =
-           any_of [] {} |> check_is_error,
-      },
-
-  any_of
-    = fun validators v =>
-        validators |> match {
-          [] => 'Error { message = "No validators satisfied" },
-          [validator, ..validators] =>
-            validator v |> match {
-              'Ok => 'Ok,
-              err => any_of validators v,
-            },
-        },
-
-  checks.check_array_validators
-    = {
-        check_validator
-          = 'Ok == array.validator is_number [1, 2, 3],
-      },
-
-  array = {
-    validator
-      = fun elements_validator a => a |> is_array |> match {
-            'Ok =>
-              let rec validate_elements = fun elements =>
-                elements |> match {
-                  [] => 'Ok,
-                  [element, ..elements] =>
-                    elements_validator element |> match {
-                      'Ok => validate_elements elements,
-                      err => err,
-                    }
-                } in
-                a |> validate_elements,
-
-            err => err,
-          },
+    any_fail_is_error = {
+      expected = 'Error {},
+      actual = all_of [ok, fail, ok] {},
+    },
   },
 
-  checks.check_record_validators
-    = {
-        check_has_any_field_of
-          = 'Ok == record.has_any_field_of ["x", "y"] { x = 3, z = 5 },
+  all_of = fun validators v =>
+    validators
+    |> match {
+      [] => 'Ok,
+      [validator, ..validators] =>
+        validator v
+        |> match {
+          'Ok => all_of validators v,
+          err => err,
+        },
+    },
 
-        check_has_only_fields
-          = 'Ok == record.has_only_fields ["x", "y"] { x = 3 },
+  checks.check_any_of = {
+    any_ok_is_ok = {
+      expected = 'Ok,
+      actual = any_of [fail, fail, ok] {},
+    },
+    empty_is_error =
+      any_of [] {} |> check_is_error,
+  },
 
-        check_has_exact_fields
-          = 'Ok == record.has_exact_fields ["x"] { x = 3 },
+  any_of = fun validators v =>
+    validators
+    |> match {
+      [] => 'Error { message = "No validators satisfied" },
+      [validator, ..validators] =>
+        validator v
+        |> match {
+          'Ok => 'Ok,
+          err => any_of validators v,
+        },
+    },
 
-        check_has_exact_fields_missing_err
-          = record.has_exact_fields ["x", "y"] { x = 3 } |> check_is_error,
+  checks.check_array_validators = {
+    check_validator = 'Ok == array.validator is_number [1, 2, 3],
+  },
 
-        check_has_exact_fields_extra_err
-          = record.has_exact_fields ["x"] { x = 3, y = 4 } |> check_is_error,
-
-        check_validator
-          = 'Ok
-            ==
-            record.validator
-              {
-                fields_validator = record.has_only_fields ["x", "y"],
-                field_validators = {
-                  x = is_number,
-                },
-              }
-              { x = 3 },
+  array = {
+    validator = fun elements_validator a =>
+      a
+      |> is_array
+      |> match {
+        'Ok =>
+          let rec validate_elements = fun elements =>
+            elements
+            |> match {
+              [] => 'Ok,
+              [element, ..elements] =>
+                elements_validator element
+                |> match {
+                  'Ok => validate_elements elements,
+                  err => err,
+                }
+            }
+          in
+          a |> validate_elements,
+        err => err,
       },
+  },
 
-  record
-    = {
-        has_all_fields
-          = fun fields r =>
-              if fields |> std.array.all (fun f => std.array.elem f (std.record.fields r)) then
-                'Ok
-              else
-                'Error {
-                  message = "Missing fields",
-                  notes = [
-                    "Expected all of: %{fields |> std.serialize},",
-                    "Found: %{r |> std.record.fields}"
-                  ],
-                },
+  checks.check_record_validators = {
+    check_has_any_field_of = 'Ok == record.has_any_field_of ["x", "y"] { x = 3, z = 5 },
 
-        has_any_field_of
-          = fun fields r =>
-              if r |> std.record.fields |> std.array.length == 0 then
-                'Error { message = "record has no fields" }
-              else if r |> std.record.fields |> std.array.any (fun f => std.array.elem f fields) then
-                'Ok
-              else
-                'Error {
-                  message = "Unexpected fields",
-                  notes = [
-                    "Expected any of: %{fields |> std.serialize},",
-                    "Found: %{r |> std.record.fields}"
-                  ],
-                },
+    check_has_only_fields = 'Ok == record.has_only_fields ["x", "y"] { x = 3 },
 
-        has_exact_fields
-          = fun fields r =>
-              all_of
-                [
-                  has_all_fields fields,
-                  has_only_fields fields,
-                ]
-                r,
+    check_has_exact_fields = 'Ok == record.has_exact_fields ["x"] { x = 3 },
 
-        has_only_fields
-          = fun fields r =>
-              if r |> std.record.fields |> std.array.all (fun f => std.array.elem f fields) then
-                'Ok
-              else
-                'Error {
-                  message = "Unexpected fields",
-                  notes = [
-                    "Expected only: %{fields |> std.serialize},",
-                    "Found: %{r |> std.record.fields}"
-                  ],
-                },
+    check_has_exact_fields_missing_err = record.has_exact_fields ["x", "y"] { x = 3 } |> check_is_error,
 
-        validator
-          = fun { fields_validator, field_validators } r =>
-              r |> is_record |> match {
-                'Ok =>
-                  r |> fields_validator |> match {
-                    'Ok =>
-                      let rec validate_fields = fun fields =>
-                        fields |> match {
-                          [] => 'Ok,
-                          [field, ..fields] =>
-                            (if std.record.has_field field field_validators then
-                              let v = std.record.get field r in
-                              let validator = std.record.get field field_validators in
-                              validator v
-                            else
-                              'Ok) |>
-                            match {
-                              'Ok => validate_fields fields,
-                              err => err,
-                            }
-                        } in
-                        r |> std.record.fields |> validate_fields,
+    check_has_exact_fields_extra_err = record.has_exact_fields ["x"] { x = 3, y = 4 } |> check_is_error,
 
-                    err => err,
-                  },
+    check_validator =
+      'Ok == record.validator
+        {
+          fields_validator = record.has_only_fields ["x", "y"],
+          field_validators = {
+            x = is_number,
+          },
+        }
+        { x = 3 },
+  },
 
-                err => err,
-              }
-      },
+  record = {
+    has_all_fields = fun fields r =>
+      if fields |> std.array.all (fun f => std.array.elem f (std.record.fields r)) then
+        'Ok
+      else
+        'Error {
+          message = "Missing fields",
+          notes = [
+            "Expected all of: %{fields |> std.serialize},",
+            "Found: %{r |> std.record.fields}"
+          ],
+        },
+
+    has_any_field_of = fun fields r =>
+      if r |> std.record.fields |> std.array.length == 0 then
+        'Error { message = "record has no fields" }
+      else if r |> std.record.fields |> std.array.any (fun f => std.array.elem f fields) then
+        'Ok
+      else
+        'Error {
+          message = "Unexpected fields",
+          notes = [
+            "Expected any of: %{fields |> std.serialize},",
+            "Found: %{r |> std.record.fields}"
+          ],
+        },
+
+    has_exact_fields = fun fields r =>
+      all_of
+        [
+          has_all_fields fields,
+          has_only_fields fields,
+        ]
+        r,
+
+    has_only_fields = fun fields r =>
+      if r |> std.record.fields |> std.array.all (fun f => std.array.elem f fields) then
+        'Ok
+      else
+        'Error {
+          message = "Unexpected fields",
+          notes = [
+            "Expected only: %{fields |> std.serialize},",
+            "Found: %{r |> std.record.fields}"
+          ],
+        },
+
+    validator = fun { fields_validator, field_validators } r =>
+      r
+      |> is_record
+      |> match {
+        'Ok =>
+          r
+          |> fields_validator
+          |> match {
+            'Ok =>
+              let rec validate_fields = fun fields =>
+                fields
+                |> match {
+                  [] => 'Ok,
+                  [field, ..fields] =>
+                    (
+                      if std.record.has_field field field_validators then
+                        let v = std.record.get field r in
+                        let validator = std.record.get field field_validators in
+                        validator v
+                      else
+                        'Ok
+                    )
+                    |> match {
+                      'Ok => validate_fields fields,
+                      err => err,
+                    }
+                }
+              in
+              r |> std.record.fields |> validate_fields,
+            err => err,
+          },
+        err => err,
+      }
+  },
 }


### PR DESCRIPTION
At the time of writing, `nickel format` doesn't support hexadecimal-representation of numbers.

This discouraged me from using `nickel format`.

I've since decided that automatic formatting is more useful than use of hex-represented numbers.

I think nickel suffers a similar downside as OCaml, where "how am I supposed to align this" seems to have ugly answers. -- I'd rather rely on `nickel format` to do that.