### PR TITLE
bugfix: key::caps_word::handle_event only if active

### DIFF
--- a/src/key/caps_word.rs
+++ b/src/key/caps_word.rs
@@ -31,7 +31,7 @@ impl Context {
                         key_modifiers,
                     },
                 ..
-            }) => {
+            }) if self.is_active => {
                 // CapsWord is deactivated for key presses other than:
                 //   - A-Z
                 //   - 0-9


### PR DESCRIPTION
Impl'd as part of #261.

(Implicitly covered by integration tests there).