### PR TITLE
Keymap Pending Key State (Fix TapHold Hold-on-interrupting-Tap)

### DIFF
--- a/features/keymap/key/tap_hold-config-interrupt-ignore.feature
+++ b/features/keymap/key/tap_hold-config-interrupt-ignore.feature
@@ -25,7 +25,6 @@ Feature: TapHold Key (configure interrupt response: ignore)
       }
       """
 
-  @ignore
   Example: rolling key presses (press TH(A), press B, release TH(A))
 
     Rolling the tap-hold key with another key
@@ -50,7 +49,6 @@ Feature: TapHold Key (configure interrupt response: ignore)
       ]
       """
 
-  @ignore
   Example: interrupting tap (press TH(A), press B, release B, release TH(A))
 
     After interrupting the tap-hold key with another key tap (press & release),

--- a/features/keymap/key/tap_hold-config-interrupt-ignore.feature
+++ b/features/keymap/key/tap_hold-config-interrupt-ignore.feature
@@ -25,7 +25,7 @@ Feature: TapHold Key (configure interrupt response: ignore)
       }
       """
 
-  Example: rolling key presses (press TH(A), press B, release TH(A))
+  Example: rolling key presses (press TH(A), press B, release TH(A), release B)
 
     Rolling the tap-hold key with another key
     (i.e. interrupting the tap-hold key with another key press),
@@ -38,6 +38,7 @@ Feature: TapHold Key (configure interrupt response: ignore)
         press (K.A & K.hold K.LeftCtrl),
         press (K.B),
         release (K.A & K.hold K.LeftCtrl),
+        release (K.B),
       ]
       """
     Then the output should be equivalent to output from
@@ -46,6 +47,7 @@ Feature: TapHold Key (configure interrupt response: ignore)
         press (K.A),
         press (K.B),
         release (K.A),
+        release (K.B),
       ]
       """
 

--- a/features/keymap/key/tap_hold-config-interrupt-presses.feature
+++ b/features/keymap/key/tap_hold-config-interrupt-presses.feature
@@ -60,10 +60,6 @@ Feature: TapHold Key (configure interrupt response: hold on key press)
         release (K.B),
       ]
       """
-    Then the HID keyboard report should equal
-      """
-      { modifiers = { left_ctrl = true } }
-      """
     Then the output should be equivalent to output from
       """
       [

--- a/features/keymap/key/tap_hold-config-interrupt-presses.feature
+++ b/features/keymap/key/tap_hold-config-interrupt-presses.feature
@@ -23,7 +23,7 @@ Feature: TapHold Key (configure interrupt response: hold on key press)
       }
       """
 
-  Example: rolling key presses (press TH(A), press B)
+  Example: rolling key presses (press TH(A), press B, release TH(A), release B)
 
     Rolling the tap-hold key
     with another key
@@ -36,6 +36,8 @@ Feature: TapHold Key (configure interrupt response: hold on key press)
       [
         press (K.A & K.hold K.LeftCtrl),
         press (K.B),
+        release (K.A & K.hold K.LeftCtrl),
+        release (K.B),
       ]
       """
     Then the output should be equivalent to output from
@@ -43,6 +45,8 @@ Feature: TapHold Key (configure interrupt response: hold on key press)
       [
         press (K.LeftCtrl),
         press (K.B),
+        release (K.LeftCtrl),
+        release (K.B),
       ]
       """
 

