### PR TITLE
libsmart_keymap: Report using KeymapHidReport struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1651,7 +1651,7 @@ version = "0.1.0"
 
 [[package]]
 name = "smart_keymap"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "smart-keymap",
 ]

--- a/firmware/ch32x035-usb-device-compositekm-c/User/usbd_composite_km.c
+++ b/firmware/ch32x035-usb-device-compositekm-c/User/usbd_composite_km.c
@@ -39,6 +39,7 @@ volatile uint16_t KB_Scan_Result =
     (1 << 0 | 1 << 1 | 1 << 3 | 1 << 11); // Keyboard Keys Current Scan Result
 volatile uint16_t KB_Scan_Last_Result =
     (1 << 0 | 1 << 1 | 1 << 3 | 1 << 11);   // Keyboard Keys Last Scan Result
+KeymapHidReport hid_report = {0};           // Keyboard HID report
 uint8_t KB_Data_Pack[8] = {0x00};           // Keyboard IN Data Packet
 uint8_t PREV_KB_Data_Pack[8] = {0x00};      // Keyboard IN Data Packet
 volatile uint8_t KB_LED_Last_Status = 0x00; // Keyboard LED Last Result
@@ -103,7 +104,8 @@ void TIM3_IRQHandler(void) {
     keyboard_led_tick();
 
     if (memcmp(KB_Data_Pack, PREV_KB_Data_Pack, sizeof(KB_Data_Pack)) == 0) {
-      keymap_tick(KB_Data_Pack);
+      keymap_tick(&hid_report);
+      memcpy(KB_Data_Pack, hid_report.keyboard, sizeof(KB_Data_Pack));
     }
 
     /* Clear interrupt flag */

--- a/firmware/ch58x-ble-hid-keyboard-c/APP/hidkbd.c
+++ b/firmware/ch58x-ble-hid-keyboard-c/APP/hidkbd.c
@@ -279,7 +279,7 @@ void HidEmu_Init() {
 uint16_t HidEmu_ProcessEvent(uint8_t task_id, uint16_t events) {
   static uint8_t send_char = 0;
   static uint8_t report_status = SUCCESS;
-  static uint8_t buf[HID_KEYBOARD_IN_RPT_LEN] = {0};
+  static KeymapHidReport hid_report = {0};
 
   if (events & SYS_EVENT_MSG) {
     uint8_t *pMsg;
@@ -323,10 +323,10 @@ uint16_t HidEmu_ProcessEvent(uint8_t task_id, uint16_t events) {
 
     keyboard_matrix_scan();
 
-    keymap_tick(buf);
+    keymap_tick(&hid_report);
 
     report_status = HidDev_Report(HID_RPT_ID_KEY_IN, HID_REPORT_TYPE_INPUT,
-                                  HID_KEYBOARD_IN_RPT_LEN, buf);
+                                  HID_KEYBOARD_IN_RPT_LEN, (unsigned char *)&hid_report.keyboard);
 
     // 13 * 625 microseconds = 8.125ms, approx 125Hz
     tmos_start_task(hidEmuTaskId, START_REPORT_EVT, 13);

--- a/smart_keymap/Cargo.toml
+++ b/smart_keymap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smart_keymap"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
 
 [lib]

--- a/tests/ceedling/test/test_keydef_taphold.c
+++ b/tests/ceedling/test/test_keydef_taphold.c
@@ -19,7 +19,8 @@ void test_taphold_dth_uth_is_tap(void) {
   // (Check the tap key gets pressed).
 
   uint8_t expected_report[8] = {0, 0, KC_C, 0, 0, 0, 0, 0};
-  uint8_t actual_report[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+  KeymapHidReport report;
+  KeymapHidReport* actual_report = &report;
 
   keymap_init();
 
@@ -31,7 +32,7 @@ void test_taphold_dth_uth_is_tap(void) {
       (struct KeymapInputEvent){.event_type = KeymapEventRelease, .value = 0});
 
   keymap_tick(actual_report);
-  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report, 8);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
 }
 
 void test_taphold_dth_uth_eventually_clears(void) {
@@ -39,7 +40,8 @@ void test_taphold_dth_uth_eventually_clears(void) {
   // (Check the tap key releases).
 
   uint8_t expected_report[8] = {0, 0, 0, 0, 0, 0, 0, 0};
-  uint8_t actual_report[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+  KeymapHidReport report;
+  KeymapHidReport* actual_report = &report;
 
   keymap_init();
 
@@ -58,14 +60,15 @@ void test_taphold_dth_uth_eventually_clears(void) {
     keymap_tick(actual_report);
   }
 
-  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report, 8);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
 }
 
 void test_taphold_dth_eventually_holds(void) {
   // Pressing T.H., is eventually the same as holding the hold key.
 
   uint8_t expected_report[8] = {MOD_LCTL, 0, 0, 0, 0, 0, 0, 0};
-  uint8_t actual_report[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+  KeymapHidReport report;
+  KeymapHidReport* actual_report = &report;
 
   keymap_init();
 
@@ -78,5 +81,5 @@ void test_taphold_dth_eventually_holds(void) {
     keymap_tick(actual_report);
   }
 
-  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report, 8);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
 }


### PR DESCRIPTION
Other smart keyboard firmware supports non-keyboard functionality, like Mouse and Consumer (Media) keys.

This PR adds a level of indirection. Instead of directly writing to `*u8`, `keymap_tick` now writes to `&mut KeymapHidReport`.

The `KeymapHidReport` struct then has a `keyboard` field.

The plan is to add `mouse` and `consumer` fields to this. May-be conditional-compilation would allow only compiling `libsmart_keymap` with the required fields.