### PR TITLE
CH32X Firmware: Refactor board / matrix scanning

### DIFF
--- a/firmware/ch32x035-usb-device-compositekm-c/ncl/ch32x-48.ncl
+++ b/firmware/ch32x035-usb-device-compositekm-c/ncl/ch32x-48.ncl
@@ -1,14 +1,8 @@
 {
   gpio_pins,
 
-  board
-    | {
-      cols | Array { port | String, pin | Number },
-      rows | Array { port | String, pin | Number },
-      key_count | Number,
-    }
-    | doc "the cols/rows, and number of keys, used for generating the matrix scan code."
-    =
+  board = {
+    matrix =
       let p = gpio_pins in
       {
         cols = [p.B1, p.A6, p.A9, p.A0, p.C3, p.A10, p.A11],
@@ -16,19 +10,17 @@
         key_count = 48,
       },
 
-  # The CH32X-48 uses a digital matrix of 7x7 rows and columns,
-  #  forming a physical 4x12 matrix of keys.
-  #
-  # The physical matrix arranges keys column-wise.
-  #
-  # Want the keymap index to refer to keys row-wise.
-  #
-  # The given column_index and row_index refer to (digital) row/col, 0..6.
-  keymap_index_for_key
-    | doc "Returns the keymap index for the key corresponding to the (0-based) digital column_index and row_index."
-    = fun { column_index | Number, row_index | Number, .. } =>
+    # The CH32X-48 uses a digital matrix of 7x7 rows and columns,
+    #  forming a physical 4x12 matrix of keys.
+    #
+    # The physical matrix arranges keys column-wise.
+    #
+    # Want the keymap index to refer to keys row-wise.
+    #
+    # The given column_index and row_index refer to (digital) row/col, 0..6.
+    keymap_index_for_key = fun { column_index | Number, row_index | Number, .. } =>
       let columnwise_index = column_index * 7 + row_index in
-      if columnwise_index >= board.key_count then
+      if columnwise_index >= matrix.key_count then
         'Error "no key at this column/row index."
       else
         let physical_column_index = std.number.floor (columnwise_index / 4) in
@@ -36,12 +28,13 @@
         let rowwise_index = physical_row_index * 12 + physical_column_index in
         'Ok rowwise_index,
 
-  # CH32X-48 uses CH32X033F8P6's PC18/PC19 (DIO/DCK) for matrix rows.
-  # Hence, disable SWD to avoid conflict.
-  disable_swd = true,
+    # CH32X-48 uses CH32X033F8P6's PC18/PC19 (DIO/DCK) for matrix rows.
+    # Hence, disable SWD to avoid conflict.
+    disable_swd = true,
 
-  led = {
-    enabled = true,
-    pin = gpio_pins.A5,
+    led = {
+      enabled = true,
+      pin = gpio_pins.A5,
+    },
   },
 }

--- a/firmware/ch32x035-usb-device-compositekm-c/ncl/codegen-matrix-row_to_col.ncl
+++ b/firmware/ch32x035-usb-device-compositekm-c/ncl/codegen-matrix-row_to_col.ncl
@@ -1,0 +1,105 @@
+# codegen for matrix scan,
+# diode direction: current from row to column.
+# impl.: pull-up rows
+{
+  board
+    | {
+      cols | Array { port | String, pin | Number },
+      rows | Array { port | String, pin | Number },
+      key_count | Number,
+    },
+
+  keymap_index_for_key,
+
+  matrix_scan = {
+    init_col_fragment = fun { port, pin, .. } =>
+      m%"
+      // %{port}%{std.to_string pin}
+      {
+        GPIO_InitTypeDef GPIO_InitStructure = { 0 };
+        GPIO_InitStructure.GPIO_Pin = GPIO_Pin_%{std.to_string pin};
+        GPIO_InitStructure.GPIO_Mode = GPIO_Mode_Out_PP;
+        GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+        GPIO_Init( GPIO%{port}, &GPIO_InitStructure );
+      }
+  "%,
+
+    init_row_fragment = fun { port, pin, .. } =>
+      m%"
+      // %{port}%{std.to_string pin}
+      {
+        GPIO_InitTypeDef GPIO_InitStructure = { 0 };
+        GPIO_InitStructure.GPIO_Pin = GPIO_Pin_%{std.to_string pin};
+        GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IPU;
+        GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+        GPIO_Init( GPIO%{port}, &GPIO_InitStructure );
+      }
+  "%,
+
+    keyboard_matrix_init
+      | doc "Generates C fragment with the keyboard_matrix_init function, for the given cols/rows."
+      = fun { cols, rows, .. } =>
+        m%"
+  void keyboard_matrix_init(void) {
+      // NOTE: this implementation is for diode's cathodes(-) which face COLUMNS.
+      //  i.e. that current flows from ROWS to COLUMNS.
+      // This implementation configures ROWS as Input (Pull Up),
+      // and COLS as Output (set low when scanned).
+
+      RCC_APB2PeriphClockCmd( RCC_APB2Periph_GPIOA, ENABLE );
+      RCC_APB2PeriphClockCmd( RCC_APB2Periph_GPIOB, ENABLE );
+      RCC_APB2PeriphClockCmd( RCC_APB2Periph_GPIOC, ENABLE );
+
+      // Cols
+      %{cols |> std.array.map init_col_fragment |> std.string.join "\n"}
+
+      // Rows
+      %{rows |> std.array.map init_row_fragment |>std.string.join "\n"}
+  }
+  "%,
+
+    matrix_scan_row_for_column = fun args @ { column_index, row_index, col, row, .. } =>
+      let maybe_idx = keymap_index_for_key args in
+      maybe_idx
+      |> match {
+        'Error err => "",
+        'Ok idx_num =>
+          let idx = std.to_string idx_num in
+          m%"
+          // Read row %{std.to_string row_index} = %{row.port}%{std.to_string row.pin}
+          // SW_r_c = SW_%{std.to_string (1 + row_index)}_%{std.to_string (1 + column_index)}
+          scan_buf[%{idx}] = GPIO_ReadInputDataBit(GPIO%{row.port}, GPIO_Pin_%{std.to_string row.pin}) != 1;
+  "%
+      },
+
+    matrix_scan_column = fun args @ { column_index, col, rows, .. } =>
+      m%"
+      // Scan column %{std.to_string column_index} = %{col.port}%{std.to_string col.pin}
+      GPIO_ResetBits(GPIO%{col.port}, GPIO_Pin_%{std.to_string col.pin});
+      Delay_Us(5);
+
+      // Read the row pins
+      %{rows |> std.array.map_with_index (fun idx r => matrix_scan_row_for_column (args & { row = r, row_index = idx })) |> std.string.join "\n"}
+
+      GPIO_SetBits(GPIO%{col.port}, GPIO_Pin_%{std.to_string col.pin});
+  "%,
+
+    keyboard_matrix_scan_raw
+      | doc "Generates C fragment with the keyboard_matrix_scan function, for the given cols/rows."
+      = fun { cols, rows, .. } =>
+        m%"
+  void keyboard_matrix_scan_raw(bool scan_buf[%{std.to_string board.key_count}]) {
+      %{board.cols |> std.array.map_with_index (fun idx c => matrix_scan_column ({ col = c, column_index = idx, rows = board.rows })) |> std.string.join "\n"}
+  }
+  "%,
+
+    is_sw_1_1_pressed =
+      let col = std.array.at 0 board.cols in
+      let row = std.array.at 0 board.rows in
+      m%"
+    GPIO_ResetBits(GPIO%{col.port}, GPIO_Pin_%{std.to_string col.pin}); // col 0
+    Delay_Us(5);
+    bool sw_1_1_is_pressed = GPIO_ReadInputDataBit(GPIO%{row.port}, GPIO_Pin_%{std.to_string row.pin}) != 1; // row0
+    "%,
+  },
+}

--- a/firmware/ch32x035-usb-device-compositekm-c/ncl/codegen-matrix-row_to_col.ncl
+++ b/firmware/ch32x035-usb-device-compositekm-c/ncl/codegen-matrix-row_to_col.ncl
@@ -2,14 +2,16 @@
 # diode direction: current from row to column.
 # impl.: pull-up rows
 {
-  board
-    | {
-      cols | Array { port | String, pin | Number },
-      rows | Array { port | String, pin | Number },
-      key_count | Number,
-    },
+  board = {
+    matrix
+      | {
+        cols | Array { port | String, pin | Number },
+        rows | Array { port | String, pin | Number },
+        key_count | Number,
+      },
 
-  keymap_index_for_key,
+    keymap_index_for_key,
+  },
 
   matrix_scan = {
     init_col_fragment = fun { port, pin, .. } =>
@@ -59,7 +61,7 @@
   "%,
 
     matrix_scan_row_for_column = fun args @ { column_index, row_index, col, row, .. } =>
-      let maybe_idx = keymap_index_for_key args in
+      let maybe_idx = board.keymap_index_for_key args in
       maybe_idx
       |> match {
         'Error err => "",
@@ -88,14 +90,14 @@
       | doc "Generates C fragment with the keyboard_matrix_scan function, for the given cols/rows."
       = fun { cols, rows, .. } =>
         m%"
-  void keyboard_matrix_scan_raw(bool scan_buf[%{std.to_string board.key_count}]) {
-      %{board.cols |> std.array.map_with_index (fun idx c => matrix_scan_column ({ col = c, column_index = idx, rows = board.rows })) |> std.string.join "\n"}
+  void keyboard_matrix_scan_raw(bool scan_buf[%{std.to_string board.matrix.key_count}]) {
+      %{board.matrix.cols |> std.array.map_with_index (fun idx c => matrix_scan_column ({ col = c, column_index = idx, rows = board.matrix.rows })) |> std.string.join "\n"}
   }
   "%,
 
     is_sw_1_1_pressed =
-      let col = std.array.at 0 board.cols in
-      let row = std.array.at 0 board.rows in
+      let col = std.array.at 0 board.matrix.cols in
+      let row = std.array.at 0 board.matrix.rows in
       m%"
     GPIO_ResetBits(GPIO%{col.port}, GPIO_Pin_%{std.to_string col.pin}); // col 0
     Delay_Us(5);

--- a/firmware/ch32x035-usb-device-compositekm-c/ncl/codegen_keyboard.ncl
+++ b/firmware/ch32x035-usb-device-compositekm-c/ncl/codegen_keyboard.ncl
@@ -12,37 +12,36 @@
         ports
       |> (std.array.fold_left (&) {}) | { _ : { port : String, pin : Number } },
 
-  board
-    | {
-      cols | Array { port | String, pin | Number },
-      rows | Array { port | String, pin | Number },
-      key_count | Number,
-    }
-    | doc "the cols/rows, and number of keys, used for generating the matrix scan code.",
-
   matrix_scan = {
     keyboard_matrix_init,
     keyboard_matrix_scan_raw,
     is_sw_1_1_pressed,
   },
 
-  keymap_index_for_key
-    | doc "Returns the keymap index for the key corresponding to the (0-based) digital column_index and row_index.",
+  board = {
+    matrix
+      | {
+        cols | Array { port | String, pin | Number },
+        rows | Array { port | String, pin | Number },
+        key_count | Number,
+      }
+      | doc "the cols/rows, and number of keys, used for generating the matrix scan code.",
 
-  disable_swd
-    | doc "Whether to disable SWD."
-    | default
-    = false,
-
-  led = {
-    enabled
-      | doc "Whether to enable the LED."
+    disable_swd
+      | doc "Whether to disable SWD."
       | default
       = false,
 
-    pin
-      | doc "The pin to use for the LED."
-      | { port | String, pin | Number },
+    led = {
+      enabled
+        | doc "Whether to enable the LED."
+        | default
+        = false,
+
+      pin
+        | doc "The pin to use for the LED."
+        | { port | String, pin | Number },
+    },
   },
 
   enter_bootloader_check = m%"
@@ -54,7 +53,7 @@
     "%,
 
   disable_swd_fragment =
-    if disable_swd then
+    if board.disable_swd then
       m%"
         // Disable SWD
         GPIO_PinRemapConfig(GPIO_Remap_SWJ_Disable, ENABLE);
@@ -63,15 +62,15 @@
       "",
 
   led_init_fragment =
-    if led.enabled then
+    if board.led.enabled then
       m%"
         // Init LED
         {
           GPIO_InitTypeDef GPIO_InitStructure = {0};
-          GPIO_InitStructure.GPIO_Pin = GPIO_Pin_%{std.to_string led.pin.pin};
+          GPIO_InitStructure.GPIO_Pin = GPIO_Pin_%{std.to_string board.led.pin.pin};
           GPIO_InitStructure.GPIO_Mode = GPIO_Mode_Out_PP;
           GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
-          GPIO_Init(GPIO%{led.pin.port}, &GPIO_InitStructure);
+          GPIO_Init(GPIO%{board.led.pin.port}, &GPIO_InitStructure);
         }
         "%
     else
@@ -98,14 +97,14 @@
   %{matrix_scan.keyboard_matrix_scan_raw args}
 
   void keyboard_matrix_scan(void) {
-      static bool debounced_state[%{std.to_string board.key_count}] = { false };
-      static bool previous_raw_scan[%{std.to_string board.key_count}] = { false };
-      static bool current_raw_scan[%{std.to_string board.key_count}] = { false };
-      static uint8_t debounce_counter[%{std.to_string board.key_count}] = { 0 };
+      static bool debounced_state[%{std.to_string board.matrix.key_count}] = { false };
+      static bool previous_raw_scan[%{std.to_string board.matrix.key_count}] = { false };
+      static bool current_raw_scan[%{std.to_string board.matrix.key_count}] = { false };
+      static uint8_t debounce_counter[%{std.to_string board.matrix.key_count}] = { 0 };
 
       keyboard_matrix_scan_raw(current_raw_scan);
 
-      for (uint32_t i = 0; i < %{std.to_string board.key_count}; i++) {
+      for (uint32_t i = 0; i < %{std.to_string board.matrix.key_count}; i++) {
           if (current_raw_scan[i] == debounced_state[i]) {
               debounce_counter[i] = 0;
           } else {
@@ -128,7 +127,7 @@
 
   # Function which blinks the LED
   keyboard_led_tick =
-    if led.enabled then
+    if board.led.enabled then
       m%"
         static uint16_t keyboard_led_timer = 0;
         static uint8_t keyboard_led_state = 0;
@@ -140,7 +139,7 @@
                 keyboard_led_timer = 0;
                 keyboard_led_state = 1 - keyboard_led_state;
 
-                GPIO_WriteBit(GPIO%{led.pin.port}, GPIO_Pin_%{std.to_string led.pin.pin}, keyboard_led_state);
+                GPIO_WriteBit(GPIO%{board.led.pin.port}, GPIO_Pin_%{std.to_string board.led.pin.pin}, keyboard_led_state);
             }
         }
         "%
@@ -160,7 +159,7 @@
 
   #include "smart_keymap.h"
 
-  %{matrix_scan.keyboard_matrix_init board}
+  %{matrix_scan.keyboard_matrix_init board.matrix}
 
   %{keyboard_init}
 
@@ -172,7 +171,7 @@
       }
   }
 
-  %{keyboard_matrix_scan board}
+  %{keyboard_matrix_scan board.matrix}
 
   %{keyboard_led_tick}
   "%

--- a/firmware/ch32x035-usb-device-compositekm-c/ncl/codegen_keyboard.ncl
+++ b/firmware/ch32x035-usb-device-compositekm-c/ncl/codegen_keyboard.ncl
@@ -1,4 +1,5 @@
-{
+(import "codegen-matrix-row_to_col.ncl")
+& {
   gpio_pins
     : { _ : { port : String, pin : Number } }
     | doc "Record with A1, A2, ... A23, B1, B2, ..., C24, mapped to { port, pin } records."
@@ -19,6 +20,12 @@
     }
     | doc "the cols/rows, and number of keys, used for generating the matrix scan code.",
 
+  matrix_scan = {
+    keyboard_matrix_init,
+    keyboard_matrix_scan_raw,
+    is_sw_1_1_pressed,
+  },
+
   keymap_index_for_key
     | doc "Returns the keymap index for the key corresponding to the (0-based) digital column_index and row_index.",
 
@@ -38,46 +45,8 @@
       | { port | String, pin | Number },
   },
 
-  init_col_fragment
-    | doc "Generates C fragment for initializing the given column pin, for keyboard_matrix_init."
-    = fun { port, pin, .. } =>
-      m%"
-      // %{port}%{std.to_string pin}
-      {
-        GPIO_InitTypeDef GPIO_InitStructure = { 0 };
-        GPIO_InitStructure.GPIO_Pin = GPIO_Pin_%{std.to_string pin};
-        GPIO_InitStructure.GPIO_Mode = GPIO_Mode_Out_PP;
-        GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
-        GPIO_Init( GPIO%{port}, &GPIO_InitStructure );
-      }
-  "%,
-
-  init_row_fragment
-    | doc "Generates C fragment for initializing the given row pin, for keyboard_matrix_init"
-    = fun { port, pin, .. } =>
-      m%"
-      // %{port}%{std.to_string pin}
-      {
-        GPIO_InitTypeDef GPIO_InitStructure = { 0 };
-        GPIO_InitStructure.GPIO_Pin = GPIO_Pin_%{std.to_string pin};
-        GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IPU;
-        GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
-        GPIO_Init( GPIO%{port}, &GPIO_InitStructure );
-      }
-  "%,
-
-  # row-to-col diodes (write col low, check if pulled-up row is low)
-  bootloader_is_sw_1_1_pressed =
-    let col = std.array.at 0 board.cols in
-    let row = std.array.at 0 board.rows in
-    m%"
-    GPIO_ResetBits(GPIO%{col.port}, GPIO_Pin_%{std.to_string col.pin}); // col 0
-    Delay_Us(5);
-    bool sw_1_1_is_pressed = GPIO_ReadInputDataBit(GPIO%{row.port}, GPIO_Pin_%{std.to_string row.pin}) != 1; // row0
-    "%,
-
   enter_bootloader_check = m%"
-    %{bootloader_is_sw_1_1_pressed}
+    %{matrix_scan.is_sw_1_1_pressed}
     if (sw_1_1_is_pressed) {
         SystemReset_StartMode(Start_Mode_BOOT);
         NVIC_SystemReset();
@@ -122,72 +91,11 @@
   }
   "%,
 
-  keyboard_matrix_init
-    | doc "Generates C fragment with the keyboard_matrix_init function, for the given cols/rows."
-    = fun { cols, rows, .. } =>
-      m%"
-  void keyboard_matrix_init(void) {
-      // NOTE: this implementation assumes diode's cathodes(-) face COLUMNS.
-      //  i.e. that current flows from ROWS to COLUMNS.
-      // This implementation configures ROWS as Input (Pull Up),
-      // and COLS as Output (set low when scanned).
-
-      RCC_APB2PeriphClockCmd( RCC_APB2Periph_GPIOA, ENABLE );
-      RCC_APB2PeriphClockCmd( RCC_APB2Periph_GPIOB, ENABLE );
-      RCC_APB2PeriphClockCmd( RCC_APB2Periph_GPIOC, ENABLE );
-
-      // Cols
-      %{cols |> std.array.map init_col_fragment |> std.string.join "\n"}
-
-      // Rows
-      %{rows |> std.array.map init_row_fragment |>std.string.join "\n"}
-  }
-  "%,
-
-  matrix_scan_row_for_column
-    | doc "Generates C fragment for reading a row, as part of COL2ROW scanning."
-    = fun args @ { column_index, row_index, col, row, .. } =>
-      let maybe_idx = keymap_index_for_key args in
-      maybe_idx
-      |> match {
-        'Error err => "",
-        'Ok idx_num =>
-          let idx = std.to_string idx_num in
-          m%"
-          // Read row %{std.to_string row_index} = %{row.port}%{std.to_string row.pin}
-          // SW_r_c = SW_%{std.to_string (1 + row_index)}_%{std.to_string (1 + column_index)}
-          scan_buf[%{idx}] = GPIO_ReadInputDataBit(GPIO%{row.port}, GPIO_Pin_%{std.to_string row.pin}) != 1;
-  "%
-      },
-
-  matrix_scan_column
-    | doc "Generates C fragment for reading a column, as part of COL2ROW scanning."
-    = fun args @ { column_index, col, rows, .. } =>
-      m%"
-      // Scan column %{std.to_string column_index} = %{col.port}%{std.to_string col.pin}
-      GPIO_ResetBits(GPIO%{col.port}, GPIO_Pin_%{std.to_string col.pin});
-      Delay_Us(5);
-
-      // Read the row pins
-      %{rows |> std.array.map_with_index (fun idx r => matrix_scan_row_for_column (args & { row = r, row_index = idx })) |> std.string.join "\n"}
-
-      GPIO_SetBits(GPIO%{col.port}, GPIO_Pin_%{std.to_string col.pin});
-  "%,
-
-  keyboard_matrix_scan_raw
-    | doc "Generates C fragment with the keyboard_matrix_scan function, for the given cols/rows."
-    = fun { cols, rows, .. } =>
-      m%"
-  void keyboard_matrix_scan_raw(bool scan_buf[%{std.to_string board.key_count}]) {
-      %{board.cols |> std.array.map_with_index (fun idx c => matrix_scan_column ({ col = c, column_index = idx, rows = board.rows })) |> std.string.join "\n"}
-  }
-  "%,
-
   keyboard_matrix_scan
     | doc "Generates C fragment with the keyboard_matrix_scan function, for the given cols/rows."
     = fun args @ { cols, rows, .. } =>
       m%"
-  %{keyboard_matrix_scan_raw args}
+  %{matrix_scan.keyboard_matrix_scan_raw args}
 
   void keyboard_matrix_scan(void) {
       static bool debounced_state[%{std.to_string board.key_count}] = { false };
@@ -252,7 +160,7 @@
 
   #include "smart_keymap.h"
 
-  %{keyboard_matrix_init board}
+  %{matrix_scan.keyboard_matrix_init board}
 
   %{keyboard_init}
 

--- a/firmware/ch32x035-usb-device-compositekm-c/ncl/weact-ch32x-core-board.ncl
+++ b/firmware/ch32x035-usb-device-compositekm-c/ncl/weact-ch32x-core-board.ncl
@@ -1,14 +1,8 @@
 {
   gpio_pins,
 
-  board
-    | {
-      cols | Array { port | String, pin | Number },
-      rows | Array { port | String, pin | Number },
-      key_count | Number,
-    }
-    | doc "the cols/rows, and number of keys, used for generating the matrix scan code."
-    =
+  board = {
+    matrix =
       let p = gpio_pins in
       {
         cols = [p.B0, p.B1],
@@ -16,8 +10,7 @@
         key_count = 4,
       },
 
-  keymap_index_for_key
-    | doc "Returns the keymap index for the key corresponding to the (0-based) digital column_index and row_index."
-    = fun { column_index | Number, row_index | Number, .. } =>
+    keymap_index_for_key = fun { column_index | Number, row_index | Number, .. } =>
       'Ok (column_index + row_index * (std.array.length board.cols)),
+  },
 }


### PR DESCRIPTION
This PR moves the Nickel codegen code for the CH32X around:

- Moves codegen related to matrix scanning to its own module.
- Moves board-specific configuration to the `board` field.

I want to be able to have matrix scanning for a matrix where the diodes have column-to-row direction. This PR iterates towards that.