### PR TITLE
Virtual Keys use key::KeyOutput

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -18,12 +18,12 @@ pub enum Event {
     /// A virtual key press for a given `key_code`.
     VirtualKeyPress {
         /// The virtual key code.
-        key_code: u8,
+        key_output: key::KeyOutput,
     },
     /// A virtual key release for a given `key_code`.
     VirtualKeyRelease {
         /// The virtual key code.
-        key_code: u8,
+        key_output: key::KeyOutput,
     },
 }
 
@@ -59,7 +59,7 @@ pub enum PressedInput<PK> {
     /// Physically pressed key.
     Key(PressedKey<PK>),
     /// Virtually pressed key, and its keycode.
-    Virtual(u8),
+    Virtual(key::KeyOutput),
 }
 
 impl<PK> PressedInput<PK> {

--- a/src/key/caps_word.rs
+++ b/src/key/caps_word.rs
@@ -54,7 +54,10 @@ impl Context {
                 if exit_caps_word {
                     self.is_active = false;
 
-                    let vk_ev = input::Event::VirtualKeyRelease { key_code: 0xE1 };
+                    let key_code = 0xE1;
+                    let vk_ev = input::Event::VirtualKeyRelease {
+                        key_output: key::KeyOutput::from_key_code(key_code),
+                    };
                     key::PressedKeyEvents::event(key::Event::Input(vk_ev))
                 } else {
                     key::PressedKeyEvents::no_events()
@@ -66,13 +69,19 @@ impl Context {
                         Event::EnableCapsWord => {
                             self.is_active = true;
 
-                            let vk_ev = input::Event::VirtualKeyPress { key_code: 0xE1 };
+                            let key_code = 0xE1;
+                            let vk_ev = input::Event::VirtualKeyPress {
+                                key_output: key::KeyOutput::from_key_code(key_code),
+                            };
                             key::PressedKeyEvents::event(key::Event::Input(vk_ev))
                         }
                         Event::DisableCapsWord => {
                             self.is_active = false;
 
-                            let vk_ev = input::Event::VirtualKeyRelease { key_code: 0xE1 };
+                            let key_code = 0xE1;
+                            let vk_ev = input::Event::VirtualKeyRelease {
+                                key_output: key::KeyOutput::from_key_code(key_code),
+                            };
                             key::PressedKeyEvents::event(key::Event::Input(vk_ev))
                         }
                     }

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -1,6 +1,6 @@
 use core::fmt::Debug;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::input;
 
@@ -185,7 +185,7 @@ pub trait Context: Clone + Copy {
 }
 
 /// Bool flags for each of the modifier keys (left ctrl, etc.).
-#[derive(Deserialize, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Default, Clone, Copy, PartialEq, Eq)]
 pub struct KeyboardModifiers {
     #[serde(default)]
     left_ctrl: bool,
@@ -376,7 +376,7 @@ impl KeyboardModifiers {
 }
 
 /// Struct for the output from [KeyState].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct KeyOutput {
     key_code: u8,
     key_modifiers: KeyboardModifiers,

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -596,16 +596,16 @@ impl<
                         .cancel_events_for_keymap_index(keymap_index);
                 }
 
-                input::Event::VirtualKeyPress { key_code } => {
-                    let pressed_key = input::PressedInput::Virtual(key_code);
+                input::Event::VirtualKeyPress { key_output } => {
+                    let pressed_key = input::PressedInput::Virtual(key_output);
                     self.pressed_inputs.push(pressed_key).unwrap();
                 }
-                input::Event::VirtualKeyRelease { key_code } => {
+                input::Event::VirtualKeyRelease { key_output } => {
                     // Remove from pressed keys.
                     self.pressed_inputs
                         .iter()
                         .position(|k| match k {
-                            input::PressedInput::Virtual(kc) => key_code == *kc,
+                            input::PressedInput::Virtual(ko) => key_output == *ko,
                             _ => false,
                         })
                         .map(|i| self.pressed_inputs.remove(i));
@@ -704,9 +704,7 @@ impl<
     pub fn pressed_keys(&self) -> heapless::Vec<key::KeyOutput, { MAX_PRESSED_KEYS }> {
         let pressed_key_codes = self.pressed_inputs.iter().filter_map(|pi| match pi {
             input::PressedInput::Key(pressed_key) => pressed_key.key_output(),
-            &input::PressedInput::Virtual(key_code) => {
-                Some(key::KeyOutput::from_key_code(key_code))
-            }
+            &input::PressedInput::Virtual(key_output) => Some(key_output),
         });
 
         pressed_key_codes.collect()


### PR DESCRIPTION
Virtual Keys were initially implemented with just `u8` as the virtual key code.

This PR updates them to take in a `key::KeyOutput` value.

The motivation for this is so that Sticky keys will be able to use virtual keys, with more than one modifier key. (This is simpler than having sticky keys manage/emit multiple virtual key events).