### PR TITLE
Key: Keymap Callback (Reset, Bootloader, etc.)

### DIFF
--- a/ncl/key-extensions.ncl
+++ b/ncl/key-extensions.ncl
@@ -57,6 +57,12 @@
       TTTT = null,
     },
 
+  keymap_callbacks = fun K =>
+    {
+      reset = { keymap_callback = "Reset" },
+      reset_to_bootloader = { keymap_callback = "ResetToBootloader" },
+    },
+
   shifted = fun K =>
     {
       Exclaim = K.N1,
@@ -194,6 +200,9 @@
 
       NUSH = K.NonUSHash,
       NUSB = K.NonUSBackslash,
+
+      RST  = K.reset,
+      BOOT = K.reset_to_bootloader,
     },
 
   literals = fun K =>

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -242,11 +242,47 @@ let validators = import "validators.ncl" in
           cv,
     },
 
+  keymap_callback
+    | doc "for key::callback::Key."
+    = {
+      SerializedJson = std.contract.from_validator serialized_json_validator,
+
+      serialized_json_validator =
+        validators.record.validator {
+          fields_validator = validators.record.has_exact_fields ["keymap_callback"],
+          field_validators = {
+            keymap_callback = validators.is_string,
+          },
+        },
+
+      is_serialized_json = fun k => 'Ok == serialized_json_validator k,
+
+      codegen_values = fun k @ { keymap_callback } =>
+        {
+          key_type = {
+            key_type = "crate::key::callback::Key",
+            as_rust_type_path = key_type,
+          },
+          key_impl = {
+            base = key_type.key_type,
+          },
+          rust_expr = "crate::key::callback::Key::new(crate::keymap::KeymapCallback::%{keymap_callback})",
+          serialized_json = k,
+        },
+
+      lift_to = fun key_impl cv =>
+        if key_impl.base == "crate::key::composite::BaseKey" then
+          cv |> composite.base_key.keymap_callback
+        else
+          cv,
+    },
+
   # Related to key::composite::TapHoldNestable trait.
   tap_hold_nestable = {
     # Wraps the codegen values for
     #   - key::keyboard::Key
     #   - key::layered::ModifierKey
+    #   - key::callback::Key
     #
     # In particular, the returned value is a codegen values record
     #  for an item which implements key::Key with associated
@@ -256,6 +292,7 @@ let validators = import "validators.ncl" in
       |> match {
         "crate::key::keyboard::Key" => cv,
         "crate::key::layered::ModifierKey" => cv,
+        "crate::key::callback::Key" => cv,
         cv => std.fail_with "bad codegen_values for tap_hold_nestable.wrap: %{cv |> std.serialize 'Json}",
       },
   },
@@ -694,6 +731,20 @@ let validators = import "validators.ncl" in
             base = key_type.key_type,
           },
           rust_expr = "crate::key::composite::BaseKey::layer_modifier(%{nested.rust_expr})",
+        },
+
+      keymap_callback = fun cv =>
+        {
+          nested = cv,
+          key_type = {
+            key_type = "crate::key::composite::BaseKey",
+            as_rust_type_path = key_type,
+            variant = "Callback",
+          },
+          key_impl = {
+            base = key_type.key_type,
+          },
+          rust_expr = "crate::key::composite::BaseKey::Callback(%{nested.rust_expr})",
         },
 
       keyboard = fun cv =>

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -4,6 +4,7 @@ let validators = import "validators.ncl" in
     std.contract.any_of [
       keyboard.Key,
       layer_modifier.Key,
+      keymap_callback.Key,
       layered.Key,
       tap_hold.Key,
       chorded.Key,
@@ -135,6 +136,23 @@ let validators = import "validators.ncl" in
             { Hold = hold_layer },
           _ => 'Error { message = "expected { layer_modifier = { default_ } } or { layer_modifier = { hold } }" },
         }
