### PR TITLE
rust: prefer assert(expected, actual) order

### DIFF
--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -753,7 +753,7 @@ mod tests {
                 key_event: Event::LayerModification(layered::LayerEvent::LayerDeactivated(layer)),
                 ..
             }) => {
-                assert_eq!(layer, 0);
+                assert_eq!(0, layer);
             }
             _ => panic!("Expected an Event::Key(LayerModification(LayerDeactivated(layer)))"),
         };
@@ -790,7 +790,7 @@ mod tests {
 
         // Assert
         let expected_active_layers = &[true];
-        assert_eq!(actual_active_layers[0..1], expected_active_layers[0..1]);
+        assert_eq!(expected_active_layers[0..1], actual_active_layers[0..1]);
     }
 
     #[test]
@@ -826,7 +826,7 @@ mod tests {
 
         // Assert
         let expected_active_layers = &[false];
-        assert_eq!(actual_active_layers[0..1], expected_active_layers[0..1]);
+        assert_eq!(expected_active_layers[0..1], actual_active_layers[0..1]);
     }
 
     #[test]
@@ -853,7 +853,7 @@ mod tests {
 
         // Assert
         let expected_keycode = Some(key::KeyOutput::from_key_code(0x06));
-        assert_eq!(actual_keycode.to_option(), expected_keycode);
+        assert_eq!(expected_keycode, actual_keycode.to_option());
     }
 
     #[test]
@@ -880,6 +880,6 @@ mod tests {
 
         // Assert
         let expected_keycode = Some(key::KeyOutput::from_key_code(0x04));
-        assert_eq!(actual_keycode.to_option(), expected_keycode);
+        assert_eq!(expected_keycode, actual_keycode.to_option());
     }
 }

--- a/src/key/doc_de_composite.md
+++ b/src/key/doc_de_composite.md
@@ -15,7 +15,7 @@ let json = r#"
 "#;
 let expected_key: Key = Key::keyboard(keyboard::Key::new(0x04));
 let actual_key: Key = serde_json::from_str(json).unwrap();
-assert_eq!(actual_key, expected_key);
+assert_eq!(expected_key, actual_key);
 ```
 
 # TapHold variant
@@ -38,7 +38,7 @@ let expected_key: Key = Key::tap_hold(tap_hold::Key {
     hold: keyboard::Key::new(224).into(),
   });
 let actual_key: Key = serde_json::from_str(json).unwrap();
-assert_eq!(actual_key, expected_key);
+assert_eq!(expected_key, actual_key);
 ```
 
 # Layer Modifier Key variant
@@ -58,7 +58,7 @@ let json = r#"
 "#;
 let expected_key: Key = Key::layer_modifier(layered::ModifierKey::Hold(2));
 let actual_key: Key = serde_json::from_str(json).unwrap();
-assert_eq!(actual_key, expected_key);
+assert_eq!(expected_key, actual_key);
 ```
 
 # Layered Key variant
@@ -84,5 +84,5 @@ let expected_key: Key = Key::layered(layered::LayeredKey::new(
     [Some(keyboard::Key::new(0x05).into()), None, Some(keyboard::Key::new(0x07).into())],
   ));
 let actual_key: Key = serde_json::from_str(json).unwrap();
-assert_eq!(actual_key, expected_key);
+assert_eq!(expected_key, actual_key);
 ```

--- a/src/key/doc_de_keyboard.md
+++ b/src/key/doc_de_keyboard.md
@@ -9,7 +9,7 @@ let json = r#"
 "#;
 let expected_key: Key = Key::new(0x04);
 let actual_key: Key = serde_json::from_str(json).unwrap();
-assert_eq!(actual_key, expected_key);
+assert_eq!(expected_key, actual_key);
 ```
 
 Modifiers:
@@ -24,7 +24,7 @@ let expected_key: Key = Key::from_modifiers(
     KeyboardModifiers::LEFT_CTRL,
 );
 let actual_key: Key = serde_json::from_str(json).unwrap();
-assert_eq!(actual_key, expected_key);
+assert_eq!(expected_key, actual_key);
 ```
 
 Key code with modifiers:
@@ -40,5 +40,5 @@ let expected_key: Key = Key::new_with_modifiers(
     KeyboardModifiers::LEFT_CTRL,
 );
 let actual_key: Key = serde_json::from_str(json).unwrap();
