### PR TITLE
Nickel Codegen: construct codegen_values

### DIFF
--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -274,6 +274,30 @@ let validators = import "validators.ncl" in
       }
       in
       tap_hold.is_serialized_json serialized_value,
+
+    check_taphold_codegen_values = {
+      # Current impl: tap_hold::Key<keyboard::Key> is still th::Key<composite::Base>
+      check_taphold_keyboard =
+        let k = {
+          hold = { key_code = 224 },
+          tap = { key_code = 4 },
+        }
+        in
+        let cv = tap_hold.codegen_values k in
+        {
+          check_key_type = {
+            actual = cv.key_type,
+            expected = {
+              as_rust_type_path = "crate::key::tap_hold::Key<crate::key::composite::BaseKey>",
+              key_type = "crate::key::tap_hold::Key",
+            }
+          },
+          check_rust_expr = {
+            actual = cv.rust_expr,
+            expected = "crate::key::tap_hold::Key::new(crate::key::composite::BaseKey::keyboard(crate::key::keyboard::Key::new(4)), crate::key::composite::BaseKey::keyboard(crate::key::keyboard::Key::new(224)))",
+          },
+        },
+    },
   },
 
   tap_hold

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -274,8 +274,11 @@ let validators = import "validators.ncl" in
       codegen_values = fun k @ { base, layered } =>
         let base_codegen_values = key.codegen_values base in
         let non_null_layered = std.array.filter ((!=) null) layered in
+        let layered_codegen_values =
+          std.array.map (fun k => if k != null then key.codegen_values k else null) layered
+        in
         let nn_layered_codegen_values =
-          std.array.map key.codegen_values non_null_layered
+          std.array.filter ((!=) null) layered_codegen_values
         in
 
         # c.f. doc_de_layered.md.
@@ -289,7 +292,7 @@ let validators = import "validators.ncl" in
             if std.array.all (fun kt => kt == base_key_type) layered_key_types then
               base_key_type
             else
