### PR TITLE
Cucumber report equivalences

### DIFF
--- a/features/keymap/key/tap_hold-config-interrupt-ignore.feature
+++ b/features/keymap/key/tap_hold-config-interrupt-ignore.feature
@@ -40,9 +40,13 @@ Feature: TapHold Key (configure interrupt response: ignore)
         release (K.A & K.hold K.LeftCtrl),
       ]
       """
-    Then the HID keyboard report should equal
+    Then the output should be equivalent to output from
       """
-      { key_codes = [K.A, K.B] }
+      [
+        press (K.A),
+        press (K.B),
+        release (K.A),
+      ]
       """
 
   Example: interrupting tap (press TH(A), press B, release B, release TH(A))
@@ -60,7 +64,12 @@ Feature: TapHold Key (configure interrupt response: ignore)
         release (K.A & K.hold K.LeftCtrl),
       ]
       """
-    Then the HID keyboard report should equal
+    Then the output should be equivalent to output from
       """
-      { key_codes = [K.A] }
+      [
+        press (K.A),
+        press (K.B),
+        release (K.B),
+        release (K.A),
+      ]
       """

--- a/features/keymap/key/tap_hold-config-interrupt-ignore.feature
+++ b/features/keymap/key/tap_hold-config-interrupt-ignore.feature
@@ -25,6 +25,7 @@ Feature: TapHold Key (configure interrupt response: ignore)
       }
       """
 
+  @ignore
   Example: rolling key presses (press TH(A), press B, release TH(A))
 
     Rolling the tap-hold key with another key
@@ -49,6 +50,7 @@ Feature: TapHold Key (configure interrupt response: ignore)
       ]
       """
 
+  @ignore
   Example: interrupting tap (press TH(A), press B, release B, release TH(A))
 
     After interrupting the tap-hold key with another key tap (press & release),

--- a/features/keymap/key/tap_hold-config-interrupt-ignore.feature
+++ b/features/keymap/key/tap_hold-config-interrupt-ignore.feature
@@ -25,7 +25,7 @@ Feature: TapHold Key (configure interrupt response: ignore)
       }
       """
 
-  Example: rolling key presses (press TH(A), press B, release TH(A)
+  Example: rolling key presses (press TH(A), press B, release TH(A))
 
     Rolling the tap-hold key with another key
     (i.e. interrupting the tap-hold key with another key press),

--- a/features/keymap/key/tap_hold-config-interrupt-presses.feature
+++ b/features/keymap/key/tap_hold-config-interrupt-presses.feature
@@ -38,9 +38,12 @@ Feature: TapHold Key (configure interrupt response: hold on key press)
         press (K.B),
       ]
       """
-    Then the HID keyboard report should equal
+    Then the output should be equivalent to output from
       """
-      { modifiers = { left_ctrl = true }, key_codes = [K.B] }
+      [
+        press (K.LeftCtrl),
+        press (K.B),
+      ]
       """
 
   Example: interrupting tap (press TH(A), press B, release B, release TH(A))
