### PR TITLE
RP2040-RTIC: improve usb reporting, add usbd-serial

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,7 +830,7 @@ dependencies = [
  "embedded-hal 1.0.0",
  "heapless 0.8.0",
  "keyberon-macros",
- "usb-device 0.3.2",
+ "usb-device",
 ]
 
 [[package]]
@@ -1230,7 +1230,7 @@ dependencies = [
  "fugit",
  "rp2040-boot2",
  "rp2040-hal",
- "usb-device 0.3.2",
+ "usb-device",
 ]
 
 [[package]]
@@ -1266,7 +1266,7 @@ dependencies = [
  "rand_core",
  "rp2040-hal-macros",
  "rp2040-pac 0.6.0",
- "usb-device 0.3.2",
+ "usb-device",
  "vcell",
  "void",
 ]
@@ -1339,7 +1339,7 @@ dependencies = [
  "rtt-target 0.4.0",
  "smart-keymap",
  "smart-keymap-nickel-helper",
- "usb-device 0.3.2",
+ "usb-device",
  "usbd-human-interface-device",
  "usbd-serial",
  "usbd-smart-keyboard",
@@ -1751,12 +1751,6 @@ checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "usb-device"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f6cc3adc849b5292b4075fc0d5fdcf2f24866e88e336dd27a8943090a520508"
-
-[[package]]
-name = "usb-device"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98816b1accafbb09085168b90f27e93d790b4bfa19d883466b5e53315b5f06a6"
@@ -1777,18 +1771,19 @@ dependencies = [
  "num_enum 0.7.3",
  "option-block",
  "packed_struct",
- "usb-device 0.3.2",
+ "usb-device",
 ]
 
 [[package]]
 name = "usbd-serial"
-version = "0.1.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db75519b86287f12dcf0d171c7cf4ecc839149fe9f3b720ac4cfce52959e1dfe"
+checksum = "065e4eaf93db81d5adac82d9cef8f8da314cb640fa7f89534b972383f1cf80fc"
 dependencies = [
  "embedded-hal 0.2.7",
- "nb 0.1.3",
- "usb-device 0.2.9",
+ "embedded-io",
+ "nb 1.1.0",
+ "usb-device",
 ]
 
 [[package]]
@@ -1809,7 +1804,7 @@ dependencies = [
  "panic-rtt-target",
  "rtt-target 0.4.0",
  "smart-keymap",
- "usb-device 0.3.2",
+ "usb-device",
  "usbd-human-interface-device",
  "usbd-serial",
 ]

--- a/rp2040-rtic-smart-keyboard/Cargo.toml
+++ b/rp2040-rtic-smart-keyboard/Cargo.toml
@@ -25,7 +25,7 @@ panic-rtt-target = { version = "0.1.2", features = ["cortex-m"] }
 rtt-target = "0.4"
 usb-device = { version = "0.3", features = ["control-buffer-256"] }
 usbd-human-interface-device = "0.5"
-usbd-serial = "0.1"
+usbd-serial = "0.2"
 
 # smart-keymap = { git = "https://github.com/rgoulter/smart-keymap.git" }
 smart-keymap = { path = "..", default-features = false }

--- a/rp2040-rtic-smart-keyboard/src/app_init.rs
+++ b/rp2040-rtic-smart-keyboard/src/app_init.rs
@@ -17,6 +17,8 @@ use usb_device::device::{StringDescriptors, UsbDeviceBuilder, UsbVidPid};
 
 use usbd_human_interface_device::usb_class::UsbHidClassBuilder;
 
+use usbd_serial::SerialPort;
+
 use crate::common::{UsbClass, UsbDevice};
 
 /// Initializes the clocks.
@@ -63,13 +65,15 @@ pub fn init_usb_device(
     pid: u16,
     mfr: &'static str,
     product: &'static str,
-) -> (UsbDevice, UsbClass) {
+) -> (UsbDevice, SerialPort<'static, UsbBus>, UsbClass) {
     let usb_class = UsbHidClassBuilder::new()
         .add_device(
             usbd_human_interface_device::device::keyboard::NKROBootKeyboardConfig::default(),
         )
         .add_device(usbd_human_interface_device::device::consumer::ConsumerControlConfig::default())
         .build(usb_bus);
+
+    let serial = SerialPort::new(&usb_bus);
 
     let usb_dev = UsbDeviceBuilder::new(usb_bus, UsbVidPid(vid, pid))
         .strings(&[StringDescriptors::new(LangID::EN_US)
@@ -79,5 +83,5 @@ pub fn init_usb_device(
         .unwrap()
         .build();
 
-    (usb_dev, usb_class)
+    (usb_dev, serial, usb_class)
 }

--- a/rp2040-rtic-smart-keyboard/src/main.rs
+++ b/rp2040-rtic-smart-keyboard/src/main.rs
@@ -186,7 +186,7 @@ mod app {
         backend.tick();
 
         usb_class.lock(|k| {
-            backend.write_reports(k);
+            let _ = backend.write_reports(k);
         });
     }
 }

--- a/usbd-smart-keyboard/Cargo.toml
+++ b/usbd-smart-keyboard/Cargo.toml
@@ -20,7 +20,7 @@ panic-rtt-target = { version = "0.1.2", features = ["cortex-m"] }
 rtt-target = "0.4"
 usb-device = { version = "0.3", features = ["control-buffer-256"] }
 usbd-human-interface-device = "0.5"
-usbd-serial = "0.1"
+usbd-serial = "0.2"
 
 # smart-keymap = { git = "https://github.com/rgoulter/smart-keymap.git" }
 smart-keymap = { path = "..", default-features = false }

--- a/usbd-smart-keyboard/src/common.rs
+++ b/usbd-smart-keyboard/src/common.rs
@@ -10,6 +10,8 @@ use usbd_human_interface_device::device::keyboard::NKROBootKeyboard;
 use usbd_human_interface_device::device::DeviceHList;
 use usbd_human_interface_device::usb_class::UsbHidClass;
 
+use usbd_serial::SerialPort;
+
 /// A USB Vendor ID.
 pub const VID: u16 = 0xcafe;
 
@@ -20,12 +22,19 @@ pub type UsbClass<B> =
 /// Polls the given [UsbDevice] with the [UsbHidClass] that has a [NKROBootKeyboard]. (e.g. [UsbClass]).
 pub fn usb_poll<B, D, Index>(
     usb_dev: &mut UsbDevice<'static, B>,
+    usb_serial: &mut SerialPort<'static, B>,
     keyboard: &mut UsbHidClass<'static, B, D>,
 ) where
     B: UsbBus,
     D: DeviceHList<'static> + Selector<NKROBootKeyboard<'static, B>, Index>,
 {
-    if usb_dev.poll(&mut [keyboard]) {
+    if usb_dev.poll(&mut [keyboard, usb_serial]) {
+        let mut buf = [0u8; 64];
+        match usb_serial.read(&mut buf) {
+            Err(_e) => {}
+            Ok(_count) => {}
+        }
+
         let interface = keyboard.device::<NKROBootKeyboard<'static, B>, _>();
         match interface.read_report() {
             Err(UsbError::WouldBlock) => {}

--- a/usbd-smart-keyboard/src/input.rs
+++ b/usbd-smart-keyboard/src/input.rs
@@ -50,16 +50,19 @@ impl<const COLS: usize, const ROWS: usize, M: MatrixScanner<COLS, ROWS>> Keyboar
 }
 
 /// Abstract interface writing keyboard/consumer HID reports.
-pub trait HIDReporter<K, C, KE, CE> {
+pub trait HIDReporter<K, C, CE> {
     /// Writes a report with the iterable of HID keyboard codes.
     /// Modifier keys are assumed to be key codes (e.g. LeftCtrl = 0xE0).
-    fn write_keyboard_report(&mut self, report: impl IntoIterator<Item = K>) -> Result<(), KE>;
+    fn write_keyboard_report(
+        &mut self,
+        report: impl IntoIterator<Item = K>,
+    ) -> Result<(), UsbHidError>;
 
     /// Writes a report with the iterable of HID consumer codes.
     fn write_consumer_report(&mut self, report: impl IntoIterator<Item = C>) -> Result<(), CE>;
 }
 
-impl<B> HIDReporter<page::Keyboard, page::Consumer, UsbHidError, UsbError> for common::UsbClass<B>
+impl<B> HIDReporter<page::Keyboard, page::Consumer, UsbError> for common::UsbClass<B>
 where
     B: UsbBus,
 {

--- a/usbd-smart-keyboard/src/input/smart_keymap.rs
+++ b/usbd-smart-keyboard/src/input/smart_keymap.rs
@@ -1,4 +1,5 @@
 use usbd_human_interface_device::page;
+use usbd_human_interface_device::UsbHidError;
 
 use crate::input::HIDReporter;
 
@@ -38,12 +39,12 @@ impl KeyboardBackend {
     }
 
     /// Writes the HID keyboard and consumer reports from the smart keymap.
-    pub fn write_reports<R, CE>(&mut self, hid_reporter: &mut R)
+    pub fn write_reports<R, CE>(&mut self, hid_reporter: &mut R) -> Result<(), UsbHidError>
     where
         CE: core::fmt::Debug, // usb error
         R: HIDReporter<page::Keyboard, page::Consumer, CE>,
     {
-        let _ = hid_reporter.write_keyboard_report(self.pressed_key_codes.clone());
+        hid_reporter.write_keyboard_report(self.pressed_key_codes.clone())
     }
 }
 

--- a/usbd-smart-keyboard/src/input/smart_keymap.rs
+++ b/usbd-smart-keyboard/src/input/smart_keymap.rs
@@ -38,11 +38,10 @@ impl KeyboardBackend {
     }
 
     /// Writes the HID keyboard and consumer reports from the smart keymap.
-    pub fn write_reports<R, KE, CE>(&mut self, hid_reporter: &mut R)
+    pub fn write_reports<R, CE>(&mut self, hid_reporter: &mut R)
     where
-        KE: core::fmt::Debug, // USBHID Keyboard Error
         CE: core::fmt::Debug, // usb error
-        R: HIDReporter<page::Keyboard, page::Consumer, KE, CE>,
+        R: HIDReporter<page::Keyboard, page::Consumer, CE>,
     {
         let _ = hid_reporter.write_keyboard_report(self.pressed_key_codes.clone());
     }


### PR DESCRIPTION
Smart Keymap is quite 'fragile' in terms of dealing with taps of tap-hold keys, and reporting this. -- Everything works in unit tests; but it makes the (apparently strict) requirement that each HID report is successfully sent.

I just tried the RP2040-RTIC again, and it was unusable. -- This PR updates the code a bit so that it better respects these assumptions.

This PR also adds usbd-serial to the code, which will hopefully allow for some printf debugging to narrow in on the issue.