### PR TITLE
Add CapsWord Key

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -24,6 +24,9 @@ pub struct PressedKey<S> {
     pub keymap_index: u16,
     /// The pressed key state.
     pub key_state: S,
+    /// Whether the key is currently pressed.
+    /// (Persistent key state can be retained even when key is not pressed).
+    pub key_pressed: bool,
 }
 
 impl<Ctx, Ev, S: crate::key::KeyState<Context = Ctx, Event = Ev>> PressedKey<S> {

--- a/src/key/caps_word.rs
+++ b/src/key/caps_word.rs
@@ -1,0 +1,91 @@
+#![doc = include_str!("doc_de_caps_word.md")]
+
+use serde::Deserialize;
+
+use crate::key;
+use crate::keymap;
+
+/// A key for HID Keyboard usage codes.
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
+pub enum Key {
+    /// Enters/Exits CapsWord mode.
+    ToggleCapsWord,
+}
+
+impl Key {
+    /// Constructs a key with the given key_code.
+    pub const fn new() -> Self {
+        Key::ToggleCapsWord
+    }
+
+    /// Constructs a pressed key state
+    pub fn new_pressed_key(&self) -> KeyState {
+        KeyState::new()
+    }
+}
+
+/// Caps Word [crate::key::KeyState].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct KeyState {
+    is_active: bool,
+}
+
+impl KeyState {
+    /// Constructs a new key state.
+    pub const fn new() -> Self {
+        Self { is_active: true }
+    }
+}
+
+impl key::KeyState for KeyState {
+    type Context = key::composite::Context;
+    type Event = key::composite::Event;
+
+    fn handle_event(
+        &mut self,
+        _context: Self::Context,
+        _keymap_index: u16,
+        event: key::Event<Self::Event>,
+    ) -> key::PressedKeyEvents<Self::Event> {
+        if let key::Event::Keymap(keymap::KeymapEvent::ResolvedKeyOutput(key::KeyOutput {
+            key_code,
+            key_modifiers:
+                key::KeyboardModifiers {
+                    left_shift,
+                    right_shift,
+                    ..
+                },
+        })) = event
+        {
+            // CapsWord is deactivated for key presses other than:
+            //   - A-Z
+            //   - 0-9
+            //   - Backspace, Delete
+            //   - Minus, Underscore
+            let is_shifted = left_shift || right_shift;
+            match key_code {
+                0x04..=0x1D => {}                // A-Z
+                0x1E..=0x27 if !is_shifted => {} // 0-9
+                0x2A => {}                       // Backspace
+                0x2D => {}                       // `-` minus
+                0x4C => {}                       // Delete
+                0xE1 => {}                       // Left Shift
+                0xE5 => {}                       // Right Shift
+                0x00 => {}                       // No key code (modifier)
+                _ => {
+                    self.is_active = false;
+                }
+            }
+        }
+        key::PressedKeyEvents::no_events()
+    }
+
+    fn key_output(&self) -> Option<key::KeyOutput> {
+        let lsft = key::KeyboardModifiers::LEFT_SHIFT;
+        Some(key::KeyOutput::from_key_modifiers(lsft))
+    }
+
+    fn is_persistent(&self) -> bool {
+        self.is_active
+    }
+}

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -212,6 +212,8 @@ pub enum KeyState {
     Keyboard(key::keyboard::KeyState),
     /// Key state for [key::layered::ModifierKeyState].
     LayerModifier(key::layered::ModifierKeyState),
+    /// Caps Word key state.
+    CapsWord(key::caps_word::KeyState),
 }
 
 impl From<key::keyboard::KeyState> for KeyState {
@@ -232,7 +234,7 @@ impl key::KeyState for KeyState {
 
     fn handle_event(
         &mut self,
-        _context: Self::Context,
+        context: Self::Context,
         keymap_index: u16,
         event: key::Event<Self::Event>,
     ) -> key::PressedKeyEvents<Self::Event> {
@@ -251,6 +253,7 @@ impl key::KeyState for KeyState {
                     key::PressedKeyEvents::no_events()
                 }
             }
+            KeyState::CapsWord(ks) => ks.handle_event(context, keymap_index, event),
             KeyState::NoOp => key::PressedKeyEvents::no_events(),
         }
     }
