### PR TITLE
rust: return PressedKeyEvents from key::chorded::AuxiliaryKey::new_pressed_key

### DIFF
--- a/src/key/chorded.rs
+++ b/src/key/chorded.rs
@@ -327,7 +327,7 @@ where
         keymap_index: u16,
     ) -> (
         input::PressedKey<Self, PressedKeyState<K>>,
-        key::ScheduledEvent<Event>,
+        key::PressedKeyEvents<K::Event>,
     ) {
         let mut pk = input::PressedKey {
             keymap_index,
@@ -339,11 +339,15 @@ where
             context.into().config.timeout,
             key::Event::key_event(keymap_index, timeout_ev),
         );
-        // TODO: return resolved PKE
-        let _pke = pk
+
+        let mut pke = key::PressedKeyEvents::scheduled_event(sch_ev.into_scheduled_event());
+
+        let n_pke = pk
             .pressed_key_state
             .check_resolution(context, keymap_index, self);
-        (pk, sch_ev)
+        pke.extend(n_pke);
+
+        (pk, pke)
     }
 
     /// Maps the Key of the Key into a new type.

--- a/src/key/composite/chorded.rs
+++ b/src/key/composite/chorded.rs
@@ -81,8 +81,7 @@ impl<K: ChordedNestable> key::Key for key::chorded::AuxiliaryKey<K> {
         keymap_index: u16,
     ) -> (Self::PressedKey, key::PressedKeyEvents<Self::Event>) {
         let fat_key = (*self).map_key(|k| k.as_fat_key());
-        let (pk, sch_ev) = fat_key.new_pressed_key(context.into(), keymap_index);
-        let pke = key::PressedKeyEvents::scheduled_event(sch_ev).into_events();
+        let (pk, pke) = fat_key.new_pressed_key(context.into(), keymap_index);
         (
             pk.map_pressed_key(
                 |k| ChordedKey::Auxiliary(k),


### PR DESCRIPTION
It's not covered by tests. But, this changes so the ChordResolved event is now emitted by AuxKey if that resolves the chord.