### PR TITLE
rust: rename key::PressedKeyEvents to key::KeyEvents

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -42,7 +42,7 @@ impl<Ctx, Ev, S: crate::key::KeyState<Context = Ctx, Event = Ev>> PressedKey<S> 
         &mut self,
         context: Ctx,
         event: crate::key::Event<Ev>,
-    ) -> crate::key::PressedKeyEvents<Ev> {
+    ) -> crate::key::KeyEvents<Ev> {
         self.key_state
             .handle_event(context, self.keymap_index, event)
     }

--- a/src/key.rs
+++ b/src/key.rs
@@ -31,43 +31,41 @@ pub type KeyPath = heapless::Vec<u16, MAX_KEY_PATH_LEN>;
 
 /// Events emitted when a [Key] is pressed.
 #[derive(Debug, PartialEq, Eq)]
-pub struct PressedKeyEvents<E, const M: usize = { MAX_KEY_EVENTS }>(
-    heapless::Vec<ScheduledEvent<E>, M>,
-);
+pub struct KeyEvents<E, const M: usize = { MAX_KEY_EVENTS }>(heapless::Vec<ScheduledEvent<E>, M>);
 
-impl<E: Copy + Debug> PressedKeyEvents<E> {
-    /// Constructs a [PressedKeyEvents] with no events scheduled.
+impl<E: Copy + Debug> KeyEvents<E> {
+    /// Constructs a [KeyEvents] with no events scheduled.
     pub fn no_events() -> Self {
-        PressedKeyEvents(None.into_iter().collect())
+        KeyEvents(None.into_iter().collect())
     }
 
-    /// Constructs a [PressedKeyEvents] with an immediate [Event].
+    /// Constructs a [KeyEvents] with an immediate [Event].
     pub fn event(event: Event<E>) -> Self {
-        PressedKeyEvents(Some(ScheduledEvent::immediate(event)).into_iter().collect())
+        KeyEvents(Some(ScheduledEvent::immediate(event)).into_iter().collect())
     }
 
-    /// Constructs a [PressedKeyEvents] with an [Event] scheduled after a delay.
+    /// Constructs a [KeyEvents] with an [Event] scheduled after a delay.
     pub fn scheduled_event(sch_event: ScheduledEvent<E>) -> Self {
-        PressedKeyEvents(Some(sch_event).into_iter().collect())
+        KeyEvents(Some(sch_event).into_iter().collect())
     }
 
-    /// Adds an event with the schedule to the [PressedKeyEvents].
+    /// Adds an event with the schedule to the [KeyEvents].
     pub fn schedule_event(&mut self, delay: u16, event: Event<E>) {
         self.0.push(ScheduledEvent::after(delay, event)).unwrap();
     }
 
-    /// Adds events from the other [PressedKeyEvents] to the [PressedKeyEvents].
-    pub fn extend(&mut self, other: PressedKeyEvents<E>) {
+    /// Adds events from the other [KeyEvents] to the [KeyEvents].
+    pub fn extend(&mut self, other: KeyEvents<E>) {
         other.0.into_iter().for_each(|ev| self.0.push(ev).unwrap());
     }
 
-    /// Adds an event from to the [PressedKeyEvents].
+    /// Adds an event from to the [KeyEvents].
     pub fn add_event(&mut self, ev: ScheduledEvent<E>) {
         self.0.push(ev).unwrap();
     }
 }
 
-impl<E: Debug, const M: usize> IntoIterator for PressedKeyEvents<E, M> {
+impl<E: Debug, const M: usize> IntoIterator for KeyEvents<E, M> {
     type Item = ScheduledEvent<E>;
     type IntoIter = <heapless::Vec<ScheduledEvent<E>, M> as IntoIterator>::IntoIter;
 
@@ -148,7 +146,7 @@ pub trait Key: Debug {
         key_path: KeyPath,
     ) -> (
         PressedKeyResult<Self::PendingKeyState, Self::KeyState>,
-        PressedKeyEvents<Self::Event>,
+        KeyEvents<Self::Event>,
     );
 
     /// Update the given pending key state with the given impl.
@@ -158,7 +156,7 @@ pub trait Key: Debug {
         context: Self::Context,
         key_path: KeyPath,
         event: Event<Self::Event>,
-    ) -> (Option<Self::KeyState>, PressedKeyEvents<Self::Event>);
+    ) -> (Option<Self::KeyState>, KeyEvents<Self::Event>);
 
     /// Return a reference to the key for the given path.
     fn lookup(
@@ -181,7 +179,7 @@ pub trait Context: Clone + Copy {
     type Event;
 
     /// Used to update the [Context]'s state.
-    fn handle_event(&mut self, event: Event<Self::Event>) -> PressedKeyEvents<Self::Event>;
+    fn handle_event(&mut self, event: Event<Self::Event>) -> KeyEvents<Self::Event>;
 }
 
 /// Bool flags for each of the modifier keys (left ctrl, etc.).
@@ -442,7 +440,7 @@ pub trait KeyState: Debug {
         context: Self::Context,
         keymap_index: u16,
         event: Event<Self::Event>,
-    ) -> PressedKeyEvents<Self::Event>;
+    ) -> KeyEvents<Self::Event>;
 
     /// Output for the pressed key state.
     fn key_output(&self) -> Option<KeyOutput>;

--- a/src/key/caps_word.rs
+++ b/src/key/caps_word.rs
@@ -18,7 +18,7 @@ pub const DEFAULT_CONTEXT: Context = Context { is_active: false };
 
 impl Context {
     /// Updates the context with the [LayerEvent].
-    pub fn handle_event<E>(&mut self, event: key::Event<E>) -> key::PressedKeyEvents<E>
+    pub fn handle_event<E>(&mut self, event: key::Event<E>) -> key::KeyEvents<E>
     where
         Event: TryFrom<E>,
         E: core::fmt::Debug + core::marker::Copy,
@@ -58,9 +58,9 @@ impl Context {
                     let vk_ev = input::Event::VirtualKeyRelease {
                         key_output: key::KeyOutput::from_key_code(key_code),
                     };
-                    key::PressedKeyEvents::event(key::Event::Input(vk_ev))
+                    key::KeyEvents::event(key::Event::Input(vk_ev))
                 } else {
-                    key::PressedKeyEvents::no_events()
+                    key::KeyEvents::no_events()
                 }
             }
             key::Event::Key { key_event, .. } => {
@@ -73,7 +73,7 @@ impl Context {
                             let vk_ev = input::Event::VirtualKeyPress {
                                 key_output: key::KeyOutput::from_key_code(key_code),
                             };
-                            key::PressedKeyEvents::event(key::Event::Input(vk_ev))
+                            key::KeyEvents::event(key::Event::Input(vk_ev))
                         }
                         Event::DisableCapsWord => {
                             self.is_active = false;
@@ -82,14 +82,14 @@ impl Context {
                             let vk_ev = input::Event::VirtualKeyRelease {
                                 key_output: key::KeyOutput::from_key_code(key_code),
                             };
-                            key::PressedKeyEvents::event(key::Event::Input(vk_ev))
+                            key::KeyEvents::event(key::Event::Input(vk_ev))
                         }
                     }
                 } else {
-                    key::PressedKeyEvents::no_events()
+                    key::KeyEvents::no_events()
                 }
             }
-            _ => key::PressedKeyEvents::no_events(),
+            _ => key::KeyEvents::no_events(),
         }
     }
 }
