### PR TITLE
Cucumber Feature Step Def'n NCL Inputs

### DIFF
--- a/.github/workflows/test-ceedling.yaml
+++ b/.github/workflows/test-ceedling.yaml
@@ -44,7 +44,9 @@ jobs:
           export GEM_HOME=$(gem environment user_gemhome)
           gem install bundler --user-install
           bundle install
-          cargo install --force cbindgen
+          wget https://github.com/mozilla/cbindgen/releases/download/0.28.0/cbindgen
+          chmod +x ./cbindgen
+          sudo cp ./cbindgen /usr/bin/cbindgen
 
       - name: Run Ceedling Tests
         run: |

--- a/features/keymap/key/keyboard.feature
+++ b/features/keymap/key/keyboard.feature
@@ -14,7 +14,6 @@ Feature: HID Keyboard Key
       """
     Then the HID keyboard report should equal
       """
-      let K = import "hid-usage-keyboard.ncl" in
       { key_codes = [K.A] }
       """
 
@@ -36,6 +35,5 @@ Feature: HID Keyboard Key
       """
     Then the HID keyboard report should equal
       """
-      let K = import "hid-usage-keyboard.ncl" in
       { modifiers = { left_ctrl = true }, key_codes = [K.A] }
       """

--- a/features/keymap/key/keyboard.feature
+++ b/features/keymap/key/keyboard.feature
@@ -9,7 +9,7 @@ Feature: HID Keyboard Key
     When the keymap registers the following input
       """
       [
-        Press(keymap_index: 0)
+        press K.A,
       ]
       """
     Then the HID keyboard report should equal
@@ -31,7 +31,7 @@ Feature: HID Keyboard Key
     When the keymap registers the following input
       """
       [
-        Press(keymap_index: 0)
+        press (K.A & K.LeftCtrl),
       ]
       """
     Then the HID keyboard report should equal

--- a/features/keymap/key/layered.feature
+++ b/features/keymap/key/layered.feature
@@ -32,7 +32,6 @@ Feature: Layered Keys
       """
     Then the HID keyboard report should equal
       """
-      let K = import "hid-usage-keyboard.ncl" in
       { key_codes = [K.A] }
       """
 
@@ -47,6 +46,5 @@ Feature: Layered Keys
       """
     Then the HID keyboard report should equal
       """
-      let K = import "hid-usage-keyboard.ncl" in
       { key_codes = [K.B] }
       """

--- a/features/keymap/key/layered.feature
+++ b/features/keymap/key/layered.feature
@@ -27,7 +27,7 @@ Feature: Layered Keys
     When the keymap registers the following input
       """
       [
-        Press(keymap_index: 1),
+        press (K.A & { layered = [ K.B ] }),
       ]
       """
     Then the HID keyboard report should equal
@@ -41,8 +41,8 @@ Feature: Layered Keys
     When the keymap registers the following input
       """
       [
-        Press(keymap_index: 0),
-        Press(keymap_index: 1),
+        press (K.layer_mod.hold 0),
+        press (K.A & { layered = [ K.B ] }),
       ]
       """
     Then the HID keyboard report should equal

--- a/features/keymap/key/tap_hold-config-interrupt-ignore.feature
+++ b/features/keymap/key/tap_hold-config-interrupt-ignore.feature
@@ -35,9 +35,9 @@ Feature: TapHold Key (configure interrupt response: ignore)
     When the keymap registers the following input
       """
       [
-        Press(keymap_index: 0),
-        Press(keymap_index: 1),
-        Release(keymap_index: 0),
+        press (K.A & K.hold K.LeftCtrl),
+        press (K.B),
+        release (K.A & K.hold K.LeftCtrl),
       ]
       """
     Then the HID keyboard report should equal
@@ -55,10 +55,10 @@ Feature: TapHold Key (configure interrupt response: ignore)
     When the keymap registers the following input
       """
       [
-        Press(keymap_index: 0),
-        Press(keymap_index: 1),
-        Release(keymap_index: 1),
-        Release(keymap_index: 0),
+        press (K.A & K.hold K.LeftCtrl),
+        press (K.B),
+        release (K.B),
+        release (K.A & K.hold K.LeftCtrl),
       ]
       """
     Then the HID keyboard report should equal

--- a/features/keymap/key/tap_hold-config-interrupt-ignore.feature
+++ b/features/keymap/key/tap_hold-config-interrupt-ignore.feature
@@ -42,7 +42,6 @@ Feature: TapHold Key (configure interrupt response: ignore)
       """
     Then the HID keyboard report should equal
       """
