### PR TITLE
features: add "chords" ncl feature to generated docs

### DIFF
--- a/features/scripts/generate-doc.sh
+++ b/features/scripts/generate-doc.sh
@@ -23,6 +23,7 @@ keymap_key_features=(
 keymap_ncl_features=(
     "layers"
     "layer_string"
+    "chords"
 )
 
 KEYMAP_KEY_FEATURES_DIR="${KEYMAP_FEATURES_DIR}/key"


### PR DESCRIPTION
Now that chords have been implemented (and work for layered keys), can add the "chords" feature spec to the generated docs.