-              (composite.tap_hold_key.codegen_values base).key_type
+              (composite.tap_hold_key.codegen_values base_codegen_values).key_type
           in
           {
             key_type = "crate::key::layered::LayeredKey",
@@ -302,14 +305,14 @@ let validators = import "validators.ncl" in
           let layered_key_types = std.array.map (fun { key_type, .. } => key_type) nn_layered_codegen_values in
           let nk_expr =
             if std.array.all (fun kt => kt == base_key_type) layered_key_types then
-              fun k => (key.codegen_values k).rust_expr
+              fun cv => cv.rust_expr
             else
-              fun k => (composite.tap_hold_key.codegen_values k).rust_expr
+              fun cv => (composite.tap_hold_key.codegen_values cv).rust_expr
           in
-          let base_expr = nk_expr base in
+          let base_expr = nk_expr base_codegen_values in
           let layered_exprs =
-            layered
-            |> std.array.map (fun lk => if lk == null then "None" else "Some(%{nk_expr lk})")
+            layered_codegen_values
+            |> std.array.map (fun cv => if cv == null then "None" else "Some(%{nk_expr cv})")
             |> std.string.join ","
           in
           "crate::key::layered::LayeredKey::new(%{base_expr}, [%{layered_exprs}])"
@@ -387,7 +390,7 @@ let validators = import "validators.ncl" in
           #     tap_key_type
           #   else
           #     composite.base_key.key_type tap in
-          let nested_key_type = (composite.base_key.codegen_values tap).key_type in
+          let nested_key_type = (composite.base_key.codegen_values tap_codegen_values).key_type in
           {
             key_type = "crate::key::tap_hold::Key",
             as_rust_type_path = "%{key_type}<%{nested_key_type.as_rust_type_path}>"
@@ -402,9 +405,9 @@ let validators = import "validators.ncl" in
           #     key.rust_expr
           #   else
           #     composite.base_key.rust_expr in
-          let nk_expr = fun k => (composite.base_key.codegen_values k).rust_expr in
-          let hold_expr = nk_expr hold in
-          let tap_expr = nk_expr tap in
+          let nk_expr = fun cv => (composite.base_key.codegen_values cv).rust_expr in
+          let hold_expr = nk_expr hold_codegen_values in
+          let tap_expr = nk_expr tap_codegen_values in
           "crate::key::tap_hold::Key::new(%{tap_expr}, %{hold_expr})"
         in
 
@@ -420,7 +423,8 @@ let validators = import "validators.ncl" in
       # A keyboard::Key lifted to composite::BaseKey
       check_base_key_keyboard =
         let k = { key_code = 4 } in
-        let cv = composite.base_key.codegen_values k in
+        let kcv = keyboard.codegen_values k in
+        let cv = composite.base_key.codegen_values kcv in
         {
           check_key_type = {
             actual = cv.key_type,
@@ -440,7 +444,8 @@ let validators = import "validators.ncl" in
       # A keyboard::Key lifted to composite::TapHoldKey
       check_tap_hold_key_keyboard =
         let k = { key_code = 4 } in
-        let cv = composite.tap_hold_key.codegen_values k in
+        let kcv = keyboard.codegen_values k in
+        let cv = composite.tap_hold_key.codegen_values kcv in
         {
           check_key_type = {
             actual = cv.key_type,
@@ -471,8 +476,8 @@ let validators = import "validators.ncl" in
       is_serialized_json = fun k => 'Ok == serialized_json_validator k,
 
       codegen_values = match {
-        k if layer_modifier.is_serialized_json k =>
-          let { rust_expr = k_expr, .. } = layer_modifier.codegen_values k in
+        cv @ { serialized_json = k, .. } if layer_modifier.is_serialized_json k =>
+          let { rust_expr = k_expr, .. } = cv in
           {
             key_type = {
               key_type = "crate::key::composite::BaseKey",
@@ -481,8 +486,8 @@ let validators = import "validators.ncl" in
             rust_expr = "crate::key::composite::BaseKey::layer_modifier(%{k_expr})",
             serialized_json = k,
           },
-        k if keyboard.is_serialized_json k =>
-          let { rust_expr = k_expr, .. } = keyboard.codegen_values k in
+        cv @ { serialized_json = k, .. } if keyboard.is_serialized_json k =>
+          let { rust_expr = k_expr, .. } = cv in
           {
             key_type = {
               key_type = "crate::key::composite::BaseKey",
@@ -507,8 +512,8 @@ let validators = import "validators.ncl" in
       is_serialized_json = fun k => 'Ok == serialized_json_validator k,
 
       codegen_values = match {
-        k if tap_hold.is_serialized_json k =>
-          let { key_type = k_key_type, rust_expr = k_expr, .. } = tap_hold.codegen_values k in
+        cv @ { serialized_json = k, .. } if tap_hold.is_serialized_json k =>
+          let { key_type = k_key_type, rust_expr = k_expr, .. } = cv in
           {
             key_type = {
               key_type = "crate::key::composite::TapHoldKey",
@@ -518,8 +523,8 @@ let validators = import "validators.ncl" in
             rust_expr = "crate::key::composite::TapHoldKey::tap_hold(%{k_expr})",
             serialized_json = k,
           },
-        k if composite.base_key.is_serialized_json k =>
-          let { key_type = k_key_type, rust_expr = k_expr, .. } = composite.base_key.codegen_values k in
+        cv @ { serialized_json = k, .. } if composite.base_key.is_serialized_json k =>
+          let { key_type = k_key_type, rust_expr = k_expr, .. } = composite.base_key.codegen_values cv in
           {
             key_type = {
               key_type = "crate::key::composite::TapHoldKey",
@@ -545,8 +550,8 @@ let validators = import "validators.ncl" in
       is_serialized_json = fun k => 'Ok == serialized_json_validator k,
 
       codegen_values = match {
-        k if layered.is_serialized_json k =>
-          let { key_type = k_key_type, rust_expr = k_expr, .. } = layered.codegen_values k in
+        cv @ { serialized_json = k, .. } if layered.is_serialized_json k =>
+          let { key_type = k_key_type, rust_expr = k_expr, .. } = cv in
           {
             key_type = {
               key_type = "crate::key::composite::LayeredKey",
@@ -556,8 +561,8 @@ let validators = import "validators.ncl" in
             rust_expr = "crate::key::composite::LayeredKey::layered(%{k_expr})",
             serialized_json = k,
           },
-        k if composite.tap_hold_key.is_serialized_json k =>
-          let { key_type = k_key_type, rust_expr = k_expr, .. } = composite.tap_hold_key.codegen_values k in
+        cv @ { serialized_json = k, .. } if composite.tap_hold_key.is_serialized_json k =>
+          let { key_type = k_key_type, rust_expr = k_expr, .. } = composite.tap_hold_key.codegen_values cv in
           {
             key_type = {
               key_type = "crate::key::composite::LayeredKey",

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -386,20 +386,6 @@ let validators = import "validators.ncl" in
       },
     },
 
-    wrap_rust_expr = match {
-      k if keyboard.is_serialized_json k =>
-        let k_expr = keyboard.rust_expr k in
-        "crate::key::composite::Key::keyboard(%{k_expr})",
-      k if layer_modifier.is_serialized_json k =>
-        let k_expr = layer_modifier.rust_expr k in
-        "crate::key::composite::Key::layer_modifier(%{k_expr})",
-      k if layered.is_serialized_json k =>
-        let k_expr = layered.key_expr k in
-        "crate::key::composite::Key::layered(%{k_expr})",
-      k if tap_hold.is_serialized_json k =>
-        let k_expr = tap_hold.rust_expr k in
-        "crate::key::composite::Key::tap_hold(%{k_expr})",
-      _ => 'Error { message = "unknown variant for key::composite::Key" },
     },
   },
 

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -4,7 +4,7 @@ let validators = import "validators.ncl" in
     | doc "The 'JSON serialized' value of the keymap. e.g. imported from keymap.json."
     | { keys | Array key.SerializedJson, .. },
 
-  checks.keyboard_is = {
+  checks.check_keyboard = {
     # Use a serialized value to check the "is" predicate.
     check_serialized_is =
       let serialized_value = { key_code = 4 } in
@@ -15,6 +15,25 @@ let validators = import "validators.ncl" in
     check_serialized_modifiers_is =
       let serialized_value = { modifiers = { left_ctrl = true } } in
       keyboard.is_serialized_json serialized_value,
+
+    check_keyboard_codegen_values = {
+      check_basic =
+        let k = { key_code = 4 } in
+        let cv = keyboard.codegen_values k in
+        {
+          check_key_type = {
+            actual = cv.key_type,
+            expected = {
+              as_rust_type_path = "crate::key::keyboard::Key",
+              key_type = "crate::key::keyboard::Key",
+            },
+          },
+          check_rust_expr = {
+            actual = cv.rust_expr,
+            expected = "crate::key::keyboard::Key::new(4)",
+          },
+        },
+    },
   },
 
   keyboard

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -496,7 +496,7 @@ let validators = import "validators.ncl" in
             rust_expr = "crate::key::composite::BaseKey::keyboard(%{k_expr})",
             serialized_json = k,
           },
-        _ => 'unknown_key_type
+        cv => std.fail_with "bad codegen_values for base_key: %{cv |> std.serialize 'Json}",
       },
     },
 
@@ -534,7 +534,7 @@ let validators = import "validators.ncl" in
             rust_expr = "crate::key::composite::TapHoldKey::Pass(%{k_expr})",
             serialized_json = k,
           },
-        _ => 'unknown_key_type
+        cv => std.fail_with "bad codegen_values for tap_hold_key: %{cv |> std.serialize 'Json}",
       },
     },
 
@@ -572,7 +572,7 @@ let validators = import "validators.ncl" in
             rust_expr = "crate::key::composite::LayeredKey::Pass(%{k_expr})",
             serialized_json = k,
           },
-        _ => 'unknown_key_type
+        cv => std.fail_with "bad codegen_values for layered_key: %{cv |> std.serialize 'Json}",
       },
     },
   },
@@ -595,7 +595,7 @@ let validators = import "validators.ncl" in
       k if layer_modifier.is_serialized_json k => layer_modifier.codegen_values k,
       k if layered.is_serialized_json k => layered.codegen_values k,
       k if tap_hold.is_serialized_json k => tap_hold.codegen_values k,
-      _ => 'unknown_key_type
+      k => std.fail_with "bad serialized_json for key: %{k |> std.serialize 'Json}",
     },
   },
 

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -435,6 +435,27 @@ let validators = import "validators.ncl" in
           },
         },
     },
+
+    check_tap_hold_key_codegen_values = {
+      # A keyboard::Key lifted to composite::TapHoldKey
+      check_tap_hold_key_keyboard =
+        let k = { key_code = 4 } in
+        let cv = composite.tap_hold_key.codegen_values k in
+        {
+          check_key_type = {
+            actual = cv.key_type,
+            expected = {
+              as_rust_type_path = "crate::key::composite::TapHoldKey<crate::key::composite::BaseKey>",
+              key_type = "crate::key::composite::TapHoldKey",
+              nested_key_type = "crate::key::composite::BaseKey",
+            },
+          },
+          check_rust_expr = {
+            actual = cv.rust_expr,
+            expected = "crate::key::composite::TapHoldKey::Pass(crate::key::composite::BaseKey::keyboard(crate::key::keyboard::Key::new(4)))",
+          },
+        },
+    },
   },
 
   composite = {

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -292,7 +292,17 @@ let validators = import "validators.ncl" in
             if std.array.all (fun kt => kt == base_key_type) layered_key_types then
               base_key_type
             else
-              (composite.tap_hold_key.codegen_values base_codegen_values).key_type
+              (
+                base_codegen_values
+                |> match {
+                  cv @ { serialized_json = k, .. } if tap_hold.is_serialized_json k =>
+                    composite.tap_hold_key.codegen_values cv,
+                  cv @ { serialized_json = k, .. } if composite.base_key.is_serialized_json k =>
+                    let bk_cv = composite.base_key.codegen_values cv in
+                    composite.tap_hold_key.codegen_values bk_cv,
+                  cv => std.fail_with "bad codegen_values for layered nested key: %{cv |> std.serialize 'Json}",
+                }
+              ).key_type
           in
           {
             key_type = "crate::key::layered::LayeredKey",
@@ -307,7 +317,18 @@ let validators = import "validators.ncl" in
             if std.array.all (fun kt => kt == base_key_type) layered_key_types then
               fun cv => cv.rust_expr
             else
-              fun cv => (composite.tap_hold_key.codegen_values cv).rust_expr
+              fun cv =>
+                (
+                  cv
+                  |> match {
+                    cv @ { serialized_json = k, .. } if tap_hold.is_serialized_json k =>
+                      composite.tap_hold_key.codegen_values cv,
+                    cv @ { serialized_json = k, .. } if composite.base_key.is_serialized_json k =>
+                      let bk_cv = composite.base_key.codegen_values cv in
+                      composite.tap_hold_key.codegen_values bk_cv,
+                    cv => std.fail_with "bad codegen_values for layered nested key: %{cv |> std.serialize 'Json}",
+                  }
+                ).rust_expr
           in
           let base_expr = nk_expr base_codegen_values in
           let layered_exprs =
@@ -441,11 +462,12 @@ let validators = import "validators.ncl" in
     },
 
     check_tap_hold_key_codegen_values = {
-      # A keyboard::Key lifted to composite::TapHoldKey
+      # A keyboard::Key lifted to composite::TapHoldKey via composite::BaseKey
       check_tap_hold_key_keyboard =
         let k = { key_code = 4 } in
         let kcv = keyboard.codegen_values k in
-        let cv = composite.tap_hold_key.codegen_values kcv in
+        let bk_cv = composite.base_key.codegen_values kcv in
+        let cv = composite.tap_hold_key.codegen_values bk_cv in
         {
           check_key_type = {
             actual = cv.key_type,
@@ -524,7 +546,7 @@ let validators = import "validators.ncl" in
             serialized_json = k,
           },
         cv @ { serialized_json = k, .. } if composite.base_key.is_serialized_json k =>
-          let { key_type = k_key_type, rust_expr = k_expr, .. } = composite.base_key.codegen_values cv in
+          let { key_type = k_key_type, rust_expr = k_expr, .. } = cv in
           {
             key_type = {
               key_type = "crate::key::composite::TapHoldKey",
@@ -562,7 +584,7 @@ let validators = import "validators.ncl" in
             serialized_json = k,
           },
         cv @ { serialized_json = k, .. } if composite.tap_hold_key.is_serialized_json k =>
-          let { key_type = k_key_type, rust_expr = k_expr, .. } = composite.tap_hold_key.codegen_values cv in
+          let { key_type = k_key_type, rust_expr = k_expr, .. } = cv in
           {
             key_type = {
               key_type = "crate::key::composite::LayeredKey",

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -61,42 +61,51 @@ let validators = import "validators.ncl" in
 
       is_serialized_json = fun k => 'Ok == serialized_json_validator k,
 
-      key_type = {
-        key_type = "crate::key::keyboard::Key",
-        as_rust_type_path = key_type,
-      },
+      codegen_values = fun k =>
+        let kt = {
+          key_type = "crate::key::keyboard::Key",
+          as_rust_type_path = key_type,
+        }
+        in
 
-      rust_expr = fun key =>
-        let rec modifiers_expr = fun m =>
-          m
+        let expr =
+          let rec modifiers_expr = fun m =>
+            m
+            |> match {
+              {} => "crate::key::KeyboardModifiers::new()",
+              { left_ctrl, ..modifiers } if left_ctrl =>
+                "crate::key::KeyboardModifiers::LEFT_CTRL.union(&%{modifiers_expr modifiers})",
+              { left_alt, ..modifiers } if left_alt =>
+                "crate::key::KeyboardModifiers::LEFT_ALT.union(&%{modifiers_expr modifiers})",
+              { left_shift, ..modifiers } if left_shift =>
+                "crate::key::KeyboardModifiers::LEFT_SHIFT.union(&%{modifiers_expr modifiers})",
+              { left_gui, ..modifiers } if left_gui =>
+                "crate::key::KeyboardModifiers::LEFT_GUI.union(&%{modifiers_expr modifiers})",
+              { right_ctrl, ..modifiers } if right_ctrl =>
+                "crate::key::KeyboardModifiers::RIGHT_CTRL.union(&%{modifiers_expr modifiers})",
+              { right_alt, ..modifiers } if right_alt =>
+                "crate::key::KeyboardModifiers::RIGHT_ALT.union(&%{modifiers_expr modifiers})",
+              { right_shift, ..modifiers } if right_shift =>
+                "crate::key::KeyboardModifiers::RIGHT_SHIFT.union(&%{modifiers_expr modifiers})",
+              { right_gui, ..modifiers } if right_gui =>
+                "crate::key::KeyboardModifiers::RIGHT_GUI.union(&%{modifiers_expr modifiers})",
+            }
+          in
+          k
           |> match {
-            {} => "crate::key::KeyboardModifiers::new()",
-            { left_ctrl, ..modifiers } if left_ctrl =>
-              "crate::key::KeyboardModifiers::LEFT_CTRL.union(&%{modifiers_expr modifiers})",
-            { left_alt, ..modifiers } if left_alt =>
-              "crate::key::KeyboardModifiers::LEFT_ALT.union(&%{modifiers_expr modifiers})",
-            { left_shift, ..modifiers } if left_shift =>
-              "crate::key::KeyboardModifiers::LEFT_SHIFT.union(&%{modifiers_expr modifiers})",
-            { left_gui, ..modifiers } if left_gui =>
-              "crate::key::KeyboardModifiers::LEFT_GUI.union(&%{modifiers_expr modifiers})",
-            { right_ctrl, ..modifiers } if right_ctrl =>
-              "crate::key::KeyboardModifiers::RIGHT_CTRL.union(&%{modifiers_expr modifiers})",
-            { right_alt, ..modifiers } if right_alt =>
-              "crate::key::KeyboardModifiers::RIGHT_ALT.union(&%{modifiers_expr modifiers})",
-            { right_shift, ..modifiers } if right_shift =>
-              "crate::key::KeyboardModifiers::RIGHT_SHIFT.union(&%{modifiers_expr modifiers})",
-            { right_gui, ..modifiers } if right_gui =>
-              "crate::key::KeyboardModifiers::RIGHT_GUI.union(&%{modifiers_expr modifiers})",
+            { key_code } =>
+              "crate::key::keyboard::Key::new(%{std.to_string key_code})",
+            { modifiers } =>
+              "crate::key::keyboard::Key::from_modifiers(%{modifiers_expr modifiers})",
+            { key_code, modifiers } =>
+              "crate::key::keyboard::Key::new_with_modifiers(%{std.to_string key_code}, %{modifiers_expr modifiers})",
           }
         in
-        key
-        |> match {
-          { key_code } =>
-            "crate::key::keyboard::Key::new(%{std.to_string key_code})",
-          { modifiers } =>
-            "crate::key::keyboard::Key::from_modifiers(%{modifiers_expr modifiers})",
-          { key_code, modifiers } =>
-            "crate::key::keyboard::Key::new_with_modifiers(%{std.to_string key_code}, %{modifiers_expr modifiers})",
+
+        {
+          key_type = kt,
+          rust_expr = expr,
+          serialized_json = k,
         },
     },
 
@@ -124,13 +133,21 @@ let validators = import "validators.ncl" in
 
       is_serialized_json = fun k => 'Ok == serialized_json_validator k,
 
-      key_type = {
-        key_type = "crate::key::layered::ModifierKey",
-        as_rust_type_path = key_type,
-      },
+      codegen_values = fun k @ { Hold = layer_index } =>
+        let kt = {
+          key_type = "crate::key::layered::ModifierKey",
+          as_rust_type_path = key_type,
+        }
+        in
 
-      rust_expr = fun { Hold = layer_index } =>
-        "crate::key::layered::ModifierKey::Hold(%{std.to_string layer_index})",
+        let expr = "crate::key::layered::ModifierKey::Hold(%{std.to_string layer_index})"
+        in
+
+        {
+          key_type = kt,
+          rust_expr = expr,
+          serialized_json = k,
+        },
     },
 
   checks.layered_is = {
@@ -178,42 +195,55 @@ let validators = import "validators.ncl" in
 
       is_serialized_json = fun k => 'Ok == serialized_json_validator k,
 
-      # c.f. doc_de_layered.md.
-      # ```
-      #   type Key = layered::LayeredKey<keyboard::Key>;
-      # ```
-      key_type = fun { base, layered } =>
-        let base_key_type = key.key_type base in
+      codegen_values = fun k @ { base, layered } =>
+        let base_codegen_values = key.codegen_values base in
         let non_null_layered = std.array.filter ((!=) null) layered in
-        let layered_key_types = std.array.map (fun nk => key.key_type nk) non_null_layered in
-        let nested_key_type =
-          if std.array.all (fun kt => kt == base_key_type) layered_key_types then
-            base_key_type
-          else
-            composite.tap_hold_key.key_type base
+        let nn_layered_codegen_values =
+          std.array.map key.codegen_values non_null_layered
         in
-        {
-          key_type = "crate::key::layered::LayeredKey",
-          as_rust_type_path = "%{key_type}<%{nested_key_type.as_rust_type_path}>",
-        },
 
-      rust_expr = fun { base, layered } =>
-        let base_key_type = key.key_type base in
-        let non_null_layered = std.array.filter ((!=) null) layered in
-        let layered_key_types = std.array.map (fun nk => key.key_type nk) non_null_layered in
-        let nk_expr =
-          if std.array.all (fun kt => kt == base_key_type) layered_key_types then
-            key.rust_expr
-          else
-            composite.tap_hold_key.rust_expr
+        # c.f. doc_de_layered.md.
+        # ```
+        #   type Key = layered::LayeredKey<keyboard::Key>;
+        # ```
+        let kt =
+          let base_key_type = base_codegen_values.key_type in
+          let layered_key_types = std.array.map (fun { key_type, .. } => key_type) nn_layered_codegen_values in
+          let nested_key_type =
+            if std.array.all (fun kt => kt == base_key_type) layered_key_types then
+              base_key_type
+            else
+              (composite.tap_hold_key.codegen_values base).key_type
+          in
+          {
+            key_type = "crate::key::layered::LayeredKey",
+            as_rust_type_path = "%{key_type}<%{nested_key_type.as_rust_type_path}>",
+          }
         in
-        let base_expr = nk_expr base in
-        let layered_exprs =
-          layered
-          |> std.array.map (fun lk => if lk == null then "None" else "Some(%{nk_expr lk})")
-          |> std.string.join ","
+
+        let expr =
+          let base_key_type = base_codegen_values.key_type in
+          let layered_key_types = std.array.map (fun { key_type, .. } => key_type) nn_layered_codegen_values in
+          let nk_expr =
+            if std.array.all (fun kt => kt == base_key_type) layered_key_types then
+              fun k => (key.codegen_values k).rust_expr
+            else
+              fun k => (composite.tap_hold_key.codegen_values k).rust_expr
+          in
+          let base_expr = nk_expr base in
+          let layered_exprs =
+            layered
+            |> std.array.map (fun lk => if lk == null then "None" else "Some(%{nk_expr lk})")
+            |> std.string.join ","
+          in
+          "crate::key::layered::LayeredKey::new(%{base_expr}, [%{layered_exprs}])"
         in
-        "crate::key::layered::LayeredKey::new(%{base_expr}, [%{layered_exprs}])",
+
+        {
+          key_type = kt,
+          rust_expr = expr,
+          serialized_json = k,
+        },
     },
 
   checks.check_tap_hold = {
@@ -245,32 +275,44 @@ let validators = import "validators.ncl" in
 
       is_serialized_json = fun k => 'Ok == serialized_json_validator k,
 
-      key_type = fun { hold, tap } =>
-        let hold_key_type = key.key_type hold in
-        let tap_key_type = key.key_type tap in
-        # let nested_key_type =
-        #   if tap_key_type == hold_key_type then
-        #     tap_key_type
-        #   else
-        #     composite.base_key.key_type tap in
-        let nested_key_type = composite.base_key.key_type tap in
-        {
-          key_type = "crate::key::tap_hold::Key",
-          as_rust_type_path = "%{key_type}<%{nested_key_type.as_rust_type_path}>"
-        },
+      codegen_values = fun k @ { hold, tap } =>
+        let hold_codegen_values = key.codegen_values hold in
+        let tap_codegen_values = key.codegen_values tap in
 
-      rust_expr = fun { hold, tap, } =>
-        let tap_kt = key.key_type tap in
-        let hold_kt = key.key_type hold in
-        # let nk_expr =
-        #   if tap_kt == hold_kt then
-        #     key.rust_expr
-        #   else
-        #     composite.base_key.rust_expr in
-        let nk_expr = composite.base_key.rust_expr in
-        let hold_expr = nk_expr hold in
-        let tap_expr = nk_expr tap in
-        "crate::key::tap_hold::Key::new(%{tap_expr}, %{hold_expr})",
+        let kt =
+          let hold_key_type = hold_codegen_values.key_type in
+          let tap_key_type = tap_codegen_values.key_type in
+          # let nested_key_type =
+          #   if tap_key_type == hold_key_type then
+          #     tap_key_type
+          #   else
+          #     composite.base_key.key_type tap in
+          let nested_key_type = (composite.base_key.codegen_values tap).key_type in
+          {
+            key_type = "crate::key::tap_hold::Key",
+            as_rust_type_path = "%{key_type}<%{nested_key_type.as_rust_type_path}>"
+          }
+        in
+
+        let expr =
+          let tap_kt = tap_codegen_values.key_type in
+          let hold_kt = hold_codegen_values.key_type in
+          # let nk_expr =
+          #   if tap_kt == hold_kt then
+          #     key.rust_expr
+          #   else
+          #     composite.base_key.rust_expr in
+          let nk_expr = fun k => (composite.base_key.codegen_values k).rust_expr in
+          let hold_expr = nk_expr hold in
+          let tap_expr = nk_expr tap in
+          "crate::key::tap_hold::Key::new(%{tap_expr}, %{hold_expr})"
+        in
+
+        {
+          key_type = kt,
+          rust_expr = expr,
+          serialized_json = k,
+        },
     },
 
   composite = {
@@ -285,27 +327,27 @@ let validators = import "validators.ncl" in
 
       is_serialized_json = fun k => 'Ok == serialized_json_validator k,
 
-      key_type = match {
-        key if layer_modifier.is_serialized_json key =>
+      codegen_values = match {
+        k if layer_modifier.is_serialized_json k =>
+          let { rust_expr = k_expr, .. } = layer_modifier.codegen_values k in
           {
-            key_type = "crate::key::composite::BaseKey",
-            as_rust_type_path = key_type,
+            key_type = {
+              key_type = "crate::key::composite::BaseKey",
+              as_rust_type_path = key_type,
+            },
+            rust_expr = "crate::key::composite::BaseKey::layer_modifier(%{k_expr})",
+            serialized_json = k,
           },
-        key if keyboard.is_serialized_json key =>
+        k if keyboard.is_serialized_json k =>
+          let { rust_expr = k_expr, .. } = keyboard.codegen_values k in
           {
-            key_type = "crate::key::composite::BaseKey",
-            as_rust_type_path = key_type,
+            key_type = {
+              key_type = "crate::key::composite::BaseKey",
+              as_rust_type_path = key_type,
+            },
+            rust_expr = "crate::key::composite::BaseKey::keyboard(%{k_expr})",
+            serialized_json = k,
           },
-        _ => 'unknown_key_type
-      },
-
-      rust_expr = match {
-        key if layer_modifier.is_serialized_json key =>
-          let expr = layer_modifier.rust_expr key in
-          "crate::key::composite::BaseKey::layer_modifier(%{expr})",
-        key if keyboard.is_serialized_json key =>
-          let expr = keyboard.rust_expr key in
-          "crate::key::composite::BaseKey::keyboard(%{expr})",
         _ => 'unknown_key_type
       },
     },
@@ -321,29 +363,29 @@ let validators = import "validators.ncl" in
 
       is_serialized_json = fun k => 'Ok == serialized_json_validator k,
 
-      key_type = match {
-        key if tap_hold.is_serialized_json key =>
+      codegen_values = match {
+        k if tap_hold.is_serialized_json k =>
+          let { key_type = k_key_type, rust_expr = k_expr, .. } = tap_hold.codegen_values k in
           {
-            key_type = "crate::key::composite::TapHoldKey",
-            nested_key_type = "crate::key::composite::BaseKey",
-            as_rust_type_path = "%{key_type}<%{nested_key_type}>",
+            key_type = {
+              key_type = "crate::key::composite::TapHoldKey",
+              nested_key_type = "crate::key::composite::BaseKey",
+              as_rust_type_path = "%{key_type}<%{nested_key_type}>",
+            },
+            rust_expr = "crate::key::composite::TapHoldKey::tap_hold(%{k_expr})",
+            serialized_json = k,
           },
-        key if composite.base_key.is_serialized_json key =>
+        k if composite.base_key.is_serialized_json k =>
+          let { key_type = k_key_type, rust_expr = k_expr, .. } = composite.base_key.codegen_values k in
           {
-            key_type = "crate::key::composite::TapHoldKey",
-            nested_key_type = "crate::key::composite::BaseKey",
-            as_rust_type_path = "%{key_type}<%{nested_key_type}>",
+            key_type = {
+              key_type = "crate::key::composite::TapHoldKey",
+              nested_key_type = "crate::key::composite::BaseKey",
+              as_rust_type_path = "%{key_type}<%{nested_key_type}>",
+            },
+            rust_expr = "crate::key::composite::TapHoldKey::Pass(%{k_expr})",
+            serialized_json = k,
           },
-        _ => 'unknown_key_type
-      },
-
-      rust_expr = match {
-        key if tap_hold.is_serialized_json key =>
-          let expr = tap_hold.rust_expr key in
-          "crate::key::composite::TapHoldKey::tap_hold(%{expr})",
-        key if composite.base_key.is_serialized_json key =>
-          let expr = composite.base_key.rust_expr key in
-          "crate::key::composite::TapHoldKey::Pass(%{expr})",
         _ => 'unknown_key_type
       },
     },
@@ -359,33 +401,31 @@ let validators = import "validators.ncl" in
 
       is_serialized_json = fun k => 'Ok == serialized_json_validator k,
 
-      key_type = match {
-        key if layered.is_serialized_json key =>
+      codegen_values = match {
+        k if layered.is_serialized_json k =>
+          let { key_type = k_key_type, rust_expr = k_expr, .. } = layered.codegen_values k in
           {
-            key_type = "crate::key::composite::LayeredKey",
-            nested_key_type = "crate::key::composite::TapHoldKey",
-            as_rust_type_path = "%{key_type}<%{nested_key_type}>",
+            key_type = {
+              key_type = "crate::key::composite::LayeredKey",
+              nested_key_type = "crate::key::composite::TapHoldKey",
+              as_rust_type_path = "%{key_type}<%{nested_key_type}>",
+            },
+            rust_expr = "crate::key::composite::LayeredKey::layered(%{k_expr})",
+            serialized_json = k,
           },
-        key if composite.tap_hold_key.is_serialized_json key =>
+        k if composite.tap_hold_key.is_serialized_json k =>
+          let { key_type = k_key_type, rust_expr = k_expr, .. } = composite.tap_hold_key.codegen_values k in
           {
-            key_type = "crate::key::composite::LayeredKey",
-            nested_key_type = "crate::key::composite::TapHoldKey",
-            as_rust_type_path = "%{key_type}<%{nested_key_type}>",
+            key_type = {
+              key_type = "crate::key::composite::LayeredKey",
+              nested_key_type = "crate::key::composite::TapHoldKey",
+              as_rust_type_path = "%{key_type}<%{nested_key_type}>",
+            },
+            rust_expr = "crate::key::composite::LayeredKey::Pass(%{k_expr})",
+            serialized_json = k,
           },
         _ => 'unknown_key_type
       },
-
-      rust_expr = match {
-        key if layered.is_serialized_json key =>
-          let expr = layered.rust_expr key in
-          "crate::key::composite::LayeredKey::layered(%{expr})",
-        key if composite.tap_hold_key.is_serialized_json key =>
-          let expr = composite.tap_hold_key.rust_expr key in
-          "crate::key::composite::LayeredKey::Pass(%{expr})",
-        _ => 'unknown_key_type
-      },
-    },
-
     },
   },
 
@@ -402,19 +442,11 @@ let validators = import "validators.ncl" in
 
     is_serialized_json = fun k => 'Ok == serialized_json_validator k,
 
-    key_type = match {
-      key if keyboard.is_serialized_json key => keyboard.key_type,
-      key if layer_modifier.is_serialized_json key => layer_modifier.key_type,
-      key if layered.is_serialized_json key => layered.key_type key,
-      key if tap_hold.is_serialized_json key => tap_hold.key_type key,
-      _ => 'unknown_key_type
-    },
-
-    rust_expr = match {
-      key if keyboard.is_serialized_json key => keyboard.rust_expr key,
-      key if layer_modifier.is_serialized_json key => layer_modifier.rust_expr key,
-      key if layered.is_serialized_json key => layered.rust_expr key,
-      key if tap_hold.is_serialized_json key => tap_hold.rust_expr key,
+    codegen_values = match {
+      k if keyboard.is_serialized_json k => keyboard.codegen_values k,
+      k if layer_modifier.is_serialized_json k => layer_modifier.codegen_values k,
+      k if layered.is_serialized_json k => layered.codegen_values k,
+      k if tap_hold.is_serialized_json k => tap_hold.codegen_values k,
       _ => 'unknown_key_type
     },
   },
@@ -460,15 +492,19 @@ let validators = import "validators.ncl" in
           0
       in
       let keys_id = "Keys%{std.to_string keymap_len}" in
-      let key_types =
+      let codegen_values =
         keys
-        |> std.array.map key.key_type
-        |> std.array.map (fun key_type => key_type.as_rust_type_path)
+        |> std.array.map key.codegen_values
+      in
+      let key_types =
+        codegen_values
+        |> std.array.map (fun { key_type, .. } => key_type)
+        |> std.array.map (fun { as_rust_type_path, .. } => as_rust_type_path)
         |> std.string.join ","
       in
       let key_exprs =
-        keys
-        |> std.array.map (fun k => "%{key.rust_expr k},")
+        codegen_values
+        |> std.array.map (fun k => "%{k.rust_expr},")
         |> std.string.join ""
       in
       m%"

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -169,7 +169,7 @@ let validators = import "validators.ncl" in
         },
     },
 
-  checks.layered_is = {
+  checks.check_layered = {
     # Use a serialized value to check the "is" predicate.
     check_serialized_base_keyboard_layered_keyboard_is =
       let serialized_value = {
@@ -180,7 +180,35 @@ let validators = import "validators.ncl" in
         ]
       }
       in
-      layered.is_serialized_json serialized_value
+      layered.is_serialized_json serialized_value,
+
+    check_layered_codegen_values = {
+      # A layered::LayeredKey of keyboard::Key
+      #  codegens to layered::LayeredKey<keyboard::Key>
+      check_layered_keyboard =
+        let k = {
+          base = { key_code = 4 },
+          layered = [
+            null,
+            { key_code = 6 },
+          ]
+        }
+        in
+        let cv = layered.codegen_values k in
+        {
+          check_key_type = {
+            actual = cv.key_type,
+            expected = {
+              as_rust_type_path = "crate::key::layered::LayeredKey<crate::key::keyboard::Key>",
+              key_type = "crate::key::layered::LayeredKey",
+            },
+          },
+          check_rust_expr = {
+            actual = cv.rust_expr,
+            expected = "crate::key::layered::LayeredKey::new(crate::key::keyboard::Key::new(4), [None,Some(crate::key::keyboard::Key::new(6))])",
+          },
+        },
+    },
   },
 
   layered

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -415,6 +415,28 @@ let validators = import "validators.ncl" in
         },
     },
 