+    },
+
+  keymap_callback
+    | doc "for key::callback::Key."
+    = {
+      Key = std.contract.from_validator key_validator,
+
+      key_validator = fun k =>
+        k
+        |> match {
+          { keymap_callback } => validators.is_string keymap_callback,
+          _ => 'Error { message = "expected { keymap_callback = <KeymapCallback variant> }" },
+        },
+
+      is_key = fun k => 'Ok == key_validator k,
+
+      to_json_serialized = fun key => key,
     },
 
   checks.layered =
@@ -323,6 +341,7 @@ let validators = import "validators.ncl" in
       |> validators.any_of [
         keyboard.key_validator,
         layer_modifier.key_validator,
+        keymap_callback.key_validator,
         layered.key_validator,
         tap_hold.key_validator,
         chorded.key_validator,
@@ -341,6 +360,8 @@ let validators = import "validators.ncl" in
       k if layered.is_key k => layered.to_json_serialized k,
       # Make key::tap_hold::Key from keys with a "hold" modifier.
       k if tap_hold.is_key k => tap_hold.to_json_serialized k,
+      # Make key::callback::Key
+      k if keymap_callback.is_key k => keymap_callback.to_json_serialized k,
       # Otherwise, keys with just a base key_code are key::keyboard keys.
       k if keyboard.is_key k => keyboard.to_json_serialized k,
       # Make key::layered::ModifierKey

--- a/ncl/keys.ncl
+++ b/ncl/keys.ncl
@@ -9,6 +9,7 @@ std.array.fold_left
     key_extensions.layered,
     key_extensions.shifted,
     key_extensions.aliases,
+    key_extensions.keymap_callbacks,
     key_extensions.abbreviations,
     key_extensions.literals,
   ]

--- a/src/key/callback.rs
+++ b/src/key/callback.rs
@@ -1,0 +1,17 @@
+use serde::Deserialize;
+
+use crate::keymap::KeymapCallback;
+
+/// A key for HID Keyboard usage codes.
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
+pub struct Key {
+    /// The keymap callback
+    pub keymap_callback: KeymapCallback,
+}
+
+impl Key {
+    /// Constructs a key with the given key_code.
+    pub const fn new(keymap_callback: KeymapCallback) -> Self {
+        Key { keymap_callback }
+    }
+}

--- a/src/key/composite/base.rs
+++ b/src/key/composite/base.rs
@@ -4,6 +4,8 @@ use core::fmt::Debug;
 use serde::Deserialize;
 
 use crate::key;
+
+use key::callback;
 use key::keyboard;
 use key::layered;
 
@@ -16,6 +18,8 @@ use super::{Context, Event, KeyState, PendingKeyState, PressedKeyResult};
 pub enum BaseKey {
     /// A layer modifier key.
     LayerModifier(layered::ModifierKey),
+    /// A callback key.
+    Callback(callback::Key),
     /// A keyboard key.
     Keyboard(keyboard::Key),
 }
@@ -38,6 +42,46 @@ impl key::Key for layered::ModifierKey {
             keymap_index,
             Event::LayerModification(lmod_ev),
         ));
