### PR TITLE
C Firmware: clang format annotations

### DIFF
--- a/firmware/ch32x035-usb-device-compositekm-c/User/usb_desc.c
+++ b/firmware/ch32x035-usb-device-compositekm-c/User/usb_desc.c
@@ -15,6 +15,7 @@
 /* Header File */
 #include "usb_desc.h"
 
+// clang-format off
 /*******************************************************************************/
 /* Device Descriptor */
 const uint8_t MyDevDescr[ ] =
@@ -34,7 +35,9 @@ const uint8_t MyDevDescr[ ] =
     0x03,                                                   // iSerialNumber
     0x01,                                                   // bNumConfigurations
 };
+// clang-format on
 
+// clang-format off
 /* Configuration Descriptor Set */
 const uint8_t MyCfgDescr[ ] =
 {
@@ -104,7 +107,9 @@ const uint8_t MyCfgDescr[ ] =
     0x08, 0x00,                                             // wMaxPacketSize
     0x01                                                    // bInterval: 1mS
 };
+// clang-format on
 
+// clang-format off
 /* Keyboard Report Descriptor */
 const uint8_t KeyRepDesc[ ] =
 {
@@ -140,7 +145,9 @@ const uint8_t KeyRepDesc[ ] =
     0x81, 0x00,                                             // Input(Data,Array,Absolute)
     0xC0                                                    // End Collection
 };
+// clang-format on
 
+// clang-format off
 /* Mouse Report Descriptor */
 const uint8_t MouseRepDesc[ ] =
 {
@@ -172,7 +179,9 @@ const uint8_t MouseRepDesc[ ] =
     0xC0,                                                   // End Collection
     0xC0                                                    // End Collection
 };
+// clang-format on
 
+// clang-format off
 /* Qualifier Descriptor */
 const uint8_t  MyQuaDesc[ ] =
 {
@@ -186,7 +195,9 @@ const uint8_t  MyQuaDesc[ ] =
     0x00,                                                   // bNumConfigurations
     0x00                                                    // bReserved
 };
+// clang-format on
 
+// clang-format off
 /* Language Descriptor */
 const uint8_t MyLangDescr[ ] =
 {
@@ -195,7 +206,9 @@ const uint8_t MyLangDescr[ ] =
     0x09,
     0x04
 };
+// clang-format on
 
+// clang-format on
 /* Manufacturer Descriptor */
 const uint8_t MyManuInfo[ ] =
 {
@@ -214,7 +227,9 @@ const uint8_t MyManuInfo[ ] =
     'n',
     0
 };
+// clang-format on
 
+// clang-format off
 /* Product Information */
 const uint8_t MyProdInfo[ ]  =
 {
@@ -237,7 +252,9 @@ const uint8_t MyProdInfo[ ]  =
     '5',
     0
 };
+// clang-format on
 
+// clang-format off
 /* Serial Number Information */
 const uint8_t  MySerNumInfo[ ] =
 {
@@ -264,3 +281,4 @@ const uint8_t  MySerNumInfo[ ] =
     '9',
     0
 };
+// clang-format on

--- a/firmware/ch58x-ble-hid-keyboard-c/APP/hidkbd.c
+++ b/firmware/ch58x-ble-hid-keyboard-c/APP/hidkbd.c
@@ -97,6 +97,7 @@ static uint8_t hidEmuTaskId = INVALID_TASK_ID;
  * LOCAL VARIABLES
  */
 
+// clang-format off
 // GAP Profile - Name attribute for SCAN RSP data
 static uint8_t scanRspData[] = {
     0x05, // length of this data
@@ -119,7 +120,9 @@ static uint8_t scanRspData[] = {
     GAP_ADTYPE_POWER_LEVEL,
     0 // 0dBm
 };
+// clang-format on
 
+// clang-format off
 // Advertising data
 static uint8_t advertData[] = {
     // flags
@@ -148,6 +151,7 @@ static uint8_t advertData[] = {
     'r',
     'd',  // connection interval range
 };
+// clang-format on
 
 // Device name attribute value
 static const uint8_t attDeviceName[GAP_DEVICE_NAME_LEN] = "HID Keyboard";

--- a/firmware/ch58x-ble-hid-keyboard-c/Profile/devinfoservice.c
+++ b/firmware/ch58x-ble-hid-keyboard-c/Profile/devinfoservice.c
@@ -118,6 +118,7 @@ static const uint8_t devInfoSoftwareRev[] = "Software Revision";
 static uint8_t       devInfoMfrNameProps = GATT_PROP_READ;
 static const uint8_t devInfoMfrName[] = "Manufacturer Name";
 
+// clang-format off
 // IEEE 11073-20601 Regulatory Certification Data List characteristic
 static uint8_t       devInfo11073CertProps = GATT_PROP_READ;
 static const uint8_t devInfo11073Cert[] = {
@@ -125,7 +126,9 @@ static const uint8_t devInfo11073Cert[] = {
     0x00,                   // authoritative body structure type
                             // authoritative body data follows below:
     'e', 'x', 'p', 'e', 'r', 'i', 'm', 'e', 'n', 't', 'a', 'l'};
+// clang-format on
 
+// clang-format off
 // System ID characteristic
 static uint8_t devInfoPnpIdProps = GATT_PROP_READ;
 static uint8_t devInfoPnpId[DEVINFO_PNP_ID_LEN] = {
@@ -134,6 +137,7 @@ static uint8_t devInfoPnpId[DEVINFO_PNP_ID_LEN] = {
     LO_UINT16(0x0000), HI_UINT16(0x0000), // Product ID (vendor-specific)
     LO_UINT16(0x0110), HI_UINT16(0x0110)  // Product version (JJ.M.N)
 };
+// clang-format on
 
 /*********************************************************************
  * Profile Attributes - Table

--- a/firmware/ch58x-ble-hid-keyboard-c/Profile/hidkbdservice.c
+++ b/firmware/ch58x-ble-hid-keyboard-c/Profile/hidkbdservice.c
@@ -77,13 +77,16 @@ const uint8_t hidProtocolModeUUID[ATT_BT_UUID_SIZE] = {
  * LOCAL VARIABLES
  */
 
+// clang-format off
 // HID Information characteristic value
 static const uint8_t hidInfo[HID_INFORMATION_LEN] = {
     LO_UINT16(0x0111), HI_UINT16(0x0111), // bcdHID (USB HID version)
     0x00,                                 // bCountryCode
     HID_FEATURE_FLAGS                     // Flags
 };
+// clang-format on
 
+// clang-format off
 // HID Report Map characteristic value
 static const uint8_t hidReportMap[] = {
     0x05, 0x01, // Usage Pg (Generic Desktop)
@@ -131,6 +134,7 @@ static const uint8_t hidReportMap[] = {
                 //
     0xC0        // End Collection
 };
+// clang-format on
 
 // HID report map length
 uint16_t hidReportMapLen = sizeof(hidReportMap);


### PR DESCRIPTION
AFAICT, these descriptors (HID, USB, BLE) have some inconsistent formatting which benefits readability.

I'd like to run `clang-format` over the (non-sdk?) C code.