@@ -259,6 +262,7 @@ impl key::KeyState for KeyState {
         match self {
             KeyState::Keyboard(ks) => Some(ks.key_output()),
             KeyState::LayerModifier(_) => None,
+            KeyState::CapsWord(ks) => ks.key_output(),
             KeyState::NoOp => None,
         }
     }

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -268,7 +268,12 @@ impl key::KeyState for KeyState {
     }
 
     fn is_persistent(&self) -> bool {
-        false
+        match self {
+            KeyState::Keyboard(_) => false,
+            KeyState::LayerModifier(_) => false,
+            KeyState::CapsWord(ks) => ks.is_persistent(),
+            KeyState::NoOp => false,
+        }
     }
 }
 

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -262,6 +262,10 @@ impl key::KeyState for KeyState {
             KeyState::NoOp => None,
         }
     }
+
+    fn is_persistent(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/src/key/composite/base.rs
+++ b/src/key/composite/base.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 use crate::key;
 
 use key::callback;
+use key::caps_word;
 use key::keyboard;
 use key::layered;
 
@@ -20,6 +21,8 @@ pub enum BaseKey {
     LayerModifier(layered::ModifierKey),
     /// A callback key.
     Callback(callback::Key),
+    /// Caps Word key
+    CapsWord(caps_word::Key),
     /// A keyboard key.
     Keyboard(keyboard::Key),
 }
@@ -109,6 +112,46 @@ impl key::Key for callback::Key {
     }
 }
 
+impl key::Key for caps_word::Key {
+    type Context = Context;
+    type Event = Event;
+    type PendingKeyState = PendingKeyState;
+    type KeyState = KeyState;
+
+    fn new_pressed_key(
+        &self,
+        _context: Self::Context,
+        _key_path: key::KeyPath,
+    ) -> (PressedKeyResult, key::PressedKeyEvents<Self::Event>) {
+        let cw_pks = self.new_pressed_key();
+        let pks = key::PressedKeyResult::Resolved(KeyState::CapsWord(cw_pks));
+        let pke = key::PressedKeyEvents::no_events();
+        (pks, pke)
+    }
+
+    fn handle_event(
+        &self,
+        _pending_state: &mut Self::PendingKeyState,
+        _context: Self::Context,
+        _key_path: key::KeyPath,
+        _event: key::Event<Self::Event>,
+    ) -> (Option<Self::KeyState>, key::PressedKeyEvents<Self::Event>) {
+        panic!()
+    }
+
+    fn lookup(
+        &self,
+        _path: &[u16],
+    ) -> &dyn key::Key<
+        Context = Self::Context,
+        Event = Self::Event,
+        PendingKeyState = Self::PendingKeyState,
+        KeyState = Self::KeyState,
+    > {
+        self
+    }
+}
+
 impl key::Key for keyboard::Key {
     type Context = Context;
     type Event = Event;
@@ -164,6 +207,7 @@ impl key::Key for BaseKey {
             BaseKey::Keyboard(key) => key::Key::new_pressed_key(key, context, key_path),
             BaseKey::LayerModifier(key) => key::Key::new_pressed_key(key, context, key_path),
             BaseKey::Callback(key) => key::Key::new_pressed_key(key, context, key_path),
+            BaseKey::CapsWord(key) => key::Key::new_pressed_key(key, context, key_path),
         }
     }
 

