### PR TITLE
Fix warnings in docs

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -31,7 +31,7 @@ pub enum Event {
     InputResolved,
 }
 
-/// A struct for associating a [crate::key::Key] with a [crate::key::PressedKeyState].
+/// A struct for associating a [crate::key::Key] with a [crate::key::KeyState].
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PressedKey<S> {
     /// The index of the pressed key in some keymap.

--- a/src/key/chorded.rs
+++ b/src/key/chorded.rs
@@ -398,35 +398,6 @@ where
     }
 }
 
-/// Trait for [PressedKeyState].
-pub trait ChordedKey<K: key::Key> {
-    /// The chorded key's "passthrough" key.
-    fn passthrough_key(&self) -> &K;
-
-    /// The chorded key's "chorded" key.
-    fn chorded_key(&self) -> Option<&K>;
-}
-
-impl<K: key::Key> ChordedKey<K> for Key<K> {
-    fn passthrough_key(&self) -> &K {
-        &self.passthrough
-    }
-
-    fn chorded_key(&self) -> Option<&K> {
-        Some(&self.chord)
-    }
-}
-
-impl<K: key::Key> ChordedKey<K> for AuxiliaryKey<K> {
-    fn passthrough_key(&self) -> &K {
-        &self.passthrough
-    }
-
-    fn chorded_key(&self) -> Option<&K> {
-        None
-    }
-}
-
 /// Events for chorded keys.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 pub enum Event {

