### PR TITLE
Remove "base" from LayeredKey

### DIFF
--- a/features/keymap/key/layered.feature
+++ b/features/keymap/key/layered.feature
@@ -13,7 +13,7 @@ Feature: Layered Keys
       let K = import "keys.ncl" in
       {
         keys = [
-          K.layer_mod.hold 0,
+          K.layer_mod.hold 1,
           K.A & { layered = [ K.B ] },
         ],
       }
@@ -40,7 +40,7 @@ Feature: Layered Keys
     When the keymap registers the following input
       """
       [
-        press (K.layer_mod.hold 0),
+        press (K.layer_mod.hold 1),
         press (K.A & { layered = [ K.B ] }),
       ]
       """

--- a/features/keymap/ncl/layers.feature
+++ b/features/keymap/ncl/layers.feature
@@ -25,7 +25,7 @@ Feature: Layers
       {
         layers = [
           [
-            K.layer_mod.hold 0,
+            K.layer_mod.hold 1,
             K.A,
           ],
           [
@@ -57,7 +57,7 @@ Feature: Layers
     When the keymap registers the following input
       """
       [
-        press (K.layer_mod.hold 0),
+        press (K.layer_mod.hold 1),
         press (K.B),
       ]
       """

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -340,70 +340,70 @@ let validators = import "validators.ncl" in
     },
   },
 
-  checks.check_layered = {
-    # Use a serialized value to check the "is" predicate.
-    check_serialized_base_keyboard_layered_keyboard_is =
-      let serialized_value = {
-        base = { key_code = 4 },
-        layered = [
-          null,
-          { key_code = 6 },
-        ]
-      }
-      in
-      layered.is_serialized_json serialized_value,
+  # checks.check_layered = {
+  #   # Use a serialized value to check the "is" predicate.
+  #   check_serialized_base_keyboard_layered_keyboard_is =
+  #     let serialized_value = {
+  #       base = { key_code = 4 },
+  #       layered = [
+  #         null,
+  #         { key_code = 6 },
+  #       ]
+  #     }
+  #     in
+  #     layered.is_serialized_json serialized_value,
 
-    check_layered_codegen_values = {
-      # A layered::LayeredKey of keyboard::Key
-      #  codegens to layered::LayeredKey<keyboard::Key>
-      check_layered_keyboard =
-        let k = {
-          base = { key_code = 4 },
-          layered = [
-            null,
-            { key_code = 6 },
-          ]
-        }
-        in
-        let cv = layered.codegen_values k in
-        {
-          check_key_type = {
-            actual = cv.key_type.as_rust_type_path,
-            expected = "crate::key::layered::LayeredKey<crate::key::composite::TapHold<crate::key::keyboard::Key>>",
-          },
-          check_rust_expr = {
-            actual = cv.rust_expr,
-            expected = "crate::key::layered::LayeredKey::new(crate::key::composite::TapHold(crate::key::keyboard::Key::new(4)), [None,Some(crate::key::composite::TapHold(crate::key::keyboard::Key::new(6)))])",
-          },
-        },
+  #   check_layered_codegen_values = {
+  #     # A layered::LayeredKey of keyboard::Key
+  #     #  codegens to layered::LayeredKey<keyboard::Key>
+  #     check_layered_keyboard =
+  #       let k = {
+  #         base = { key_code = 4 },
+  #         layered = [
+  #           null,
+  #           { key_code = 6 },
+  #         ]
+  #       }
+  #       in
+  #       let cv = layered.codegen_values k in
+  #       {
+  #         check_key_type = {
+  #           actual = cv.key_type.as_rust_type_path,
+  #           expected = "crate::key::layered::LayeredKey<crate::key::composite::TapHold<crate::key::keyboard::Key>>",
+  #         },
+  #         check_rust_expr = {
+  #           actual = cv.rust_expr,
+  #           expected = "crate::key::layered::LayeredKey::new(crate::key::composite::TapHold(crate::key::keyboard::Key::new(4)), [None,Some(crate::key::composite::TapHold(crate::key::keyboard::Key::new(6)))])",
+  #         },
+  #       },
 
-      # A layered::LayeredKey of mix of tap_hold::Key<'keyboard::Key'> and keyboard::Key
-      #  codegens to layered::LayeredKey<composite::TapHoldKey<composite::BaseKey>>
-      check_layered_composite_taphold_keyboard =
-        let k = {
-          base = {
-            hold = { key_code = 224 },
-            tap = { key_code = 4 },
-          },
-          layered = [
-            null,
-            { key_code = 6 },
-          ]
-        }
-        in
-        let cv = layered.codegen_values k in
-        {
-          check_key_type = {
-            actual = cv.key_type.as_rust_type_path,
-            expected = "crate::key::layered::LayeredKey<crate::key::composite::TapHoldKey<crate::key::keyboard::Key>>",
-          },
-          check_rust_expr = {
-            actual = cv.rust_expr,
-            expected = "crate::key::layered::LayeredKey::new(crate::key::composite::TapHoldKey::TapHold(crate::key::tap_hold::Key::new(crate::key::keyboard::Key::new(4), crate::key::keyboard::Key::new(224))), [None,Some(crate::key::composite::TapHoldKey::Pass(crate::key::keyboard::Key::new(6)))])",
-          },
-        },
-    },
-  },
+  #     # A layered::LayeredKey of mix of tap_hold::Key<'keyboard::Key'> and keyboard::Key
+  #     #  codegens to layered::LayeredKey<composite::TapHoldKey<composite::BaseKey>>
+  #     check_layered_composite_taphold_keyboard =
+  #       let k = {
+  #         base = {
+  #           hold = { key_code = 224 },
+  #           tap = { key_code = 4 },
+  #         },
+  #         layered = [
+  #           null,
+  #           { key_code = 6 },
+  #         ]
+  #       }
+  #       in
+  #       let cv = layered.codegen_values k in
+  #       {
+  #         check_key_type = {
+  #           actual = cv.key_type.as_rust_type_path,
+  #           expected = "crate::key::layered::LayeredKey<crate::key::composite::TapHoldKey<crate::key::keyboard::Key>>",
+  #         },
+  #         check_rust_expr = {
+  #           actual = cv.rust_expr,
+  #           expected = "crate::key::layered::LayeredKey::new(crate::key::composite::TapHoldKey::TapHold(crate::key::tap_hold::Key::new(crate::key::keyboard::Key::new(4), crate::key::keyboard::Key::new(224))), [None,Some(crate::key::composite::TapHoldKey::Pass(crate::key::keyboard::Key::new(6)))])",
+  #         },
+  #       },
+  #   },
+  # },
 
   layered
     | doc "for key::layered::LayeredKey."
@@ -414,16 +414,14 @@ let validators = import "validators.ncl" in
       # e.g.:
       # ```
       #   {
-      #     "base": 4,
       #     "layered": [5, null, 7]
       #   }
       # ```
       # JSON serialization of key::layered::Layered has fields: { base, layered }
       serialized_json_validator =
         validators.record.validator {
-          fields_validator = validators.record.has_exact_fields ["base", "layered"],
+          fields_validator = validators.record.has_exact_fields ["layered"],
           field_validators = {
-            base = key.serialized_json_validator,
             layered =
               validators.array.validator (
                 validators.any_of [
@@ -436,8 +434,7 @@ let validators = import "validators.ncl" in
 
       is_serialized_json = fun k => 'Ok == serialized_json_validator k,
 
-      codegen_values = fun k @ { base, layered } =>
-        let base_cv = base |> key.codegen_values |> layered_nestable.wrap in
+      codegen_values = fun k @ { layered } =>
         let non_null_layered = std.array.filter ((!=) null) layered in
         let layered_cvs =
           std.array.map (fun k => if k != null then k |> key.codegen_values |> layered_nestable.wrap else null) layered
@@ -446,29 +443,27 @@ let validators = import "validators.ncl" in
           std.array.filter ((!=) null) layered_cvs
         in
 
-        let target_type = unified_key_impl_for_codegen_values ([base_cv] @ nn_layered_cvs) in
+        let target_type = unified_key_impl_for_codegen_values (nn_layered_cvs) in
 
         {
           nested = {
-            base = base_cv |> key.lift_to target_type,
             layered =
               layered_cvs
               |> std.array.map (fun cv => if cv != null then cv |> key.lift_to target_type else null),
           },
           key_type = {
             key_type = "crate::key::layered::LayeredKey",
-            nested_key_type = nested.base.key_type,
+            nested_key_type = nested.layered |> std.array.first |> fun cv => cv.key_type,
             as_rust_type_path = "%{key_type}<%{nested_key_type.as_rust_type_path}>",
           },
           key_impl = {} & nested.base.key_impl,
           rust_expr =
-            let base_expr = nested.base.rust_expr in
             let layered_exprs =
               nested.layered
               |> std.array.map (fun cv => if cv == null then "None" else "Some(%{cv.rust_expr})")
               |> std.string.join ","
             in
-            "crate::key::layered::LayeredKey::new(%{base_expr}, [%{layered_exprs}])",
+            "crate::key::layered::LayeredKey::new([%{layered_exprs}])",
           serialized_json = k,
         },
 
@@ -476,7 +471,6 @@ let validators = import "validators.ncl" in
         rest
         & {
           nested = {
-            base = f cv.nested.base,
             layered = std.array.map (fun cv => if cv != null then f cv else null) cv.nested.layered,
           },
         },

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -129,40 +129,40 @@ let validators = import "validators.ncl" in
         { Hold = hold_layer },
     },
 
-  checks.layered =
-    let K = import "keys.ncl" in
-    {
-      keymap_example_layered_keyboard = {
-        actual = K.A & { layered = [ null, K.C] },
-        expected = {
-          key_code = 4,
-          layered = [
-            null,
-            { key_code = 6 },
-          ],
-        },
-      },
+  # checks.layered =
+  #   let K = import "keys.ncl" in
+  #   {
+  #     keymap_example_layered_keyboard = {
+  #       actual = K.A & { layered = [ null, K.C] },
+  #       expected = {
+  #         key_code = 4,
+  #         layered = [
+  #           null,
+  #           { key_code = 6 },
+  #         ],
+  #       },
+  #     },
 
-      check_layered_base_keyboard_base_is_key =
-        let k = K.A & { layered = [ null, K.C] } in
-        let { layered, ..base_key } = k in
-        key.is_key base_key,
+  #     check_layered_base_keyboard_base_is_key =
+  #       let k = K.A & { layered = [ null, K.C] } in
+  #       let { layered, ..base_key } = k in
+  #       key.is_key base_key,
 
-      check_layered_base_keyboard_is_key =
-        let key = K.A & { layered = [ null, K.C] } in
-        layered.is_key key,
+  #     check_layered_base_keyboard_is_key =
+  #       let key = K.A & { layered = [ null, K.C] } in
+  #       layered.is_key key,
 
-      check_serialized_layered_keyboard = {
-        actual = K.A & { layered = [ null, K.C] } |> key.to_json_serialized,
-        expected = {
-          base = { key_code = 4 },
-          layered = [
-            null,
-            { key_code = 6 },
-          ],
-        },
-      },
-    },
+  #     check_serialized_layered_keyboard = {
+  #       actual = K.A & { layered = [ null, K.C] } |> key.to_json_serialized,
+  #       expected = {
+  #         base = { key_code = 4 },
+  #         layered = [
+  #           null,
+  #           { key_code = 6 },
+  #         ],
+  #       },
+  #     },
+  #   },
 
   layered
     | doc "for key::layered::LayeredKey."
@@ -193,11 +193,11 @@ let validators = import "validators.ncl" in
 
       to_json_serialized = fun { layered = layered_keys, ..base_key } =>
         {
-          base = key.to_json_serialized base_key,
+          # base = key.to_json_serialized base_key,
           layered =
             std.array.map
               (fun k => if k != null then key.to_json_serialized k else null)
-              layered_keys,
+              ([base_key] @ layered_keys),
         },
     },
 

--- a/ncl/layered-key.ncl
+++ b/ncl/layered-key.ncl
@@ -23,8 +23,8 @@
   update_active_layers_for_input = fun input active_layers =>
     input
     |> match {
-      'Press { layer_modifier = { hold }, .. } => activate_layer active_layers hold,
-      'Release { layer_modifier = { hold }, .. } => deactivate_layer active_layers hold,
+      'Press { layer_modifier = { hold }, .. } => activate_layer active_layers (hold - 1),
+      'Release { layer_modifier = { hold }, .. } => deactivate_layer active_layers (hold - 1),
       _ => active_layers,
     },
 

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -311,10 +311,10 @@ mod tests {
         type K = composite::Key;
         let keys: [K; 2] = [
             K::layer_modifier(key::layered::ModifierKey::Hold(0)),
-            K::layered(key::layered::LayeredKey::new(
-                key::keyboard::Key::new(0x04).into(),
-                [Some(key::keyboard::Key::new(0x05).into())],
-            )),
+            K::layered(key::layered::LayeredKey::new([
+                Some(key::keyboard::Key::new(0x04).into()),
+                Some(key::keyboard::Key::new(0x05).into()),
+            ])),
         ];
         let mut context: Ctx = DEFAULT_CONTEXT;
         let keymap_index: u16 = 0;
@@ -346,10 +346,10 @@ mod tests {
         type K = composite::Key;
         let keys: [K; 2] = [
             K::layer_modifier(key::layered::ModifierKey::Hold(0)),
-            K::layered(key::layered::LayeredKey::new(
-                key::keyboard::Key::new(0x04).into(),
-                [Some(key::keyboard::Key::new(0x05).into())],
-            )),
+            K::layered(key::layered::LayeredKey::new([
+                Some(key::keyboard::Key::new(0x04).into()),
+                Some(key::keyboard::Key::new(0x05).into()),
+            ])),
         ];
         let mut context: Ctx = DEFAULT_CONTEXT;
         let keymap_index: u16 = 0;
@@ -384,10 +384,10 @@ mod tests {
         type K = composite::Key;
         let keys: [K; 3] = [
             K::layer_modifier(key::layered::ModifierKey::Hold(0)),
-            K::layered(key::layered::LayeredKey::new(
-                key::keyboard::Key::new(0x04).into(),
-                [Some(key::keyboard::Key::new(0x05).into())],
-            )),
+            K::layered(key::layered::LayeredKey::new([
+                Some(key::keyboard::Key::new(0x04).into()),
+                Some(key::keyboard::Key::new(0x05).into()),
+            ])),
             K::keyboard(key::keyboard::Key::new(0x06)),
         ];
         let context: Ctx = DEFAULT_CONTEXT;
@@ -412,10 +412,10 @@ mod tests {
         type K = composite::Key;
         let keys: [K; 3] = [
             K::layer_modifier(key::layered::ModifierKey::Hold(0)),
-            K::layered(key::layered::LayeredKey::new(
-                key::keyboard::Key::new(0x04).into(),
-                [Some(key::keyboard::Key::new(0x05).into())],
-            )),
+            K::layered(key::layered::LayeredKey::new([
+                Some(key::keyboard::Key::new(0x04).into()),
+                Some(key::keyboard::Key::new(0x05).into()),
+            ])),
             K::keyboard(key::keyboard::Key::new(0x06)),
         ];
         let context: Ctx = DEFAULT_CONTEXT;

--- a/src/key/composite/layered.rs
+++ b/src/key/composite/layered.rs
@@ -81,8 +81,8 @@ impl<K: LayeredNestable> key::Key for LayeredKey<K> {
         match self {
             LayeredKey::Layered(key) => match path {
                 [] => panic!(),
-                [0, path @ ..] => key.base.lookup(path),
-                [n, path @ ..] => key.layered[(n - 1) as usize].as_ref().unwrap().lookup(path),
+                // [0, path @ ..] => key.base.lookup(path),
+                [n, path @ ..] => key.layered[*n as usize].as_ref().unwrap().lookup(path),
             },
             LayeredKey::Pass(key) => key.lookup(path),
         }

--- a/tests/rust/layered.rs
+++ b/tests/rust/layered.rs
@@ -21,10 +21,10 @@ const KEYS: Keys2<MK, LK, Ctx, Ev, PKS, KS> = tuples::Keys2::new((
     composite::Chorded(composite::Layered(composite::TapHold(
         layered::ModifierKey::Hold(0),
     ))),
-    composite::Chorded(composite::LayeredKey::Layered(layered::LayeredKey::new(
-        composite::TapHold(keyboard::Key::new(0x04)),
-        [Some(composite::TapHold(keyboard::Key::new(0x05)))],
-    ))),
+    composite::Chorded(composite::LayeredKey::Layered(layered::LayeredKey::new([
+        Some(composite::TapHold(keyboard::Key::new(0x04))),
+        Some(composite::TapHold(keyboard::Key::new(0x05))),
+    ]))),
 ));
 
 const CONTEXT: Ctx = composite::DEFAULT_CONTEXT;

--- a/tests/rust/layered/tap_hold.rs
+++ b/tests/rust/layered/tap_hold.rs
@@ -18,20 +18,20 @@ type K0 = composite::Chorded<composite::LayeredKey<composite::TapHoldKey<keyboar
 type K1 = composite::Chorded<composite::LayeredKey<composite::TapHoldKey<keyboard::Key>>>;
 
 const KEYS: Keys2<K0, K1, Ctx, Ev, PKS, KS> = tuples::Keys2::new((
-    composite::Chorded(composite::LayeredKey::Layered(layered::LayeredKey::new(
-        composite::TapHoldKey::TapHold(tap_hold::Key {
+    composite::Chorded(composite::LayeredKey::Layered(layered::LayeredKey::new([
+        Some(composite::TapHoldKey::TapHold(tap_hold::Key {
             tap: keyboard::Key::new(0x04),
             hold: keyboard::Key::new(0x05),
-        }),
-        [None; 1],
-    ))),
-    composite::Chorded(composite::LayeredKey::Layered(layered::LayeredKey::new(
-        composite::TapHoldKey::TapHold(tap_hold::Key {
+        })),
+        None,
+    ]))),
+    composite::Chorded(composite::LayeredKey::Layered(layered::LayeredKey::new([
+        Some(composite::TapHoldKey::TapHold(tap_hold::Key {
             tap: keyboard::Key::new(0x06),
             hold: keyboard::Key::new(0x07),
-        }),
-        [None; 1],
-    ))),
+        })),
+        None,
+    ]))),
 ));
 const CONTEXT: Ctx = composite::DEFAULT_CONTEXT;
 

--- a/tests/rust/tap_hold/layered.rs
+++ b/tests/rust/tap_hold/layered.rs
@@ -24,10 +24,10 @@ const KEYS: Keys2<K0, K1, Ctx, Ev, PKS, KS> = tuples::Keys2::new((
             hold: composite::BaseKey::LayerModifier(layered::ModifierKey::Hold(0)),
         },
     ))),
-    composite::Chorded(composite::LayeredKey::Layered(layered::LayeredKey::new(
-        composite::TapHold(keyboard::Key::new(0x04)),
-        [Some(composite::TapHold(keyboard::Key::new(0x05)))],
-    ))),
+    composite::Chorded(composite::LayeredKey::Layered(layered::LayeredKey::new([
+        Some(composite::TapHold(keyboard::Key::new(0x04))),
+        Some(composite::TapHold(keyboard::Key::new(0x05))),
+    ]))),
 ));
 const CONTEXT: Ctx = composite::DEFAULT_CONTEXT;
 


### PR DESCRIPTION
Although I like the idea of "base key & [additional layers]".. -- the layer indices then need to be offset by 1.

This PR is an attempt to see if removing base key would simplify that. (Otherwise, 'base' is always enabled; and arrays can otherwise be 1-based indices).