-      let K = import "hid-usage-keyboard.ncl" in
       { key_codes = [K.A, K.B] }
       """
 
@@ -63,6 +62,5 @@ Feature: TapHold Key (configure interrupt response: ignore)
       """
     Then the HID keyboard report should equal
       """
-      let K = import "hid-usage-keyboard.ncl" in
       { key_codes = [K.A] }
       """

--- a/features/keymap/key/tap_hold-config-interrupt-presses.feature
+++ b/features/keymap/key/tap_hold-config-interrupt-presses.feature
@@ -34,8 +34,8 @@ Feature: TapHold Key (configure interrupt response: hold on key press)
     When the keymap registers the following input
       """
       [
-        Press(keymap_index: 0),
-        Press(keymap_index: 1),
+        press (K.A & K.hold K.LeftCtrl),
+        press (K.B),
       ]
       """
     Then the HID keyboard report should equal
@@ -53,9 +53,9 @@ Feature: TapHold Key (configure interrupt response: hold on key press)
     When the keymap registers the following input
       """
       [
-        Press(keymap_index: 0),
-        Press(keymap_index: 1),
-        Release(keymap_index: 1),
+        press (K.A & K.hold K.LeftCtrl),
+        press (K.B),
+        release (K.B),
       ]
       """
     Then the HID keyboard report should equal

--- a/features/keymap/key/tap_hold-config-interrupt-presses.feature
+++ b/features/keymap/key/tap_hold-config-interrupt-presses.feature
@@ -40,7 +40,6 @@ Feature: TapHold Key (configure interrupt response: hold on key press)
       """
     Then the HID keyboard report should equal
       """
-      let K = import "hid-usage-keyboard.ncl" in
       { modifiers = { left_ctrl = true }, key_codes = [K.B] }
       """
 
@@ -60,6 +59,5 @@ Feature: TapHold Key (configure interrupt response: hold on key press)
       """
     Then the HID keyboard report should equal
       """
-      let K = import "hid-usage-keyboard.ncl" in
       { modifiers = { left_ctrl = true } }
       """

--- a/features/keymap/key/tap_hold-config-timeout.feature
+++ b/features/keymap/key/tap_hold-config-timeout.feature
@@ -16,7 +16,7 @@ Feature: TapHold Key (configure resolve-as-hold timeout)
     When the keymap registers the following input
       """
       [
-        Press(keymap_index: 0)
+        press (K.A & K.hold K.LeftCtrl),
       ]
       """
     And the keymap ticks 60 times
@@ -44,7 +44,7 @@ Feature: TapHold Key (configure resolve-as-hold timeout)
     When the keymap registers the following input
       """
       [
-        Press(keymap_index: 0)
+        press (K.A & K.hold K.LeftCtrl),
       ]
       """
     And the keymap ticks 10000 times

--- a/features/keymap/key/tap_hold-config-timeout.feature
+++ b/features/keymap/key/tap_hold-config-timeout.feature
@@ -22,7 +22,6 @@ Feature: TapHold Key (configure resolve-as-hold timeout)
     And the keymap ticks 60 times
     Then the HID keyboard report should equal
       """
-      let K = import "hid-usage-keyboard.ncl" in
       { modifiers = { left_ctrl = true } }
       """
 

--- a/features/keymap/key/tap_hold.feature
+++ b/features/keymap/key/tap_hold.feature
@@ -43,7 +43,6 @@ Feature: TapHold Key
       """
     Then the HID keyboard report should equal
       """
-      let K = import "hid-usage-keyboard.ncl" in
       { key_codes = [K.A] }
       """
 
@@ -58,6 +57,5 @@ Feature: TapHold Key
     And the keymap ticks 500 times
     Then the HID keyboard report should equal
       """
-      let K = import "hid-usage-keyboard.ncl" in
       { modifiers = { left_ctrl = true } }
       """

--- a/features/keymap/key/tap_hold.feature
+++ b/features/keymap/key/tap_hold.feature
@@ -37,8 +37,8 @@ Feature: TapHold Key
     When the keymap registers the following input
       """
       [
-        Press(keymap_index: 0),
-        Release(keymap_index: 0)
+        press (K.A & K.hold K.LeftCtrl),
+        release (K.A & K.hold K.LeftCtrl),
       ]
       """
     Then the HID keyboard report should equal
@@ -52,7 +52,7 @@ Feature: TapHold Key
     When the keymap registers the following input
       """
       [
-        Press(keymap_index: 0)
+        press (K.A & K.hold K.LeftCtrl),
       ]
       """
     And the keymap ticks 500 times

--- a/features/keymap/ncl/layers.feature
+++ b/features/keymap/ncl/layers.feature
@@ -49,7 +49,6 @@ Feature: Layers
       """
     Then the HID keyboard report should equal
       """
-      let K = import "hid-usage-keyboard.ncl" in
       { key_codes = [K.A] }
       """
 
