### PR TITLE
ncl: rename "serialized json" to "json value"

### DIFF
--- a/ncl/import-keymap-json.ncl
+++ b/ncl/import-keymap-json.ncl
@@ -1,3 +1,3 @@
 {
-  serialized_json_keymap = import "keymap.json"
+  json_keymap = import "keymap.json"
 }

--- a/ncl/inputs-to-json.ncl
+++ b/ncl/inputs-to-json.ncl
@@ -55,18 +55,18 @@
       in
       { default_layer = 0, active_layers = initial_active_layers }
     in
-    let { serialized_json, .. } =
+    let { json_value, .. } =
       std.array.fold_left
-        (fun { layer_state = ls, serialized_json = sj } input =>
+        (fun { layer_state = ls, json_value = jv } input =>
           # Assumes all `press lmod` in input_enum is
           #  where lmod is not layered.
           # e.g. unhandled case ['Press LMod 0, 'Press { layered = [LMod 1] }, ..]
           {
             layer_state = LK.update_layer_state_for_input input ls,
-            serialized_json = sj @ [input_as_json ls input]
+            json_value = jv @ [input_as_json ls input]
           }
         )
-        { layer_state = initial_layer_state, serialized_json = [] }
+        { layer_state = initial_layer_state, json_value = [] }
         inputs
-    in serialized_json
+    in json_value
 }

--- a/ncl/inputs-to-json.ncl
+++ b/ncl/inputs-to-json.ncl
@@ -7,7 +7,7 @@
   # from ['Press k | 'Release k],
   # where 'k is a keymap.ncl key def
   #  (either LK, or the K of active layer).
