### PR TITLE
rust: simplify impl LayeredNestable for TapHold<>

### DIFF
--- a/src/key/composite/layered.rs
+++ b/src/key/composite/layered.rs
@@ -21,17 +21,7 @@ pub trait LayeredNestable:
     fn as_fat_key(self) -> TapHoldKey<BaseKey>;
 }
 
-impl LayeredNestable for TapHold<key::layered::ModifierKey> {
-    fn as_fat_key(self) -> TapHoldKey<BaseKey> {
-        TapHold::as_fat_key(self)
-    }
-}
-impl LayeredNestable for TapHold<key::keyboard::Key> {
-    fn as_fat_key(self) -> TapHoldKey<BaseKey> {
-        TapHold::as_fat_key(self)
-    }
-}
-impl LayeredNestable for TapHold<BaseKey> {
+impl<K: TapHoldNestable> LayeredNestable for TapHold<K> {
     fn as_fat_key(self) -> TapHoldKey<BaseKey> {
         TapHold::as_fat_key(self)
     }


### PR DESCRIPTION
This PR simplifies the `impl LayeredNestable`, by using a generic for the `TapHold` passthrough type.

This is an interesting benefit to the `key::Key` trait. -- The disadvantage of `key::Key` having `PressedKey` as an associated type is that e.g. `key::keyboard::Key` then needs to have different newtypes to implement `key::Key` for Base/TapHold/Layered/etc.

However, that verbosity makes the *Nestable* trait much simpler to implement: it's either an enum, or a passthrough newtype.