@@ -117,11 +117,7 @@ impl Key {
     }
 
     /// Constructs a pressed key state
-    pub fn new_pressed_key<E>(
-        &self,
-        context: Context,
-        keymap_index: u16,
-    ) -> key::PressedKeyEvents<E>
+    pub fn new_pressed_key<E>(&self, context: Context, keymap_index: u16) -> key::KeyEvents<E>
     where
         Event: Into<E>,
         E: core::fmt::Debug + core::marker::Copy,
@@ -135,8 +131,7 @@ impl Key {
                 }
             }
         };
-        let pke =
-            key::PressedKeyEvents::event(key::Event::key_event(keymap_index, key_event.into()));
+        let pke = key::KeyEvents::event(key::Event::key_event(keymap_index, key_event.into()));
         pke
     }
 }

--- a/src/key/chorded.rs
+++ b/src/key/chorded.rs
@@ -240,7 +240,7 @@ impl<K: key::composite::ChordedNestable> Key<K> {
         key_path: key::KeyPath,
     ) -> (
         key::PressedKeyResult<K::PendingKeyState, K::KeyState>,
-        key::PressedKeyEvents<K::Event>,
+        key::KeyEvents<K::Event>,
     ) {
         let keymap_index: u16 = key_path[0];
         let pks = PendingKeyState::new(context.into(), keymap_index);
@@ -268,7 +268,7 @@ impl<K: key::composite::ChordedNestable> Key<K> {
                 ctx.config.timeout,
                 key::Event::key_event(keymap_index, timeout_ev),
             );
-            let pke = key::PressedKeyEvents::scheduled_event(sch_ev.into_scheduled_event());
+            let pke = key::KeyEvents::scheduled_event(sch_ev.into_scheduled_event());
 
             (pk, pke)
         }
