### PR TITLE
rust: fix clippy suggestions

### DIFF
--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -102,10 +102,12 @@ impl key::Context for Context {
             self.chorded_context.handle_event(e);
         }
 
-        if let key::Event::Key { key_event, .. } = event {
-            if let Event::LayerModification(ev) = key_event {
-                self.layer_context.handle_event(ev);
-            }
+        if let key::Event::Key {
+            key_event: Event::LayerModification(ev),
+            ..
+        } = event
+        {
+            self.layer_context.handle_event(ev);
         }
     }
 }

--- a/src/key/composite/layered.rs
+++ b/src/key/composite/layered.rs
@@ -77,7 +77,7 @@ impl<K: LayeredNestable> key::Key for LayeredKey<K> {
     ) -> (Self::PressedKey, key::PressedKeyEvents<Self::Event>) {
         match self {
             LayeredKey::Layered(key) => {
-                let (layered_pk, pke) = key.new_pressed_key(context.into(), keymap_index);
+                let (layered_pk, pke) = key.new_pressed_key(context, keymap_index);
                 let pk = input::PressedKey {
                     key: LayeredKey::Pass(layered_pk.key),
                     keymap_index,
@@ -86,7 +86,7 @@ impl<K: LayeredNestable> key::Key for LayeredKey<K> {
                 (pk, pke)
             }
             LayeredKey::Pass(key) => {
-                let (passthrough_pk, pke) = key.new_pressed_key(context.into(), keymap_index);
+                let (passthrough_pk, pke) = key.new_pressed_key(context, keymap_index);
                 let pk = input::PressedKey {
                     key: LayeredKey::Pass(passthrough_pk.key),
                     keymap_index,

--- a/src/key/composite/tap_hold.rs
+++ b/src/key/composite/tap_hold.rs
@@ -183,7 +183,7 @@ impl<K: TapHoldNestable> TapHoldPressedKeyState<K> {
             TapHoldPressedKeyState::TapHold(pks) => {
                 TapHoldPressedKeyState::TapHold(pks.into_pressed_key())
             }
-            TapHoldPressedKeyState::Pass(pks) => TapHoldPressedKeyState::Pass(pks.into()),
+            TapHoldPressedKeyState::Pass(pks) => TapHoldPressedKeyState::Pass(pks),
         }
     }
 }
@@ -208,21 +208,13 @@ impl<K: Copy + Into<TapHoldKey<NK>>, NK: TapHoldNestable> key::PressedKeyState<K
 
         match (k, self) {
             (TapHoldKey::TapHold(key), TapHoldPressedKeyState::TapHold(pks)) => {
-                if let Ok(ev) = event.try_into_key_event(|event| event.try_into()) {
-                    let events = pks.handle_event_for(context.into(), keymap_index, &key, ev);
-                    events.into_events()
-                } else {
-                    key::PressedKeyEvents::no_events()
-                }
+                let events = pks.handle_event_for(context, keymap_index, &key, event);
+                events.into_events()
             }
             (TapHoldKey::Pass(key), TapHoldPressedKeyState::Pass(pks)) => {
-                if let Ok(ev) = event.try_into_key_event(|event| event.try_into()) {
-                    let k: BaseKey = key.into();
-                    let events = pks.handle_event_for(context.into(), keymap_index, &k, ev);
-                    events.into_events()
-                } else {
-                    key::PressedKeyEvents::no_events()
-                }
+                let k: BaseKey = key.into();
+                let events = pks.handle_event_for(context, keymap_index, &k, event);
+                events.into_events()
             }
             _ => key::PressedKeyEvents::no_events(),
         }

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -278,10 +278,7 @@ impl KeyboardModifiers {
 
     /// Predicate for whether the key code is a modifier key code.
     pub const fn is_modifier_key_code(key_code: u8) -> bool {
-        match key_code {
-            0xE0..=0xE7 => true,
-            _ => false,
-        }
+        matches!(key_code, 0xE0..=0xE7)
     }
 
     /// Constructs a Vec of key codes from the modifiers.

--- a/src/key/tap_hold.rs
+++ b/src/key/tap_hold.rs
@@ -311,14 +311,10 @@ where
 
         // Check for interrupting taps
         // (track other key press, if this PKS has not resolved)
-        match self.state {
-            TapHoldState::Pending => match event {
-                key::Event::Input(input::Event::Press { keymap_index: ki }) => {
-                    self.other_pressed_keymap_index = Some(ki);
-                }
-                _ => {}
-            },
-            _ => {}
+        if self.state == TapHoldState::Pending {
+            if let key::Event::Input(input::Event::Press { keymap_index: ki }) = event {
+                self.other_pressed_keymap_index = Some(ki);
+            }
         }
 
         // Resolve tap-hold state per the event.


### PR DESCRIPTION
I'd assumed devenv's pre-commit hook for clippy would have prevented clippy warnings from being checked in, since the rustfmt hook has an impact. Apparently not.

This PR fixes (most) of clippy's suggestions.