-assert_eq!(actual_key, expected_key);
+assert_eq!(expected_key, actual_key);
 ```

--- a/src/key/doc_de_layered.md
+++ b/src/key/doc_de_layered.md
@@ -10,7 +10,7 @@ let json = r#"
 "#;
 let expected_key: ModifierKey = ModifierKey::Hold(2);
 let actual_key: ModifierKey = serde_json::from_str(json).unwrap();
-assert_eq!(actual_key, expected_key);
+assert_eq!(expected_key, actual_key);
 ```
 
 # Layered Keys
@@ -35,5 +35,5 @@ let expected_key: Key = layered::LayeredKey::new(
   [Some(keyboard::Key::new(0x05)), None, Some(keyboard::Key::new(0x07))],
 );
 let actual_key: Key = serde_json::from_str(json).unwrap();
-assert_eq!(actual_key, expected_key);
+assert_eq!(expected_key, actual_key);
 ```

--- a/src/key/doc_de_tap_hold.md
+++ b/src/key/doc_de_tap_hold.md
@@ -11,6 +11,6 @@ let expected_key: Key<keyboard::Key> = Key {
   tap: keyboard::Key::new(4),
 };
 let actual_key: Key<keyboard::Key> = serde_json::from_str(json).unwrap();
-assert_eq!(actual_key, expected_key);
+assert_eq!(expected_key, actual_key);
 ```
 

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -292,7 +292,7 @@ mod tests {
 
         let (_pressed_key, layer_event) = key.new_pressed_key();
 
-        assert_eq!(layer_event, LayerEvent::LayerActivated(layer));
+        assert_eq!(LayerEvent::LayerActivated(layer), layer_event);
     }
 
     #[test]
