### PR TITLE
Brush up consistency of key::composite Base/TapHold/Layered impls

### DIFF
--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -311,13 +311,13 @@ impl<K: LayeredNestable> key::Key for Layered<K> {
         keymap_index: u16,
     ) -> (Self::PressedKey, key::PressedKeyEvents<Self::Event>) {
         let Layered(key) = self;
-        let (pk, events) = <K as key::Key>::new_pressed_key(key, context, keymap_index);
-        let lpk = input::PressedKey {
-            key: LayeredKey::Pass(pk.key),
+        let (passthrough_pk, pke) = <K as key::Key>::new_pressed_key(key, context, keymap_index);
+        let pk = input::PressedKey {
+            key: LayeredKey::Pass(passthrough_pk.key),
             keymap_index,
-            pressed_key_state: LayeredPressedKeyState::<TapHoldKey<BaseKey>>(pk),
+            pressed_key_state: LayeredPressedKeyState::<TapHoldKey<BaseKey>>(passthrough_pk),
         };
-        (lpk, events)
+        (pk, pke)
     }
 }
 

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -134,13 +134,11 @@ impl key::Key for layered::ModifierKey {
             keymap_index,
             pressed_key_state: pks.into(),
         };
-        (
-            pk.into_pressed_key(),
-            key::PressedKeyEvents::event(key::Event::key_event(
-                keymap_index,
-                Event::LayerModification(lmod_ev),
-            )),
-        )
+        let pke = key::PressedKeyEvents::event(key::Event::key_event(
+            keymap_index,
+            Event::LayerModification(lmod_ev),
+        ));
+        (pk.into_pressed_key(), pke)
     }
 }
 

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -609,13 +609,8 @@ impl<K: Copy + Into<TapHoldKey<NK>>, NK: TapHoldNestable> key::PressedKeyState<K
                 }
             }
             (TapHoldKey::Pass(key), TapHoldPressedKeyState::Pass(pks)) => {
-                let k: BaseKey = key.into();
-
-                if let Ok(ev) = event.try_into_key_event(|event| {
-                    event
-                        .try_into()
-                        .map_err(|_| key::EventError::UnmappableEvent)
-                }) {
+                if let Ok(ev) = event.try_into_key_event(|event| event.try_into()) {
+                    let k: BaseKey = key.into();
                     let events = pks.handle_event_for(context.into(), keymap_index, &k, ev);
                     events.into_events()
                 } else {

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -248,8 +248,8 @@ impl<K: TapHoldNestable> key::Key for TapHold<K> {
         keymap_index: u16,
     ) -> (Self::PressedKey, key::PressedKeyEvents<Self::Event>) {
         let TapHold(key) = self;
-        let (pressed_key, events) = <K as key::Key>::new_pressed_key(key, context, keymap_index);
-        (pressed_key.into_pressed_key(), events)
+        let (pk, pke) = <K as key::Key>::new_pressed_key(key, context, keymap_index);
+        (pk.into_pressed_key(), pke)
     }
 }
 

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -277,22 +277,24 @@ impl<K: LayeredNestable> key::Key for LayeredKey<K> {
     ) -> (Self::PressedKey, key::PressedKeyEvents<Self::Event>) {
         match self {
             LayeredKey::Layered(key) => {
-                let (pk, events) = key.new_pressed_key(context.into(), keymap_index);
-                let lpk = input::PressedKey {
-                    key: LayeredKey::Pass(pk.key),
+                let (layered_pk, pke) = key.new_pressed_key(context.into(), keymap_index);
+                let pk = input::PressedKey {
+                    key: LayeredKey::Pass(layered_pk.key),
                     keymap_index,
-                    pressed_key_state: LayeredPressedKeyState::<TapHoldKey<BaseKey>>(pk),
+                    pressed_key_state: LayeredPressedKeyState::<TapHoldKey<BaseKey>>(layered_pk),
                 };
-                (lpk, events)
+                (pk, pke)
             }
             LayeredKey::Pass(key) => {
-                let (pk, events) = key.new_pressed_key(context.into(), keymap_index);
-                let lpk = input::PressedKey {
-                    key: LayeredKey::Pass(pk.key),
+                let (passthrough_pk, pke) = key.new_pressed_key(context.into(), keymap_index);
+                let pk = input::PressedKey {
+                    key: LayeredKey::Pass(passthrough_pk.key),
                     keymap_index,
-                    pressed_key_state: LayeredPressedKeyState::<TapHoldKey<BaseKey>>(pk),
+                    pressed_key_state: LayeredPressedKeyState::<TapHoldKey<BaseKey>>(
+                        passthrough_pk,
+                    ),
                 };
-                (lpk, events)
+                (pk, pke)
             }
         }
     }

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -518,6 +518,7 @@ impl<K: Copy + Into<BaseKey>> key::PressedKeyState<K> for BasePressedKeyState {
         event: key::Event<Event>,
     ) -> key::PressedKeyEvents<Event> {
         let bk: BaseKey = (*key).into();
+
         match (bk, self) {
             (BaseKey::LayerModifier(key), BasePressedKeyState::LayerModifier(pks)) => {
                 if let Ok(ev) = event.try_into_key_event(|e| e.try_into()) {
@@ -539,6 +540,7 @@ impl<K: Copy + Into<BaseKey>> key::PressedKeyState<K> for BasePressedKeyState {
 
     fn key_output(&self, key: &K) -> key::KeyOutputState {
         let bk: BaseKey = (*key).into();
+
         match (bk, self) {
             (BaseKey::Keyboard(key), BasePressedKeyState::Keyboard(pks)) => pks.key_output(&key),
             _ => key::KeyOutputState::no_output(),

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -225,14 +225,13 @@ impl<K: TapHoldNestable> key::Key for TapHoldKey<K> {
     ) -> (Self::PressedKey, key::PressedKeyEvents<Self::Event>) {
         match self {
             TapHoldKey::TapHold(key) => {
-                let (pressed_key, events) =
+                let (pressed_key, pke) =
                     <tap_hold::Key<K> as key::Key>::new_pressed_key(key, context, keymap_index);
-                (pressed_key.map_pressed_key(|k| k, |pks| pks), events)
+                (pressed_key.map_pressed_key(|k| k, |pks| pks), pke)
             }
             TapHoldKey::Pass(key) => {
-                let (pressed_key, events) =
-                    <K as key::Key>::new_pressed_key(key, context, keymap_index);
-                (pressed_key.into_pressed_key(), events.into_events())
+                let (pk, pke) = <K as key::Key>::new_pressed_key(key, context, keymap_index);
+                (pk.into_pressed_key(), pke.into_events())
             }
         }
     }


### PR DESCRIPTION
The implementation of `new_pressed_key` for `key::composite`'s Base, TapHold(Key), and Layered(Key) is a bit of a sore spot.

This PR makes minor changes to reduce some of the inconsistencies between these.