### PR TITLE
C lsp

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -23,9 +23,10 @@
   };
 
   packages = [
-    pkgs.cmake-language-server
     pkgs.cargo-binutils
     pkgs.cargo-nextest
+    pkgs.clang-tools
+    pkgs.cmake-language-server
     pkgs.elf2uf2-rs
     pkgs.just
     pkgs.lldb

--- a/firmware/ch32x035-usb-device-compositekm-c/.gitignore
+++ b/firmware/ch32x035-usb-device-compositekm-c/.gitignore
@@ -1,1 +1,3 @@
 build*
+.clangd
+compile_commands.json

--- a/firmware/ch32x035-usb-device-compositekm-c/CMakeLists.txt
+++ b/firmware/ch32x035-usb-device-compositekm-c/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.29)
 
 project(usb-device-compositekm)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 add_executable(usb-device-compositekm
   generated/matrix.c
   User/ch32x035_it.c

--- a/firmware/ch58x-ble-hid-keyboard-c/.gitignore
+++ b/firmware/ch58x-ble-hid-keyboard-c/.gitignore
@@ -4,3 +4,5 @@
 tmp/
 
 build*
+.clangd
+compile_commands.json

--- a/firmware/ch58x-ble-hid-keyboard-c/CMakeLists.txt
+++ b/firmware/ch58x-ble-hid-keyboard-c/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.29)
 project(ble-hid-keyboard)
 enable_language(C ASM)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 add_executable(HID_Keyboard
     APP/hidkbd.c
     APP/hidkbd_main.c


### PR DESCRIPTION
My current feeling is it's better to export compile commands, but to not restrict the cmake build dir to `build`.

`clangd` seems to work when configured with a `.clangd` file with contents:

```
CompileFlags:
  Remove: 
    - -mcmodel=medany
    - -mabi=*
    - -march=*
    - -mno-save-restore
    - -G
  CompilationDatabase: "build"
```