### PR TITLE
Feature Spec: Caps Word Key

### DIFF
--- a/features/keymap/key/caps_word.feature
+++ b/features/keymap/key/caps_word.feature
@@ -1,0 +1,58 @@
+Feature: Caps Word Key
+
+  The "Caps Word" key can be thought of as "Caps Lock, for a single word".
+
+  Where Caps Lock shifts all keys until it is disabled,
+   Caps Word shifts while alphabetical keys (and underscore) are typed.
+
+  A motivating use case is typing out `CONSTANTS_LIKE_THIS`,
+   automatically leaving the caps word mode when space is hit.
+
+  For examples of this key in other smart keyboard firmware, see e.g.:
+
+  - [QMK's caps word feature](https://docs.qmk.fm/#/feature_caps_word),
+
+  - [ZMK's caps word keycode](https://docs.qmk.fm/keycodes#mod-tap-keys)
+
+  Background:
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        keys = [
+          K.caps_word.toggle,
+          K.A,
+          K.B,
+          K.Space,
+        ]
+      }
+      """
+
+  Example: acts as 'tap' when tapped
+    When the keymap registers the following input
+      """
+      [
+        press K.caps_word.toggle,
+        release K.caps_word.toggle,
+        press K.A,
+        release K.A,
+        press K.Space,
+        release K.Space,
+        press K.A,
+        release K.A,
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        press (K.LeftShift),
+        press K.A,
+        release K.A,
+        release (K.LeftShift),
+        press K.Space,
+        release K.Space,
+        press K.A,
+        release K.A,
+      ]
+      """

--- a/features/scripts/generate-doc.sh
+++ b/features/scripts/generate-doc.sh
@@ -18,6 +18,7 @@ keymap_key_features=(
     "tap_hold-config-interrupt-presses"
     "tap_hold-config-interrupt-tap"
     "layered"
+    "caps_word"
 )
 
 keymap_ncl_features=(

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -251,13 +251,50 @@ impl HIDKeyboardReporter {
 
 /// For tracking distinct HID reports from the keymap.
 #[cfg(feature = "std")]
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq)]
 pub struct DistinctReports(Vec<[u8; 8]>);
 
 #[cfg(feature = "std")]
 impl Default for DistinctReports {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(feature = "std")]
+impl core::cmp::PartialEq for DistinctReports {
+    fn eq(&self, other: &Self) -> bool {
+        // First element in DistinctReports should be [0; 8].
+        if self.0[0] != other.0[0] {
+            return false;
+        }
+
+        let mut i: usize = 1;
+        let mut j: usize = 1;
+
+        let self_len = self.0.len();
+        let other_len = other.0.len();
+
+        // Compare the rest of the elements.
+        while i < self_len && j < other_len {
+            // Ignore [0; 8] elements.
+            // (The reports are distinct; so, no two elements should be equal)
+            while (i < self_len - 1) && self.0[i] == [0; 8] {
+                i += 1;
+            }
+            while (j < other_len - 1) && other.0[j] == [0; 8] {
+                j += 1;
+            }
+
+            if self.0[i] != other.0[j] {
+                return false;
+            }
+
+            i += 1;
+            j += 1;
+        }
+
+        return i == self_len && j == other_len;
     }
 }
 

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -21,7 +21,7 @@ type Keymap = keymap::Keymap<Vec<Key>>;
 /// Keymap with basic keycodes, useful for the "check report equivalences" step.
 const TEST_KEYMAP_NCL: &str = r#"
   let K = import "keys.ncl" in
-  { keys = [ K.A, K.B, K.C, K.LeftCtrl ] }
+  { keys = [ K.A, K.B, K.C, K.Space, K.Backspace, K.LeftShift, K.LeftCtrl ] }
 "#;
 
 #[derive(Debug)]


### PR DESCRIPTION
This PR adds a Cucumber spec for the Caps Word key.

- The test keymap used by cucumber for "report equivalent to" needed some extra keys.
- The distinct-reports `==` has been relaxed so as to ignore `[0; 8]` values (other than at the start, end of the DistinctReports value).