### PR TITLE
rust: keymap: use Index, not IndexMut

### DIFF
--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -1,5 +1,5 @@
 use core::fmt::Debug;
-use core::ops::IndexMut;
+use core::ops::Index;
 
 use crate::input;
 use crate::key;
@@ -291,7 +291,7 @@ impl<
                 Event = composite::Event,
                 PressedKey = composite::PressedKey,
             > + ?Sized,
-        I: IndexMut<usize, Output = K>,
+        I: Index<usize, Output = K>,
     > core::fmt::Debug for Keymap<I>
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -313,7 +313,7 @@ impl<
                 Event = composite::Event,
                 PressedKey = composite::PressedKey,
             > + ?Sized,
-        I: IndexMut<usize, Output = K>,
+        I: Index<usize, Output = K>,
     > Keymap<I>
 {
     /// Constructs a new keymap with the given key definitions and context.
@@ -428,7 +428,7 @@ impl<
 
                 match ev {
                     input::Event::Press { keymap_index } => {
-                        let key = &mut self.key_definitions[keymap_index as usize];
+                        let key = &self.key_definitions[keymap_index as usize];
 
                         let (pk, pke) = key.new_pressed_key(self.context, keymap_index);
 

--- a/src/tuples.rs
+++ b/src/tuples.rs
@@ -1,5 +1,5 @@
 use core::fmt::Debug;
-use core::ops::{Index, IndexMut};
+use core::ops::Index;
 
 use crate::key;
 
@@ -40,22 +40,6 @@ impl<
     fn index(&self, idx: usize) -> &Self::Output {
         match idx {
             0 => &self.0,
-            _ => panic!("Index out of bounds"),
-        }
-    }
-}
-
-impl<
-        K0: key::Key<Context = Ctx, Event = Ev, PressedKey = PK> + 'static,
-        Ctx,
-        Ev,
-        PK,
-        const M: usize,
-    > IndexMut<usize> for Keys1<K0, Ctx, Ev, PK, M>
-{
-    fn index_mut(&mut self, idx: usize) -> &mut Self::Output {
-        match idx {
-            0 => &mut self.0,
             _ => panic!("Index out of bounds"),
         }
     }
@@ -129,29 +113,6 @@ macro_rules! define_keys {
                         match idx {
                             #(
                                 I => &self.I,
-                            )*
-                            _ => panic!("Index out of bounds"),
-                        }
-                    }
-                }
-
-                impl<
-                    #(
-                        K~I: crate::key::Key<Context = Ctx, Event = Ev, PressedKey = PK> + 'static,
-                    )*
-                Ctx,
-                Ev,
-                PK,
-                const M: usize,
-                > core::ops::IndexMut<usize> for [<Keys $n>]<
-                    #(K~I,)*
-                Ctx, Ev, PK, M
-                    >
-                {
-                    fn index_mut(&mut self, idx: usize) -> &mut Self::Output {
-                        match idx {
-                            #(
-                                I => &mut self.I,
                             )*
                             _ => panic!("Index out of bounds"),
                         }


### PR DESCRIPTION
An improvement surfaced while working on #216.

Since the dynamic key is no longer the mutable "dynamic key" impl., Keymap only needs to use `Index` not `IndexMut`.