### PR TITLE
Key State Persistence

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -24,6 +24,9 @@ pub struct PressedKey<S> {
     pub keymap_index: u16,
     /// The pressed key state.
     pub key_state: S,
+    /// Whether the key is currently pressed.
+    /// (Persistent key state can be retained even when key is not pressed).
+    pub key_pressed: bool,
 }
 
 impl<Ctx, Ev, S: crate::key::KeyState<Context = Ctx, Event = Ev>> PressedKey<S> {

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -262,6 +262,10 @@ impl key::KeyState for KeyState {
             KeyState::NoOp => None,
         }
     }
+
+    fn is_persistent(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/src/key/keyboard.rs
+++ b/src/key/keyboard.rs
@@ -101,4 +101,8 @@ impl key::KeyState for KeyState {
     fn key_output(&self) -> Option<key::KeyOutput> {
         Some(self.key_output())
     }
+
+    fn is_persistent(&self) -> bool {
+        false
+    }
 }

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -447,6 +447,12 @@ pub trait KeyState: Debug {
         event: Event<Self::Event>,
     ) -> PressedKeyEvents<Self::Event>;
 
+    /// Whether the key state should remain pressed after the key has been released.
+    ///
+    /// If this is true when the key is released, the key state will persist,
+    ///  and any subsequent key presses will be handled by the key state.
+    fn is_persistent(&self) -> bool;
+
     /// Output for the pressed key state.
     fn key_output(&self) -> Option<KeyOutput>;
 }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -422,6 +422,7 @@ impl<
                 .push(input::PressedKey {
                     key_state,
                     keymap_index,
+                    key_pressed: true,
                 })
                 .unwrap();
 
@@ -519,6 +520,7 @@ impl<
                                 .push(input::PressedKey {
                                     key_state,
                                     keymap_index,
+                                    key_pressed: true,
                                 })
                                 .unwrap();
                         }
@@ -590,6 +592,7 @@ impl<
             |input::PressedKey {
                  key_state,
                  keymap_index,
+                 ..
              }| {
                 key_state
                     .handle_event(self.context, *keymap_index, ev)

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -8,6 +8,8 @@ use crate::key;
 
 use key::{composite, Context, Event};
 
+use key::KeyState as _;
+
 const MAX_PENDING_EVENTS: usize = 32;
 const MAX_SCHEDULED_EVENTS: usize = 32;
 
@@ -589,8 +591,6 @@ impl<
                  key_state,
                  keymap_index,
              }| {
-                use key::KeyState as _;
-
                 key_state
                     .handle_event(self.context, *keymap_index, ev)
                     .into_iter()


### PR DESCRIPTION
This PR:

- Adds `key::KeyState::is_persistent`.
- Implements Keymap functionality in `process_input` to handle persistent key state.

"Key State Persistence" means the key state stays pressed even when the key is released.

I expect this will be useful for things like caps word, "sticky" modifier keys, and tap-dance keys.

There's some overlap with "pending" key state here.. -- Depends on perspective; but when you press a key with pending state (tap-hold, chorded, sequence), the current implementation is that it's state is "pending" until it resolves to a key state. -- An alternative implementation might have it immediately be a pressed key state, where the pressed key state itself handles whether it's resolved or not. -- Perhaps if I implemented sticky keys before tap-hold keys, that's the approach I would have taken!