### PR TITLE
Rust Size Optimization (Nightly)

### DIFF
--- a/.github/workflows/firmware-ch32x.yaml
+++ b/.github/workflows/firmware-ch32x.yaml
@@ -58,12 +58,15 @@ jobs:
           sudo tar -xvf ./xpack-riscv-none-elf-gcc-${GCC_VERSION}-linux-x64.tar.gz --directory=/opt
 
       - name: Rust Add Target
-        run: rustup target add "${CH32X_TARGET}"
+        run: |
+          rustup target add "${CH32X_TARGET}"
+          rustup toolchain install nightly
+          rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
 
       - name: Build Keymap
         run: |
           env RUSTFLAGS="-Zlocation-detail=none -Zfmt-debug=none" \
-          cargo build \
+          cargo +nightly build \
             --release \
             -Z build-std=core \
             -Z build-std-features="optimize_for_size" \

--- a/.github/workflows/firmware-ch32x.yaml
+++ b/.github/workflows/firmware-ch32x.yaml
@@ -62,8 +62,12 @@ jobs:
 
       - name: Build Keymap
         run: |
+          env RUSTFLAGS="-Zlocation-detail=none -Zfmt-debug=none" \
           cargo build \
             --release \
+            -Z build-std=core \
+            -Z build-std-features="optimize_for_size" \
+            -Z build-std-features=panic_immediate_abort \
             --package "smart_keymap" \
             --target "${CH32X_TARGET}" \
             --no-default-features

--- a/devenv.nix
+++ b/devenv.nix
@@ -15,7 +15,8 @@
     c.enable = true;
     ruby.enable = true;
     rust = {
-      channel = "stable";
+      channel = "nightly";
+      components = [ "rustc" "cargo" "clippy" "rustfmt" "rust-analyzer" "rust-src" ];
       enable = true;
       targets = ["riscv32imac-unknown-none-elf" "thumbv6m-none-eabi"];
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 /// Structs for input to the keymap.
-pub mod input;
+pub mod input; // x
 /// Smart key interface and implementations.
 ///
 /// The core interface for the smart keymap library is [key::Key],


### PR DESCRIPTION
Following tips from https://github.com/johnthagen/min-sized-rust

These optimizations bring the firmware size for the 48key-rgoulter keymap with the ch32x firmware down to 52% of flash (compared to 68% before these changes).

AFAICT, removing location-detail is done already (I observed no change to firmware size). Using build-std=core had only marginal impact on firmware size. The 'immediate abort' on panics had a small effect on firmware size.

The lion's share of the size reduction comes from setting `fmt-debug=None`. This requires the nightly toolchain to enact.

It may be that CH32 can't be stuffed with every bell & whistle with a large keymap.