### PR TITLE
STM32F4 rtic: use smart_keymap::split::Message

### DIFF
--- a/stm32f4-rtic-smart-keyboard/src/bin/minif4_36-rev2021_4-lhs.rs
+++ b/stm32f4-rtic-smart-keyboard/src/bin/minif4_36-rev2021_4-lhs.rs
@@ -82,9 +82,9 @@ mod app {
     use usb_device::bus::UsbBusAllocator;
     use usbd_human_interface_device::UsbHidError;
 
+    use smart_keymap::split::BUFFER_SIZE;
     use usbd_smart_keyboard::input::smart_keymap::keymap_index_of;
     use usbd_smart_keyboard::input::smart_keymap::KeyboardBackend;
-    use usbd_smart_keyboard::split::transport::BUFFER_LENGTH;
 
     use stm32f4_rtic_smart_keyboard::split::app_prelude::*;
 
@@ -111,7 +111,7 @@ mod app {
 
     #[init(local = [
         ep_memory: [u32; 1024] = [0; 1024],
-        rx_buf: [u8; BUFFER_LENGTH] = [0; BUFFER_LENGTH],
+        rx_buf: [u8; BUFFER_SIZE] = [0; BUFFER_SIZE],
         usb_bus: Option<UsbBusAllocator<UsbBusType>> = None
     ])]
     fn init(c: init::Context) -> (SharedResources, LocalResources, init::Monotonics) {

--- a/stm32f4-rtic-smart-keyboard/src/bin/minif4_36-rev2021_4-rhs.rs
+++ b/stm32f4-rtic-smart-keyboard/src/bin/minif4_36-rev2021_4-rhs.rs
@@ -82,9 +82,9 @@ mod app {
     use usb_device::bus::UsbBusAllocator;
     use usbd_human_interface_device::UsbHidError;
 
+    use smart_keymap::split::BUFFER_SIZE;
     use usbd_smart_keyboard::input::smart_keymap::keymap_index_of;
     use usbd_smart_keyboard::input::smart_keymap::KeyboardBackend;
-    use usbd_smart_keyboard::split::transport::BUFFER_LENGTH;
 
     use stm32f4_rtic_smart_keyboard::split::app_prelude::*;
 
@@ -111,7 +111,7 @@ mod app {
 
     #[init(local = [
         ep_memory: [u32; 1024] = [0; 1024],
-        rx_buf: [u8; BUFFER_LENGTH] = [0; BUFFER_LENGTH],
+        rx_buf: [u8; BUFFER_SIZE] = [0; BUFFER_SIZE],
         usb_bus: Option<UsbBusAllocator<UsbBusType>> = None
     ])]
     fn init(c: init::Context) -> (SharedResources, LocalResources, init::Monotonics) {

--- a/stm32f4-rtic-smart-keyboard/src/split/app_init.rs
+++ b/stm32f4-rtic-smart-keyboard/src/split/app_init.rs
@@ -10,7 +10,7 @@ use hal::{
     Listen,
 };
 
-use usbd_smart_keyboard::split::transport::BUFFER_LENGTH;
+use smart_keymap::split::BUFFER_SIZE;
 
 use crate::split::transport::{TransportReader, TransportWriter};
 
@@ -18,7 +18,7 @@ pub fn init_serial(
     clocks: &Clocks,
     (pb6, pb7): (gpiob::PB6, gpiob::PB7),
     usart1: USART1,
-    buf: &'static mut [u8; BUFFER_LENGTH],
+    buf: &'static mut [u8; BUFFER_SIZE],
 ) -> (TransportWriter, TransportReader) {
     let pins = (pb6.into_alternate(), pb7.into_alternate());
     let mut serial = Serial::new(

--- a/stm32f4-rtic-smart-keyboard/src/split/app_prelude.rs
+++ b/stm32f4-rtic-smart-keyboard/src/split/app_prelude.rs
@@ -17,5 +17,4 @@ pub use usbd_smart_keyboard::input::Keyboard;
 pub use usbd_smart_keyboard::split::transport::LayoutMessage;
 
 pub use crate::split::app_init as split_app_init;
-pub use crate::split::transport::{split_read_event, split_write_event};
 pub use crate::split::transport::{TransportReader, TransportWriter};

--- a/stm32f4-rtic-smart-keyboard/src/split/transport.rs
+++ b/stm32f4-rtic-smart-keyboard/src/split/transport.rs
@@ -38,14 +38,3 @@ impl TransportWriter {
         block!(self.tx.flush()).unwrap();
     }
 }
-
-pub fn split_read_event(buf: &mut [u8; BUFFER_LENGTH], rx: &mut Rx<USART1>) -> Option<Event> {
-    rx.read().ok().and_then(|b: u8| receive_byte(buf, b))
-}
-
-pub fn split_write_event(event: Event, tx: &mut Tx<USART1>) {
-    for &b in &ser(event) {
-        block!(tx.write(b)).unwrap();
-    }
-    block!(tx.flush()).unwrap();
-}


### PR DESCRIPTION
When trying to implement firmware for the CH32X-36 (#229, #239), I've observed issues.

This PR combines work from #236 and #237; i.e. using the split message serialization/deserialization in smart_keymap to do split messages for the full-duplex UART MiniF4-36 rev2021.4 impl.