--- a/src/key/composite/base.rs
+++ b/src/key/composite/base.rs
@@ -81,7 +81,7 @@ impl key::Key for callback::Key {
     ) -> (PressedKeyResult, key::PressedKeyEvents<Self::Event>) {
         let &callback::Key { keymap_callback } = self;
         let pks = key::PressedKeyResult::Resolved(KeyState::NoOp);
-        let pke = key::PressedKeyEvents::event(key::Event::KeymapCallback(keymap_callback));
+        let pke = key::PressedKeyEvents::event(key::Event::Keymap(keymap_callback));
         (pks, pke)
     }
 

--- a/src/key/composite/base.rs
+++ b/src/key/composite/base.rs
@@ -81,7 +81,8 @@ impl key::Key for callback::Key {
     ) -> (PressedKeyResult, key::PressedKeyEvents<Self::Event>) {
         let &callback::Key { keymap_callback } = self;
         let pks = key::PressedKeyResult::Resolved(KeyState::NoOp);
-        let pke = key::PressedKeyEvents::event(key::Event::Keymap(keymap_callback));
+        let km_ev = crate::keymap::KeymapEvent::Callback(keymap_callback);
+        let pke = key::PressedKeyEvents::event(key::Event::Keymap(km_ev));
         (pks, pke)
     }
 

--- a/src/key/composite/base.rs
+++ b/src/key/composite/base.rs
@@ -252,6 +252,12 @@ impl From<callback::Key> for BaseKey {
     }
 }
 
+impl From<caps_word::Key> for BaseKey {
+    fn from(key: caps_word::Key) -> Self {
+        BaseKey::CapsWord(key)
+    }
+}
+
 impl BaseKey {
     /// Constructs a [BaseKey::Keyboard] from the given [keyboard::Key].
     pub const fn keyboard(key: keyboard::Key) -> Self {

--- a/src/key/composite/tap_hold.rs
+++ b/src/key/composite/tap_hold.rs
@@ -23,6 +23,7 @@ pub trait TapHoldNestable:
 
 impl TapHoldNestable for key::layered::ModifierKey {}
 impl TapHoldNestable for key::callback::Key {}
+impl TapHoldNestable for key::caps_word::Key {}
 impl TapHoldNestable for key::keyboard::Key {}
 impl TapHoldNestable for BaseKey {}
 

--- a/src/key/doc_de_caps_word.md
+++ b/src/key/doc_de_caps_word.md
@@ -1,0 +1,14 @@
+# JSON
+
+Plain key code:
+
+```rust
+use smart_keymap::key::caps_word::Key;
+let json = r#"
+  "ToggleCapsWord"
+"#;
+let expected_key: Key = Key::ToggleCapsWord;
+let actual_key: Key = serde_json::from_str(json).unwrap();
+assert_eq!(expected_key, actual_key);
+```
+

--- a/src/key/keyboard.rs
+++ b/src/key/keyboard.rs
@@ -101,4 +101,8 @@ impl key::KeyState for KeyState {
     fn key_output(&self) -> Option<key::KeyOutput> {
         Some(self.key_output())
     }
+
+    fn is_persistent(&self) -> bool {
+        false
+    }
 }

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -447,6 +447,12 @@ pub trait KeyState: Debug {
         event: Event<Self::Event>,
     ) -> PressedKeyEvents<Self::Event>;
 
+    /// Whether the key state should remain pressed after the key has been released.
+    ///
+    /// If this is true when the key is released, the key state will persist,
+    ///  and any subsequent key presses will be handled by the key state.
+    fn is_persistent(&self) -> bool;
+
     /// Output for the pressed key state.
     fn key_output(&self) -> Option<KeyOutput>;
 }

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -485,7 +485,7 @@ pub enum Event<T> {
         key_event: T,
     },
     /// Invoke a keymap callback
-    KeymapCallback(crate::keymap::KeymapCallback),
+    Keymap(crate::keymap::KeymapCallback),
 }
 
 impl<T: Copy> Event<T> {
@@ -508,7 +508,7 @@ impl<T: Copy> Event<T> {
                 key_event: f(key_event),
                 keymap_index,
             },
-            Event::KeymapCallback(cb) => Event::KeymapCallback(cb),
+            Event::Keymap(cb) => Event::Keymap(cb),
         }
     }
 