@@ -60,4 +63,12 @@ Feature: TapHold Key (configure interrupt response: hold on key press)
     Then the HID keyboard report should equal
       """
       { modifiers = { left_ctrl = true } }
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        press (K.LeftCtrl),
+        press (K.B),
+        release (K.B),
+      ]
       """

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -231,8 +231,8 @@ pub struct DistinctReports(Vec<[u8; 8]>);
 #[cfg(feature = "std")]
 impl DistinctReports {
     /// Constructs a new DistinctReports.
-    pub const fn new() -> Self {
-        Self(Vec::new())
+    pub fn new() -> Self {
+        Self(vec![[0; 8]])
     }
 
     /// Adds the report to the distinct reports.

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -223,6 +223,27 @@ impl HIDKeyboardReporter {
     }
 }
 
+/// For tracking distinct HID reports from the keymap.
+#[cfg(feature = "std")]
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DistinctReports(Vec<[u8; 8]>);
+
+#[cfg(feature = "std")]
+impl DistinctReports {
+    /// Constructs a new DistinctReports.
+    pub const fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    /// Adds the report to the distinct reports.
+    pub fn update(&mut self, report: [u8; 8]) {
+        match self.0.last() {
+            Some(last_report) if last_report == &report => {}
+            _ => self.0.push(report),
+        }
+    }
+}
+
 /// State for a keymap that handles input, and outputs HID keyboard reports.
 #[derive(Debug)]
 pub struct Keymap<I> {

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -92,9 +92,7 @@ struct DocstringKeymap {
     keys: Vec<Key>,
 }
 
-#[given("a keymap.ncl:")]
-fn setup_nickel_keymap(world: &mut KeymapWorld, step: &Step) {
-    let keymap_ncl = step.docstring().unwrap();
+fn load_keymap(keymap_ncl: &str) -> Keymap {
     match nickel_json_serialization_for_keymap(
         format!("{}/ncl", env!("CARGO_MANIFEST_DIR")),
         keymap_ncl,
@@ -105,8 +103,7 @@ fn setup_nickel_keymap(world: &mut KeymapWorld, step: &Step) {
                 Ok(keymap) => {
                     let dyn_keys = keymap.keys.into_iter().collect();
                     let context = key::composite::Context::from_config(keymap.config);
-                    world.keymap_ncl = keymap_ncl.into();
-                    world.keymap = LoadedKeymap::keymap(keymap::Keymap::new(dyn_keys, context));
+                    keymap::Keymap::new(dyn_keys, context)
                 }
                 Err(e) => {
                     panic!(
@@ -125,6 +122,13 @@ fn setup_nickel_keymap(world: &mut KeymapWorld, step: &Step) {
             ),
         },
     }
+}
+
+#[given("a keymap.ncl:")]
+fn setup_nickel_keymap(world: &mut KeymapWorld, step: &Step) {
+    let keymap_ncl = step.docstring().unwrap();
+    world.keymap_ncl = keymap_ncl.into();
+    world.keymap = LoadedKeymap::keymap(load_keymap(keymap_ncl));
 }
 
 #[when("the keymap registers the following input")]

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -39,6 +39,7 @@ impl LoadedKeymap {
             _ => panic!("No keymap loaded"),
         }
     }
+
     pub fn tick(&mut self) {
         match self {
             LoadedKeymap::Keymap {
@@ -51,6 +52,7 @@ impl LoadedKeymap {
             _ => panic!("No keymap loaded"),
         }
     }
+
     pub fn boot_keyboard_report(&self) -> [u8; 8] {
         match self {
             LoadedKeymap::Keymap { keymap, .. } => {

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -16,6 +16,8 @@ use smart_keymap_nickel_helper::{
 
 type Key = key::composite::Key;
 
+type Keymap = keymap::Keymap<Vec<Key>>;
+
 /// Keymap with basic keycodes, useful for the "check report equivalences" step.
 const TEST_KEYMAP_NCL: &str = r#"
   let K = import "keys.ncl" in
@@ -26,13 +28,13 @@ const TEST_KEYMAP_NCL: &str = r#"
 enum LoadedKeymap {
     NoKeymap,
     Keymap {
-        keymap: keymap::Keymap<Vec<Key>>,
+        keymap: Keymap,
         distinct_reports: keymap::DistinctReports,
     },
 }
 
 impl LoadedKeymap {
-    pub fn keymap(keymap: keymap::Keymap<Vec<Key>>) -> Self {
+    pub fn keymap(keymap: Keymap) -> Self {
         LoadedKeymap::Keymap {
             keymap,
             distinct_reports: keymap::DistinctReports::new(),

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -16,6 +16,12 @@ use smart_keymap_nickel_helper::{
 
 type Key = key::composite::Key;
 
+/// Keymap with basic keycodes, useful for the "check report equivalences" step.
+const TEST_KEYMAP_NCL: &str = r#"
+  let K = import "keys.ncl" in
+  { keys = [ K.A, K.B, K.C, K.LeftCtrl ] }
+"#;
+
 #[derive(Debug)]
 enum LoadedKeymap {
     NoKeymap,

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -41,7 +41,13 @@ impl LoadedKeymap {
     }
     pub fn tick(&mut self) {
         match self {
-            LoadedKeymap::Keymap { keymap, .. } => keymap.tick(),
+            LoadedKeymap::Keymap {
+                keymap,
+                distinct_reports,
+            } => {
+                keymap.tick();
+                distinct_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+            }
             _ => panic!("No keymap loaded"),
         }
     }

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -229,6 +229,24 @@ fn check_tick_report(world: &mut KeymapWorld, step: &Step) {
     }
 }
 
+#[then("the output should be equivalent to output from")]
+fn check_report_equivalences(world: &mut KeymapWorld, step: &Step) {
+    let mut test_keymap = load_keymap(TEST_KEYMAP_NCL);
+    let mut expected_reports = keymap::DistinctReports::new();
+
+    let inputs_ncl = step.docstring().unwrap();
+    let inputs = inputs_from_ncl(TEST_KEYMAP_NCL, inputs_ncl);
+
+    for input in inputs {
+        test_keymap.handle_input(input);
+        test_keymap.tick();
+        expected_reports.update(test_keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    let actual_reports = world.keymap.distinct_reports();
+    assert_eq!(&expected_reports, actual_reports);
+}
+
 fn main() {
     futures::executor::block_on(KeymapWorld::run("features/keymap/"));
 }

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -23,6 +23,10 @@ enum LoadedKeymap {
 }
 
 impl LoadedKeymap {
+    pub fn keymap(keymap: keymap::Keymap<Vec<Key>>) -> Self {
+        LoadedKeymap::Keymap(keymap)
+    }
+
     pub fn handle_input(&mut self, ev: input::Event) {
         match self {
             LoadedKeymap::Keymap(keymap) => keymap.handle_input(ev),
@@ -80,7 +84,7 @@ fn setup_nickel_keymap(world: &mut KeymapWorld, step: &Step) {
                     let dyn_keys = keymap.keys.into_iter().collect();
                     let context = key::composite::Context::from_config(keymap.config);
                     world.keymap_ncl = keymap_ncl.into();
-                    world.keymap = LoadedKeymap::Keymap(keymap::Keymap::new(dyn_keys, context));
+                    world.keymap = LoadedKeymap::keymap(keymap::Keymap::new(dyn_keys, context));
                 }
                 Err(e) => {
                     panic!(

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -19,12 +19,18 @@ type Key = key::composite::Key;
 #[derive(Debug)]
 enum LoadedKeymap {
     NoKeymap,
-    Keymap { keymap: keymap::Keymap<Vec<Key>> },
+    Keymap {
+        keymap: keymap::Keymap<Vec<Key>>,
+        distinct_reports: keymap::DistinctReports,
+    },
 }
 
 impl LoadedKeymap {
     pub fn keymap(keymap: keymap::Keymap<Vec<Key>>) -> Self {
-        LoadedKeymap::Keymap { keymap }
+        LoadedKeymap::Keymap {
+            keymap,
+            distinct_reports: keymap::DistinctReports::new(),
+        }
     }
 
     pub fn handle_input(&mut self, ev: input::Event) {

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -43,7 +43,13 @@ impl LoadedKeymap {
 
     pub fn handle_input(&mut self, ev: input::Event) {
         match self {
-            LoadedKeymap::Keymap { keymap, .. } => keymap.handle_input(ev),
+            LoadedKeymap::Keymap {
+                keymap,
+                distinct_reports,
+            } => {
+                keymap.handle_input(ev);
+                distinct_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+            }
             _ => panic!("No keymap loaded"),
         }
     }

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -76,6 +76,15 @@ impl LoadedKeymap {
             _ => panic!("No keymap loaded"),
         }
     }
+
+    pub fn distinct_reports(&self) -> &keymap::DistinctReports {
+        match self {
+            LoadedKeymap::Keymap {
+                distinct_reports, ..
+            } => distinct_reports,
+            _ => panic!("No keymap loaded"),
+        }
+    }
 }
 #[derive(Debug, World)]
 pub struct KeymapWorld {

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -85,7 +85,7 @@ impl Default for KeymapWorld {
 }
 
 #[derive(Deserialize)]
-struct Keymap {
+struct DocstringKeymap {
     config: key::composite::Config,
     keys: Vec<Key>,
 }
@@ -98,7 +98,7 @@ fn setup_nickel_keymap(world: &mut KeymapWorld, step: &Step) {
         keymap_ncl,
     ) {
         Ok(json) => {
-            let keymap_result: serde_json::Result<Keymap> = serde_json::from_str(&json);
+            let keymap_result: serde_json::Result<DocstringKeymap> = serde_json::from_str(&json);
             match keymap_result {
                 Ok(keymap) => {
                     let dyn_keys = keymap.keys.into_iter().collect();

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -248,5 +248,9 @@ fn check_report_equivalences(world: &mut KeymapWorld, step: &Step) {
 }
 
 fn main() {
-    futures::executor::block_on(KeymapWorld::run("features/keymap/"));
+    futures::executor::block_on(
+        KeymapWorld::cucumber().filter_run("features/keymap/", |_, _, scenario| {
+            !scenario.tags.iter().any(|t| t == "ignore")
+        }),
+    );
 }

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -131,22 +131,16 @@ fn setup_nickel_keymap(world: &mut KeymapWorld, step: &Step) {
     world.keymap = LoadedKeymap::keymap(load_keymap(keymap_ncl));
 }
 
-#[when("the keymap registers the following input")]
-fn perform_input(world: &mut KeymapWorld, step: &Step) {
-    let inputs_ncl = step.docstring().unwrap();
+fn inputs_from_ncl(keymap_ncl: &str, inputs_ncl: &str) -> Vec<input::Event> {
     match nickel_json_serialization_for_inputs(
         format!("{}/ncl", env!("CARGO_MANIFEST_DIR")),
-        world.keymap_ncl.as_str(),
+        keymap_ncl,
         inputs_ncl,
     ) {
         Ok(json) => {
             let inputs_result: serde_json::Result<Vec<input::Event>> = serde_json::from_str(&json);
             match inputs_result {
-                Ok(inputs) => {
-                    for input in inputs {
-                        world.keymap.handle_input(input);
-                    }
-                }
+                Ok(inputs) => inputs,
                 Err(e) => {
                     panic!(
                         "\n\nerror deserailizing JSON:\n\nDeserialization Error:\n\n{}\n\nJSON:\n{}",
@@ -163,6 +157,16 @@ fn perform_input(world: &mut KeymapWorld, step: &Step) {
                 nickel_error_message
             ),
         },
+    }
+}
+
+#[when("the keymap registers the following input")]
+fn perform_input(world: &mut KeymapWorld, step: &Step) {
+    let inputs_ncl = step.docstring().unwrap();
+    let inputs = inputs_from_ncl(world.keymap_ncl.as_str(), inputs_ncl);
+
+    for input in inputs {
+        world.keymap.handle_input(input);
     }
 }
 

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -19,29 +19,29 @@ type Key = key::composite::Key;
 #[derive(Debug)]
 enum LoadedKeymap {
     NoKeymap,
-    Keymap(keymap::Keymap<Vec<Key>>),
+    Keymap { keymap: keymap::Keymap<Vec<Key>> },
 }
 
 impl LoadedKeymap {
     pub fn keymap(keymap: keymap::Keymap<Vec<Key>>) -> Self {
-        LoadedKeymap::Keymap(keymap)
+        LoadedKeymap::Keymap { keymap }
     }
 
     pub fn handle_input(&mut self, ev: input::Event) {
         match self {
-            LoadedKeymap::Keymap(keymap) => keymap.handle_input(ev),
+            LoadedKeymap::Keymap { keymap, .. } => keymap.handle_input(ev),
             _ => panic!("No keymap loaded"),
         }
     }
     pub fn tick(&mut self) {
         match self {
-            LoadedKeymap::Keymap(keymap) => keymap.tick(),
+            LoadedKeymap::Keymap { keymap, .. } => keymap.tick(),
             _ => panic!("No keymap loaded"),
         }
     }
     pub fn boot_keyboard_report(&self) -> [u8; 8] {
         match self {
-            LoadedKeymap::Keymap(keymap) => {
+            LoadedKeymap::Keymap { keymap, .. } => {
                 smart_keymap::keymap::KeymapOutput::new(keymap.pressed_keys())
                     .as_hid_boot_keyboard_report()
             }


### PR DESCRIPTION
Currently, some of the tap-hold behaviour isn't quite correct.

This PR makes it easier to write tests checking this behaviour.

Rather than crafting tests which specifically assert what each report is at each time, this PR allows writing Cucumber specs where the output is asserted to be "equivalent to" output for a simpler keymap.