@@ -64,6 +63,5 @@ Feature: Layers
       """
     Then the HID keyboard report should equal
       """
-      let K = import "hid-usage-keyboard.ncl" in
       { key_codes = [K.B] }
       """

--- a/features/keymap/ncl/layers.feature
+++ b/features/keymap/ncl/layers.feature
@@ -44,7 +44,7 @@ Feature: Layers
     When the keymap registers the following input
       """
       [
-        Press(keymap_index: 1),
+        press (K.A),
       ]
       """
     Then the HID keyboard report should equal
@@ -58,8 +58,8 @@ Feature: Layers
     When the keymap registers the following input
       """
       [
-        Press(keymap_index: 0),
-        Press(keymap_index: 1),
+        press (K.layer_mod.hold 0),
+        press (K.B),
       ]
       """
     Then the HID keyboard report should equal

--- a/ncl/inputs-to-json.ncl
+++ b/ncl/inputs-to-json.ncl
@@ -1,0 +1,69 @@
+{
+  inputs,
+
+  layered_keys,
+
+  # Construct [smart_keymap::input::Event(kmi)]
+  # from ['Press k | 'Release k],
+  # where 'k is a keymap.ncl key def
+  #  (either LK, or the K of active layer).
+  inputs_as_serialized_json_input_events =
+    let LK = import "layered-key.ncl" in
+    let lookup_keymap_index = fun active_layers k =>
+      layered_keys
+      |> std.array.map_with_index (fun idx lk =>
+        if lk == k then
+          idx
+        else if (LK.active_key lk active_layers) == k then
+          idx
+        else
+          false
+      )
+      |> std.array.filter (fun idx => idx != false)
+      |> match {
+        [idx, ..] => idx,
+        _ =>
+          std.fail_with m%"
+               unable to find keymap_index for:
+
+               active_layers=
+               %{active_layers |> std.serialize 'Json},
+
+               k=
+               %{k |> std.serialize 'Json}
+
+               layered_keys=
+               %{layered_keys |> std.serialize 'Json}
+               "%
+      }
+    in
+    let input_as_json = fun active_layers input =>
+      input
+      |> match {
+        'Press k => { Press = { keymap_index = (lookup_keymap_index active_layers k) } },
+        'Release k => { Release = { keymap_index = (lookup_keymap_index active_layers k) } },
+      }
+    in
+    let initial_active_layers =
+      layered_keys
+      |> std.array.first
+      |> match {
+        { layered, .. } => std.array.map (std.function.const false) layered,
+        _ => [],
+      }
+    in
+    let { serialized_json, .. } =
+      std.array.fold_left
+        (fun { active_layers = al, serialized_json = sj } input =>
+          # Assumes all `press lmod` in input_enum is
+          #  where lmod is not layered.
+          # e.g. unhandled case ['Press LMod 0, 'Press { layered = [LMod 1] }, ..]
+          {
+            active_layers = LK.update_active_layers_for_input input al,
+            serialized_json = sj @ [input_as_json al input]
+          }
+        )
+        { active_layers = initial_active_layers, serialized_json = [] }
+        inputs
+    in serialized_json
+}

--- a/ncl/inputs.ncl
+++ b/ncl/inputs.ncl
@@ -1,0 +1,4 @@
+{
+  press = fun k => 'Press k,
+  release = fun k => 'Release k,
+}

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -331,6 +331,8 @@ let validators = import "validators.ncl" in
     else
       l,
 
+  layers_of_keys = layers |> std.array.map layer_as_array_of_keys,
+
   layered_keys
     | doc "Constructs array of key::layered::LayeredKey values from layers."
     =
@@ -339,9 +341,8 @@ let validators = import "validators.ncl" in
       else if std.array.length layers <= 1 then
         std.array.at 0 layers
       else
-        let layers = layers |> std.array.map layer_as_array_of_keys in
-        let base_keys = std.array.first layers in
-        let layered_keys = std.array.drop_first layers in
+        let base_keys = std.array.first layers_of_keys in
+        let layered_keys = std.array.drop_first layers_of_keys in
         std.array.generate
           (fun idx =>
             let base_key = std.array.at idx base_keys in

--- a/ncl/layered-key.ncl
+++ b/ncl/layered-key.ncl
@@ -1,0 +1,72 @@
+# Functions emulating layers & layered keys.
+{
+  set_layer = fun b active_layers idx =>
+    let len = std.array.length active_layers in
+    if idx < len then
+      (std.array.slice 0 idx active_layers)
+      @ [b]
+      @ (std.array.slice (idx + 1) len active_layers)
+    else
+      active_layers @ (std.array.generate (std.function.const false) (idx - len)) @ [b],
+
+  checks.check_activate_layer = {
+    basic = {
+      expected = [ false, false, true ],
+      actual = activate_layer [ false, false, false ] 2,
+    },
+  },
+
+  activate_layer = set_layer true,
+
+  deactivate_layer = set_layer false,
+
+  update_active_layers_for_input = fun input active_layers =>
+    input
+    |> match {
+      'Press { layer_modifier = { hold }, .. } => activate_layer active_layers hold,
+      'Release { layer_modifier = { hold }, .. } => deactivate_layer active_layers hold,
+      _ => active_layers,
+    },
+
+  checks.check_active_key = {
+    base = {
+      expected = { key_code = "A" },
+      actual = active_key { key_code = "A", layered = ["B", "C", "D"], } [ false, false, false ],
+    },
+    base_none = {
+      expected = { key_code = "A" },
+      actual = active_key { key_code = "A", layered = ["B", "C", "D"], } [],
+    },
+    layered = {
+      expected = "C",
+      actual = active_key { key_code = "A", layered = ["B", "C", "D"], } [ true, true, false ],
+    },
+  },
+
+  active_key = fun lk active_layers =>
+    lk
+    |> match {
+      { layered, ..base_key } =>
+        let zipped_layered_keys =
+          std.array.zip_with
+            (fun a k => { layer_is_active = a, key = k })
+            active_layers
+            layered
+        in
+        let zipped_active_keys =
+          std.array.filter
+            (fun { layer_is_active, .. } => layer_is_active)
+            zipped_layered_keys
+        in
+        let active_keys =
+          std.array.map
+            (fun { key, .. } => key)
+            zipped_active_keys
+        in
+        if (std.array.length active_keys) > 0 then
+          std.array.last active_keys
+        else
+          base_key,
+      k => k,
+    },
+}

--- a/ncl/ncl.mk
+++ b/ncl/ncl.mk
@@ -28,6 +28,7 @@ ncl-format:
 	   ncl/checks.ncl \
 	   ncl/hid-report.ncl \
 	   ncl/import-keymap-json.ncl \
+	   ncl/inputs-to-json.ncl \
 	   ncl/inputs.ncl \
        ncl/key-extensions.ncl  \
        ncl/keymap-ncl-to-json.ncl \

--- a/ncl/ncl.mk
+++ b/ncl/ncl.mk
@@ -28,6 +28,7 @@ ncl-format:
 	   ncl/checks.ncl \
 	   ncl/hid-report.ncl \
 	   ncl/import-keymap-json.ncl \
+	   ncl/inputs.ncl \
        ncl/key-extensions.ncl  \
        ncl/keymap-ncl-to-json.ncl \
 	   ncl/keymap-codegen.ncl \

--- a/ncl/ncl.mk
+++ b/ncl/ncl.mk
@@ -32,4 +32,5 @@ ncl-format:
        ncl/keymap-ncl-to-json.ncl \
 	   ncl/keymap-codegen.ncl \
 	   ncl/keys.ncl \
+	   ncl/layered-key.ncl \
 	   ncl/validators.ncl

--- a/smart-keymap-nickel-helper/src/lib.rs
+++ b/smart-keymap-nickel-helper/src/lib.rs
@@ -242,7 +242,7 @@ pub fn nickel_json_serialization_for_inputs(
 /// Evaluates the Nickel expr for an HID, returning the json serialization.
 pub fn nickel_to_json_for_hid_report(
     ncl_import_path: String,
-    keymap_ncl: &str,
+    hid_report_ncl: &str,
 ) -> io::Result<String> {
     let mut nickel_command = Command::new("nickel")
         .args([
@@ -256,7 +256,19 @@ pub fn nickel_to_json_for_hid_report(
         .spawn()?;
 
     let child_stdin = nickel_command.stdin.as_mut().unwrap();
-    child_stdin.write_all(format!(r#"(import "hid-report.ncl") & ({})"#, keymap_ncl).as_bytes())?;
+    child_stdin.write_all(
+        format!(
+            r#"
+                (import "hid-report.ncl")
+                & (
+                    let K = import "hid-usage-keyboard.ncl" in
+                    {}
+                )
+            "#,
+            hid_report_ncl
+        )
+        .as_bytes(),
+    )?;
 
     let output = nickel_command.wait_with_output()?;
 


### PR DESCRIPTION
Change the "pressed inputs" step definition doc string to, e.g.:

```
      [
        press (K.A & K.hold K.LeftCtrl),
        press (K.B),
        release (K.B),
        release (K.A & K.hold K.LeftCtrl),
      ]
```

Instead of `Press(keymap_index: 0)`.

(Also: the Ceedling CI job now only takes 6s to install deps, not 60s).