+  checks.check_composite = {
+    check_base_key_codegen_values = {
+      # A keyboard::Key lifted to composite::BaseKey
+      check_base_key_keyboard =
+        let k = { key_code = 4 } in
+        let cv = composite.base_key.codegen_values k in
+        {
+          check_key_type = {
+            actual = cv.key_type,
+            expected = {
+              as_rust_type_path = "crate::key::composite::BaseKey",
+              key_type = "crate::key::composite::BaseKey",
+            },
+          },
+          check_rust_expr = {
+            actual = cv.rust_expr,
+            expected = "crate::key::composite::BaseKey::keyboard(crate::key::keyboard::Key::new(4))",
+          },
+        },
+    },
+  },
+
   composite = {
     base_key = {
       SerializedJson = std.contract.from_validator serialized_json_validator,

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -208,6 +208,35 @@ let validators = import "validators.ncl" in
             expected = "crate::key::layered::LayeredKey::new(crate::key::keyboard::Key::new(4), [None,Some(crate::key::keyboard::Key::new(6))])",
           },
         },
+
+      # A layered::LayeredKey of mix of tap_hold::Key<'keyboard::Key'> and keyboard::Key
+      #  codegens to layered::LayeredKey<composite::TapHoldKey<composite::BaseKey>>
+      check_layered_composite_taphold_keyboard =
+        let k = {
+          base = {
+            hold = { key_code = 224 },
+            tap = { key_code = 4 },
+          },
+          layered = [
+            null,
+            { key_code = 6 },
+          ]
+        }
+        in
+        let cv = layered.codegen_values k in
+        {
+          check_key_type = {
+            actual = cv.key_type,
+            expected = {
+              as_rust_type_path = "crate::key::layered::LayeredKey<crate::key::composite::TapHoldKey<crate::key::composite::BaseKey>>",
+              key_type = "crate::key::layered::LayeredKey"
+            },
+          },
+          check_rust_expr = {
+            actual = cv.rust_expr,
+            expected = "crate::key::layered::LayeredKey::new(crate::key::composite::TapHoldKey::tap_hold(crate::key::tap_hold::Key::new(crate::key::composite::BaseKey::keyboard(crate::key::keyboard::Key::new(4)), crate::key::composite::BaseKey::keyboard(crate::key::keyboard::Key::new(224)))), [None,Some(crate::key::composite::TapHoldKey::Pass(crate::key::composite::BaseKey::keyboard(crate::key::keyboard::Key::new(6))))])",
+          },
+        },
     },
   },
 


### PR DESCRIPTION
This PR iterates towards Nickel codegen support for `LayeredKey<c::TapHoldKey<keyboard::Key>>`. (Currently, instead, it's `LayeredKey<c::TapHoldKey<c::BaseKey>>`).

* Moves from `key_type = fun k => ...`, `rust_expr = fun k => ...` to instead `codegen_values = fun k => { key_type, rust_expr, .. }`.
* Adds several checks in keymap-codegen, covering current behaviour for some tricky cases.