@@ -533,7 +533,7 @@ impl<T: Copy> Event<T> {
                     keymap_index,
                 })
                 .map_err(|_| EventError::UnmappableEvent),
-            Event::KeymapCallback(cb) => Ok(Event::KeymapCallback(cb)),
+            Event::Keymap(cb) => Ok(Event::Keymap(cb)),
         }
     }
 }

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -485,7 +485,7 @@ pub enum Event<T> {
         key_event: T,
     },
     /// Invoke a keymap callback
-    Keymap(crate::keymap::KeymapCallback),
+    Keymap(crate::keymap::KeymapEvent),
 }
 
 impl<T: Copy> Event<T> {

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -6,6 +6,8 @@ use crate::input;
 
 /// Keymap Callback keys
 pub mod callback;
+/// CapsWord key(s).
+pub mod caps_word;
 /// Chorded keys. (Chording functionality).
 pub mod chorded;
 /// HID Keyboard keys.

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -422,6 +422,7 @@ impl<
                 .push(input::PressedKey {
                     key_state,
                     keymap_index,
+                    key_pressed: true,
                 })
                 .unwrap();
 
@@ -519,6 +520,7 @@ impl<
                                 .push(input::PressedKey {
                                     key_state,
                                     keymap_index,
+                                    key_pressed: true,
                                 })
                                 .unwrap();
                         }
@@ -590,6 +592,7 @@ impl<
             |input::PressedKey {
                  key_state,
                  keymap_index,
+                 ..
              }| {
                 key_state
                     .handle_event(self.context, *keymap_index, ev)

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -305,6 +305,8 @@ pub enum KeymapCallback {
 pub enum KeymapEvent {
     /// Callback event (emitted by callback key).
     Callback(KeymapCallback),
+    /// A pressed key resolved to a state with this key output.
+    ResolvedKeyOutput(key::KeyOutput),
 }
 
 #[derive(Debug)]
@@ -542,6 +544,12 @@ impl<
                                     key_pressed: true,
                                 })
                                 .unwrap();
