### PR TITLE
Restore PressedInput / Virtual Keys

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -42,3 +42,20 @@ impl<Ctx, Ev, S: crate::key::KeyState<Context = Ctx, Event = Ev>> PressedKey<S> 
         self.key_state.key_output()
     }
 }
+
+/// State resulting from [Event].
+#[derive(Debug, Clone, Copy)]
+pub enum PressedInput<PK> {
+    /// Physically pressed key.
+    Key(PressedKey<PK>),
+}
+
+impl<PK> PressedInput<PK> {
+    /// Constructor for a [PressedInput::Key].
+    pub fn new_pressed_key(key_state: PK, keymap_index: u16) -> Self {
+        Self::Key(PressedKey {
+            keymap_index,
+            key_state,
+        })
+    }
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -48,6 +48,8 @@ impl<Ctx, Ev, S: crate::key::KeyState<Context = Ctx, Event = Ev>> PressedKey<S> 
 pub enum PressedInput<PK> {
     /// Physically pressed key.
     Key(PressedKey<PK>),
+    /// Virtually pressed key, and its keycode.
+    Virtual(u8),
 }
 
 impl<PK> PressedInput<PK> {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -639,6 +639,9 @@ impl<
     pub fn pressed_keys(&self) -> heapless::Vec<key::KeyOutput, { MAX_PRESSED_KEYS }> {
         let pressed_key_codes = self.pressed_inputs.iter().filter_map(|pi| match pi {
             input::PressedInput::Key(pressed_key) => pressed_key.key_output(),
+            &input::PressedInput::Virtual(key_code) => {
+                Some(key::KeyOutput::from_key_code(key_code))
+            }
         });
 
         pressed_key_codes.collect()


### PR DESCRIPTION
Reverts #252

- Virtual keys had been removed to simplify #251.

- Recall: virtual keys (key code output, not tied to a key press) had been added to implement tap-hold's 'tap' functionality. Tap-Hold's tap functionality was later reworked with `keymap::Keymap`'s pending key state functionality.

- #251 was to implement "persistent key state". "persistent" in that the key state would remain even after the key was released. -- But, I don't think this works well with 'complex' keys (keys which have pending state; e.g. tap-hold, chorded keys).

  - e.g. if caps-word were put on a chord, it would be difficult to then re-toggle the caps-word key on the chord.
    - prior to 'persistent key state', it's a valid assumption that `KeyState::handle_event`'s `keymap_index`, and `event.keymap_index` can be used to know the event is for the same key. But, with 'persistent key state', a persistent caps-word key state would receive an event "press" for the chord's passthrough key, and it would be difficult to distinguish this from a chord press. -- There might be a way to support this case with persistent key state (e.g. work with the more general 'key path' rather than 'keymap index'), but my impression is it gets very complex very quickly.

- Persistent key state would have meant 'virtual keys' are unnecessary, though: since persistent key state could imitate key code output without requiring key presses.

- But, if not implementing 'persistent key state', then virtual keys are useful for smart keys like 'macros'.