### PR TITLE
rp2040-rtic: codegen board.ncl field

### DIFF
--- a/rp2040-rtic-smart-keyboard/examples/board-pico42.ncl
+++ b/rp2040-rtic-smart-keyboard/examples/board-pico42.ncl
@@ -1,16 +1,15 @@
 {
   gpio_pins,
 
-  usb
-    = {
+  board = {
+    usb = {
       vid = 0xCAFE,
       pid = 0x0005,
       manufacturer = "rgoulter keyboard-labs",
       product = "Pico42"
     },
 
-  matrix
-    =
+    matrix =
       let p = gpio_pins in
       {
         cols = [
@@ -36,18 +35,20 @@
         key_count = 42,
       },
 
-  keymap_index_for_key = fun { column_index, row_index } =>
-    let NO = null in
-    let keymap_indices = [
-      [ 0,  1,  2,  3,  4, NO, NO,  5,  6,  7,  8,  9],
-      [10, 11, 12, 13, 14, NO, NO, 15, 16, 17, 18, 19],
-      [20, 21, 22, 23, 24, NO, NO, 25, 26, 27, 28, 29],
-      [30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41],
-    ]
-    in
-    let row = std.array.at row_index keymap_indices in
-    std.array.at column_index row |> match {
+    keymap_index_for_key = fun { column_index, row_index } =>
+      let NO = null in
+      let keymap_indices = [
+        [ 0,  1,  2,  3,  4, NO, NO,  5,  6,  7,  8,  9],
+        [10, 11, 12, 13, 14, NO, NO, 15, 16, 17, 18, 19],
+        [20, 21, 22, 23, 24, NO, NO, 25, 26, 27, 28, 29],
+        [30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41],
+      ]
+      in
+      let row = std.array.at row_index keymap_indices in
+      std.array.at column_index row
+      |> match {
         idx if idx != null => 'Key idx,
         _ => 'NoKey,
-    },
+      },
+  },
 }

--- a/rp2040-rtic-smart-keyboard/ncl/codegen.ncl
+++ b/rp2040-rtic-smart-keyboard/ncl/codegen.ncl
@@ -1,6 +1,5 @@
 {
-  GpioPin
-    = { id | String, type | String, },
+  GpioPin = { id | String, type | String, },
 
   gpio_pins
     : { _ | GpioPin }
@@ -13,15 +12,16 @@
         (fun port_name => # GP
           std.array.map
             (fun pin_num => # 0, 1, .. 29
-               {
-                 # GP0 = ...
-                 "%{port_name}%{std.to_string pin_num}" =
-                   {
-                     "id" = "gpio%{std.to_string pin_num}",
-                     "type" = "bank0::Gpio%{std.to_string pin_num}",
-                   },
-               })
-            pins)
+              {
+                # GP0 = ...
+                "%{port_name}%{std.to_string pin_num}" = {
+                  "id" = "gpio%{std.to_string pin_num}",
+                  "type" = "bank0::Gpio%{std.to_string pin_num}",
+                },
+              }
+            )
+            pins
+        )
         ports
       |> (std.array.fold_left (&) {}) | { _ : GpioPin },
 
@@ -37,12 +37,12 @@
     | doc "Returns the keymap index for the key corresponding to the (0-based) digital column_index and row_index.",
 
   usb
-   | {
-       vid | Number,
-       pid | Number,
-       manufacturer | String,
-       product | String,
-     },
+    | {
+      vid | Number,
+      pid | Number,
+      manufacturer | String,
+      product | String,
+    },
 
   board_rs =
     let col_count = matrix.cols |> std.array.length in
@@ -50,37 +50,44 @@
     let row_count = matrix.rows |> std.array.length in
     let const_rows_expr = row_count |> std.to_string in
     let keymap_indices_expr =
-      let keymap_index_expr =
-        match {
-          'Key idx => "Some(%{std.to_string idx})",
-          'NoKey   => "None",
-        } in
+      let keymap_index_expr = match {
+        'Key idx => "Some(%{std.to_string idx})",
+        'NoKey => "None",
+      }
+      in
       let cols_expr = fun row_idx =>
         std.array.generate
           (fun col_idx =>
-             keymap_index_for_key
-               {
-                 row_index = row_idx,
-                 column_index = col_idx,
-               } |>
-             keymap_index_expr)
-          col_count in
+            keymap_index_for_key {
+              row_index = row_idx,
+              column_index = col_idx,
+            }
+            |> keymap_index_expr
+          )
+          col_count
+      in
       let row_expr = fun row_idx =>
-        "[ %{std.string.join ", " (cols_expr row_idx)} ]" in
+        "[ %{std.string.join ", " (cols_expr row_idx)} ]"
+      in
       let row_exprs = std.array.generate row_expr row_count in
-      "[ %{std.string.join ", " row_exprs} ]" in
+      "[ %{std.string.join ", " row_exprs} ]"
+    in
     let macro_cols_expr =
       let macro_col_expr = fun col_idx =>
         let { id, .. } = std.array.at col_idx matrix.cols in
