### PR TITLE
tests: chorded: check alternate input order

### DIFF
--- a/tests/rust/chorded.rs
+++ b/tests/rust/chorded.rs
@@ -115,6 +115,34 @@ fn press_chord_acts_as_chord() {
 }
 
 #[test]
+fn press_chord_alt_order_acts_as_chord() {
+    // Assemble
+    let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
+
+    // Act
+    // (press the auxiliary key first)
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    while keymap.has_scheduled_events() {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    // Assert
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x06, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
 fn nested_tap_chord_acts_as_chord() {
     // Assemble
     let mut keymap = Keymap::new(KEYS, CONTEXT);


### PR DESCRIPTION
Found while working on #216.

This PR adds a test case checking the chord behaviour for chording with the alternate input order. ("AB" has been covered, but not "BA").