@@ -312,7 +312,7 @@ impl<K: key::composite::ChordedNestable> AuxiliaryKey<K> {
         key_path: key::KeyPath,
     ) -> (
         key::PressedKeyResult<K::PendingKeyState, K::KeyState>,
-        key::PressedKeyEvents<K::Event>,
+        key::KeyEvents<K::Event>,
     ) {
         let keymap_index: u16 = key_path[0];
         let pks = PendingKeyState::new(context.into(), keymap_index);
@@ -323,7 +323,7 @@ impl<K: key::composite::ChordedNestable> AuxiliaryKey<K> {
             match resolution {
                 ChordResolution::Chord => {
                     let pk = key::PressedKeyResult::Resolved(key::composite::KeyState::NoOp);
-                    let pke = key::PressedKeyEvents::no_events();
+                    let pke = key::KeyEvents::no_events();
 
                     (pk, pke)
                 }
@@ -342,7 +342,7 @@ impl<K: key::composite::ChordedNestable> AuxiliaryKey<K> {
                 ctx.config.timeout,
                 key::Event::key_event(keymap_index, timeout_ev),
             );
-            let pke = key::PressedKeyEvents::scheduled_event(sch_ev.into_scheduled_event());
+            let pke = key::KeyEvents::scheduled_event(sch_ev.into_scheduled_event());
 
             (pk, pke)
         }

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -98,11 +98,8 @@ impl Default for Context {
 
 impl key::Context for Context {
     type Event = Event;
-    fn handle_event(
-        &mut self,
-        event: key::Event<Self::Event>,
-    ) -> key::PressedKeyEvents<Self::Event> {
-        let mut pke = key::PressedKeyEvents::no_events();
+    fn handle_event(&mut self, event: key::Event<Self::Event>) -> key::KeyEvents<Self::Event> {
+        let mut pke = key::KeyEvents::no_events();
 
         let caps_word_ev = self.caps_word_context.handle_event(event);
         pke.extend(caps_word_ev);
@@ -274,23 +271,23 @@ impl key::KeyState for KeyState {
         _context: Self::Context,
         keymap_index: u16,
         event: key::Event<Self::Event>,
-    ) -> key::PressedKeyEvents<Self::Event> {
+    ) -> key::KeyEvents<Self::Event> {
         match self {
-            KeyState::Keyboard(_) => key::PressedKeyEvents::no_events(),
+            KeyState::Keyboard(_) => key::KeyEvents::no_events(),
             KeyState::LayerModifier(ks) => {
                 if let Ok(ev) = event.try_into_key_event(|e| e.try_into()) {
                     let l_ev = ks.handle_event(keymap_index, ev);
                     if let Some(l_ev) = l_ev {
                         let c_ev = Event::LayerModification(l_ev);
-                        key::PressedKeyEvents::event(key::Event::key_event(keymap_index, c_ev))
+                        key::KeyEvents::event(key::Event::key_event(keymap_index, c_ev))
                     } else {
-                        key::PressedKeyEvents::no_events()
+                        key::KeyEvents::no_events()
                     }
                 } else {
-                    key::PressedKeyEvents::no_events()
+                    key::KeyEvents::no_events()
                 }
             }
-            KeyState::NoOp => key::PressedKeyEvents::no_events(),
+            KeyState::NoOp => key::KeyEvents::no_events(),
         }
     }
 

--- a/src/key/composite/base.rs
+++ b/src/key/composite/base.rs
@@ -37,11 +37,11 @@ impl key::Key for layered::ModifierKey {
         &self,
         _context: Self::Context,
         key_path: key::KeyPath,
-    ) -> (PressedKeyResult, key::PressedKeyEvents<Self::Event>) {
+    ) -> (PressedKeyResult, key::KeyEvents<Self::Event>) {
         let keymap_index: u16 = key_path[0];
         let (m_ks, lmod_ev) = self.new_pressed_key();
         let pks = key::PressedKeyResult::Resolved(KeyState::LayerModifier(m_ks));
-        let pke = key::PressedKeyEvents::event(key::Event::key_event(
+        let pke = key::KeyEvents::event(key::Event::key_event(
             keymap_index,
             Event::LayerModification(lmod_ev),
         ));
@@ -54,7 +54,7 @@ impl key::Key for layered::ModifierKey {
         _context: Self::Context,
         _key_path: key::KeyPath,
         _event: key::Event<Self::Event>,
-    ) -> (Option<Self::KeyState>, key::PressedKeyEvents<Self::Event>) {
+    ) -> (Option<Self::KeyState>, key::KeyEvents<Self::Event>) {
         panic!()
     }
 
@@ -81,11 +81,11 @@ impl key::Key for callback::Key {
         &self,
         _context: Self::Context,
         _key_path: key::KeyPath,
-    ) -> (PressedKeyResult, key::PressedKeyEvents<Self::Event>) {
+    ) -> (PressedKeyResult, key::KeyEvents<Self::Event>) {
         let &callback::Key { keymap_callback } = self;
         let pks = key::PressedKeyResult::Resolved(KeyState::NoOp);
         let km_ev = crate::keymap::KeymapEvent::Callback(keymap_callback);
-        let pke = key::PressedKeyEvents::event(key::Event::Keymap(km_ev));
+        let pke = key::KeyEvents::event(key::Event::Keymap(km_ev));
         (pks, pke)
     }
 
@@ -95,7 +95,7 @@ impl key::Key for callback::Key {
         _context: Self::Context,
         _key_path: key::KeyPath,
         _event: key::Event<Self::Event>,
-    ) -> (Option<Self::KeyState>, key::PressedKeyEvents<Self::Event>) {
+    ) -> (Option<Self::KeyState>, key::KeyEvents<Self::Event>) {
         panic!()
     }
 
@@ -122,7 +122,7 @@ impl key::Key for caps_word::Key {
         &self,
         context: Self::Context,
         key_path: key::KeyPath,
-    ) -> (PressedKeyResult, key::PressedKeyEvents<Self::Event>) {
+    ) -> (PressedKeyResult, key::KeyEvents<Self::Event>) {
         let caps_word_context = context.into();
         let keymap_index: u16 = key_path[0];
         let pke = self.new_pressed_key(caps_word_context, keymap_index);
@@ -136,7 +136,7 @@ impl key::Key for caps_word::Key {
         _context: Self::Context,
         _key_path: key::KeyPath,
         _event: key::Event<Self::Event>,
-    ) -> (Option<Self::KeyState>, key::PressedKeyEvents<Self::Event>) {
+    ) -> (Option<Self::KeyState>, key::KeyEvents<Self::Event>) {
         panic!()
     }
 
@@ -163,10 +163,10 @@ impl key::Key for keyboard::Key {
         &self,
         _context: Self::Context,
         _key_path: key::KeyPath,
-    ) -> (PressedKeyResult, key::PressedKeyEvents<Self::Event>) {
+    ) -> (PressedKeyResult, key::KeyEvents<Self::Event>) {
         let k_ks = self.new_pressed_key();
         let pks = key::PressedKeyResult::Resolved(KeyState::Keyboard(k_ks));
-        let pke = key::PressedKeyEvents::no_events();
+        let pke = key::KeyEvents::no_events();
         (pks, pke)
     }
 
@@ -176,7 +176,7 @@ impl key::Key for keyboard::Key {
         _context: Self::Context,
         _key_path: key::KeyPath,
         _event: key::Event<Self::Event>,
-    ) -> (Option<Self::KeyState>, key::PressedKeyEvents<Self::Event>) {
+    ) -> (Option<Self::KeyState>, key::KeyEvents<Self::Event>) {
         panic!()
     }
 
@@ -203,7 +203,7 @@ impl key::Key for BaseKey {
         &self,
         context: Self::Context,
         key_path: key::KeyPath,
-    ) -> (PressedKeyResult, key::PressedKeyEvents<Self::Event>) {
+    ) -> (PressedKeyResult, key::KeyEvents<Self::Event>) {
         match self {
             BaseKey::Keyboard(key) => key::Key::new_pressed_key(key, context, key_path),
             BaseKey::LayerModifier(key) => key::Key::new_pressed_key(key, context, key_path),
@@ -218,7 +218,7 @@ impl key::Key for BaseKey {
         _context: Self::Context,
         _key_path: key::KeyPath,
         _event: key::Event<Self::Event>,
-    ) -> (Option<Self::KeyState>, key::PressedKeyEvents<Self::Event>) {
+    ) -> (Option<Self::KeyState>, key::KeyEvents<Self::Event>) {
         panic!()
     }
 

--- a/src/key/composite/chorded.rs
+++ b/src/key/composite/chorded.rs
@@ -52,7 +52,7 @@ impl<K: ChordedNestable> key::Key for key::chorded::Key<K> {
         &self,
         context: Self::Context,
         key_path: key::KeyPath,
-    ) -> (PressedKeyResult, key::PressedKeyEvents<Self::Event>) {
+    ) -> (PressedKeyResult, key::KeyEvents<Self::Event>) {
         self.new_pressed_key(context, key_path)
     }
 
@@ -62,7 +62,7 @@ impl<K: ChordedNestable> key::Key for key::chorded::Key<K> {
         context: Self::Context,
         key_path: key::KeyPath,
         event: key::Event<Self::Event>,
-    ) -> (Option<Self::KeyState>, key::PressedKeyEvents<Self::Event>) {
+    ) -> (Option<Self::KeyState>, key::KeyEvents<Self::Event>) {
         let keymap_index: u16 = key_path[0];
         match pending_state {
             PendingKeyState::Chorded(ch_pks) => {
@@ -94,13 +94,13 @@ impl<K: ChordedNestable> key::Key for key::chorded::Key<K> {
 
                         (Some(ks), pke)
                     } else {
-                        (None, key::PressedKeyEvents::no_events())
+                        (None, key::KeyEvents::no_events())
                     }
                 } else {
-                    (None, key::PressedKeyEvents::no_events())
+                    (None, key::KeyEvents::no_events())
                 }
             }
-            _ => (None, key::PressedKeyEvents::no_events()),
+            _ => (None, key::KeyEvents::no_events()),
         }
     }
 
@@ -133,7 +133,7 @@ impl<K: ChordedNestable> key::Key for key::chorded::AuxiliaryKey<K> {
         &self,
         context: Self::Context,
         key_path: key::KeyPath,
-    ) -> (PressedKeyResult, key::PressedKeyEvents<Self::Event>) {
+    ) -> (PressedKeyResult, key::KeyEvents<Self::Event>) {
         self.new_pressed_key(context, key_path)
     }
 
@@ -143,7 +143,7 @@ impl<K: ChordedNestable> key::Key for key::chorded::AuxiliaryKey<K> {
         context: Self::Context,
         key_path: key::KeyPath,
         event: key::Event<Self::Event>,
-    ) -> (Option<Self::KeyState>, key::PressedKeyEvents<Self::Event>) {
+    ) -> (Option<Self::KeyState>, key::KeyEvents<Self::Event>) {
         let keymap_index = key_path[0];
         match pending_state {
             PendingKeyState::Chorded(ch_pks) => {
@@ -171,20 +171,20 @@ impl<K: ChordedNestable> key::Key for key::chorded::AuxiliaryKey<K> {
                         (Some(ks), pke)
                     } else if let Some(key::chorded::ChordResolution::Chord) = ch_state {
                         let ch_r_ev = key::chorded::Event::ChordResolved(true);
-                        let pke = key::PressedKeyEvents::event(key::Event::key_event(
+                        let pke = key::KeyEvents::event(key::Event::key_event(
                             keymap_index,
                             ch_r_ev.into(),
                         ));
 
                         (Some(KeyState::NoOp), pke)
                     } else {
-                        (None, key::PressedKeyEvents::no_events())
+                        (None, key::KeyEvents::no_events())
                     }
                 } else {
-                    (None, key::PressedKeyEvents::no_events())
+                    (None, key::KeyEvents::no_events())
                 }
             }
-            _ => (None, key::PressedKeyEvents::no_events()),
+            _ => (None, key::KeyEvents::no_events()),
         }
     }
 
@@ -214,7 +214,7 @@ impl<K: ChordedNestable> key::Key for ChordedKey<K> {
         &self,
         context: Self::Context,
         key_path: key::KeyPath,
-    ) -> (PressedKeyResult, key::PressedKeyEvents<Self::Event>) {
+    ) -> (PressedKeyResult, key::KeyEvents<Self::Event>) {
         match self {
             ChordedKey::Chorded(key) => key.new_pressed_key(context, key_path),
             ChordedKey::Auxiliary(key) => key.new_pressed_key(context, key_path),
@@ -228,7 +228,7 @@ impl<K: ChordedNestable> key::Key for ChordedKey<K> {
         context: Self::Context,
         key_path: key::KeyPath,
         event: key::Event<Self::Event>,
-    ) -> (Option<Self::KeyState>, key::PressedKeyEvents<Self::Event>) {
+    ) -> (Option<Self::KeyState>, key::KeyEvents<Self::Event>) {
         match self {
             ChordedKey::Chorded(key) => key.handle_event(pending_state, context, key_path, event),
             ChordedKey::Auxiliary(key) => key.handle_event(pending_state, context, key_path, event),
@@ -263,7 +263,7 @@ impl<K: ChordedNestable> key::Key for Chorded<K> {
         &self,
         context: Self::Context,
         key_path: key::KeyPath,
-    ) -> (PressedKeyResult, key::PressedKeyEvents<Self::Event>) {
+    ) -> (PressedKeyResult, key::KeyEvents<Self::Event>) {
         let Chorded(key) = self;
         key.new_pressed_key(context, key_path)
     }
@@ -274,7 +274,7 @@ impl<K: ChordedNestable> key::Key for Chorded<K> {
         context: Self::Context,
         key_path: key::KeyPath,
         event: key::Event<Self::Event>,
-    ) -> (Option<Self::KeyState>, key::PressedKeyEvents<Self::Event>) {
+    ) -> (Option<Self::KeyState>, key::KeyEvents<Self::Event>) {
         let Chorded(key) = self;
         key.handle_event(pending_state, context, key_path, event)
     }

--- a/src/key/composite/layered.rs
+++ b/src/key/composite/layered.rs
@@ -49,7 +49,7 @@ impl<K: LayeredNestable> key::Key for LayeredKey<K> {
         &self,
         context: Self::Context,
         key_path: key::KeyPath,
-    ) -> (PressedKeyResult, key::PressedKeyEvents<Self::Event>) {
+    ) -> (PressedKeyResult, key::KeyEvents<Self::Event>) {
         match self {
             LayeredKey::Layered(key) => key.new_pressed_key(context, key_path),
             LayeredKey::Pass(key) => key.new_pressed_key(context, key_path),
@@ -62,7 +62,7 @@ impl<K: LayeredNestable> key::Key for LayeredKey<K> {
         context: Self::Context,
         key_path: key::KeyPath,
         event: key::Event<Self::Event>,
-    ) -> (Option<Self::KeyState>, key::PressedKeyEvents<Self::Event>) {
+    ) -> (Option<Self::KeyState>, key::KeyEvents<Self::Event>) {
         match self {
             LayeredKey::Layered(_) => panic!(),
             LayeredKey::Pass(key) => key.handle_event(pending_state, context, key_path, event),
@@ -102,7 +102,7 @@ impl<K: LayeredNestable> key::Key for Layered<K> {
         &self,
         context: Self::Context,
         key_path: key::KeyPath,
-    ) -> (PressedKeyResult, key::PressedKeyEvents<Self::Event>) {
+    ) -> (PressedKeyResult, key::KeyEvents<Self::Event>) {
         let Layered(key) = self;
         key.new_pressed_key(context, key_path)
     }
@@ -113,7 +113,7 @@ impl<K: LayeredNestable> key::Key for Layered<K> {
         context: Self::Context,
         key_path: key::KeyPath,
         event: key::Event<Self::Event>,
-    ) -> (Option<Self::KeyState>, key::PressedKeyEvents<Self::Event>) {
+    ) -> (Option<Self::KeyState>, key::KeyEvents<Self::Event>) {
         let Layered(key) = self;
         key.handle_event(pending_state, context, key_path, event)
     }

--- a/src/key/composite/tap_hold.rs
+++ b/src/key/composite/tap_hold.rs
@@ -52,10 +52,10 @@ impl<K: TapHoldNestable> key::Key for key::tap_hold::Key<K> {
         &self,
         context: Self::Context,
         key_path: key::KeyPath,
-    ) -> (PressedKeyResult, key::PressedKeyEvents<Self::Event>) {
+    ) -> (PressedKeyResult, key::KeyEvents<Self::Event>) {
         let (th_pks, sch_ev) = self.new_pressed_key(context.into(), key_path.clone());
         let pk = key::PressedKeyResult::Pending(key_path, PendingKeyState::TapHold(th_pks));
-        let pke = key::PressedKeyEvents::scheduled_event(sch_ev.into_scheduled_event());
+        let pke = key::KeyEvents::scheduled_event(sch_ev.into_scheduled_event());
         (pk, pke)
     }
 
@@ -65,7 +65,7 @@ impl<K: TapHoldNestable> key::Key for key::tap_hold::Key<K> {
         context: Self::Context,
         key_path: key::KeyPath,
         event: key::Event<Self::Event>,
-    ) -> (Option<Self::KeyState>, key::PressedKeyEvents<Self::Event>) {
+    ) -> (Option<Self::KeyState>, key::KeyEvents<Self::Event>) {
         let keymap_index = key_path[0];
         match pending_state {
             PendingKeyState::TapHold(th_pks) => {
@@ -88,13 +88,13 @@ impl<K: TapHoldNestable> key::Key for key::tap_hold::Key<K> {
 
                         (Some(ks), pke)
                     } else {
-                        (None, key::PressedKeyEvents::no_events())
+                        (None, key::KeyEvents::no_events())
                     }
                 } else {
-                    (None, key::PressedKeyEvents::no_events())
+                    (None, key::KeyEvents::no_events())
                 }
             }
-            _ => (None, key::PressedKeyEvents::no_events()),
+            _ => (None, key::KeyEvents::no_events()),
         }
     }
 
@@ -127,7 +127,7 @@ impl<K: TapHoldNestable> key::Key for TapHoldKey<K> {
         &self,
         context: Self::Context,
         key_path: key::KeyPath,
-    ) -> (PressedKeyResult, key::PressedKeyEvents<Self::Event>) {
+    ) -> (PressedKeyResult, key::KeyEvents<Self::Event>) {
         match self {
             TapHoldKey::TapHold(key) => {
                 <key::tap_hold::Key<K> as key::Key>::new_pressed_key(key, context, key_path)
@@ -142,7 +142,7 @@ impl<K: TapHoldNestable> key::Key for TapHoldKey<K> {
         context: Self::Context,
         key_path: key::KeyPath,
         event: key::Event<Self::Event>,
-    ) -> (Option<Self::KeyState>, key::PressedKeyEvents<Self::Event>) {
+    ) -> (Option<Self::KeyState>, key::KeyEvents<Self::Event>) {
         match self {
             TapHoldKey::TapHold(key) => key.handle_event(pending_state, context, key_path, event),
             TapHoldKey::Pass(key) => key.handle_event(pending_state, context, key_path, event),
@@ -175,7 +175,7 @@ impl<K: TapHoldNestable> key::Key for TapHold<K> {
         &self,
         context: Self::Context,
         key_path: key::KeyPath,
-    ) -> (PressedKeyResult, key::PressedKeyEvents<Self::Event>) {
+    ) -> (PressedKeyResult, key::KeyEvents<Self::Event>) {
         let TapHold(key) = self;
         key.new_pressed_key(context, key_path)
     }
@@ -186,7 +186,7 @@ impl<K: TapHoldNestable> key::Key for TapHold<K> {
         context: Self::Context,
         key_path: key::KeyPath,
         event: key::Event<Self::Event>,
-    ) -> (Option<Self::KeyState>, key::PressedKeyEvents<Self::Event>) {
+    ) -> (Option<Self::KeyState>, key::KeyEvents<Self::Event>) {
         let TapHold(key) = self;
         key.handle_event(pending_state, context, key_path, event)
     }

--- a/src/key/keyboard.rs
+++ b/src/key/keyboard.rs
@@ -94,8 +94,8 @@ impl key::KeyState for KeyState {
         _context: Self::Context,
         _keymap_index: u16,
         _event: key::Event<Self::Event>,
-    ) -> key::PressedKeyEvents<Self::Event> {
-        key::PressedKeyEvents::no_events()
+    ) -> key::KeyEvents<Self::Event> {
+        key::KeyEvents::no_events()
     }
 
     fn key_output(&self) -> Option<key::KeyOutput> {

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -257,7 +257,7 @@ where
         key_path: key::KeyPath,
     ) -> (
         key::PressedKeyResult<K::PendingKeyState, K::KeyState>,
-        key::PressedKeyEvents<K::Event>,
+        key::KeyEvents<K::Event>,
     ) {
         let layer_context: Context = context.into();
         let (layer, passthrough_key) = self


### PR DESCRIPTION
This PR renames `key::PressedKeyEvents` to `key::KeyEvents`.

- e.g. CapsWord emits events, and this isn't directly related to the pressed caps word key.

`KeyEvents` still smurfs a bit; but `Events` would be a lame name for a type.