### PR TITLE
bugfix: handle double key release

### DIFF
--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -803,4 +803,28 @@ mod tests {
         let expected_report: [u8; 8] = [0, 0, 0x04, 0, 0, 0, 0, 0];
         assert_eq!(expected_report, actual_report);
     }
+
+    #[test]
+    fn test_keymap_handles_press_after_extra_release() {
+        use key::{composite, keyboard};
+        use tuples::Keys1;
+
+        use composite::{Context, Event, KeyState, PendingKeyState};
+
+        // Assemble
+        let keys: Keys1<composite::Key, Context, Event, PendingKeyState, KeyState> =
+            Keys1::new((composite::Key::keyboard(keyboard::Key::new(0x04)),));
+        let context: Context = composite::DEFAULT_CONTEXT;
+        let mut keymap = Keymap::new(keys, context);
+
+        // Act
+        keymap.handle_input(input::Event::Release { keymap_index: 0 });
+        keymap.tick();
+        keymap.handle_input(input::Event::Press { keymap_index: 0 });
+        let actual_report = keymap.boot_keyboard_report();
+
+        // Assert
+        let expected_report: [u8; 8] = [0, 0, 0x04, 0, 0, 0, 0, 0];
+        assert_eq!(expected_report, actual_report);
+    }
 }

--- a/tests/ceedling/test/test_keymap.c
+++ b/tests/ceedling/test/test_keymap.c
@@ -117,3 +117,20 @@ void test_keyboard_keypress_sequence_da_db_ua(void) {
     copy_hid_boot_keyboard_report(actual_report);
     TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report, 8);
 }
+
+void test_keyboard_keypress_after_keyrelease(void) {
+    uint8_t expected_report[8] = {0, 0, KC_A, 0, 0, 0, 0, 0};
+    uint8_t actual_report[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+    keymap_init();
+
+    keymap_register_input_keyrelease(2);
+    keymap_tick(actual_report);
+    keymap_register_input_keyrelease(2);
+    keymap_tick(actual_report);
+    keymap_register_input_keypress(2); // Third key in the keymap is A
+
+    copy_hid_boot_keyboard_report(actual_report);
+
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report, 8);
+}


### PR DESCRIPTION
I'm observing cases where a key press received from a split-RHS, but doesn't result in a key press.

My first guess is that this is because a "key press" is being missed, and the keymap doesn't handle (extra) key releases well.