### PR TITLE
Feature: layer "default" layer modifier key

### DIFF
--- a/features/keymap/ncl/layers-default.feature
+++ b/features/keymap/ncl/layers-default.feature
@@ -1,0 +1,39 @@
+Feature: Layers (Default Layer)
+
+  The `K.layer_mod.set_default` key allows setting the Default layer.
+
+  Background:
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        layers = [
+          [
+            K.layer_mod.set_default 0,
+            K.layer_mod.set_default 1,
+            K.A,
+          ],
+          [
+            K.TTTT,
+            K.TTTT,
+            K.B,
+          ],
+        ],
+      }
+      """
+
+  Example: tapping the set default layer modifier key changes the default layer
+
+    When the keymap registers the following input
+      """
+      [
+        press (K.layer_mod.set_default 1),
+        release (K.layer_mod.set_default 1),
+        press (K.B),
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { key_codes = [K.B] }
+      """

--- a/features/scripts/generate-doc.sh
+++ b/features/scripts/generate-doc.sh
@@ -22,6 +22,7 @@ keymap_key_features=(
 
 keymap_ncl_features=(
     "layers"
+    "layers-default"
     "layer_string"
     "chords"
 )

--- a/ncl/inputs-to-json.ncl
+++ b/ncl/inputs-to-json.ncl
@@ -9,12 +9,12 @@
   #  (either LK, or the K of active layer).
   inputs_as_serialized_json_input_events =
     let LK = import "layered-key.ncl" in
-    let lookup_keymap_index = fun active_layers k =>
+    let lookup_keymap_index = fun layer_state @ { active_layers, .. } k =>
       layered_keys
       |> std.array.map_with_index (fun idx lk =>
         if lk == k then
           idx
-        else if (LK.active_key lk active_layers) == k then
+        else if (LK.active_key lk layer_state) == k then
           idx
         else
           false
@@ -26,8 +26,8 @@
           std.fail_with m%"
                unable to find keymap_index for:
 
-               active_layers=
-               %{active_layers |> std.serialize 'Json},
+               layer_state=
+               %{layer_state |> std.serialize 'Json},
 
                k=
                %{k |> std.serialize 'Json}
@@ -37,33 +37,36 @@
                "%
       }
     in
-    let input_as_json = fun active_layers input =>
+    let input_as_json = fun layer_state @ { active_layers, .. } input =>
       input
       |> match {
-        'Press k => { Press = { keymap_index = (lookup_keymap_index active_layers k) } },
-        'Release k => { Release = { keymap_index = (lookup_keymap_index active_layers k) } },
+        'Press k => { Press = { keymap_index = (lookup_keymap_index layer_state k) } },
+        'Release k => { Release = { keymap_index = (lookup_keymap_index layer_state k) } },
       }
     in
-    let initial_active_layers =
-      layered_keys
-      |> std.array.first
-      |> match {
-        { layered, .. } => std.array.map (std.function.const false) layered,
-        _ => [],
-      }
+    let initial_layer_state =
+      let initial_active_layers =
+        layered_keys
+        |> std.array.first
+        |> match {
+          { layered, .. } => std.array.map (std.function.const false) layered,
+          _ => [],
+        }
+      in
+      { active_layers = initial_active_layers }
     in
     let { serialized_json, .. } =
       std.array.fold_left
-        (fun { active_layers = al, serialized_json = sj } input =>
+        (fun { layer_state = ls, serialized_json = sj } input =>
           # Assumes all `press lmod` in input_enum is
           #  where lmod is not layered.
           # e.g. unhandled case ['Press LMod 0, 'Press { layered = [LMod 1] }, ..]
           {
-            active_layers = LK.update_active_layers_for_input input al,
-            serialized_json = sj @ [input_as_json al input]
+            layer_state = LK.update_layer_state_for_input input ls,
+            serialized_json = sj @ [input_as_json ls input]
           }
         )
-        { active_layers = initial_active_layers, serialized_json = [] }
+        { layer_state = initial_layer_state, serialized_json = [] }
         inputs
     in serialized_json
 }

--- a/ncl/inputs-to-json.ncl
+++ b/ncl/inputs-to-json.ncl
@@ -53,7 +53,7 @@
           _ => [],
         }
       in
-      { active_layers = initial_active_layers }
+      { default_layer = 0, active_layers = initial_active_layers }
     in
     let { serialized_json, .. } =
       std.array.fold_left

--- a/ncl/layered-key.ncl
+++ b/ncl/layered-key.ncl
@@ -21,7 +21,7 @@
 
   deactivate_layer = set_layer false,
 
-  update_layer_state_for_input = fun input layer_state @ { active_layers, .. } =>
+  update_layer_state_for_input = fun input layer_state @ { default_layer, active_layers } =>
     input
     |> match {
       'Press { layer_modifier = { hold }, .. } =>
@@ -30,6 +30,9 @@
       'Release { layer_modifier = { hold }, .. } =>
         let { active_layers = al, ..layer_state } = layer_state in
         { active_layers = deactivate_layer al hold } & layer_state,
+      'Release { layer_modifier = { default_ }, .. } =>
+        let { default_layer, ..layer_state } = layer_state in
+        { default_layer = default_ } & layer_state,
       _ => layer_state,
     },
 
@@ -48,7 +51,13 @@
     },
   },
 
-  active_key = fun lk layer_state @ { active_layers, .. } =>
+  active_key = fun lk layer_state @ { default_layer, active_layers, .. } =>
+    let active_layers =
+      if default_layer > 0 then
+        activate_layer active_layers default_layer
+      else
+        active_layers
+    in
     lk
     |> match {
       { passthrough, .. } =>

--- a/ncl/layered-key.ncl
+++ b/ncl/layered-key.ncl
@@ -21,34 +21,38 @@
 
   deactivate_layer = set_layer false,
 
-  update_active_layers_for_input = fun input active_layers =>
+  update_layer_state_for_input = fun input layer_state @ { active_layers, .. } =>
     input
     |> match {
-      'Press { layer_modifier = { hold }, .. } => activate_layer active_layers hold,
-      'Release { layer_modifier = { hold }, .. } => deactivate_layer active_layers hold,
-      _ => active_layers,
+      'Press { layer_modifier = { hold }, .. } =>
+        let { active_layers = al, ..layer_state } = layer_state in
+        { active_layers = activate_layer al hold } & layer_state,
+      'Release { layer_modifier = { hold }, .. } =>
+        let { active_layers = al, ..layer_state } = layer_state in
+        { active_layers = deactivate_layer al hold } & layer_state,
+      _ => layer_state,
     },
 
   checks.check_active_key = {
     base = {
       expected = { key_code = "A" },
-      actual = active_key { key_code = "A", layered = ["B", "C", "D"], } [ false, false, false ],
+      actual = active_key { key_code = "A", layered = ["B", "C", "D"], } { active_layers = [ false, false, false ] },
     },
     base_none = {
       expected = { key_code = "A" },
-      actual = active_key { key_code = "A", layered = ["B", "C", "D"], } [],
+      actual = active_key { key_code = "A", layered = ["B", "C", "D"], } { active_layers = [], }
     },
     layered = {
       expected = "C",
-      actual = active_key { key_code = "A", layered = ["B", "C", "D"], } [ true, true, false ],
+      actual = active_key { key_code = "A", layered = ["B", "C", "D"], } { active_layers = [ true, true, false ] },
     },
   },
 
-  active_key = fun lk active_layers =>
+  active_key = fun lk layer_state @ { active_layers, .. } =>
     lk
     |> match {
       { passthrough, .. } =>
-        active_key passthrough active_layers,
+        active_key passthrough layer_state,
       { layered, ..base_key } =>
         let zipped_layered_keys =
           std.array.zip_with


### PR DESCRIPTION
This PR adds & implements a Cucumber spec for the "set default layer" modifier key.

The somewhat-cumbersome `ncl/layered-key.ncl` code is updated to work with "layer state", rather than just "active layers".