### PR TITLE
ncl: comment, clarifying tap_hold.unify_cv

### DIFF
--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -413,12 +413,14 @@ let validators = import "validators.ncl" in
         #     i.e. a type which implements composite::TapHoldNestable.
         #     (i.e. composite::BaseKey).
         let unify_cv = fun cv =>
-          # let nested_key_type =
-          #   if tap_key_type == hold_key_type then
-          #     tap_key_type
-          #   else
-          #     composite.base_key.key_type tap in
-          composite.base_key.codegen_values cv
+          if tap_kt == hold_kt then
+            # Unlike other key::composite types,
+            #  key::composite::BaseKey does not have a "passthrough" newtype equivalent,
+            #  so the tap_hold's nested key type is unified to BaseKey
+            #  even if the tap and hold keys are the same type.
+            composite.base_key.codegen_values cv
+          else
+            composite.base_key.codegen_values cv
         in
 
         {


### PR DESCRIPTION
The NCL codegen for `key::tap_hold::Key` has a `unify_cv` which had been left with a `# TODO` comment.

This had impacted layered-keys of tap-hold keys. (e.g. the thumb keys and home row mods in 36-key rgoulter, etc.).

'codegen value' are NCL values which help produce the Rust types & expression segments.

"unify_cv" is a function which transforms the nested codegen-values to a unified type. e.g. unifies 'tap' and 'hold' of the key::tap_hold::Key codegen values, or the 'base'/'layered' of the key::layered::LayeredKey codegen values.

The impl. for `key::tap_hold::Key` is just "lift everything to key::composite::BaseKey". -- This PR updates the comment to explain why this is a reasonable approach.

(Later, if `BaseKey` grows to be an enum with several variants, it would be a good idea to also implement an equivalent `Base` newtype, and update the this codegen value to use that).