### PR TITLE
tests: cucumber: use filter_run_and_exit, so `cargo test` fails

### DIFF
--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -272,7 +272,7 @@ fn check_report_equivalences(world: &mut KeymapWorld, step: &Step) {
 
 fn main() {
     futures::executor::block_on(
-        KeymapWorld::cucumber().filter_run("features/keymap/", |_, _, scenario| {
+        KeymapWorld::cucumber().filter_run_and_exit("features/keymap/", |_, _, scenario| {
             !scenario.tags.iter().any(|t| t == "ignore")
         }),
     );


### PR DESCRIPTION
Apparently the intention of the cucumber-rs authors is to use `run`, use Summarize on the result from, & assert on the results from *that*.

Using `run_and_exit` exits with non-zero status as I'd expect.