### PR TITLE
STM32f4 rtic:  minif4 36 rev2024 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,6 +1666,7 @@ dependencies = [
  "cortex-m-rt",
  "cortex-m-rtic",
  "embedded-hal 1.0.0",
+ "embedded-hal-nb",
  "frunk",
  "fugit",
  "generic-array",

--- a/stm32f4-rtic-smart-keyboard/Cargo.toml
+++ b/stm32f4-rtic-smart-keyboard/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 embedded-hal = "1.0"
+embedded-hal-nb = "1.0"
 stm32f4xx-hal = { version = "0.22", features = ["rtic1", "stm32f401", "usb_fs"] }
 systick-monotonic = "1.0.0"
 

--- a/stm32f4-rtic-smart-keyboard/src/bin/minif4_36-rev2021_4-lhs.rs
+++ b/stm32f4-rtic-smart-keyboard/src/bin/minif4_36-rev2021_4-lhs.rs
@@ -1,0 +1,260 @@
+#![no_main]
+#![no_std]
+
+#[cfg(not(custom_board))]
+mod board {
+    pub use stm32f4_rtic_smart_keyboard::input::Input;
+
+    pub use stm32f4_rtic_smart_keyboard::app_prelude::VID;
+
+    pub const COLS: usize = 5;
+    pub const ROWS: usize = 4;
+
+    #[rustfmt::skip]
+    pub const KEYMAP_INDICES: [[Option<u16>; COLS]; ROWS] = [
+        [ Some(0),  Some(1),  Some(2),  Some(3),  Some(4)],
+        [Some(10), Some(11), Some(12), Some(13), Some(14)],
+        [Some(20), Some(21), Some(22), Some(23), Some(24)],
+        [Some(30), Some(31), Some(32),     None,     None],
+    ];
+
+    pub const PID: u16 = 0x0005;
+    pub const MANUFACTURER: &str = "smart-keyboard";
+    pub const PRODUCT: &str = "MiniF4-36 rev2021.4 LHS";
+
+    pub type Keyboard = usbd_smart_keyboard::input::Keyboard<COLS, ROWS, Matrix>;
+
+    pub type PressedKeys = usbd_smart_keyboard::input::PressedKeys<COLS, ROWS>;
+
+    pub type Matrix = usbd_smart_keyboard::matrix::DirectPinMatrix<Input, COLS, ROWS>;
+
+    macro_rules! keyboard {
+        ($gpioa:ident, $gpiob:ident) => {
+            crate::board::Keyboard {
+                matrix: crate::board::Matrix::new([
+                    [
+                        Some($gpiob.pb15.into_pull_up_input().erase()),
+                        Some($gpioa.pa8.into_pull_up_input().erase()),
+                        Some($gpioa.pa9.into_pull_up_input().erase()),
+                        Some($gpioa.pa10.into_pull_up_input().erase()),
+                        Some($gpioa.pa2.into_pull_up_input().erase()),
+                    ],
+                    [
+                        Some($gpiob.pb5.into_pull_up_input().erase()),
+                        Some($gpioa.pa15.into_pull_up_input().erase()),
+                        Some($gpiob.pb3.into_pull_up_input().erase()),
+                        Some($gpiob.pb4.into_pull_up_input().erase()),
+                        Some($gpiob.pb10.into_pull_up_input().erase()),
+                    ],
+                    [
+                        Some($gpioa.pa1.into_pull_up_input().erase()),
+                        Some($gpiob.pb1.into_pull_up_input().erase()),
+                        Some($gpiob.pb0.into_pull_up_input().erase()),
+                        Some($gpioa.pa7.into_pull_up_input().erase()),
+                        Some($gpioa.pa6.into_pull_up_input().erase()),
+                    ],
+                    [
+                        Some($gpioa.pa5.into_pull_up_input().erase()),
+                        Some($gpioa.pa4.into_pull_up_input().erase()),
+                        Some($gpioa.pa3.into_pull_up_input().erase()),
+                        None,
+                        None,
+                    ],
+                ]),
+                debouncer: keyberon::debounce::Debouncer::new(
+                    crate::board::PressedKeys::default(),
+                    crate::board::PressedKeys::default(),
+                    25,
+                ),
+            }
+        };
+    }
+
+    pub(crate) use keyboard;
+}
+
+#[rtic::app(device = stm32f4xx_hal::pac, peripherals = true, dispatchers = [SPI1])]
+mod app {
+    // set the panic handler
+    use panic_rtt_target as _;
+
+    use rtt_target::{rprintln, rtt_init_print};
+    use usb_device::bus::UsbBusAllocator;
+    use usbd_human_interface_device::UsbHidError;
+
+    use usbd_smart_keyboard::input::smart_keymap::keymap_index_of;
+    use usbd_smart_keyboard::input::smart_keymap::KeyboardBackend;
+    use usbd_smart_keyboard::split::transport::BUFFER_LENGTH;
+
+    use stm32f4_rtic_smart_keyboard::split::app_prelude::*;
+
+    use super::board;
+
+    use board::Keyboard;
+    use board::KEYMAP_INDICES;
+
+    #[shared]
+    struct SharedResources {
+        usb_dev: UsbDevice,
+        usb_class: UsbClass,
+    }
+
+    #[local]
+    struct LocalResources {
+        keyboard: Keyboard,
+        backend: KeyboardBackend,
+        report_success: bool,
+        timer: timer::CounterUs<pac::TIM3>,
+        split_conn_tx: TransportWriter,
+        split_conn_rx: TransportReader,
+    }
+
+    #[init(local = [
+        ep_memory: [u32; 1024] = [0; 1024],
+        rx_buf: [u8; BUFFER_LENGTH] = [0; BUFFER_LENGTH],
+        usb_bus: Option<UsbBusAllocator<UsbBusType>> = None
+    ])]
+    fn init(c: init::Context) -> (SharedResources, LocalResources, init::Monotonics) {
+        let rcc = c.device.RCC.constrain();
+        let clocks = app_init::init_clocks(rcc);
+
+        rtt_init_print!();
+        rprintln!("init");
+
+        let gpioa = c.device.GPIOA.split();
+        let gpiob = c.device.GPIOB.split();
+        let _ = gpiob;
+
+        let usb = USB::new(
+            (
+                c.device.OTG_FS_GLOBAL,
+                c.device.OTG_FS_DEVICE,
+                c.device.OTG_FS_PWRCLK,
+            ),
+            (gpioa.pa11, gpioa.pa12),
+            &clocks,
+        );
+        *c.local.usb_bus = Some(UsbBusType::new(usb, c.local.ep_memory));
+        let usb_bus = c.local.usb_bus.as_ref().unwrap();
+
+        let (usb_dev, usb_class) = app_init::init_usb_device(
+            usb_bus,
+            board::VID,
+            board::PID,
+            board::MANUFACTURER,
+            board::PRODUCT,
+        );
+
+        let timer = app_init::init_timer(&clocks, c.device.TIM3);
+        unsafe {
+            pac::NVIC::unmask(pac::Interrupt::TIM3);
+            // pac::NVIC::unmask(pac::Interrupt::USART1); // ??
+        }
+
+        let keyboard = board::keyboard!(gpioa, gpiob);
+
+        let backend = {
+            use smart_keymap::init;
+            use smart_keymap::keymap::Keymap;
+            let keymap = Keymap::new(init::KEY_DEFINITIONS, init::CONTEXT);
+            KeyboardBackend::new(keymap)
+        };
+
+        let (split_conn_tx, split_conn_rx) = split_app_init::init_serial(
+            &clocks,
+            (gpiob.pb6, gpiob.pb7),
+            c.device.USART1,
+            c.local.rx_buf,
+        );
+
+        (
+            SharedResources { usb_dev, usb_class },
+            LocalResources {
+                timer,
+                keyboard,
+                backend,
+                report_success: true,
+                split_conn_rx,
+                split_conn_tx,
+            },
+            init::Monotonics(),
+        )
+    }
+
+    #[task(binds = USART1, priority = 5, local = [split_conn_rx])]
+    fn rx(c: rx::Context) {
+        let rx::LocalResources { split_conn_rx } = c.local;
+        if let Some(event) = split_conn_rx.read() {
+            layout::spawn(LayoutMessage::Event(event)).unwrap();
+        }
+    }
+
+    #[task(binds = OTG_FS, priority = 2, shared = [usb_dev,  usb_class])]
+    fn usb_tx(c: usb_tx::Context) {
+        let usb_tx::SharedResources { usb_dev, usb_class } = c.shared;
+        (usb_dev, usb_class).lock(usb_poll);
+    }
+
+    #[task(binds = OTG_FS_WKUP, priority = 2, shared = [usb_dev,  usb_class])]
+    fn usb_rx(c: usb_rx::Context) {
+        let usb_rx::SharedResources { usb_dev, usb_class } = c.shared;
+        (usb_dev, usb_class).lock(usb_poll);
+    }
+
+    #[task(priority = 3, capacity = 8, shared = [usb_class, usb_dev], local = [backend, report_success])]
+    fn layout(c: layout::Context, message: LayoutMessage) {
+        let layout::SharedResources {
+            mut usb_class,
+            mut usb_dev,
+        } = c.shared;
+        let layout::LocalResources {
+            backend,
+            report_success,
+        } = c.local;
+        match message {
+            LayoutMessage::Tick => {
+                if *report_success {
+                    backend.tick();
+                }
+
+                if usb_dev.lock(|d| d.state()) != UsbDeviceState::Configured {
+                    return;
+                }
+
+                usb_class.lock(|k| {
+                    let res = backend.write_reports(k);
+                    match res {
+                        Err(UsbHidError::WouldBlock) => *report_success = false,
+                        Err(UsbHidError::UsbError(_)) => panic!(),
+                        Err(UsbHidError::SerializationError) => panic!(),
+                        Err(UsbHidError::Duplicate) => *report_success = true,
+                        Ok(_) => *report_success = true,
+                    }
+                });
+            }
+            LayoutMessage::Event(event) => {
+                backend.event(event);
+            }
+        };
+    }
+
+    #[task(binds = TIM3, priority = 1, local = [keyboard, timer, split_conn_tx])]
+    fn tick(c: tick::Context) {
+        let tick::LocalResources {
+            keyboard,
+            split_conn_tx,
+            timer,
+        } = c.local;
+
+        timer.start(1.millis()).ok();
+
+        for event in keyboard.events() {
+            if let Some(event) = keymap_index_of(&KEYMAP_INDICES, event) {
+                split_conn_tx.write(event);
+                layout::spawn(LayoutMessage::Event(event)).unwrap();
+            }
+        }
+
+        layout::spawn(LayoutMessage::Tick).unwrap();
+    }
+}

