### PR TITLE
More TapHold Behaviour Improvements

### DIFF
--- a/firmware/ch58x-ble-hid-keyboard-c/APP/hidkbd.c
+++ b/firmware/ch58x-ble-hid-keyboard-c/APP/hidkbd.c
@@ -323,9 +323,7 @@ uint16_t HidEmu_ProcessEvent(uint8_t task_id, uint16_t events) {
 
     keyboard_matrix_scan();
 
-    if (report_status == SUCCESS) {
-      keymap_tick(buf);
-    }
+    keymap_tick(buf);
 
     report_status = HidDev_Report(HID_RPT_ID_KEY_IN, HID_REPORT_TYPE_INPUT,
                                   HID_KEYBOARD_IN_RPT_LEN, buf);

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -14,8 +14,8 @@ pub const MAX_PRESSED_KEYS: usize = 16;
 
 const MAX_QUEUED_INPUT_EVENTS: usize = 32;
 
-// Number of ticks before the next input event is processed in tick().
-const INPUT_QUEUE_TICK_DELAY: u8 = 1;
+/// Number of ticks before the next input event is processed in tick().
+pub const INPUT_QUEUE_TICK_DELAY: u8 = 1;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 struct ScheduledEvent<E: Debug> {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -544,14 +544,14 @@ impl<
 
     /// Advances the state of the keymap by one tick.
     pub fn tick(&mut self) {
-        if !self.input_queue.is_empty() {
-            if self.input_queue_delay_counter == 0 {
-                let ie = self.input_queue.dequeue().unwrap();
-                self.process_input(ie);
-                self.input_queue_delay_counter = INPUT_QUEUE_TICK_DELAY;
-            } else {
-                self.input_queue_delay_counter -= 1;
-            }
+        if !self.input_queue.is_empty() && self.input_queue_delay_counter == 0 {
+            let ie = self.input_queue.dequeue().unwrap();
+            self.process_input(ie);
+            self.input_queue_delay_counter = INPUT_QUEUE_TICK_DELAY;
+        }
+
+        if self.input_queue_delay_counter > 0 {
+            self.input_queue_delay_counter -= 1;
         }
 
         self.event_scheduler.tick();

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -392,8 +392,10 @@ impl<
     pub fn handle_input(&mut self, ev: input::Event) {
         self.input_queue.enqueue(ev).unwrap();
 
-        if let Some(ie) = self.input_queue.dequeue() {
+        if self.input_queue_delay_counter == 0 {
+            let ie = self.input_queue.dequeue().unwrap();
             self.process_input(ie);
+            self.input_queue_delay_counter = INPUT_QUEUE_TICK_DELAY;
         }
     }
 

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -326,7 +326,7 @@ impl<
             hid_reporter: HIDKeyboardReporter::new(),
             pending_key_state: None,
             input_queue: heapless::spsc::Queue::new(),
-            input_queue_delay_counter: INPUT_QUEUE_TICK_DELAY,
+            input_queue_delay_counter: 0,
         }
     }
 
@@ -339,7 +339,7 @@ impl<
         while !self.input_queue.is_empty() {
             self.input_queue.dequeue().unwrap();
         }
-        self.input_queue_delay_counter = INPUT_QUEUE_TICK_DELAY;
+        self.input_queue_delay_counter = 0;
     }
 
     // If the pending key state is resolved,

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -15,7 +15,7 @@ pub const MAX_PRESSED_KEYS: usize = 16;
 const MAX_QUEUED_INPUT_EVENTS: usize = 32;
 
 // Number of ticks before the next input event is processed in tick().
-const INPUT_QUEUE_TICK_DELAY: u8 = 10;
+const INPUT_QUEUE_TICK_DELAY: u8 = 1;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 struct ScheduledEvent<E: Debug> {

--- a/tests/ceedling/test/test_keydef_taphold.c
+++ b/tests/ceedling/test/test_keydef_taphold.c
@@ -26,6 +26,7 @@ void test_taphold_dth_uth_is_tap(void) {
     keymap_init();
 
     keymap_register_input_keypress(0); // First key in keymap is TapHold(C, _)
+    keymap_tick(actual_report);
     keymap_register_input_keyrelease(0);
 
     keymap_tick(actual_report);
@@ -42,6 +43,7 @@ void test_taphold_dth_uth_eventually_clears(void) {
     keymap_init();
 
     keymap_register_input_keypress(0); // First key in keymap is TapHold(C, _)
+    keymap_tick(actual_report);
     keymap_register_input_keyrelease(0);
 
     keymap_tick(actual_report);

--- a/tests/ceedling/test/test_keymap.c
+++ b/tests/ceedling/test/test_keymap.c
@@ -42,6 +42,7 @@ void test_keyboard_keyrelease(void) {
     keymap_init();
 
     keymap_register_input_keypress(2);
+    keymap_tick(actual_report);
     keymap_register_input_keyrelease(2);
 
     copy_hid_boot_keyboard_report(actual_report);
@@ -58,6 +59,7 @@ void test_keyboard_keypress_sequence_da_db(void) {
     keymap_init();
 
     keymap_register_input_keypress(2); // Third key in the keymap is A
+    keymap_tick(actual_report);
     keymap_register_input_keypress(3); // Fourth key in the keymap is B
 
     copy_hid_boot_keyboard_report(actual_report);
@@ -73,6 +75,7 @@ void test_keyboard_keypress_sequence_db_da(void) {
     keymap_init();
 
     keymap_register_input_keypress(3); // Fourth key in the keymap is B
+    keymap_tick(actual_report);
     keymap_register_input_keypress(2); // Third key in the keymap is A
 
     copy_hid_boot_keyboard_report(actual_report);
@@ -88,7 +91,9 @@ void test_keyboard_keypress_sequence_da_db_ub(void) {
     keymap_init();
 
     keymap_register_input_keypress(2); // Third key in the keymap is A
+    keymap_tick(actual_report);
     keymap_register_input_keypress(3); // Fourth key in the keymap is B
+    keymap_tick(actual_report);
     keymap_register_input_keyrelease(3);
 
     copy_hid_boot_keyboard_report(actual_report);
@@ -104,7 +109,9 @@ void test_keyboard_keypress_sequence_da_db_ua(void) {
     keymap_init();
 
     keymap_register_input_keypress(2); // Third key in the keymap is A
+    keymap_tick(actual_report);
     keymap_register_input_keypress(3); // Fourth key in the keymap is B
+    keymap_tick(actual_report);
     keymap_register_input_keyrelease(2);
 
     copy_hid_boot_keyboard_report(actual_report);

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -49,6 +49,11 @@ impl LoadedKeymap {
             } => {
                 keymap.handle_input(ev);
                 distinct_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+                for _ in 0..smart_keymap::keymap::INPUT_QUEUE_TICK_DELAY {
+                    keymap.tick();
+                    distinct_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+                }
             }
             _ => panic!("No keymap loaded"),
         }

--- a/tests/rust/layered.rs
+++ b/tests/rust/layered.rs
@@ -45,6 +45,9 @@ fn press_active_layer_when_layer_mod_held() {
 
     // Act
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    for _ in 0..smart_keymap::keymap::INPUT_QUEUE_TICK_DELAY {
+        keymap.tick();
+    }
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
     let actual_report = keymap.boot_keyboard_report();
 
@@ -60,7 +63,13 @@ fn press_retained_when_layer_mod_released() {
 
     // Act
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    for _ in 0..smart_keymap::keymap::INPUT_QUEUE_TICK_DELAY {
+        keymap.tick();
+    }
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    for _ in 0..smart_keymap::keymap::INPUT_QUEUE_TICK_DELAY {
+        keymap.tick();
+    }
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
     let actual_report = keymap.boot_keyboard_report();
 
@@ -76,7 +85,13 @@ fn uses_base_when_pressed_after_layer_mod_released() {
 
     // Act
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    for _ in 0..smart_keymap::keymap::INPUT_QUEUE_TICK_DELAY {
+        keymap.tick();
+    }
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    for _ in 0..smart_keymap::keymap::INPUT_QUEUE_TICK_DELAY {
+        keymap.tick();
+    }
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
     let actual_report = keymap.boot_keyboard_report();
 

--- a/tests/rust/tap_hold.rs
+++ b/tests/rust/tap_hold.rs
@@ -60,6 +60,9 @@ fn key_uninterrupted_tap_is_reported() {
 
     // Act
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    for _ in 0..smart_keymap::keymap::INPUT_QUEUE_TICK_DELAY {
+        keymap.tick();
+    }
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
     keymap.tick();
     actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());

--- a/tests/rust/tap_hold/layered.rs
+++ b/tests/rust/tap_hold/layered.rs
@@ -86,6 +86,10 @@ fn uses_base_when_pressed_after_hold_layer_mod_released() {
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
     actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
+    for _ in 0..smart_keymap::keymap::INPUT_QUEUE_TICK_DELAY {
+        keymap.tick();
+    }
+
     // Act
     // Press the layered key; it should be the base key.
     keymap.handle_input(input::Event::Press { keymap_index: 1 });

--- a/usbd-smart-keyboard/src/input/smart_keymap.rs
+++ b/usbd-smart-keyboard/src/input/smart_keymap.rs
@@ -31,12 +31,18 @@ impl KeyboardBackend {
     /// A time event.
     ///
     /// This method must be called regularly, typically every millisecond.
-    pub fn tick(&mut self) {
+    ///
+    /// Returns true if the pressed_key_codes have changed.
+    pub fn tick(&mut self) -> bool {
         self.keymap.tick();
+
+        let old_pressed_key_codes = core::mem::take(&mut self.pressed_key_codes);
 
         let keymap_output = self.keymap.report_output();
         let pressed_keycodes = keymap_output.pressed_key_codes();
         self.pressed_key_codes = pressed_keycodes.iter().map(|&key| key.into()).collect();
+
+        old_pressed_key_codes != self.pressed_key_codes
     }
 
     /// Writes the HID keyboard and consumer reports from the smart keymap.

--- a/usbd-smart-keyboard/src/input/smart_keymap.rs
+++ b/usbd-smart-keyboard/src/input/smart_keymap.rs
@@ -6,6 +6,7 @@ use crate::input::HIDReporter;
 /// The keyboard "backend", manages the keyboard from the events received
 /// (presses/releases of coordinates on a keyboard layout).
 /// through to listing HID scancodes to report using HIDs.
+#[derive(Debug)]
 pub struct KeyboardBackend {
     keymap: smart_keymap::keymap::Keymap<smart_keymap::init::KeyDefinitionsType>,
     pressed_key_codes: heapless::Vec<page::Keyboard, 16>,

--- a/usbd-smart-keyboard/src/input/smart_keymap.rs
+++ b/usbd-smart-keyboard/src/input/smart_keymap.rs
@@ -9,7 +9,7 @@ use crate::input::HIDReporter;
 #[derive(Debug)]
 pub struct KeyboardBackend {
     keymap: smart_keymap::keymap::Keymap<smart_keymap::init::KeyDefinitionsType>,
-    pressed_key_codes: heapless::Vec<page::Keyboard, 16>,
+    pressed_key_codes: heapless::Vec<page::Keyboard, { smart_keymap::keymap::MAX_PRESSED_KEYS }>,
 }
 
 impl KeyboardBackend {


### PR DESCRIPTION
So admittedly this PR is not as narrow and focused as it could be.

But, altogether these changes address buggy behaviour in the smart keymap library to do with tap-hold functionality.

Long-story-short: this PR updates `keymap::Keymap::handle_input` to only process 1 input event at a time.

It took me a long time to track down the buggy behaviour. -- The automated tests clearly work, but the library running on firmware ran into buggy behaviour. -- Observed behaviour involved tap-hold keys being "skipped". e.g. pressing and releasing a tap-hold key would result in no key being reported.

So, obviously there were differences between how the HID firmware was getting reports using the smart keymap library, and how the automated tests were.

My initial guess was that calls to `tick()` were more frequently than reports were being sent. -- However, this was an easy guess to disprove. (A quick way to 'test' this was to replace the reported char with 'a' to 'z', 0x04 to 0x1D. It was easy to observe that the keyboard firmware could easily handle reporting this sequence without any skips. -- Hence, any "missing" keys observed was due to buggy smart keymap logic).

By adding copious amounts of logging to the RP2040 firmware, I was able to see what events were going on & what the state was when reproducing buggy tap-hold behaviour.

An assumption being made was that `handle_event` would only ever be called once per ms. -- I expect that it's difficult/rare to be able to press keys at precisely the same millisecond.

However, turns out that, to my understanding, debouncing means that multiple events may be reported in the same millisecond. -- This is how the keymap state was updating more frequently than the reports were being sent.

This PR, then, updates the keymap logic to only handle only one input event between each tick() call.

The "input event period" has been reduced to 1, from 10. -- I think having it as 10 wasn't a big issue on the Pico42, but on the 128Hz CH58x-60 firmware, it induced significant lag.