+        (pks, pke)
+    }
+
+    fn handle_event(
+        &self,
+        _pending_state: &mut Self::PendingKeyState,
+        _context: Self::Context,
+        _key_path: key::KeyPath,
+        _event: key::Event<Self::Event>,
+    ) -> (Option<Self::KeyState>, key::PressedKeyEvents<Self::Event>) {
+        panic!()
+    }
+
+    fn lookup(
+        &self,
+        _path: &[u16],
+    ) -> &dyn key::Key<
+        Context = Self::Context,
+        Event = Self::Event,
+        PendingKeyState = Self::PendingKeyState,
+        KeyState = Self::KeyState,
+    > {
+        self
+    }
+}
+
+impl key::Key for callback::Key {
+    type Context = Context;
+    type Event = Event;
+    type PendingKeyState = PendingKeyState;
+    type KeyState = KeyState;
+
+    fn new_pressed_key(
+        &self,
+        _context: Self::Context,
+        _key_path: key::KeyPath,
+    ) -> (PressedKeyResult, key::PressedKeyEvents<Self::Event>) {
+        let &callback::Key { keymap_callback } = self;
+        let pks = key::PressedKeyResult::Resolved(KeyState::NoOp);
+        let pke = key::PressedKeyEvents::event(key::Event::KeymapCallback(keymap_callback));
         (pks, pke)
     }
 
@@ -118,6 +162,7 @@ impl key::Key for BaseKey {
         match self {
             BaseKey::Keyboard(key) => key::Key::new_pressed_key(key, context, key_path),
             BaseKey::LayerModifier(key) => key::Key::new_pressed_key(key, context, key_path),
+            BaseKey::Callback(key) => key::Key::new_pressed_key(key, context, key_path),
         }
     }
 

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -4,6 +4,8 @@ use serde::Deserialize;
 
 use crate::input;
 
+/// Keymap Callback keys
+pub mod callback;
 /// Chorded keys. (Chording functionality).
 pub mod chorded;
 /// HID Keyboard keys.

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -501,6 +501,8 @@ pub enum Event<T> {
         /// A [Key::Event] event.
         key_event: T,
     },
+    /// Invoke a keymap callback
+    KeymapCallback(crate::keymap::KeymapCallback),
 }
 
 impl<T: Copy> Event<T> {
@@ -523,6 +525,7 @@ impl<T: Copy> Event<T> {
                 key_event: f(*key_event),
                 keymap_index: *keymap_index,
             },
+            Event::KeymapCallback(cb) => Event::KeymapCallback(*cb),
         }
     }
 
@@ -547,6 +550,7 @@ impl<T: Copy> Event<T> {
                     keymap_index: *keymap_index,
                 })
                 .map_err(|_| EventError::UnmappableEvent),
+            Event::KeymapCallback(cb) => Ok(Event::KeymapCallback(*cb)),
         }
     }
 }

--- a/src/key/tap_hold.rs
+++ b/src/key/tap_hold.rs
@@ -182,6 +182,7 @@ impl PendingKeyState {
                         // Key held long enough to resolve as hold.
                         Some(TapHoldState::Hold)
                     }
+                    _ => None,
                 }
             }
             InterruptResponse::HoldOnKeyTap => {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -388,6 +388,19 @@ impl<
             .unwrap();
     }
 
+    /// Registers the given callback to the keymap.
+    ///
+    /// Only one callback is set for each callback id.
+    pub fn set_callback_extern(
+        &mut self,
+        callback_id: KeymapCallback,
+        callback_fn: extern "C" fn() -> (),
+    ) {
+        self.callbacks
+            .insert(callback_id, CallbackFunction::ExternC(callback_fn))
+            .unwrap();
+    }
+
     // If the pending key state is resolved,
     //  then clear the pending key state.
     fn resolve_pending_key_state(&mut self, key_state: composite::KeyState) {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -542,6 +542,18 @@ impl<
     // Called from handle_all_pending_events,
     //  and for handling the (resolving) queue of events from pending key state.
     fn handle_event(&mut self, ev: key::Event<composite::Event>) {
+        if let key::Event::KeymapCallback(callback_id) = ev {
+            match self.callbacks.get(&callback_id) {
+                Some(CallbackFunction::Rust(callback_fn)) => {
+                    callback_fn();
+                }
+                Some(CallbackFunction::ExternC(callback_fn)) => {
+                    callback_fn();
+                }
+                None => {}
+            }
+        }
+
         // pending state needs to handle events
         if let Some(PendingState {
             key_path,


### PR DESCRIPTION
This PR implements "Reset" and "Reset to Bootloader" keys.

It does that by adding a new (base) key: the callback key. When the Callback key is pressed, the Keymap will invoke the associated keymap callback.

Callback behaviour is specific to the *keyboard* firmware implementation.

Currently, the only keymap callbacks are "Reset" and "Reset to Bootloader". -- It might make sense to support some kind of custom identifier for keymap callbacks, which would enable other smart callback keys like RGB controls (on/off/hsv/next effect/etc.), Bluetooth controls, etc.

The CH32X firmware has been updated with an implementation for the BOOT key.
