### PR TITLE
usbd-smart-keyboard: feature flag usbd-serial

### DIFF
--- a/rp2040-rtic-smart-keyboard/Cargo.toml
+++ b/rp2040-rtic-smart-keyboard/Cargo.toml
@@ -29,7 +29,7 @@ usbd-serial = "0.2"
 
 # smart-keymap = { git = "https://github.com/rgoulter/smart-keymap.git" }
 smart-keymap = { path = "..", default-features = false }
-usbd-smart-keyboard = { path = "../usbd-smart-keyboard" }
+usbd-smart-keyboard = { path = "../usbd-smart-keyboard", features = ["usbd-serial"] }
 
 [build-dependencies]
 smart-keymap-nickel-helper = { path = "../smart-keymap-nickel-helper" }

--- a/usbd-smart-keyboard/Cargo.toml
+++ b/usbd-smart-keyboard/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Richard Goulter <richard.goulter@gmail.com>"]
 edition = "2018"
 
+[features]
+usbd-serial = []
+
 [dependencies]
 cortex-m = "0.7"
 cortex-m-rt = { version = "0.7", features = ["device"] }


### PR DESCRIPTION
When porting over the onekey example & adapting it to use the `usbd-smart-keyboard` crate (which descends from the keyberon-using code I'd written over at keyboard-labs), I found that the STM32F4 didn't work when using usbd-serial.

This likely has something to do with STM32F4xx only having 4 USB endpoints.

I'm not exactly sure where those 4 are coming from. (tinyuf2 + hid device with keyboard and consumer control?). But, using conditional compilation avoids this.