-  inputs_as_serialized_json_input_events =
+  inputs_as_json_value_input_events =
     let LK = import "layered-key.ncl" in
     let lookup_keymap_index = fun layer_state @ { active_layers, .. } k =>
       layered_keys

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -1,6 +1,6 @@
 let validators = import "validators.ncl" in
 {
-  serialized_json_keymap
+  json_keymap
     | doc "The 'JSON serialized' value of the keymap. e.g. imported from keymap.json."
     | { keys | Array key.SerializedJson, .. },
 
@@ -1050,7 +1050,7 @@ let validators = import "validators.ncl" in
     | doc "Text contents of the keymap.rs generated from the keymap.json"
     =
       let { config, keys } =
-        serialized_json_keymap
+        json_keymap
         & {
           config = {
             chorded = {

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -1,8 +1,8 @@
 let validators = import "validators.ncl" in
 {
   json_keymap
-    | doc "The 'JSON serialized' value of the keymap. e.g. imported from keymap.json."
-    | { keys | Array key.SerializedJson, .. },
+    | doc "The 'JSON' value of the keymap. e.g. imported from keymap.json."
+    | { keys | Array key.JsonValue, .. },
 
   # Given an array of codegen_values,
   #  return the 'wrapper type' that unifies all the values.
@@ -46,9 +46,9 @@ let validators = import "validators.ncl" in
     & (impl_for "chorded" "crate::key::composite::ChordedKey" chorded_impls),
 
   keyboard_modifiers = {
-    SerializedJson = std.contract.from_validator serialized_json_validator,
+    JsonValue = std.contract.from_validator json_value_validator,
 
-    serialized_json_validator =
+    json_value_validator =
       validators.record.validator {
         fields_validator =
           validators.record.has_only_fields [
@@ -73,7 +73,7 @@ let validators = import "validators.ncl" in
         },
       },
 
-    is_serialized_json = fun k => 'Ok == serialized_json_validator k,
+    is_json_value = fun k => 'Ok == json_value_validator k,
 
     expr = match {
       {} => "crate::key::KeyboardModifiers::new()",
@@ -97,16 +97,16 @@ let validators = import "validators.ncl" in
   },
 
   checks.check_keyboard = {
-    # Use a serialized value to check the "is" predicate.
-    check_serialized_is =
-      let serialized_value = { key_code = 4 } in
-      keyboard.is_serialized_json serialized_value,
-    check_serialized_with_modifier_is =
-      let serialized_value = { key_code = 4, modifiers = { left_ctrl = true } } in
-      keyboard.is_serialized_json serialized_value,
-    check_serialized_modifiers_is =
-      let serialized_value = { modifiers = { left_ctrl = true } } in
-      keyboard.is_serialized_json serialized_value,
+    # Use a JSON value to check the "is" predicate.
+    check_json_is =
+      let json_value = { key_code = 4 } in
+      keyboard.is_json_value json_value,
+    check_json_with_modifier_is =
+      let json_value = { key_code = 4, modifiers = { left_ctrl = true } } in
+      keyboard.is_json_value json_value,
+    check_json_modifiers_is =
+      let json_value = { modifiers = { left_ctrl = true } } in
+      keyboard.is_json_value json_value,
 
     check_keyboard_codegen_values = {
       check_basic =
@@ -131,10 +131,10 @@ let validators = import "validators.ncl" in
   keyboard
     | doc "for key::keyboard::Key."
     = {
-      SerializedJson = std.contract.from_validator serialized_json_validator,
+      JsonValue = std.contract.from_validator json_value_validator,
 
       # c.f. doc_de_keyboard.md.
-      serialized_json_validator =
+      json_value_validator =
         validators.record.validator {
           fields_validator =
             validators.all_of [
@@ -143,11 +143,11 @@ let validators = import "validators.ncl" in
             ],
           field_validators = {
             key_code = validators.is_number,
-            modifiers = keyboard_modifiers.serialized_json_validator,
+            modifiers = keyboard_modifiers.json_value_validator,
           },
         },
 
-      is_serialized_json = fun k => 'Ok == serialized_json_validator k,
+      is_json_value = fun k => 'Ok == json_value_validator k,
 
       codegen_values = fun k =>
         {
@@ -168,7 +168,7 @@ let validators = import "validators.ncl" in
               { key_code, modifiers } =>
                 "crate::key::keyboard::Key::new_with_modifiers(%{std.to_string key_code}, %{keyboard_modifiers.expr modifiers})",
             },
-          serialized_json = k,
+          json_value = k,
         },
 
       lift_to = fun key_impl cv =>
@@ -181,16 +181,16 @@ let validators = import "validators.ncl" in
   caps_word
     | doc "for key::caps_word::Key."
     = {
-      SerializedJson = std.contract.from_validator serialized_json_validator,
+      JsonValue = std.contract.from_validator json_value_validator,
 
-      serialized_json_validator = fun k =>
+      json_value_validator = fun k =>
         k
         |> match {
           "ToggleCapsWord" => 'Ok,
           _ => 'Error { message = "Expected \"ToggleCapsWord\"" },
         },
 
-      is_serialized_json = fun k => 'Ok == serialized_json_validator k,
+      is_json_value = fun k => 'Ok == json_value_validator k,
 
       codegen_values = fun k =>
         {
@@ -202,7 +202,7 @@ let validators = import "validators.ncl" in
             base = key_type.key_type,
           },
           rust_expr = "crate::key::caps_word::Key::ToggleCapsWord",
-          serialized_json = k,
+          json_value = k,
         },
 
       lift_to = fun key_impl cv =>
@@ -213,20 +213,20 @@ let validators = import "validators.ncl" in
     },
 
   checks.layer_modifier_is = {
-    # Use a serialized value to check the "is" predicate.
-    check_serialized_is =
-      let serialized_value = { Hold = 0 } in
-      layer_modifier.is_serialized_json serialized_value
+    # Use a json value to check the "is" predicate.
+    check_json_is =
+      let json_value = { Hold = 0 } in
+      layer_modifier.is_json_value json_value
   },
 
   layer_modifier
     | doc "for key::layered::ModifierKey."
     = {
-      SerializedJson = std.contract.from_validator serialized_json_validator,
+      JsonValue = std.contract.from_validator json_value_validator,
 
       # c.f. doc_de_layered.md.
       # JSON serialization of key::layered::ModifierKey has variants: Default(layer), Hold(layer).
-      serialized_json_validator =
+      json_value_validator =
         validators.record.validator {
           fields_validator =
             validators.all_of [
@@ -238,7 +238,7 @@ let validators = import "validators.ncl" in
           },
         },
 
-      is_serialized_json = fun k => 'Ok == serialized_json_validator k,
+      is_json_value = fun k => 'Ok == json_value_validator k,
 
       codegen_values = fun k =>
         k
@@ -253,7 +253,7 @@ let validators = import "validators.ncl" in
                 base = key_type.key_type,
               },
               rust_expr = "crate::key::layered::ModifierKey::Default(%{std.to_string layer_index})",
-              serialized_json = k,
+              json_value = k,
             },
           { Hold = layer_index } =>
             {
@@ -265,7 +265,7 @@ let validators = import "validators.ncl" in
                 base = key_type.key_type,
               },
               rust_expr = "crate::key::layered::ModifierKey::Hold(%{std.to_string layer_index})",
-              serialized_json = k,
+              json_value = k,
             },
         },
 
@@ -279,9 +279,9 @@ let validators = import "validators.ncl" in
   keymap_callback
     | doc "for key::callback::Key."
     = {
-      SerializedJson = std.contract.from_validator serialized_json_validator,
+      JsonValue = std.contract.from_validator json_value_validator,
 
-      serialized_json_validator =
+      json_value_validator =
         validators.record.validator {
           fields_validator = validators.record.has_exact_fields ["keymap_callback"],
           field_validators = {
@@ -289,7 +289,7 @@ let validators = import "validators.ncl" in
           },
         },
 
-      is_serialized_json = fun k => 'Ok == serialized_json_validator k,
+      is_json_value = fun k => 'Ok == json_value_validator k,
 
       codegen_values = fun k @ { keymap_callback } =>
         {
@@ -301,7 +301,7 @@ let validators = import "validators.ncl" in
             base = key_type.key_type,
           },
           rust_expr = "crate::key::callback::Key::new(crate::keymap::KeymapCallback::%{keymap_callback})",
-          serialized_json = k,
+          json_value = k,
         },
 
       lift_to = fun key_impl cv =>
@@ -334,14 +334,14 @@ let validators = import "validators.ncl" in
   },
 
   checks.check_tap_hold = {
-    # Use a serialized value to check the "is" predicate.
-    check_serialized_tap_keyboard_hold_keyboard_is =
-      let serialized_value = {
+    # Use a json value to check the "is" predicate.
+    check_json_tap_keyboard_hold_keyboard_is =
+      let json_value = {
         hold = { key_code = 224 },
         tap = { key_code = 4 },
       }
       in
-      tap_hold.is_serialized_json serialized_value,
+      tap_hold.is_json_value json_value,
 
     check_taphold_codegen_values = {
       # Current impl: tap_hold::Key<keyboard::Key> is still th::Key<composite::Base>
@@ -368,20 +368,20 @@ let validators = import "validators.ncl" in
   tap_hold
     | doc "for key::tap_hold::Key."
     = {
-      SerializedJson = std.contract.from_validator serialized_json_validator,
+      JsonValue = std.contract.from_validator json_value_validator,
 
       # c.f. doc_de_tap_hold.md.
       # JSON serialization of key::tap_hold::Key is { tap: key, hold: key }
-      serialized_json_validator =
+      json_value_validator =
         validators.record.validator {
           fields_validator = validators.record.has_exact_fields ["tap", "hold"],
           field_validators = {
-            tap = key.serialized_json_validator,
-            hold = key.serialized_json_validator,
+            tap = key.json_value_validator,
+            hold = key.json_value_validator,
           },
         },
 
-      is_serialized_json = fun k => 'Ok == serialized_json_validator k,
+      is_json_value = fun k => 'Ok == json_value_validator k,
 
       codegen_values = fun k @ { hold, tap } =>
         let hold_cv = hold |> key.codegen_values |> tap_hold_nestable.wrap in
@@ -404,7 +404,7 @@ let validators = import "validators.ncl" in
             let hold_expr = nested.hold.rust_expr in
             let tap_expr = nested.tap.rust_expr in
             "crate::key::tap_hold::Key::new(%{tap_expr}, %{hold_expr})",
-          serialized_json = k,
+          json_value = k,
         },
 
       map_nested = fun f cv @ { nested, ..rest } =>
@@ -438,9 +438,9 @@ let validators = import "validators.ncl" in
   },
 
   checks.check_layered = {
-    # Use a serialized value to check the "is" predicate.
-    check_serialized_base_keyboard_layered_keyboard_is =
-      let serialized_value = {
+    # Use a json value to check the "is" predicate.
+    check_json_base_keyboard_layered_keyboard_is =
+      let json_value = {
         base = { key_code = 4 },
         layered = [
           null,
@@ -448,7 +448,7 @@ let validators = import "validators.ncl" in
         ]
       }
       in
-      layered.is_serialized_json serialized_value,
+      layered.is_json_value json_value,
 
     check_layered_codegen_values = {
       # A layered::LayeredKey of keyboard::Key
@@ -505,7 +505,7 @@ let validators = import "validators.ncl" in
   layered
     | doc "for key::layered::LayeredKey."
     = {
-      SerializedJson = std.contract.from_validator serialized_json_validator,
+      JsonValue = std.contract.from_validator json_value_validator,
 
       # c.f. doc_de_layered.md.
       # e.g.:
@@ -516,22 +516,22 @@ let validators = import "validators.ncl" in
       #   }
       # ```
       # JSON serialization of key::layered::Layered has fields: { base, layered }
-      serialized_json_validator =
+      json_value_validator =
         validators.record.validator {
           fields_validator = validators.record.has_exact_fields ["base", "layered"],
           field_validators = {
-            base = key.serialized_json_validator,
+            base = key.json_value_validator,
             layered =
               validators.array.validator (
                 validators.any_of [
                   validators.is_null,
-                  key.serialized_json_validator,
+                  key.json_value_validator,
                 ]
               ),
           },
         },
 
-      is_serialized_json = fun k => 'Ok == serialized_json_validator k,
+      is_json_value = fun k => 'Ok == json_value_validator k,
 
       codegen_values = fun k @ { base, layered } =>
         let base_cv = base |> key.codegen_values |> layered_nestable.wrap in
@@ -566,7 +566,7 @@ let validators = import "validators.ncl" in
               |> std.string.join ","
             in
             "crate::key::layered::LayeredKey::new(%{base_expr}, [%{layered_exprs}])",
-          serialized_json = k,
+          json_value = k,
         },
 
       map_nested = fun f cv @ { nested, ..rest } =>
@@ -604,19 +604,19 @@ let validators = import "validators.ncl" in
   chorded
     | doc "for key::chorded::Key."
     = {
-      SerializedJson = std.contract.from_validator serialized_json_validator,
+      JsonValue = std.contract.from_validator json_value_validator,
 
       # JSON serialization of key::chorded::Key is { chord: key, passthrough: key }
-      serialized_json_validator =
+      json_value_validator =
         validators.record.validator {
           fields_validator = validators.record.has_exact_fields ["chord", "passthrough"],
           field_validators = {
-            chord = key.serialized_json_validator,
-            passthrough = key.serialized_json_validator,
+            chord = key.json_value_validator,
+            passthrough = key.json_value_validator,
           },
         },
 
-      is_serialized_json = fun k => 'Ok == serialized_json_validator k,
+      is_json_value = fun k => 'Ok == json_value_validator k,
 
       codegen_values = fun k @ { chord, passthrough } =>
         let chord_cv = chord |> key.codegen_values |> chorded_nestable.wrap in
@@ -643,7 +643,7 @@ let validators = import "validators.ncl" in
             let chord_expr = nested.chord.rust_expr in
             let passthrough_expr = nested.passthrough.rust_expr in
             "crate::key::chorded::Key::new(%{chord_expr}, %{passthrough_expr})",
-          serialized_json = k,
+          json_value = k,
         },
 
       map_nested = fun f cv @ { nested, ..rest } =>
@@ -664,18 +664,18 @@ let validators = import "validators.ncl" in
   chorded_aux
     | doc "for key::chorded::AuxiliaryKey."
     = {
-      SerializedJson = std.contract.from_validator serialized_json_validator,
+      JsonValue = std.contract.from_validator json_value_validator,
 
       # JSON serialization of key::chorded::AuxiliaryKey is { passthrough: key }
-      serialized_json_validator =
+      json_value_validator =
         validators.record.validator {
           fields_validator = validators.record.has_exact_fields ["passthrough"],
           field_validators = {
-            passthrough = key.serialized_json_validator,
+            passthrough = key.json_value_validator,
           },
         },
 
-      is_serialized_json = fun k => 'Ok == serialized_json_validator k,
+      is_json_value = fun k => 'Ok == json_value_validator k,
 
       codegen_values = fun k @ { passthrough } =>
         let passthrough_cv = passthrough |> key.codegen_values |> chorded_nestable.wrap in
@@ -697,7 +697,7 @@ let validators = import "validators.ncl" in
           rust_expr =
             let passthrough_expr = nested.passthrough.rust_expr in
             "crate::key::chorded::AuxiliaryKey::new(%{passthrough_expr})",
-          serialized_json = k,
+          json_value = k,
         },
 
       map_nested = fun f cv @ { nested, ..rest } =>
@@ -997,32 +997,32 @@ let validators = import "validators.ncl" in
   },
 
   key = {
-    SerializedJson = std.contract.from_validator serialized_json_validator,
+    JsonValue = std.contract.from_validator json_value_validator,
 
-    serialized_json_validator =
+    json_value_validator =
       validators.any_of [
-        keyboard.serialized_json_validator,
-        caps_word.serialized_json_validator,
-        layer_modifier.serialized_json_validator,
-        keymap_callback.serialized_json_validator,
-        layered.serialized_json_validator,
-        tap_hold.serialized_json_validator,
-        chorded.serialized_json_validator,
-        chorded_aux.serialized_json_validator,
+        keyboard.json_value_validator,
+        caps_word.json_value_validator,
+        layer_modifier.json_value_validator,
+        keymap_callback.json_value_validator,
+        layered.json_value_validator,
+        tap_hold.json_value_validator,
+        chorded.json_value_validator,
+        chorded_aux.json_value_validator,
       ],
 
-    is_serialized_json = fun k => 'Ok == serialized_json_validator k,
+    is_json_value = fun k => 'Ok == json_value_validator k,
 
     codegen_values = match {
-      k if keyboard.is_serialized_json k => keyboard.codegen_values k,
-      k if caps_word.is_serialized_json k => caps_word.codegen_values k,
-      k if layer_modifier.is_serialized_json k => layer_modifier.codegen_values k,
-      k if keymap_callback.is_serialized_json k => keymap_callback.codegen_values k,
-      k if layered.is_serialized_json k => layered.codegen_values k,
-      k if tap_hold.is_serialized_json k => tap_hold.codegen_values k,
-      k if chorded.is_serialized_json k => chorded.codegen_values k,
-      k if chorded_aux.is_serialized_json k => chorded_aux.codegen_values k,
-      k => std.fail_with "bad serialized_json for key: %{k |> std.serialize 'Json}",
+      k if keyboard.is_json_value k => keyboard.codegen_values k,
+      k if caps_word.is_json_value k => caps_word.codegen_values k,
+      k if layer_modifier.is_json_value k => layer_modifier.codegen_values k,
+      k if keymap_callback.is_json_value k => keymap_callback.codegen_values k,
+      k if layered.is_json_value k => layered.codegen_values k,
+      k if tap_hold.is_json_value k => tap_hold.codegen_values k,
+      k if chorded.is_json_value k => chorded.codegen_values k,
+      k if chorded_aux.is_json_value k => chorded_aux.codegen_values k,
+      k => std.fail_with "bad json_value for key: %{k |> std.serialize 'Json}",
     },
 
     lift_to = fun key_impl cv @ { key_type = { key_type, .. }, .. } =>

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -70,8 +70,8 @@ let validators = import "validators.ncl" in
         expected = { key_code = 4 },
       },
 
-      check_serialized_key_code = {
-        actual = K.A |> key.to_json_serialized,
+      check_json_value_key_code = {
+        actual = K.A |> key.to_json_value,
         expected = { key_code = 4 },
       },
     },
@@ -96,7 +96,7 @@ let validators = import "validators.ncl" in
 
       is_key = fun k => 'Ok == key_validator k,
 
-      to_json_serialized = fun key => key,
+      to_json_value = fun key => key,
     },
 
   checks.layer_modifier =
@@ -107,8 +107,8 @@ let validators = import "validators.ncl" in
         expected = { layer_modifier.hold = 0 },
       },
 
-      check_serialized_hold = {
-        actual = K.layer_mod.hold 0 |> key.to_json_serialized,
+      check_json_value_hold = {
+        actual = K.layer_mod.hold 0 |> key.to_json_value,
         expected = { Hold = 0 },
       },
     },
@@ -128,7 +128,7 @@ let validators = import "validators.ncl" in
 
       is_key = fun k => 'Ok == key_validator k,
 
-      to_json_serialized = fun layer_modifier_key =>
+      to_json_value = fun layer_modifier_key =>
         layer_modifier_key
         |> match {
           { layer_modifier = { default_ = default_layer } } =>
@@ -153,7 +153,7 @@ let validators = import "validators.ncl" in
 
       is_key = fun k => 'Ok == key_validator k,
 
-      to_json_serialized = fun key => key,
+      to_json_value = fun key => key,
     },
 
   caps_word
@@ -170,7 +170,7 @@ let validators = import "validators.ncl" in
 
       is_key = fun k => 'Ok == key_validator k,
 
-      to_json_serialized = fun key => key,
+      to_json_value = fun key => key,
     },
 
   checks.layered =
@@ -196,8 +196,8 @@ let validators = import "validators.ncl" in
         let key = K.A & { layered = [ null, K.C] } in
         layered.is_key key,
 
-      check_serialized_layered_keyboard = {
-        actual = K.A & { layered = [ null, K.C] } |> key.to_json_serialized,
+      check_json_value_layered_keyboard = {
+        actual = K.A & { layered = [ null, K.C] } |> key.to_json_value,
         expected = {
           base = { key_code = 4 },
           layered = [
@@ -235,12 +235,12 @@ let validators = import "validators.ncl" in
 
       is_key = fun k => 'Ok == key_validator k,
 
-      to_json_serialized = fun { layered = layered_keys, ..base_key } =>
+      to_json_value = fun { layered = layered_keys, ..base_key } =>
         {
-          base = key.to_json_serialized base_key,
+          base = key.to_json_value base_key,
           layered =
             std.array.map
-              (fun k => if k != null then key.to_json_serialized k else null)
+              (fun k => if k != null then key.to_json_value k else null)
               layered_keys,
         },
     },
@@ -262,13 +262,13 @@ let validators = import "validators.ncl" in
         let key = K.A & K.hold K.LeftCtrl in
         tap_hold.is_key key,
 
-      check_tap_keyboard_hold_keyboard_to_json_serialized_keyboard = {
-        actual = K.A & K.hold K.LeftCtrl |> tap_hold.to_json_serialized,
+      check_tap_keyboard_hold_keyboard_to_json_json_value_keyboard = {
+        actual = K.A & K.hold K.LeftCtrl |> tap_hold.to_json_value,
         expected = { tap = { key_code = 4 }, hold = { modifiers = { left_ctrl = true } } },
       },
 
-      check_serialized_tap_keyboard_hold_keyboard = {
-        actual = K.A & K.hold K.LeftCtrl |> key.to_json_serialized,
+      check_json_value_tap_keyboard_hold_keyboard = {
+        actual = K.A & K.hold K.LeftCtrl |> key.to_json_value,
         expected = { tap = { key_code = 4 }, hold = { modifiers = { left_ctrl = true } } },
       },
     },
@@ -295,10 +295,10 @@ let validators = import "validators.ncl" in
 
       is_key = fun k => 'Ok == key_validator k,
 
-      to_json_serialized = fun { hold = hold_key, ..tap_key } =>
+      to_json_value = fun { hold = hold_key, ..tap_key } =>
         {
-          hold = key.to_json_serialized hold_key,
-          tap = key.to_json_serialized tap_key,
+          hold = key.to_json_value hold_key,
+          tap = key.to_json_value tap_key,
         },
     },
 
@@ -324,10 +324,10 @@ let validators = import "validators.ncl" in
 
       is_key = fun k => 'Ok == key_validator k,
 
-      to_json_serialized = fun { chord = chord_key, passthrough = passthrough_key } =>
+      to_json_value = fun { chord = chord_key, passthrough = passthrough_key } =>
         {
-          chord = key.to_json_serialized chord_key,
-          passthrough = key.to_json_serialized passthrough_key,
+          chord = key.to_json_value chord_key,
+          passthrough = key.to_json_value passthrough_key,
         },
     },
 
@@ -345,9 +345,9 @@ let validators = import "validators.ncl" in
 
       is_key = fun k => 'Ok == key_validator k,
 
-      to_json_serialized = fun { passthrough = passthrough_key } =>
+      to_json_value = fun { passthrough = passthrough_key } =>
         {
-          passthrough = key.to_json_serialized passthrough_key,
+          passthrough = key.to_json_value passthrough_key,
         },
     },
 
@@ -369,24 +369,24 @@ let validators = import "validators.ncl" in
 
     is_key = fun k => 'Ok == key_validator k,
 
-    to_json_serialized = match {
+    to_json_value = match {
       # Make key::chorded::Key
-      k if chorded.is_key k => chorded.to_json_serialized k,
+      k if chorded.is_key k => chorded.to_json_value k,
       # Make key::chorded::AuxiliaryKey
-      k if chorded_aux.is_key k => chorded_aux.to_json_serialized k,
+      k if chorded_aux.is_key k => chorded_aux.to_json_value k,
       # Make key::tap_hold::Key from keys with a "hold" modifier.
       # Make key::layered::LayeredKey
-      k if layered.is_key k => layered.to_json_serialized k,
+      k if layered.is_key k => layered.to_json_value k,
       # Make key::tap_hold::Key from keys with a "hold" modifier.
-      k if tap_hold.is_key k => tap_hold.to_json_serialized k,
+      k if tap_hold.is_key k => tap_hold.to_json_value k,
       # Make key::callback::Key
-      k if keymap_callback.is_key k => keymap_callback.to_json_serialized k,
+      k if keymap_callback.is_key k => keymap_callback.to_json_value k,
       # Make key::caps_word::Key
-      k if caps_word.is_key k => caps_word.to_json_serialized k,
+      k if caps_word.is_key k => caps_word.to_json_value k,
       # Otherwise, keys with just a base key_code are key::keyboard keys.
-      k if keyboard.is_key k => keyboard.to_json_serialized k,
+      k if keyboard.is_key k => keyboard.to_json_value k,
       # Make key::layered::ModifierKey
-      k if layer_modifier.is_key k => layer_modifier.to_json_serialized k,
+      k if layer_modifier.is_key k => layer_modifier.to_json_value k,
       # Null values (None) stay null
       null => null,
       _ => std.fail_with "unsupported item in keymap.ncl",
@@ -499,7 +499,7 @@ let validators = import "validators.ncl" in
         }
       in
       {
-        keys = chorded_keys |> std.array.map key.to_json_serialized,
+        keys = chorded_keys |> std.array.map key.to_json_value,
         config = config_,
       },
 }

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -488,7 +488,7 @@ let validators = import "validators.ncl" in
       )
       layered_keys,
 
-  serialized_json_keymap
+  json_keymap
     | default
     | doc "The keymap.json output value."
     =

--- a/ncl/scripts/keymap-ncl-to-json.sh
+++ b/ncl/scripts/keymap-ncl-to-json.sh
@@ -21,5 +21,5 @@ nickel export \
   --import-path="${NCL_DIR}" \
   keymap-ncl-to-json.ncl \
   keymap.ncl \
-  --field="serialized_json_keymap" \
+  --field="json_keymap" \
   > "${DEST}"

--- a/smart-keymap-nickel-helper/src/lib.rs
+++ b/smart-keymap-nickel-helper/src/lib.rs
@@ -175,7 +175,7 @@ pub fn nickel_json_serialization_for_keymap(
 }
 
 /// Evaluates the Nickel expr for inputs, with a given keymap ncl, returning the json serialization.
-pub fn nickel_json_serialization_for_inputs(
+pub fn nickel_json_value_for_inputs(
     ncl_import_path: String,
     keymap_ncl: &str,
     inputs_ncl: &str,
@@ -185,7 +185,7 @@ pub fn nickel_json_serialization_for_inputs(
             "export",
             "--format=json",
             format!("--import-path={}", ncl_import_path).as_ref(),
-            "--field=inputs_as_serialized_json_input_events",
+            "--field=inputs_as_json_value_input_events",
         ])
         .stdin(Stdio::piped())
         .stderr(Stdio::piped())

--- a/smart-keymap-nickel-helper/src/lib.rs
+++ b/smart-keymap-nickel-helper/src/lib.rs
@@ -134,7 +134,7 @@ pub fn nickel_json_serialization_for_keymap(
             "export",
             "--format=json",
             format!("--import-path={}", ncl_import_path).as_ref(),
-            "--field=serialized_json_keymap",
+            "--field=json_keymap",
         ])
         .stdin(Stdio::piped())
         .stderr(Stdio::piped())

--- a/smart-keymap-nickel-helper/src/lib.rs
+++ b/smart-keymap-nickel-helper/src/lib.rs
@@ -125,10 +125,7 @@ pub fn rustfmt(rust_src: String) -> String {
 }
 
 /// Evaluates the Nickel expr for a keymap, returning the json serialization.
-pub fn nickel_json_serialization_for_keymap(
-    ncl_import_path: String,
-    keymap_ncl: &str,
-) -> NickelResult {
+pub fn nickel_json_value_for_keymap(ncl_import_path: String, keymap_ncl: &str) -> NickelResult {
     let spawn_nickel_result = Command::new("nickel")
         .args([
             "export",

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -10,8 +10,8 @@ use smart_keymap::key;
 use smart_keymap::keymap;
 
 use smart_keymap_nickel_helper::{
-    nickel_json_serialization_for_keymap, nickel_json_value_for_inputs,
-    nickel_to_json_for_hid_report, NickelError,
+    nickel_json_value_for_inputs, nickel_json_value_for_keymap, nickel_to_json_for_hid_report,
+    NickelError,
 };
 
 type Key = key::composite::Key;
@@ -129,10 +129,7 @@ struct DocstringKeymap {
 }
 
 fn load_keymap(keymap_ncl: &str) -> Keymap {
-    match nickel_json_serialization_for_keymap(
-        format!("{}/ncl", env!("CARGO_MANIFEST_DIR")),
-        keymap_ncl,
-    ) {
+    match nickel_json_value_for_keymap(format!("{}/ncl", env!("CARGO_MANIFEST_DIR")), keymap_ncl) {
         Ok(json) => {
             let keymap_result: serde_json::Result<DocstringKeymap> = serde_json::from_str(&json);
             match keymap_result {

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -10,7 +10,7 @@ use smart_keymap::key;
 use smart_keymap::keymap;
 
 use smart_keymap_nickel_helper::{
-    nickel_json_serialization_for_inputs, nickel_json_serialization_for_keymap,
+    nickel_json_serialization_for_keymap, nickel_json_value_for_inputs,
     nickel_to_json_for_hid_report, NickelError,
 };
 
@@ -168,7 +168,7 @@ fn setup_nickel_keymap(world: &mut KeymapWorld, step: &Step) {
 }
 
 fn inputs_from_ncl(keymap_ncl: &str, inputs_ncl: &str) -> Vec<input::Event> {
-    match nickel_json_serialization_for_inputs(
+    match nickel_json_value_for_inputs(
         format!("{}/ncl", env!("CARGO_MANIFEST_DIR")),
         keymap_ncl,
         inputs_ncl,


### PR DESCRIPTION
This PR improves upon the naming of "serialized json" used throughout the Nickel code.

The intent of "serialized json" was to convey that the values agree with what the serde json encoding expects. -- i.e. a JSON encoding of a 'serialised json' value could be deserialised with serde-json to get the Rust value. (That's what the Cucumber test suite does).

However, I find the term a bit awkward, since the "serialized json" is neither a json-encoded string, nor a serialization.

"JSON value" is a more precise term.