--- a/src/key/chorded.rs
+++ b/src/key/chorded.rs
@@ -443,7 +443,7 @@ pub struct PendingKeyState {
 }
 
 impl PendingKeyState {
-    /// Constructs a new [PressedKeyState].
+    /// Constructs a new [PendingKeyState].
     pub fn new(context: Context, keymap_index: u16) -> Self {
         let sibling_indices = context.sibling_indices(keymap_index);
         let pressed_indices: heapless::Vec<u16, MAX_CHORD_SIZE> = context

--- a/src/key/composite/chorded.rs
+++ b/src/key/composite/chorded.rs
@@ -38,7 +38,7 @@ pub enum ChordedKey<K: ChordedNestable> {
     Pass(K),
 }
 
-/// Newtype for [ChordedNestable] keys so they can implement [key::Key] for [ChordedPressedKey].
+/// Newtype for [ChordedNestable] keys so they can implement [key::Key].
 #[derive(Debug, Clone, Copy)]
 pub struct Chorded<K: ChordedNestable>(pub K);
 
@@ -294,24 +294,24 @@ impl<K: ChordedNestable> key::Key for Chorded<K> {
 }
 
 impl ChordedKey<LayeredKey<TapHoldKey<BaseKey>>> {
-    /// Constructs a [Key] from the given [key::keyboard::Key].
+    /// Constructs a [ChordedKey] from the given [key::keyboard::Key].
     pub const fn keyboard(key: key::keyboard::Key) -> Self {
         ChordedKey::Pass(LayeredKey::Pass(TapHoldKey::keyboard(key)))
     }
 
-    /// Constructs a [Key] from the given [key::tap_hold::Key].
+    /// Constructs a [ChordedKey] from the given [key::tap_hold::Key].
     pub const fn tap_hold(key: key::tap_hold::Key<BaseKey>) -> Self {
         ChordedKey::Pass(LayeredKey::Pass(TapHoldKey::tap_hold(key)))
     }
 
-    /// Constructs a [Key] from the given [key::layered::ModifierKey].
+    /// Constructs a [ChordedKey] from the given [key::layered::ModifierKey].
     pub const fn layer_modifier(key: key::layered::ModifierKey) -> Self {
         ChordedKey::Pass(LayeredKey::Pass(TapHoldKey::layer_modifier(key)))
     }
 }
 
 impl<K: LayeredNestable> ChordedKey<LayeredKey<K>> {
-    /// Constructs a [Key] from the given [key::layered::LayeredKey].
+    /// Constructs a [ChordedKey] from the given [key::layered::LayeredKey].
     pub const fn layered(key: key::layered::LayeredKey<K>) -> Self {
         ChordedKey::Pass(LayeredKey::Layered(key))
     }

--- a/src/key/composite/layered.rs
+++ b/src/key/composite/layered.rs
@@ -35,7 +35,7 @@ pub enum LayeredKey<K: LayeredNestable> {
     Pass(K),
 }
 
-/// Newtype for [LayeredNestable] keys so they can implement [key::Key] for [LayeredPressedKey].
+/// Newtype for [LayeredNestable] keys so they can implement [key::Key].
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Layered<K: LayeredNestable>(pub K);
 
@@ -130,24 +130,24 @@ impl<K: LayeredNestable> key::Key for Layered<K> {
 }
 
 impl LayeredKey<TapHoldKey<BaseKey>> {
-    /// Constructs a [Key] from the given [key::keyboard::Key].
+    /// Constructs a [LayeredKey] from the given [key::keyboard::Key].
     pub const fn keyboard(key: key::keyboard::Key) -> Self {
         Self::Pass(TapHoldKey::keyboard(key))
     }
 
-    /// Constructs a [Key] from the given [key::tap_hold::Key].
+    /// Constructs a [LayeredKey] from the given [key::tap_hold::Key].
     pub const fn tap_hold(key: key::tap_hold::Key<BaseKey>) -> Self {
         Self::Pass(TapHoldKey::tap_hold(key))
     }
 
-    /// Constructs a [Key] from the given [key::layered::ModifierKey].
+    /// Constructs a [LayeredKey] from the given [key::layered::ModifierKey].
     pub const fn layer_modifier(key: key::layered::ModifierKey) -> Self {
         Self::Pass(TapHoldKey::layer_modifier(key))
     }
 }
 
 impl<K: LayeredNestable> LayeredKey<K> {
-    /// Constructs a [Key] from the given [key::layered::LayeredKey].
+    /// Constructs a [LayeredKey] from the given [key::layered::LayeredKey].
     pub const fn layered(key: key::layered::LayeredKey<K>) -> Self {
         Self::Layered(key)
     }
@@ -161,7 +161,7 @@ impl Layered<TapHold<key::keyboard::Key>> {
 }
 
 impl Layered<TapHoldKey<key::keyboard::Key>> {
-    /// Constructs a [Key] from the given [key::tap_hold::Key].
+    /// Constructs a [Layered] newtype from the given [key::tap_hold::Key].
     pub const fn tap_hold(key: key::tap_hold::Key<key::keyboard::Key>) -> Self {
         Self(TapHoldKey::TapHold(key))
     }

--- a/src/key/composite/tap_hold.rs
+++ b/src/key/composite/tap_hold.rs
@@ -36,7 +36,7 @@ pub enum TapHoldKey<K: TapHoldNestable> {
     Pass(K),
 }
 
-/// Newtype for [TapHoldNestable] keys so they can implement [key::Key] for [TapHoldPressedKey].
+/// Newtype for [TapHoldNestable] keys so they can implement [key::Key].
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TapHold<K: TapHoldNestable>(pub K);
 

--- a/src/key/doc_de_chorded.md
+++ b/src/key/doc_de_chorded.md
@@ -5,14 +5,14 @@ simultaneously pressing multiple keys results in the behaviour of another
 key. e.g. pressing 'qw' keys together might send "Backspace"
 
 In this module,
-- [Context] stores the [Chord]s of the keymap.
-  - [Chord] is defined in terms of keymap indices.
-- [Key] describes a key which is part of a chord
+- [chorded::Context] stores the chords of the keymap.
+  - Chord is defined in terms of keymap indices. (See: [chorded::ChordIndices]).
+- [chorded::Key] and [chorded::AuxiliaryKey] describe keys which are part of a chord
   - This includes its 'passthrough key';
     the behaviour of the key when the chord
     didn't succeed.
     (e.g. 'q' or 'w' for the chord 'qw').
-- [KeyState] manages chord resolution.
+- [chorded::PendingKeyState] manages chord resolution.
   - If a timeout event is received for the key:
     - if the PKS does not have a satisfied chord,
       the PKS resolves to "Timed out",

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -270,7 +270,7 @@ pub enum LayerEvent {
     LayerDeactivated(LayerIndex),
 }
 
-/// Unit-like struct, for [crate::key::PressedKeyState] of [ModifierKey].
+/// Unit-like struct, for [crate::key::KeyState] of [ModifierKey].
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ModifierKeyState(ModifierKey);
 

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -150,7 +150,7 @@ pub trait Key: Debug {
     type Context: Copy;
 
     /// The associated `Event` is to be handled by the associated [Context],
-    ///  and any active [PressedKey]s.
+    ///  pending key states, and key states.
     type Event: Copy + Debug + PartialEq;
 
     /// Associated pending key state.
@@ -401,7 +401,7 @@ impl KeyboardModifiers {
     }
 }
 
-/// Struct for the output from [PressedKey].
+/// Struct for the output from [KeyState].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct KeyOutput {
     key_code: u8,
@@ -456,9 +456,6 @@ impl KeyOutput {
 }
 
 /// Implements functionality for the pressed key.
-///
-/// e.g. [tap_hold::KeyState] implements behaviour resolving
-///  the pressed tap hold key as either 'tap' or 'hold'.
 pub trait KeyState: Debug {
     /// The type of `Context` the pressed key state handles.
     type Context;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //! # Implementation Overview
 //!
 //! The heart of the library is the [key] module, and its
-//! [key::Key], [key::Context], [key::PressedKey] traits.
+//! [key::Key], [key::Context], [key::KeyState] traits.
 //!
 //! These provide the interface with which 'smart keys' are implemented.
 
@@ -47,7 +47,7 @@ pub mod input;
 /// Smart key interface and implementations.
 ///
 /// The core interface for the smart keymap library is [key::Key],
-///  and its associated [key::Context] and [key::PressedKeyState] types.
+///  and its associated [key::Context], `PendingKeyState`, and [key::KeyState] types.
 /// Together, these are used to define smart key behaviour.
 pub mod key;
 /// Keymap implementation.


### PR DESCRIPTION
Some drift from previous PRs; docs hadn't been updated to reflect the new types.