### PR TITLE
keymap: remove unused input events

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -15,20 +15,6 @@ pub enum Event {
         /// The index of the key in the keymap.
         keymap_index: u16,
     },
-    /// A virtual key press for a given `key_code`.
-    VirtualKeyPress {
-        /// The virtual key code.
-        key_code: u8,
-        /// Inserts the virtual key before the pressed key with this keymap index.
-        pressed_keymap_index: u16,
-    },
-    /// A virtual key release for a given `key_code`.
-    VirtualKeyRelease {
-        /// The virtual key code.
-        key_code: u8,
-    },
-    /// No-op
-    InputResolved,
 }
 
 /// A struct for associating a [crate::key::Key] with a [crate::key::KeyState].

--- a/src/key/tap_hold.rs
+++ b/src/key/tap_hold.rs
@@ -182,7 +182,6 @@ impl PendingKeyState {
                         // Key held long enough to resolve as hold.
                         Some(TapHoldState::Hold)
                     }
-                    _ => None,
                 }
             }
             InterruptResponse::HoldOnKeyTap => {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -499,37 +499,6 @@ impl<
                     self.event_scheduler
                         .cancel_events_for_keymap_index(keymap_index);
                 }
-
-                input::Event::VirtualKeyPress {
-                    key_code,
-                    pressed_keymap_index,
-                } => {
-                    // Insert into pressed_keys before the pressed key with the
-                    //  given keymap index.
-                    let pressed_key = input::PressedInput::Virtual(key_code);
-                    let pos = self
-                        .pressed_inputs
-                        .iter()
-                        .position(|k| match k {
-                            input::PressedInput::Key(pressed_key) => {
-                                pressed_key.keymap_index == pressed_keymap_index
-                            }
-                            _ => false,
-                        })
-                        .unwrap_or(self.pressed_inputs.len());
-                    self.pressed_inputs.insert(pos, pressed_key).unwrap();
-                }
-                input::Event::VirtualKeyRelease { key_code } => {
-                    // Remove from pressed keys.
-                    self.pressed_inputs
-                        .iter()
-                        .position(|k| match k {
-                            input::PressedInput::Virtual(kc) => key_code == *kc,
-                            _ => false,
-                        })
-                        .map(|i| self.pressed_inputs.remove(i));
-                }
-                _ => {}
             }
         }
 


### PR DESCRIPTION
Remove unused `input::Event` variants.

- `InputResolved` was a kludge related to tap-hold keys or chording.
- `VirtualKey` was how tap-hold keys were initially implemented. -- However, with the key state rewrite, it's unlikely this variant will be useful.