### PR TITLE
firmware: ch32x: disable SWD (SDI)

### DIFF
--- a/firmware/ch32x035-usb-device-compositekm-c/User/main.c
+++ b/firmware/ch32x035-usb-device-compositekm-c/User/main.c
@@ -25,6 +25,7 @@
 #include "debug.h"
 
 #include "ch32x035_dbgmcu.h"
+#include "ch32x035_gpio.h"
 #include "ch32x035_misc.h"
 
 #include "ch32x035_usbfs_device.h"
@@ -60,6 +61,8 @@ int main(void) {
   printf("TIM3 Init OK!\r\n");
 
   static uint8_t sending = 0;
+
+  GPIO_PinRemapConfig(GPIO_Remap_SWJ_Disable, ENABLE);
 
   /* Usb Init */
   USBFS_RCC_Init();


### PR DESCRIPTION
Per the CH32X035 Reference Manual, section 8.3.2.1 Remap Register 1 (AFIO_PCFR1), the `SW_CFG` bits control whether SWD is enabled/not.

By default, SWD is enabled.

That explains why the CH32X-48 board, which uses the DIO/DCK pins, has issues with its row6.

This PR disables SWD in the firmware. -- Though, stuff like this (& the "which switch to use for enable-bootloader-on-start") should be covered by the codegen.