+
+                            // The resolved key state has output. Emit this as an event.
+                            if let Some(ko) = key_state.key_output() {
+                                let km_ev = KeymapEvent::ResolvedKeyOutput(ko);
+                                self.handle_event(key::Event::Keymap(km_ev));
+                            }
                         }
                         key::PressedKeyResult::Pending(key_path, pending_key_state) => {
                             self.pending_key_state = Some(PendingState {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -300,6 +300,13 @@ pub enum KeymapCallback {
     ResetToBootloader,
 }
 
+/// Events related to the keymap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeymapEvent {
+    /// Callback event (emitted by callback key).
+    Callback(KeymapCallback),
+}
+
 #[derive(Debug)]
 enum CallbackFunction {
     /// C callback
@@ -571,7 +578,7 @@ impl<
     // Called from handle_all_pending_events,
     //  and for handling the (resolving) queue of events from pending key state.
     fn handle_event(&mut self, ev: key::Event<composite::Event>) {
-        if let key::Event::Keymap(callback_id) = ev {
+        if let key::Event::Keymap(KeymapEvent::Callback(callback_id)) = ev {
             match self.callbacks.get(&callback_id) {
                 Some(CallbackFunction::Rust(callback_fn)) => {
                     callback_fn();

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -8,6 +8,8 @@ use crate::key;
 
 use key::{composite, Context, Event};
 
+use key::KeyState as _;
+
 const MAX_PENDING_EVENTS: usize = 32;
 const MAX_SCHEDULED_EVENTS: usize = 32;
 
@@ -589,8 +591,6 @@ impl<
                  key_state,
                  keymap_index,
              }| {
-                use key::KeyState as _;
-
                 key_state
                     .handle_event(self.context, *keymap_index, ev)
                     .into_iter()

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -571,7 +571,7 @@ impl<
     // Called from handle_all_pending_events,
     //  and for handling the (resolving) queue of events from pending key state.
     fn handle_event(&mut self, ev: key::Event<composite::Event>) {
-        if let key::Event::KeymapCallback(callback_id) = ev {
+        if let key::Event::Keymap(callback_id) = ev {
             match self.callbacks.get(&callback_id) {
                 Some(CallbackFunction::Rust(callback_fn)) => {
                     callback_fn();

--- a/tests/rust/caps_word.rs
+++ b/tests/rust/caps_word.rs
@@ -1,0 +1,112 @@
+use smart_keymap::input;
+use smart_keymap::key;
+use smart_keymap::keymap;
+use smart_keymap::tuples;
+
+use keymap::DistinctReports;
+use keymap::Keymap;
+
+use key::{caps_word, composite, keyboard};
+use tuples::Keys4;
+
+type Ctx = composite::Context;
+type Ev = composite::Event;
+type PKS = composite::PendingKeyState;
+type KS = composite::KeyState;
+type CK = composite::Chorded<composite::Layered<composite::TapHold<caps_word::Key>>>;
+type K = composite::Chorded<composite::Layered<composite::TapHold<keyboard::Key>>>;
+
+const KEYS: Keys4<CK, K, K, K, Ctx, Ev, PKS, KS> = tuples::Keys4::new((
+    composite::Chorded(composite::Layered(
+        composite::TapHold(caps_word::Key::new()),
+    )),
+    composite::Chorded(
+        composite::Layered(composite::TapHold(keyboard::Key::new(0x04))), // A
+    ),
+    composite::Chorded(
+        composite::Layered(composite::TapHold(keyboard::Key::new(0x05))), // B
+    ),
+    composite::Chorded(
+        composite::Layered(composite::TapHold(keyboard::Key::new(0x2C))), // Space
+    ),
+));
+
+const CONTEXT: Ctx = composite::DEFAULT_CONTEXT;
+
+#[test]
+fn tap_caps_word_shifts_keyboard_keys() {
+    // Assemble
+    let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
+
+    // Act
+    // Tap CapsWord
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    // Press "A"
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    while keymap.has_scheduled_events() {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    // Assert
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0x02, 0, 0, 0, 0, 0, 0, 0],
+        [0x02, 0, 0x04, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn tap_caps_word_spc_deactivates_caps_word() {
+    // Assemble
+    let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
+
+    // Act
+    // Tap CapsWord
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    // Tap "A"
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    // Tap "Spc"
+    keymap.handle_input(input::Event::Press { keymap_index: 3 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    keymap.handle_input(input::Event::Release { keymap_index: 3 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    // Press "A"
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    while keymap.has_scheduled_events() {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    // Assert
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0x02, 0, 0, 0, 0, 0, 0, 0],
+        [0x02, 0, 0x04, 0, 0, 0, 0, 0],
+        [0x02, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x2C, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x04, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
+}

--- a/tests/rust/keymap.rs
+++ b/tests/rust/keymap.rs
@@ -1,3 +1,4 @@
+mod caps_word;
 mod chorded;
 mod layered;
 mod tap_hold;


### PR DESCRIPTION
"Caps Word" is similar to "Caps Lock", but auto-deactivates when a non-word key is pressed. This makes it useful for typing out constants in programming languages.

This PR implements Caps Word by using a persistent key state which outputs the shift key (and deactivates when e.g. Space is pressed).

Builds upon persistent key state from #251.

There may be other ways to implement Caps Word. e.g. Maybe the keymap supports some kind of "output filtering"/"output mapping". I haven't thought about how smart-keymap might implement the fancy "magic key" or "adaptive key". -- But, in any case, it's better to have *an* implementation now, than a better implementation later.