--- a/features/keymap/key/tap_hold-config-interrupt-tap.feature
+++ b/features/keymap/key/tap_hold-config-interrupt-tap.feature
@@ -1,0 +1,74 @@
+Feature: TapHold Key (configure interrupt response: hold on tap)
+
+  The tap hold key's response to interruptions can be configured.
+
+  "Resolves as 'Hold' when interrupted by key tap" can be configured
+   by setting `config.tap_hold.interrupt_response`
+   to `"HoldOnKeyTap"` in `keymap.ncl`.
+
+  Background:
+
+    Let's demonstrate tap-hold "hold on interrupting key tap" behaviour
+    using a keymap with a tap-hold key, and a keyboard key:
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        config.tap_hold.interrupt_response = "HoldOnKeyTap",
+        keys = [
+          K.A & K.hold K.LeftCtrl,
+          K.B
+        ]
+      }
+      """
+
+  Example: rolling key presses (press TH(A), press B, release TH(A), release B)
+
+    Rolling the tap-hold key
+    with another key
+    (i.e. interrupting the tap-hold key with another key press),
+     for a tap-hold key configured with `interrupt_response = "HoldOnKeyTap"`
+     resolves the tap-hold key as 'tap'.
+
+    When the keymap registers the following input
+      """
+      [
+        press (K.A & K.hold K.LeftCtrl),
+        press (K.B),
+        release (K.A & K.hold K.LeftCtrl),
+        release (K.B),
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        press (K.A),
+        press (K.B),
+        release (K.A),
+        release (K.B),
+      ]
+      """
+
+  Example: interrupting tap (press TH(A), press B, release B, release TH(A))
+
+    Interrupting the tap-hold key with another key tap (press & release),
+     for a tap-hold key configured with `interrupt_response = "HoldOnKeyTap"`
+     resolves the key as "hold".
+
+    When the keymap registers the following input
+      """
+      [
+        press (K.A & K.hold K.LeftCtrl),
+        press (K.B),
+        release (K.B),
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        press (K.LeftCtrl),
+        press (K.B),
+        release (K.B),
+      ]
+      """

--- a/src/input.rs
+++ b/src/input.rs
@@ -27,6 +27,8 @@ pub enum Event {
         /// The virtual key code.
         key_code: u8,
     },
+    /// No-op
+    InputResolved,
 }
 
 /// A struct for associating a [crate::key::Key] with a [crate::key::PressedKeyState].

--- a/src/key/tap_hold.rs
+++ b/src/key/tap_hold.rs
@@ -343,31 +343,6 @@ where
             }
         }
 
-        match event {
-            key::Event::Input(input::Event::Release { keymap_index: ki }) if keymap_index == ki => {
-                match (self.state, &self.pressed_key) {
-                    // Tap Hold key released, and the tap hold key is "tap";
-                    //  so, we send virtual key tap (press, scheduled release) with the
-                    //  pressed key's output.
-                    (TapHoldState::Tap, Some(pk)) => {
-                        if let Some(key_output) = pk.key_output().to_option() {
-                            let key_code = key_output.key_code();
-                            let press_ev = input::Event::VirtualKeyPress {
-                                key_code,
-                                pressed_keymap_index: keymap_index,
-                            };
-                            let release_ev = input::Event::VirtualKeyRelease { key_code };
-                            let mut events = key::PressedKeyEvents::event(press_ev.into());
-                            events.schedule_event(10, release_ev.into());
-                            pke.extend(events);
-                        }
-
-                        pke
-                    }
-                    _ => pke,
-                }
-            }
-            _ => pke,
-        }
+        pke
     }
 }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -442,6 +442,7 @@ impl<
                             })
                             .map(|i| self.pressed_inputs.remove(i));
                     }
+                    _ => {}
                 }
             }
         }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -292,7 +292,8 @@ impl<
 
     /// Handles input events.
     pub fn handle_input(&mut self, ev: input::Event) {
-        if let Some(_pending_state) = &self.pending_key_state {
+        if let Some(PendingState { queued_events, .. }) = &mut self.pending_key_state {
+            queued_events.push(ev.into()).unwrap();
         } else {
             // Update each of the pressed keys with the event.
             self.pressed_inputs.iter_mut().for_each(|pi| {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -328,7 +328,7 @@ impl<
                 i += 1;
             }
 
-            self.handle_all_pending_events();
+            self.handle_pending_events();
         }
     }
 
@@ -357,8 +357,6 @@ impl<
                             .for_each(|sch_ev| self.event_scheduler.schedule_event(sch_ev));
                     }
                 });
-
-                self.handle_all_pending_events();
 
                 match ev {
                     input::Event::Press { keymap_index } => {
@@ -434,7 +432,7 @@ impl<
 
         self.handle_resolved_pending_key_state(ev.into());
 
-        self.handle_all_pending_events();
+        self.handle_pending_events();
     }
 
     // Called from handle_all_pending_events,
@@ -472,9 +470,9 @@ impl<
         }
     }
 
-    fn handle_all_pending_events(&mut self) {
+    fn handle_pending_events(&mut self) {
         // take from pending
-        while let Some(ev) = self.event_scheduler.dequeue() {
+        if let Some(ev) = self.event_scheduler.dequeue() {
             self.handle_event(ev);
         }
     }
@@ -483,7 +481,7 @@ impl<
     pub fn tick(&mut self) {
         self.event_scheduler.tick();
 
-        self.handle_all_pending_events();
+        self.handle_pending_events();
     }
 
     /// Returns the the pressed key outputs.

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -258,6 +258,7 @@ pub struct Keymap<I> {
     pressed_inputs: heapless::Vec<input::PressedInput<composite::PressedKey>, 16>,
     event_scheduler: EventScheduler<composite::Event>,
     hid_reporter: HIDKeyboardReporter,
+    pending_key_state: Option<PendingState>,
 }
 
 impl<
@@ -277,6 +278,7 @@ impl<
             pressed_inputs: heapless::Vec::new(),
             event_scheduler: EventScheduler::new(),
             hid_reporter: HIDKeyboardReporter::new(),
+            pending_key_state: None,
         }
     }
 
@@ -285,6 +287,7 @@ impl<
         self.pressed_inputs.clear();
         self.event_scheduler.init();
         self.hid_reporter.init();
+        self.pending_key_state = None;
     }
 
     /// Handles input events.

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -324,6 +324,9 @@ impl<
             //  delaying each consecutive event by a tick
             //  (in order to allow press/release events to affect the HID report)
             let mut i = 1;
+            self.input_queue
+                .enqueue(input::Event::InputResolved)
+                .unwrap();
             for ev in queued_events {
                 match ev {
                     key::Event::Input(ie) => {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -37,12 +37,16 @@ impl<E: Debug> EventScheduler<E> {
     pub fn schedule_event(&mut self, scheduled_event: key::ScheduledEvent<E>) {
         match scheduled_event.schedule {
             key::Schedule::Immediate => {
-                self.pending_events.enqueue(scheduled_event.event).unwrap();
+                self.enqueue_event(scheduled_event.event);
             }
             key::Schedule::After(delay) => {
                 self.schedule_after(delay as u32, scheduled_event.event);
             }
         }
+    }
+
+    pub fn enqueue_event(&mut self, event: Event<E>) {
+        self.pending_events.enqueue(event).unwrap();
     }
 
     pub fn schedule_after(&mut self, delay: u32, event: Event<E>) {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -317,7 +317,7 @@ impl<
             // Schedule each of the queued events,
             //  delaying each consecutive event by a tick
             //  (in order to allow press/release events to affect the HID report)
-            let mut i = 0;
+            let mut i = 1;
             for ev in queued_events {
                 self.event_scheduler.schedule_after(i, ev);
                 i += 1;

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -506,6 +506,12 @@ impl<
     pub fn boot_keyboard_report(&self) -> [u8; 8] {
         KeymapOutput::new(self.pressed_keys()).as_hid_boot_keyboard_report()
     }
+
+    #[doc(hidden)]
+    pub fn has_scheduled_events(&self) -> bool {
+        self.event_scheduler.pending_events.len() > 0
+            || self.event_scheduler.scheduled_events.len() > 0
+    }
 }
 
 #[cfg(test)]

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -242,6 +242,11 @@ impl DistinctReports {
             _ => self.0.push(report),
         }
     }
+
+    /// Access reports as slice of reports.
+    pub fn reports(&self) -> &[[u8; 8]] {
+        self.0.as_slice()
+    }
 }
 
 #[derive(Debug)]

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -496,8 +496,8 @@ impl<
     /// Updates the keymap indicating a report is sent; returns the reportable keymap output.
     pub fn report_output(&mut self) -> KeymapOutput {
         self.hid_reporter.update(self.pressed_keys());
-        let output = KeymapOutput::new(self.hid_reporter.reportable_key_outputs());
         self.hid_reporter.report_sent();
+        let output = KeymapOutput::new(self.hid_reporter.reportable_key_outputs());
         output
     }
 

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -244,6 +244,12 @@ impl DistinctReports {
     }
 }
 
+#[derive(Debug)]
+struct PendingState {
+    keymap_index: u16,
+    queued_events: heapless::Vec<key::Event<composite::Event>, 16>,
+}
+
 /// State for a keymap that handles input, and outputs HID keyboard reports.
 #[derive(Debug)]
 pub struct Keymap<I> {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -373,27 +373,31 @@ impl<
         }
     }
 
+    fn handle_event(&mut self, ev: key::Event<composite::Event>) {
+        // Update each of the pressed keys with the event.
+        self.pressed_inputs.iter_mut().for_each(|pi| {
+            if let input::PressedInput::Key { pressed_key, .. } = pi {
+                pressed_key
+                    .handle_event(self.context, ev)
+                    .into_iter()
+                    .for_each(|sch_ev| self.event_scheduler.schedule_event(sch_ev));
+            }
+        });
+
+        // Update context with the event
+        if let key::Event::Key { key_event, .. } = ev {
+            self.context.handle_event(key_event);
+        }
+
+        if let Event::Input(input_ev) = ev {
+            self.handle_input(input_ev);
+        }
+    }
+
     fn handle_all_pending_events(&mut self) {
         // take from pending
         while let Some(ev) = self.event_scheduler.dequeue() {
-            // Update each of the pressed keys with the event.
-            self.pressed_inputs.iter_mut().for_each(|pi| {
-                if let input::PressedInput::Key { pressed_key, .. } = pi {
-                    pressed_key
-                        .handle_event(self.context, ev)
-                        .into_iter()
-                        .for_each(|sch_ev| self.event_scheduler.schedule_event(sch_ev));
-                }
-            });
-
-            // Update context with the event
-            if let key::Event::Key { key_event, .. } = ev {
-                self.context.handle_event(key_event);
-            }
-
-            if let Event::Input(input_ev) = ev {
-                self.handle_input(input_ev);
-            }
+            self.handle_event(ev);
         }
     }
 

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -243,6 +243,14 @@ fn check_report_equivalences(world: &mut KeymapWorld, step: &Step) {
         expected_reports.update(test_keymap.report_output().as_hid_boot_keyboard_report());
     }
 
+    // tick() the 'actual' keymap
+    // (incl. updating the 'actual' distinct reports).
+    // Helps with cases where a pending key (e.g. tap-hold)
+    // resolves, and has scheduled events.
+    for _ in 0..20 {
+        world.keymap.tick();
+    }
+
     let actual_reports = world.keymap.distinct_reports();
     assert_eq!(&expected_reports, actual_reports);
 }

--- a/tests/rust/tap_hold.rs
+++ b/tests/rust/tap_hold.rs
@@ -53,6 +53,27 @@ fn key_tapped() {
 }
 
 #[test]
+fn key_uninterrupted_tap_is_reported() {
+    // Assemble
+    let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
+
+    // Act
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    keymap.tick();
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    // Assert
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x04, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
 fn key_unaffected_by_prev_key_release() {
     // When a tap-hold key is pressed,
     //  it schedules a Timeout event after 200 ticks.

--- a/tests/rust/tap_hold/hold_on_interrupt_press.rs
+++ b/tests/rust/tap_hold/hold_on_interrupt_press.rs
@@ -39,11 +39,17 @@ fn rolled_presses_resolves_hold() {
     let mut actual_reports = DistinctReports::new();
 
     // Act
-    // Roll the keys: press 0, press 1, ...
+    // Roll the keys: press 0, press 1, release 0, release 1
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
     actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
     actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     while keymap.has_scheduled_events() {
@@ -56,6 +62,8 @@ fn rolled_presses_resolves_hold() {
         [0, 0, 0, 0, 0, 0, 0, 0],
         [0x01, 0, 0, 0, 0, 0, 0, 0],
         [0x01, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     assert_eq!(expected_reports, actual_reports.reports());
 }

--- a/tests/rust/tap_hold/hold_on_interrupt_tap.rs
+++ b/tests/rust/tap_hold/hold_on_interrupt_tap.rs
@@ -39,7 +39,7 @@ fn rolled_presses_resolves_tap() {
     let mut actual_reports = DistinctReports::new();
 
     // Act
-    // Roll the keys: press 0, press 1, release 0,
+    // Roll the keys: press 0, press 1, release 0, release 1
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
     actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
@@ -47,6 +47,9 @@ fn rolled_presses_resolves_tap() {
     actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
     actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     while keymap.has_scheduled_events() {
@@ -60,6 +63,7 @@ fn rolled_presses_resolves_tap() {
         [0, 0, 0x04, 0, 0, 0, 0, 0],
         [0, 0, 0x04, 0x05, 0, 0, 0, 0],
         [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     assert_eq!(expected_reports, actual_reports.reports());
 }

--- a/tests/rust/tap_hold/hold_on_interrupt_tap.rs
+++ b/tests/rust/tap_hold/hold_on_interrupt_tap.rs
@@ -3,6 +3,7 @@ use smart_keymap::key;
 use smart_keymap::keymap;
 use smart_keymap::tuples;
 
+use keymap::DistinctReports;
 use keymap::Keymap;
 
 use key::{composite, keyboard, tap_hold};
@@ -35,32 +36,63 @@ const CONTEXT: Ctx = Ctx {
 fn rolled_presses_resolves_tap() {
     // Assemble
     let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
 
     // Act
     // Roll the keys: press 0, press 1, release 0,
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    let actual_report = keymap.boot_keyboard_report();
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    while keymap.has_scheduled_events() {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
 
     // Assert
-    let expected_report: [u8; 8] = [0, 0, 0x04, 0x05, 0, 0, 0, 0];
-    assert_eq!(expected_report, actual_report);
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, 0x04, 0x05, 0, 0, 0, 0],
+        [0, 0, 0x05, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn interrupting_tap_resolves_hold() {
     // Assemble
     let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
 
     // Act
-    // Press the TH key, then interrupt it with a press.
+    // Press the TH key, then interrupt it with a tap.
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
     keymap.handle_input(input::Event::Release { keymap_index: 1 });
-    let actual_report = keymap.boot_keyboard_report();
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    while keymap.has_scheduled_events() {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
 
     // Assert
-    let expected_report: [u8; 8] = [0x01, 0, 0, 0, 0, 0, 0, 0];
-    assert_eq!(expected_report, actual_report);
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0x01, 0, 0, 0, 0, 0, 0, 0],
+        [0x01, 0, 0x05, 0, 0, 0, 0, 0],
+        [0x01, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
 }

--- a/tests/rust/tap_hold/interrupt_ignore.rs
+++ b/tests/rust/tap_hold/interrupt_ignore.rs
@@ -32,7 +32,7 @@ fn rolled_presses() {
     let mut actual_reports = DistinctReports::new();
 
     // Act
-    // Roll the keys: press 0, press 1, release 0,
+    // Roll the keys: press 0, press 1, release 0, release 1
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
     actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
@@ -40,6 +40,9 @@ fn rolled_presses() {
     actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
     actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     while keymap.has_scheduled_events() {
@@ -53,6 +56,7 @@ fn rolled_presses() {
         [0, 0, 0x04, 0, 0, 0, 0, 0],
         [0, 0, 0x04, 0x05, 0, 0, 0, 0],
         [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     assert_eq!(expected_reports, actual_reports.reports());
 }

--- a/tests/rust/tap_hold/layered.rs
+++ b/tests/rust/tap_hold/layered.rs
@@ -3,6 +3,7 @@ use smart_keymap::key;
 use smart_keymap::keymap;
 use smart_keymap::tuples;
 
+use keymap::DistinctReports;
 use keymap::Keymap;
 
 use key::{composite, keyboard, layered, tap_hold};
@@ -36,50 +37,65 @@ fn press_active_layer_when_hold_layer_mod_held() {
     //    we need to use the aggregate composite::Key
     //    as the nested key type.
     let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
 
     // Act
     // - Press the tap-hold key.
     // - Resolve the tap-hold as hold (Time the tap-hold key out)
     // - Press the layered key.
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
     // Tick until the tap-hold's timeout event occurs.
-    for _ in 0..200 {
+    while keymap.has_scheduled_events() {
         keymap.tick();
-        let _ = keymap.pressed_keys();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     }
 
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    let actual_report = keymap.boot_keyboard_report();
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Assert
     // - Check the keycode from the layer is used.
-    let expected_report: [u8; 8] = [0, 0, 0x05, 0, 0, 0, 0, 0];
-    assert_eq!(expected_report, actual_report);
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x05, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn uses_base_when_pressed_after_hold_layer_mod_released() {
     // Assemble
     let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
 
     // 1. Press the tap-hold key
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
     // 2. Resolve the tap-hold as hold (Time the tap-hold key out)
     // Tick until the tap-hold's timeout event occurs.
-    for _ in 0..200 {
+    while keymap.has_scheduled_events() {
         keymap.tick();
-        let _ = keymap.pressed_keys();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     }
-    keymap.tick();
+
     // 3. Release the tap-hold key (release layered::LayerModifier::Hold)
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Act
     // Press the layered key; it should be the base key.
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    let actual_report = keymap.boot_keyboard_report();
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Assert
-    let expected_report: [u8; 8] = [0, 0, 0x04, 0, 0, 0, 0, 0];
-    assert_eq!(expected_report, actual_report);
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x04, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
 }


### PR DESCRIPTION
Whew, this took a while! -- Hoping to get back to smaller PRs after this.

The problem this PR solves:

- The [ignored](https://github.com/rgoulter/smart-keymap/blob/15da3cd7adb396b3f9106fc5d1395383000c964e/features/keymap/key/tap_hold-config-interrupt-ignore.feature#L53) cucumber feature covers it pretty well.
- With tap-hold hold-on-interrupting-tap, for a sequence like "press (TH(shift)), press A, release A".. the output should be the same as "press shift, press A, release A". -- However, the behaviour didn't reflect this. (The interrupting tap resolves the key to 'hold', but then discards the tap).

The solution to this involves rearranging how `keymap::Keymap` considers pending key state.

This PR has the Keymap have a pending state if a pressed key is 'pending'. (e.g. tap hold key when pressed is 'pending', until resolved as either 'tap' or 'hold'). -- Inputs are passed to the pending key, but otherwise don't affect output until the key resolves.  Once the pending key resolves, the inputs from the pending state are then re-played, affecting output.

(This also adjusts the solution used for tap-hold "tap" output; previously, 'tap' was emulated using virtual pressed keys; that was because the resolved-as-tap tap-hold key was removed as a pressed-input once its key was released. Now, the 'tap' output can be had from the resolved tap-hold key).

(It may be cleaner to refactor the PressedKeyState into "PendingPressedKeyState" and (resolved) "PressedKeyState").

-- Trying this out on a keyboard, it's pretty close. Apparently buggy in some cases.