### PR TITLE
Cargo optimize

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,3 +13,8 @@ rustflags = [
   "-C", "llvm-args=--inline-threshold=5",
   "-C", "no-vectorize-loops",
 ]
+
+[profile.release]
+opt-level = "z"
+codegen-units = 1
+lto = true

--- a/.github/workflows/firmware-ch32x.yaml
+++ b/.github/workflows/firmware-ch32x.yaml
@@ -11,6 +11,7 @@ on:
     branches:
       - master
     paths:
+      - '.cargo/**'
       - 'ncl/**/*.ncl'
       - 'src/**'
       - 'smart_keymap/**'
@@ -19,6 +20,7 @@ on:
     branches:
       - '*'
     paths:
+      - '.cargo/**'
       - 'ncl/**/*.ncl'
       - 'src/**'
       - 'smart_keymap/**'

--- a/.github/workflows/test-ceedling.yaml
+++ b/.github/workflows/test-ceedling.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
     paths:
+      - '.cargo/**'
       - 'ncl/**/*.ncl'
       - 'src/**'
       - 'smart_keymap/**'
@@ -13,6 +14,7 @@ on:
     branches:
       - '*'
     paths:
+      - '.cargo/**'
       - 'ncl/**/*.ncl'
       - 'src/**'
       - 'smart_keymap/**'


### PR DESCRIPTION
Ran into problems with firmware size when impl. another smart key.

On master, the 48-rgoulter firmware is at about 84% of CH32 flash size.

This PR adjusts the release profile to reduce firmware size.