--- a/stm32f4-rtic-smart-keyboard/src/bin/minif4_36-rev2021_4-rhs.rs
+++ b/stm32f4-rtic-smart-keyboard/src/bin/minif4_36-rev2021_4-rhs.rs
@@ -1,0 +1,260 @@
+#![no_main]
+#![no_std]
+
+#[cfg(not(custom_board))]
+mod board {
+    pub use stm32f4_rtic_smart_keyboard::input::Input;
+
+    pub use stm32f4_rtic_smart_keyboard::app_prelude::VID;
+
+    pub const COLS: usize = 5;
+    pub const ROWS: usize = 4;
+
+    #[rustfmt::skip]
+    pub const KEYMAP_INDICES: [[Option<u16>; COLS]; ROWS] = [
+        [ Some(5),  Some(6),  Some(7),  Some(8),  Some(9)],
+        [Some(15), Some(16), Some(17), Some(18), Some(19)],
+        [Some(25), Some(26), Some(27), Some(28), Some(29)],
+        [Some(33), Some(34), Some(35),     None,     None],
+    ];
+
+    pub const PID: u16 = 0x0005;
+    pub const MANUFACTURER: &str = "smart-keyboard";
+    pub const PRODUCT: &str = "MiniF4-36 rev2021.4 RHS";
+
+    pub type Keyboard = usbd_smart_keyboard::input::Keyboard<COLS, ROWS, Matrix>;
+
+    pub type PressedKeys = usbd_smart_keyboard::input::PressedKeys<COLS, ROWS>;
+
+    pub type Matrix = usbd_smart_keyboard::matrix::DirectPinMatrix<Input, COLS, ROWS>;
+
+    macro_rules! keyboard {
+        ($gpioa:ident, $gpiob:ident) => {
+            crate::board::Keyboard {
+                matrix: crate::board::Matrix::new([
+                    [
+                        Some($gpioa.pa2.into_pull_up_input().erase()),
+                        Some($gpioa.pa10.into_pull_up_input().erase()),
+                        Some($gpioa.pa9.into_pull_up_input().erase()),
+                        Some($gpioa.pa8.into_pull_up_input().erase()),
+                        Some($gpiob.pb15.into_pull_up_input().erase()),
+                    ],
+                    [
+                        Some($gpiob.pb10.into_pull_up_input().erase()),
+                        Some($gpiob.pb4.into_pull_up_input().erase()),
+                        Some($gpiob.pb3.into_pull_up_input().erase()),
+                        Some($gpioa.pa15.into_pull_up_input().erase()),
+                        Some($gpiob.pb5.into_pull_up_input().erase()),
+                    ],
+                    [
+                        Some($gpioa.pa6.into_pull_up_input().erase()),
+                        Some($gpioa.pa7.into_pull_up_input().erase()),
+                        Some($gpiob.pb0.into_pull_up_input().erase()),
+                        Some($gpiob.pb1.into_pull_up_input().erase()),
+                        Some($gpioa.pa1.into_pull_up_input().erase()),
+                    ],
+                    [
+                        Some($gpioa.pa3.into_pull_up_input().erase()),
+                        Some($gpioa.pa4.into_pull_up_input().erase()),
+                        Some($gpioa.pa5.into_pull_up_input().erase()),
+                        None,
+                        None,
+                    ],
+                ]),
+                debouncer: keyberon::debounce::Debouncer::new(
+                    crate::board::PressedKeys::default(),
+                    crate::board::PressedKeys::default(),
+                    25,
+                ),
+            }
+        };
+    }
+
+    pub(crate) use keyboard;
+}
+
+#[rtic::app(device = stm32f4xx_hal::pac, peripherals = true, dispatchers = [SPI1])]
+mod app {
+    // set the panic handler
+    use panic_rtt_target as _;
+
+    use rtt_target::{rprintln, rtt_init_print};
+    use usb_device::bus::UsbBusAllocator;
+    use usbd_human_interface_device::UsbHidError;
+
+    use usbd_smart_keyboard::input::smart_keymap::keymap_index_of;
+    use usbd_smart_keyboard::input::smart_keymap::KeyboardBackend;
+    use usbd_smart_keyboard::split::transport::BUFFER_LENGTH;
+
+    use stm32f4_rtic_smart_keyboard::split::app_prelude::*;
+
+    use super::board;
+
+    use board::Keyboard;
+    use board::KEYMAP_INDICES;
+
+    #[shared]
+    struct SharedResources {
+        usb_dev: UsbDevice,
+        usb_class: UsbClass,
+    }
+
+    #[local]
+    struct LocalResources {
+        keyboard: Keyboard,
+        backend: KeyboardBackend,
+        report_success: bool,
+        timer: timer::CounterUs<pac::TIM3>,
+        split_conn_tx: TransportWriter,
+        split_conn_rx: TransportReader,
+    }
+
+    #[init(local = [
+        ep_memory: [u32; 1024] = [0; 1024],
+        rx_buf: [u8; BUFFER_LENGTH] = [0; BUFFER_LENGTH],
+        usb_bus: Option<UsbBusAllocator<UsbBusType>> = None
+    ])]
+    fn init(c: init::Context) -> (SharedResources, LocalResources, init::Monotonics) {
+        let rcc = c.device.RCC.constrain();
+        let clocks = app_init::init_clocks(rcc);
+
+        rtt_init_print!();
+        rprintln!("init");
+
+        let gpioa = c.device.GPIOA.split();
+        let gpiob = c.device.GPIOB.split();
+        let _ = gpiob;
+
+        let usb = USB::new(
+            (
+                c.device.OTG_FS_GLOBAL,
+                c.device.OTG_FS_DEVICE,
+                c.device.OTG_FS_PWRCLK,
+            ),
+            (gpioa.pa11, gpioa.pa12),
+            &clocks,
+        );
+        *c.local.usb_bus = Some(UsbBusType::new(usb, c.local.ep_memory));
+        let usb_bus = c.local.usb_bus.as_ref().unwrap();
+
+        let (usb_dev, usb_class) = app_init::init_usb_device(
+            usb_bus,
+            board::VID,
+            board::PID,
+            board::MANUFACTURER,
+            board::PRODUCT,
+        );
+
+        let timer = app_init::init_timer(&clocks, c.device.TIM3);
+        unsafe {
+            pac::NVIC::unmask(pac::Interrupt::TIM3);
+            // pac::NVIC::unmask(pac::Interrupt::USART1); // ??
+        }
+
+        let keyboard = board::keyboard!(gpioa, gpiob);
+
+        let backend = {
+            use smart_keymap::init;
+            use smart_keymap::keymap::Keymap;
+            let keymap = Keymap::new(init::KEY_DEFINITIONS, init::CONTEXT);
+            KeyboardBackend::new(keymap)
+        };
+
+        let (split_conn_tx, split_conn_rx) = split_app_init::init_serial(
+            &clocks,
+            (gpiob.pb6, gpiob.pb7),
+            c.device.USART1,
+            c.local.rx_buf,
+        );
+
+        (
+            SharedResources { usb_dev, usb_class },
+            LocalResources {
+                timer,
+                keyboard,
+                backend,
+                report_success: true,
+                split_conn_rx,
+                split_conn_tx,
+            },
+            init::Monotonics(),
+        )
+    }
+
+    #[task(binds = USART1, priority = 5, local = [split_conn_rx])]
+    fn rx(c: rx::Context) {
+        let rx::LocalResources { split_conn_rx } = c.local;
+        if let Some(event) = split_conn_rx.read() {
+            layout::spawn(LayoutMessage::Event(event)).unwrap();
+        }
+    }
+
+    #[task(binds = OTG_FS, priority = 2, shared = [usb_dev,  usb_class])]
+    fn usb_tx(c: usb_tx::Context) {
+        let usb_tx::SharedResources { usb_dev, usb_class } = c.shared;
+        (usb_dev, usb_class).lock(usb_poll);
+    }
+
+    #[task(binds = OTG_FS_WKUP, priority = 2, shared = [usb_dev,  usb_class])]
+    fn usb_rx(c: usb_rx::Context) {
+        let usb_rx::SharedResources { usb_dev, usb_class } = c.shared;
+        (usb_dev, usb_class).lock(usb_poll);
+    }
+
+    #[task(priority = 3, capacity = 8, shared = [usb_class, usb_dev], local = [backend, report_success])]
+    fn layout(c: layout::Context, message: LayoutMessage) {
+        let layout::SharedResources {
+            mut usb_class,
+            mut usb_dev,
+        } = c.shared;
+        let layout::LocalResources {
+            backend,
+            report_success,
+        } = c.local;
+        match message {
+            LayoutMessage::Tick => {
+                if *report_success {
+                    backend.tick();
+                }
+
+                if usb_dev.lock(|d| d.state()) != UsbDeviceState::Configured {
+                    return;
+                }
+
+                usb_class.lock(|k| {
+                    let res = backend.write_reports(k);
+                    match res {
+                        Err(UsbHidError::WouldBlock) => *report_success = false,
+                        Err(UsbHidError::UsbError(_)) => panic!(),
+                        Err(UsbHidError::SerializationError) => panic!(),
+                        Err(UsbHidError::Duplicate) => *report_success = true,
+                        Ok(_) => *report_success = true,
+                    }
+                });
+            }
+            LayoutMessage::Event(event) => {
+                backend.event(event);
+            }
+        };
+    }
+
+    #[task(binds = TIM3, priority = 1, local = [keyboard, timer, split_conn_tx])]
+    fn tick(c: tick::Context) {
+        let tick::LocalResources {
+            keyboard,
+            split_conn_tx,
+            timer,
+        } = c.local;
+
+        timer.start(1.millis()).ok();
+
+        for event in keyboard.events() {
+            if let Some(event) = keymap_index_of(&KEYMAP_INDICES, event) {
+                split_conn_tx.write(event);
+                layout::spawn(LayoutMessage::Event(event)).unwrap();
+            }
+        }
+
+        layout::spawn(LayoutMessage::Tick).unwrap();
+    }
+}