-        "$gpio_pins.%{id}.into_pull_up_input().into_dyn_pin()" in
+        "$gpio_pins.%{id}.into_pull_up_input().into_dyn_pin()"
+      in
       let macro_col_exprs = std.array.generate macro_col_expr col_count in
-      "[%{std.string.join "," macro_col_exprs}]" in
+      "[%{std.string.join "," macro_col_exprs}]"
+    in
     let macro_rows_expr =
       let macro_row_expr = fun row_idx =>
         let { id, .. } = std.array.at row_idx matrix.rows in
-        "$gpio_pins.%{id}.into_push_pull_output().into_dyn_pin()" in
+        "$gpio_pins.%{id}.into_push_pull_output().into_dyn_pin()"
+      in
       let macro_row_exprs = std.array.generate macro_row_expr row_count in
-      "[%{std.string.join "," macro_row_exprs}]" in
+      "[%{std.string.join "," macro_row_exprs}]"
+    in
 
     let vid_expr = usb.vid |> std.to_string in
     let pid_expr = usb.pid |> std.to_string in

--- a/rp2040-rtic-smart-keyboard/ncl/codegen.ncl
+++ b/rp2040-rtic-smart-keyboard/ncl/codegen.ncl
@@ -25,29 +25,31 @@
         ports
       |> (std.array.fold_left (&) {}) | { _ : GpioPin },
 
-  matrix
-    | {
-      cols | Array GpioPin,
-      rows | Array GpioPin,
-      key_count | Number,
-    }
-    | doc "the cols/rows, and number of keys, used for generating the matrix scan code.",
+  board = {
+    usb
+      | {
+        vid | Number,
+        pid | Number,
+        manufacturer | String,
+        product | String,
+      },
 
-  keymap_index_for_key
-    | doc "Returns the keymap index for the key corresponding to the (0-based) digital column_index and row_index.",
+    matrix
+      | {
+        cols | Array GpioPin,
+        rows | Array GpioPin,
+        key_count | Number,
+      }
+      | doc "the cols/rows, and number of keys, used for generating the matrix scan code.",
 
-  usb
-    | {
-      vid | Number,
-      pid | Number,
-      manufacturer | String,
-      product | String,
-    },
+    keymap_index_for_key
+      | doc "Returns the keymap index for the key corresponding to the (0-based) digital column_index and row_index.",
+  },
 
   board_rs =
-    let col_count = matrix.cols |> std.array.length in
+    let col_count = board.matrix.cols |> std.array.length in
     let const_cols_expr = col_count |> std.to_string in
-    let row_count = matrix.rows |> std.array.length in
+    let row_count = board.matrix.rows |> std.array.length in
     let const_rows_expr = row_count |> std.to_string in
     let keymap_indices_expr =
       let keymap_index_expr = match {
@@ -58,7 +60,7 @@
       let cols_expr = fun row_idx =>
         std.array.generate
           (fun col_idx =>
-            keymap_index_for_key {
+            board.keymap_index_for_key {
               row_index = row_idx,
               column_index = col_idx,
             }
@@ -74,7 +76,7 @@
     in
     let macro_cols_expr =
       let macro_col_expr = fun col_idx =>
-        let { id, .. } = std.array.at col_idx matrix.cols in
+        let { id, .. } = std.array.at col_idx board.matrix.cols in
         "$gpio_pins.%{id}.into_pull_up_input().into_dyn_pin()"
       in
       let macro_col_exprs = std.array.generate macro_col_expr col_count in
@@ -82,17 +84,17 @@
     in
     let macro_rows_expr =
       let macro_row_expr = fun row_idx =>
-        let { id, .. } = std.array.at row_idx matrix.rows in
+        let { id, .. } = std.array.at row_idx board.matrix.rows in
         "$gpio_pins.%{id}.into_push_pull_output().into_dyn_pin()"
       in
       let macro_row_exprs = std.array.generate macro_row_expr row_count in
       "[%{std.string.join "," macro_row_exprs}]"
     in
 
-    let vid_expr = usb.vid |> std.to_string in
-    let pid_expr = usb.pid |> std.to_string in
-    let manufacturer_expr = "\"%{usb.manufacturer}\"" in
-    let product_expr = "\"%{usb.product}\"" in
+    let vid_expr = board.usb.vid |> std.to_string in
+    let pid_expr = board.usb.pid |> std.to_string in
+    let manufacturer_expr = "\"%{board.usb.manufacturer}\"" in
+    let product_expr = "\"%{board.usb.product}\"" in
     m%"
 mod board {
     use rp2040_hal as hal;


### PR DESCRIPTION
Similar to #224, this rearranges the fields used in the `board-*.ncl` so the `matrix` and `keymap_index_for_key` are fields under the `board` field.

Having a `board-*.ncl` with a `board` field seems a bit redundant, but it allows this modular pattern:

```
{
  field_dependency0,
  field_dependency1,
  field_dependency2,

  field_provides = {
    ...
  },
}
```

So, rather than `board.ncl` providing 3 fields, it provides 1 field.

Either arrangement is fine; but I like the idea of board-related things being provided by the `board` field.