### PR TITLE
rust: change key::Context::handle_event to use key::Event

### DIFF
--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -83,9 +83,11 @@ impl Default for Context {
 
 impl key::Context for Context {
     type Event = Event;
-    fn handle_event(&mut self, event: Self::Event) {
-        if let Event::LayerModification(ev) = event {
-            self.layer_context.handle_event(ev);
+    fn handle_event(&mut self, event: key::Event<Self::Event>) {
+        if let key::Event::Key { key_event, .. } = event {
+            if let Event::LayerModification(ev) = key_event {
+                self.layer_context.handle_event(ev);
+            }
         }
     }
 }
@@ -209,10 +211,7 @@ mod tests {
 
         // Act
         let event = match maybe_ev {
-            Some(key::ScheduledEvent {
-                event: key::Event::Key { key_event, .. },
-                ..
-            }) => key_event,
+            Some(key::ScheduledEvent { event, .. }) => event,
             _ => panic!("Expected Some(ScheduledEvent(Event::Key(_)))"),
         };
         context.handle_event(event);
@@ -246,7 +245,7 @@ mod tests {
             key::Event::Input(input::Event::Release { keymap_index: 0 }),
         );
         let key_ev = match events.into_iter().next().map(|sch_ev| sch_ev.event) {
-            Some(key::Event::Key { key_event, .. }) => key_event,
+            Some(key_event) => key_event,
             _ => panic!("Expected an Event::Key(_)"),
         };
 

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -106,12 +106,9 @@ impl Context {
     pub fn layer_state(&self) -> &[bool; LAYER_COUNT] {
         &self.active_layers
     }
-}
 
-impl key::Context for Context {
-    type Event = LayerEvent;
-
-    fn handle_event(&mut self, event: Self::Event) {
+    /// Updates the context with the [LayerEvent].
+    pub fn handle_event(&mut self, event: LayerEvent) {
         match event {
             LayerEvent::LayerActivated(layer) => {
                 self.active_layers.activate(layer);
@@ -367,8 +364,6 @@ mod tests {
 
     #[test]
     fn test_context_handling_event_adjusts_active_layers() {
-        use key::Context as _;
-
         let mut context: Context = Context::default();
 
         context.handle_event(LayerEvent::LayerActivated(1));
@@ -451,9 +446,18 @@ mod tests {
         let layered_key = LayeredKey::new(expected_key, [None, None, None]);
 
         // Act: activate all layers, press layered key
-        context.handle_event(LayerEvent::LayerActivated(0).into());
-        context.handle_event(LayerEvent::LayerActivated(1).into());
-        context.handle_event(LayerEvent::LayerActivated(2).into());
+        context.handle_event(key::Event::key_event(
+            0,
+            LayerEvent::LayerActivated(0).into(),
+        ));
+        context.handle_event(key::Event::key_event(
+            0,
+            LayerEvent::LayerActivated(1).into(),
+        ));
+        context.handle_event(key::Event::key_event(
+            0,
+            LayerEvent::LayerActivated(2).into(),
+        ));
         let keymap_index = 9; // arbitrary
         let (actual_pressed_key, _actual_event) =
             layered_key.new_pressed_key(context, keymap_index);
@@ -484,9 +488,18 @@ mod tests {
         );
 
         // Act: activate all layers, press layered key
-        context.handle_event(LayerEvent::LayerActivated(0).into());
-        context.handle_event(LayerEvent::LayerActivated(1).into());
-        context.handle_event(LayerEvent::LayerActivated(2).into());
+        context.handle_event(key::Event::key_event(
+            0,
+            LayerEvent::LayerActivated(0).into(),
+        ));
+        context.handle_event(key::Event::key_event(
+            0,
+            LayerEvent::LayerActivated(1).into(),
+        ));
+        context.handle_event(key::Event::key_event(
+            0,
+            LayerEvent::LayerActivated(2).into(),
+        ));
         let keymap_index = 9; // arbitrary
         let (actual_pressed_key, _actual_event) =
             layered_key.new_pressed_key(context, keymap_index);
@@ -513,8 +526,14 @@ mod tests {
         );
 
         // Act: activate all layers, press layered key
-        context.handle_event(LayerEvent::LayerActivated(0).into());
-        context.handle_event(LayerEvent::LayerActivated(2).into());
+        context.handle_event(key::Event::key_event(
+            0,
+            LayerEvent::LayerActivated(0).into(),
+        ));
+        context.handle_event(key::Event::key_event(
+            0,
+            LayerEvent::LayerActivated(2).into(),
+        ));
         let keymap_index = 9; // arbitrary
         let (actual_pressed_key, _actual_event) =
             layered_key.new_pressed_key(context, keymap_index);

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -129,12 +129,12 @@ pub trait Context: Clone + Copy {
     type Event;
 
     /// Used to update the [Context]'s state.
-    fn handle_event(&mut self, event: Self::Event);
+    fn handle_event(&mut self, event: Event<Self::Event>);
 }
 
 impl Context for () {
     type Event = ();
-    fn handle_event(&mut self, _event: Self::Event) {}
+    fn handle_event(&mut self, _event: Event<Self::Event>) {}
 }
 
 /// Bool flags for each of the modifier keys (left ctrl, etc.).

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -490,9 +490,7 @@ impl<
         });
 
         // Update context with the event
-        if let key::Event::Key { key_event, .. } = ev {
-            self.context.handle_event(key_event);
-        }
+        self.context.handle_event(ev);
 
         if let Event::Input(input_ev) = ev {
             self.process_input(input_ev);


### PR DESCRIPTION
Some smart key functionality is going to benefit from Context handling the *key::Event*, not just the `key::*::Event` for that key.