### PR TITLE
RP2040 USB HID TapHold Tap improvements - Mitigate Race Condition

### DIFF
--- a/tests/ceedling/test/test_keydef_taphold.c
+++ b/tests/ceedling/test/test_keydef_taphold.c
@@ -47,8 +47,8 @@ void test_taphold_dth_uth_eventually_clears(void) {
     keymap_tick(actual_report);
 
     // The 'tap' from the TapHold key should be released.
-    // after ten ticks.
-    for (int i = 0; i < 20; i++) {
+    // after ... an implementation-specific number of ticks.
+    for (int i = 0; i < 50; i++) {
         keymap_tick(actual_report);
     }
 

--- a/usbd-smart-keyboard/src/input/smart_keymap.rs
+++ b/usbd-smart-keyboard/src/input/smart_keymap.rs
@@ -46,6 +46,10 @@ impl KeyboardBackend {
     {
         hid_reporter.write_keyboard_report(self.pressed_key_codes.clone())
     }
+
+    pub fn pressed_key_codes(&self) -> &heapless::Vec<page::Keyboard, 16> {
+        &self.pressed_key_codes
+    }
 }
 
 /// Constructs a [smart_keymap::input::Event] from a [keyberon::layout::Event],


### PR DESCRIPTION
It seems like there's a race condition in the code. -- I observe a significant percentage of "tap hold misses" (i.e. tap-hold should resolves as tap, but the tap is never reported) with my Pico42 board running the rp2040-rtic firmware. The CH32-48 board does not observe similar misses.

With tap-hold taps, the 'tap' only lasts *1 tick* of the keymap. So, if multiple reports are 'written' before the USB endpoint has sent them to host, the tap would be 'missed'. 

e.g. in the firmware for CH32-48 adapted from the CH32 EVT, the `tick()` is only invoked if the USB transaction has been sent. (A `sending` flag is set when the report is written, which is only cleared when the interface is not-busy; when the interface is not-busy, the sent-report is memcpy'd to the prev-report, which allows the `keymap_tick()` to be called in the TIM3 IRQ handler).

My impression of the Rust code is its behaviour *should* be similar.

This PR mitigates the race condition by introducing a delay between dequeues of queued input events. -- On the one hand, it's really not an elegant solution. On the other hand, it make the library more robust to use with less-than-perfect firmware. -- In practice, it's likely not too impactful on keyboard performance.