### PR TITLE
ncl: keymap-codegen: splat with the default config

### DIFF
--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -1131,6 +1131,7 @@ pub mod init {
     pub const CONFIG: crate::key::composite::Config = crate::key::composite::Config {
         chorded: %{chorded_config_expr},
         tap_hold: %{tap_hold_config_expr},
+        ..crate::key::composite::DEFAULT_CONFIG
     };
 
     /// Number of layers supported by the [crate::key::layered] implementation.

--- a/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
+++ b/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
@@ -10,6 +10,7 @@ pub mod init {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,
         },
+        ..crate::key::composite::DEFAULT_CONFIG
     };
 
     /// Number of layers supported by the [crate::key::layered] implementation.

--- a/tests/ncl/keymap-1key-simple/expected.rs
+++ b/tests/ncl/keymap-1key-simple/expected.rs
@@ -10,6 +10,7 @@ pub mod init {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,
         },
+        ..crate::key::composite::DEFAULT_CONFIG
     };
 
     /// Number of layers supported by the [crate::key::layered] implementation.

--- a/tests/ncl/keymap-1key-tap_hold/expected.rs
+++ b/tests/ncl/keymap-1key-tap_hold/expected.rs
@@ -10,6 +10,7 @@ pub mod init {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,
         },
+        ..crate::key::composite::DEFAULT_CONFIG
     };
 
     /// Number of layers supported by the [crate::key::layered] implementation.

--- a/tests/ncl/keymap-2key-2layer-composite/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-composite/expected.rs
@@ -10,6 +10,7 @@ pub mod init {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,
         },
+        ..crate::key::composite::DEFAULT_CONFIG
     };
 
     /// Number of layers supported by the [crate::key::layered] implementation.

--- a/tests/ncl/keymap-2key-2layer-simple/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-simple/expected.rs
@@ -10,6 +10,7 @@ pub mod init {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,
         },
+        ..crate::key::composite::DEFAULT_CONFIG
     };
 
     /// Number of layers supported by the [crate::key::layered] implementation.

--- a/tests/ncl/keymap-2key-chorded/expected.rs
+++ b/tests/ncl/keymap-2key-chorded/expected.rs
@@ -10,6 +10,7 @@ pub mod init {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,
         },
+        ..crate::key::composite::DEFAULT_CONFIG
     };
 
     /// Number of layers supported by the [crate::key::layered] implementation.

--- a/tests/ncl/keymap-48key-basic/expected.rs
+++ b/tests/ncl/keymap-48key-basic/expected.rs
@@ -10,6 +10,7 @@ pub mod init {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,
         },
+        ..crate::key::composite::DEFAULT_CONFIG
     };
 
     /// Number of layers supported by the [crate::key::layered] implementation.

--- a/tests/ncl/keymap-48key-rgoulter/expected.rs
+++ b/tests/ncl/keymap-48key-rgoulter/expected.rs
@@ -10,6 +10,7 @@ pub mod init {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::HoldOnKeyTap,
         },
+        ..crate::key::composite::DEFAULT_CONFIG
     };
 
     /// Number of layers supported by the [crate::key::layered] implementation.

--- a/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
@@ -10,6 +10,7 @@ pub mod init {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,
         },
+        ..crate::key::composite::DEFAULT_CONFIG
     };
 
     /// Number of layers supported by the [crate::key::layered] implementation.

--- a/tests/ncl/keymap-60key-dvorak-simple/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple/expected.rs
@@ -10,6 +10,7 @@ pub mod init {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,
         },
+        ..crate::key::composite::DEFAULT_CONFIG
     };
 
     /// Number of layers supported by the [crate::key::layered] implementation.


### PR DESCRIPTION
Adding this to the codegen means that `key::composite::Context` (and hence, `DEFAULT_CONTEXT`) can have fields added without needing to update the codegen. -- This makes it easier to make incremental changes to the code.

"Struct literal update syntax" https://doc.rust-lang.org/book/appendix-02-operators.html