@@ -317,7 +317,7 @@ mod tests {
         let first_ev = actual_events.into_iter().next();
         if let Some(actual_layer_event) = first_ev {
             let expected_layer_event = LayerEvent::LayerDeactivated(layer);
-            assert_eq!(actual_layer_event, expected_layer_event);
+            assert_eq!(expected_layer_event, actual_layer_event);
         } else {
             panic!("Expected Some LayerDeactivated event");
         }
@@ -382,8 +382,8 @@ mod tests {
         let expected_pressed_key_state = expected_key.new_pressed_key();
 
         assert_eq!(
+            BasePressedKeyState::Keyboard(expected_pressed_key_state),
             actual_pressed_key.pressed_key_state,
-            BasePressedKeyState::Keyboard(expected_pressed_key_state)
         );
     }
 
@@ -412,10 +412,10 @@ mod tests {
         // Assert
         let expected_pressed_key_state = expected_key.new_pressed_key();
         let expected_key_output = expected_pressed_key_state.key_output(&expected_key);
-        assert_eq!(actual_key_output, expected_key_output);
+        assert_eq!(expected_key_output, actual_key_output);
         assert_eq!(
+            Some(KeyOutput::from_key_code(0x04)),
             actual_key_output.to_option(),
-            Some(KeyOutput::from_key_code(0x04))
         );
     }
 
@@ -443,8 +443,8 @@ mod tests {
         // Assert
         let expected_pressed_key_state = expected_key.new_pressed_key();
         assert_eq!(
+            BasePressedKeyState::Keyboard(expected_pressed_key_state),
             actual_pressed_key.pressed_key_state,
-            BasePressedKeyState::Keyboard(expected_pressed_key_state)
         );
     }
 
@@ -475,8 +475,8 @@ mod tests {
         // Assert
         let expected_pressed_key_state = expected_key.new_pressed_key();
         assert_eq!(
+            BasePressedKeyState::Keyboard(expected_pressed_key_state),
             actual_pressed_key.pressed_key_state,
-            BasePressedKeyState::Keyboard(expected_pressed_key_state)
         );
     }
 
@@ -502,8 +502,8 @@ mod tests {
         // Assert
         let expected_pressed_key_state = expected_key.new_pressed_key();
         assert_eq!(
+            BasePressedKeyState::Keyboard(expected_pressed_key_state),
             actual_pressed_key.pressed_key_state,
-            BasePressedKeyState::Keyboard(expected_pressed_key_state)
         );
     }
 
@@ -513,7 +513,7 @@ mod tests {
 
         let actual_key: key::keyboard::Key = ron::from_str("Key(key_code: 0x04)").unwrap();
         let expected_key: key::keyboard::Key = keyboard::Key::new(0x04);
-        assert_eq!(actual_key, expected_key);
+        assert_eq!(expected_key, actual_key);
     }
 
     #[test]
@@ -523,14 +523,14 @@ mod tests {
         let actual_key: Option<key::keyboard::Key> =
             ron::from_str("Some(Key(key_code: 0x04))").unwrap();
         let expected_key: Option<key::keyboard::Key> = Some(keyboard::Key::new(0x04));
-        assert_eq!(actual_key, expected_key);
+        assert_eq!(expected_key, actual_key);
     }
 
     #[test]
     fn test_deserialize_ron_array1_u8() {
         let actual: [u8; 1] = ron::from_str("(5)").unwrap();
         let expected: [u8; 1] = [5];
-        assert_eq!(actual, expected);
+        assert_eq!(expected, actual);
     }
 
     #[test]
@@ -538,7 +538,7 @@ mod tests {
         let actual: [Option<key::keyboard::Key>; 1] =
             ron::from_str("(Some(Key(key_code: 0x04)))").unwrap();
         let expected: [Option<key::keyboard::Key>; 1] = [Some(keyboard::Key::new(0x04))];
-        assert_eq!(actual, expected);
+        assert_eq!(expected, actual);
     }
 
     #[test]
@@ -546,7 +546,7 @@ mod tests {
         let actual: Option<key::keyboard::Key> =
             serde_json::from_str(r#"{"key_code": 4}"#).unwrap();
         let expected: Option<key::keyboard::Key> = Some(keyboard::Key::new(0x04));
-        assert_eq!(actual, expected);
+        assert_eq!(expected, actual);
     }
 
     #[test]
@@ -555,7 +555,7 @@ mod tests {
             serde_json::from_str(r#"[{"key_code": 4}]"#).unwrap();
         let mut expected: heapless::Vec<Option<key::keyboard::Key>, 1> = heapless::Vec::new();
         expected.push(Some(keyboard::Key::new(0x04))).unwrap();
-        assert_eq!(actual, expected);
+        assert_eq!(expected, actual);
     }
 
     #[test]
@@ -563,7 +563,7 @@ mod tests {
         let actual: [Option<key::keyboard::Key>; 1] =
             serde_json::from_str(r#"[{"key_code": 4}]"#).unwrap();
         let expected: [Option<key::keyboard::Key>; 1] = [Some(keyboard::Key::new(0x04))];
-        assert_eq!(actual, expected);
+        assert_eq!(expected, actual);
     }
 
     #[test]
@@ -572,7 +572,7 @@ mod tests {
             ron::from_str("(base: (key_code: 0x04), layered: [])").unwrap();
         let expected_key: LayeredKey<key::keyboard::Key> =
             LayeredKey::new(key::keyboard::Key::new(0x04), []);
-        assert_eq!(actual_key, expected_key);
+        assert_eq!(expected_key, actual_key);
     }
 
     #[test]
@@ -581,7 +581,7 @@ mod tests {
             serde_json::from_str(r#"{"base": {"key_code": 4}, "layered": []}"#).unwrap();
         let expected_key: LayeredKey<key::keyboard::Key> =
             LayeredKey::new(key::keyboard::Key::new(0x04), []);
-        assert_eq!(actual_key, expected_key);
+        assert_eq!(expected_key, actual_key);
     }
 
     #[test]
@@ -590,7 +590,7 @@ mod tests {
             ron::from_str("LayeredKey(base: Key(key_code: 0x04), layered: [None])").unwrap();
         let expected_key: LayeredKey<key::keyboard::Key> =
             LayeredKey::new(key::keyboard::Key::new(0x04), [None]);
-        assert_eq!(actual_key, expected_key);
+        assert_eq!(expected_key, actual_key);
     }
 
     #[test]
@@ -602,6 +602,6 @@ mod tests {
         let actual_active_layers: Vec<LayerIndex> = layer_state.active_layers().collect();
         let expected_active_layers: Vec<LayerIndex> = vec![3, 1, 0];
 
-        assert_eq!(actual_active_layers, expected_active_layers);
+        assert_eq!(expected_active_layers, actual_active_layers);
     }
 }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -464,7 +464,7 @@ mod tests {
 
         // Assert - check the 0xE0 gets considered as a "modifier".
         let expected_report: [u8; 8] = [0x01, 0, 0x04, 0, 0, 0, 0, 0];
-        assert_eq!(actual_report, expected_report);
+        assert_eq!(expected_report, actual_report);
     }
 
     #[test]
@@ -484,7 +484,7 @@ mod tests {
             .iter()
             .map(|kc| key::KeyOutput::from_key_code(*kc))
             .collect();
-        assert_eq!(actual_outputs, expected_outputs);
+        assert_eq!(expected_outputs, actual_outputs);
     }
 
     #[test]
@@ -506,7 +506,7 @@ mod tests {
             .iter()
             .map(|kc| key::KeyOutput::from_key_code(*kc))
             .collect();
-        assert_eq!(actual_outputs, expected_outputs);
+        assert_eq!(expected_outputs, actual_outputs);
     }
 
     #[test]
@@ -529,7 +529,7 @@ mod tests {
             .iter()
             .map(|kc| key::KeyOutput::from_key_code(*kc))
             .collect();
-        assert_eq!(actual_outputs, expected_outputs);
+        assert_eq!(expected_outputs, actual_outputs);
     }
 
     #[test]
@@ -569,8 +569,8 @@ mod tests {
             .map(|kc| key::KeyOutput::from_key_code(*kc))
             .collect();
         assert_eq!(
+            KeymapOutput::new(expected_outputs).as_hid_boot_keyboard_report(),
             KeymapOutput::new(actual_outputs).as_hid_boot_keyboard_report(),
-            KeymapOutput::new(expected_outputs).as_hid_boot_keyboard_report()
         );
     }
 
@@ -595,7 +595,7 @@ mod tests {
 
         // Assert
         let expected_report: [u8; 8] = [0, 0, 0x04, 0, 0, 0, 0, 0];
-        assert_eq!(actual_report, expected_report);
+        assert_eq!(expected_report, actual_report);
     }
 
     #[test]
@@ -617,6 +617,6 @@ mod tests {
 
         // Assert
         let expected_report: [u8; 8] = [0, 0, 0x04, 0, 0, 0, 0, 0];
-        assert_eq!(actual_report, expected_report);
+        assert_eq!(expected_report, actual_report);
     }
 }

--- a/tests/rust/layered.rs
+++ b/tests/rust/layered.rs
@@ -35,7 +35,7 @@ fn press_base_key_when_no_layers_active() {
 
     // Assert
     let expected_report: [u8; 8] = [0, 0, 0x04, 0, 0, 0, 0, 0];
-    assert_eq!(actual_report, expected_report);
+    assert_eq!(expected_report, actual_report,);
 }
 
 #[test]
@@ -50,7 +50,7 @@ fn press_active_layer_when_layer_mod_held() {
 
     // Assert
     let expected_report: [u8; 8] = [0, 0, 0x05, 0, 0, 0, 0, 0];
-    assert_eq!(actual_report, expected_report);
+    assert_eq!(expected_report, actual_report);
 }
 
 #[test]
@@ -66,7 +66,7 @@ fn press_retained_when_layer_mod_released() {
 
     // Assert
     let expected_report: [u8; 8] = [0, 0, 0x05, 0, 0, 0, 0, 0];
-    assert_eq!(actual_report, expected_report);
+    assert_eq!(expected_report, actual_report);
 }
 
 #[test]
@@ -82,5 +82,5 @@ fn uses_base_when_pressed_after_layer_mod_released() {
 
     // Assert
     let expected_report: [u8; 8] = [0, 0, 0x04, 0, 0, 0, 0, 0];
-    assert_eq!(actual_report, expected_report);
+    assert_eq!(expected_report, actual_report);
 }

--- a/tests/rust/tap_hold.rs
+++ b/tests/rust/tap_hold.rs
@@ -35,7 +35,7 @@ fn key_tapped() {
 
     // Assert
     let expected_report: [u8; 8] = [0, 0, 0x04, 0, 0, 0, 0, 0];
-    assert_eq!(actual_report, expected_report);
+    assert_eq!(expected_report, actual_report);
 }
 
 #[test]
@@ -68,5 +68,5 @@ fn key_unaffected_by_prev_key_release() {
     // Assert
     // Second timeout not invoked, key is still "Pending" state.
     let expected_report: [u8; 8] = [0, 0, 0, 0, 0, 0, 0, 0];
-    assert_eq!(actual_report, expected_report);
+    assert_eq!(expected_report, actual_report);
 }

--- a/tests/rust/tap_hold/hold_on_interrupt_press.rs
+++ b/tests/rust/tap_hold/hold_on_interrupt_press.rs
@@ -44,7 +44,7 @@ fn rolled_presses_resolves_hold() {
 
     // Assert
     let expected_report: [u8; 8] = [0x01, 0, 0x05, 0, 0, 0, 0, 0];
-    assert_eq!(actual_report, expected_report);
+    assert_eq!(expected_report, actual_report);
 }
 
 #[test]
@@ -60,5 +60,5 @@ fn interrupting_press_resolves_hold() {
 
     // Assert
     let expected_report: [u8; 8] = [0x01, 0, 0x05, 0, 0, 0, 0, 0];
-    assert_eq!(actual_report, expected_report);
+    assert_eq!(expected_report, actual_report);
 }

--- a/tests/rust/tap_hold/hold_on_interrupt_tap.rs
+++ b/tests/rust/tap_hold/hold_on_interrupt_tap.rs
@@ -45,7 +45,7 @@ fn rolled_presses_resolves_tap() {
 
     // Assert
     let expected_report: [u8; 8] = [0, 0, 0x04, 0x05, 0, 0, 0, 0];
-    assert_eq!(actual_report, expected_report);
+    assert_eq!(expected_report, actual_report);
 }
 
 #[test]
@@ -62,5 +62,5 @@ fn interrupting_tap_resolves_hold() {
 
     // Assert
     let expected_report: [u8; 8] = [0x01, 0, 0, 0, 0, 0, 0, 0];
-    assert_eq!(actual_report, expected_report);
+    assert_eq!(expected_report, actual_report);
 }

--- a/tests/rust/tap_hold/interrupt_ignore.rs
+++ b/tests/rust/tap_hold/interrupt_ignore.rs
@@ -38,7 +38,7 @@ fn rolled_presses() {
 
     // Assert
     let expected_report: [u8; 8] = [0, 0, 0x04, 0x05, 0, 0, 0, 0];
-    assert_eq!(actual_report, expected_report);
+    assert_eq!(expected_report, actual_report);
 }
 
 #[test]
@@ -64,13 +64,13 @@ fn rolled_presses_desc_keycodes() {
         keymap.tick();
         let actual_report = keymap.report_output().as_hid_boot_keyboard_report();
         let expected_report: [u8; 8] = [0, 0, K_O, 0, 0, 0, 0, 0];
-        assert_eq!(actual_report, expected_report);
+        assert_eq!(expected_report, actual_report);
     }
     {
         keymap.tick();
         let actual_report = keymap.report_output().as_hid_boot_keyboard_report();
         let expected_report: [u8; 8] = [0, 0, K_O, K_G, 0, 0, 0, 0];
-        assert_eq!(actual_report, expected_report);
+        assert_eq!(expected_report, actual_report);
     }
 
     keymap.handle_input(input::Event::Release { keymap_index: 1 });
@@ -97,12 +97,12 @@ fn rolled_presses_desc_keycodes() {
         keymap.tick();
         let actual_report = keymap.report_output().as_hid_boot_keyboard_report();
         let expected_report: [u8; 8] = [0, 0, K_O, 0, 0, 0, 0, 0];
-        assert_eq!(actual_report, expected_report);
+        assert_eq!(expected_report, actual_report);
     }
     {
         keymap.tick();
         let actual_report = keymap.report_output().as_hid_boot_keyboard_report();
         let expected_report: [u8; 8] = [0, 0, K_O, K_G, 0, 0, 0, 0];
-        assert_eq!(actual_report, expected_report);
+        assert_eq!(expected_report, actual_report);
     }
 }

--- a/tests/rust/tap_hold/layered.rs
+++ b/tests/rust/tap_hold/layered.rs
@@ -54,7 +54,7 @@ fn press_active_layer_when_hold_layer_mod_held() {
     // Assert
     // - Check the keycode from the layer is used.
     let expected_report: [u8; 8] = [0, 0, 0x05, 0, 0, 0, 0, 0];
-    assert_eq!(actual_report, expected_report);
+    assert_eq!(expected_report, actual_report);
 }
 
 #[test]
@@ -81,5 +81,5 @@ fn uses_base_when_pressed_after_hold_layer_mod_released() {
 
     // Assert
     let expected_report: [u8; 8] = [0, 0, 0x04, 0, 0, 0, 0, 0];
-    assert_eq!(actual_report, expected_report);
+    assert_eq!(expected_report, actual_report);
 }


### PR DESCRIPTION
Probably either order of (expected, actual) or (actual, expected) is fine. -- But it needs to be consistent within the codebase.

I find it easier to read "expected, actual" order of assert errors, since LHS gets printed first.