--- a/stm32f4-rtic-smart-keyboard/src/input.rs
+++ b/stm32f4-rtic-smart-keyboard/src/input.rs
@@ -1,0 +1,6 @@
+pub use stm32f4xx_hal as hal;
+
+use hal::gpio;
+
+/// An ID-erased PullUp input.
+pub type Input = gpio::ErasedPin<gpio::Input>;

--- a/stm32f4-rtic-smart-keyboard/src/lib.rs
+++ b/stm32f4-rtic-smart-keyboard/src/lib.rs
@@ -8,3 +8,5 @@ pub mod app_prelude;
 pub mod common;
 
 pub mod input;
+
+pub mod split;

--- a/stm32f4-rtic-smart-keyboard/src/lib.rs
+++ b/stm32f4-rtic-smart-keyboard/src/lib.rs
@@ -6,3 +6,5 @@ pub mod app_init;
 pub mod app_prelude;
 
 pub mod common;
+
+pub mod input;

--- a/stm32f4-rtic-smart-keyboard/src/split.rs
+++ b/stm32f4-rtic-smart-keyboard/src/split.rs
@@ -1,0 +1,3 @@
+pub mod app_init;
+pub mod app_prelude;
+pub mod transport;

--- a/stm32f4-rtic-smart-keyboard/src/split/app_init.rs
+++ b/stm32f4-rtic-smart-keyboard/src/split/app_init.rs
@@ -1,0 +1,33 @@
+use stm32f4xx_hal as hal;
+
+use hal::{
+    gpio::gpiob,
+    pac::USART1,
+    rcc::Clocks,
+    serial::config::Config,
+    serial::{Event, Serial},
+    time::U32Ext,
+    Listen,
+};
+
+use crate::split::transport::{TransportReader, TransportWriter};
+
+pub fn init_serial(
+    clocks: &Clocks,
+    (pb6, pb7): (gpiob::PB6, gpiob::PB7),
+    usart1: USART1,
+    buf: &'static mut [u8; 4],
+) -> (TransportWriter, TransportReader) {
+    let pins = (pb6.into_alternate(), pb7.into_alternate());
+    let mut serial = Serial::new(
+        usart1,
+        pins,
+        Config::default().baudrate(9_600.bps()),
+        &clocks,
+    )
+    .unwrap();
+    serial.listen(Event::RxNotEmpty);
+
+    let (tx, rx) = serial.split();
+    (TransportWriter { tx }, TransportReader { buf, rx })
+}

--- a/stm32f4-rtic-smart-keyboard/src/split/app_init.rs
+++ b/stm32f4-rtic-smart-keyboard/src/split/app_init.rs
@@ -10,13 +10,15 @@ use hal::{
     Listen,
 };
 
+use usbd_smart_keyboard::split::transport::BUFFER_LENGTH;
+
 use crate::split::transport::{TransportReader, TransportWriter};
 
 pub fn init_serial(
     clocks: &Clocks,
     (pb6, pb7): (gpiob::PB6, gpiob::PB7),
     usart1: USART1,
-    buf: &'static mut [u8; 4],
+    buf: &'static mut [u8; BUFFER_LENGTH],
 ) -> (TransportWriter, TransportReader) {
     let pins = (pb6.into_alternate(), pb7.into_alternate());
     let mut serial = Serial::new(

--- a/stm32f4-rtic-smart-keyboard/src/split/app_prelude.rs
+++ b/stm32f4-rtic-smart-keyboard/src/split/app_prelude.rs
@@ -1,0 +1,21 @@
+pub use crate::app_prelude::*;
+
+pub use stm32f4xx_hal as hal;
+
+pub use hal::{
+    serial,
+    serial::config::Config,
+    serial::{Event, Serial},
+    time::U32Ext,
+    Listen,
+};
+
+pub use usb_device::prelude::UsbDeviceState;
+pub use usbd_human_interface_device::usb_class::UsbHidClassBuilder;
+
+pub use usbd_smart_keyboard::input::Keyboard;
+pub use usbd_smart_keyboard::split::transport::LayoutMessage;
+
+pub use crate::split::app_init as split_app_init;
+pub use crate::split::transport::{split_read_event, split_write_event};
+pub use crate::split::transport::{TransportReader, TransportWriter};

--- a/stm32f4-rtic-smart-keyboard/src/split/transport.rs
+++ b/stm32f4-rtic-smart-keyboard/src/split/transport.rs
@@ -1,0 +1,50 @@
+use embedded_hal_nb::serial::Read;
+use embedded_hal_nb::serial::Write;
+use nb::block;
+use stm32f4xx_hal as hal;
+
+use hal::{
+    pac::USART1,
+    serial::{Rx, Tx},
+};
+use keyberon::layout::Event;
+
+use usbd_smart_keyboard::split::transport::{receive_byte, ser};
+
+pub struct TransportReader {
+    pub buf: &'static mut [u8; 4],
+    pub rx: Rx<USART1>,
+}
+
+pub struct TransportWriter {
+    pub tx: Tx<USART1>,
+}
+
+impl TransportReader {
+    pub fn read(&mut self) -> Option<Event> {
+        self.rx
+            .read()
+            .ok()
+            .and_then(|b: u8| receive_byte(&mut self.buf, b))
+    }
+}
+
+impl TransportWriter {
+    pub fn write(&mut self, event: Event) {
+        for &b in &ser(event) {
+            block!(self.tx.write(b)).unwrap();
+        }
+        block!(self.tx.flush()).unwrap();
+    }
+}
+
+pub fn split_read_event(buf: &mut [u8; 4], rx: &mut Rx<USART1>) -> Option<Event> {
+    rx.read().ok().and_then(|b: u8| receive_byte(buf, b))
+}
+
+pub fn split_write_event(event: Event, tx: &mut Tx<USART1>) {
+    for &b in &ser(event) {
+        block!(tx.write(b)).unwrap();
+    }
+    block!(tx.flush()).unwrap();
+}

--- a/stm32f4-rtic-smart-keyboard/src/split/transport.rs
+++ b/stm32f4-rtic-smart-keyboard/src/split/transport.rs
@@ -7,12 +7,13 @@ use hal::{
     pac::USART1,
     serial::{Rx, Tx},
 };
-use keyberon::layout::Event;
 
-use usbd_smart_keyboard::split::transport::{receive_byte, ser};
+use smart_keymap::input::Event;
+
+use usbd_smart_keyboard::split::transport::{receive_byte, ser, BUFFER_LENGTH};
 
 pub struct TransportReader {
-    pub buf: &'static mut [u8; 4],
+    pub buf: &'static mut [u8; BUFFER_LENGTH],
     pub rx: Rx<USART1>,
 }
 
@@ -38,7 +39,7 @@ impl TransportWriter {
     }
 }
 
-pub fn split_read_event(buf: &mut [u8; 4], rx: &mut Rx<USART1>) -> Option<Event> {
+pub fn split_read_event(buf: &mut [u8; BUFFER_LENGTH], rx: &mut Rx<USART1>) -> Option<Event> {
     rx.read().ok().and_then(|b: u8| receive_byte(buf, b))
 }
 

--- a/usbd-smart-keyboard/src/split/transport.rs
+++ b/usbd-smart-keyboard/src/split/transport.rs
@@ -1,4 +1,7 @@
-use keyberon::layout::Event;
+use smart_keymap::input::Event;
+
+/// Length of the buffer used to serialize [LayoutMessage]s.
+pub const BUFFER_LENGTH: usize = 3;
 
 /// Messages for the RTIC task which manages the Keyberon layout.
 #[derive(Debug)]
@@ -16,8 +19,12 @@ pub enum LayoutMessage {
 #[allow(clippy::result_unit_err)]
 pub fn de(bytes: &[u8]) -> Result<Event, ()> {
     match *bytes {
-        [b'P', i, j, b'\n'] => Ok(Event::Press(i, j)),
-        [b'R', i, j, b'\n'] => Ok(Event::Release(i, j)),
+        [b'P', i, b'\n'] => Ok(Event::Press {
+            keymap_index: i as u16,
+        }),
+        [b'R', i, b'\n'] => Ok(Event::Release {
+            keymap_index: i as u16,
+        }),
         _ => Err(()),
     }
 }
@@ -26,19 +33,19 @@ pub fn de(bytes: &[u8]) -> Result<Event, ()> {
 ///
 /// The serialisation format must be compatible with
 /// the serialisation format in `de`.
-pub fn ser(e: Event) -> [u8; 4] {
+pub fn ser(e: Event) -> [u8; BUFFER_LENGTH] {
     match e {
-        Event::Press(i, j) => [b'P', i, j, b'\n'],
-        Event::Release(i, j) => [b'R', i, j, b'\n'],
+        Event::Press { keymap_index } => [b'P', keymap_index as u8, b'\n'],
+        Event::Release { keymap_index } => [b'R', keymap_index as u8, b'\n'],
     }
 }
 
 /// Deserialise an array of bytes into maybe a Keyberon Event.
-pub fn receive_byte(buf: &mut [u8; 4], b: u8) -> Option<Event> {
+pub fn receive_byte(buf: &mut [u8; BUFFER_LENGTH], b: u8) -> Option<Event> {
     buf.rotate_left(1);
-    buf[3] = b;
+    buf[BUFFER_LENGTH - 1] = b;
 
-    if buf[3] == b'\n' {
+    if buf[BUFFER_LENGTH - 1] == b'\n' {
         de(&buf[..]).ok()
     } else {
         None


### PR DESCRIPTION
This PR copies across code for the MiniF4-36, rev 2024.1. (Because I've got a build of MiniF4 rev2024.1 which supports full-duplex UART).

Changes to the code from keyboard-labs:
- the same `mod board` abstraction, that the `main.rs` uses in the `-rtic-smart-keyboard` crates.
- changes the split transport code to encode `smart_keymap` `Event`, rather than `Keyberon` events.
- minor updates for newer STM32F4xx HAL.

Stuff like that the STM32F4-RTIC code assumes UART1 is used as the split transport does limit usefulness; but it's not a priority to improve limitations like that.