### PR TITLE
Pass Context by Reference

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -40,7 +40,7 @@ impl<Ctx, Ev, S: crate::key::KeyState<Context = Ctx, Event = Ev>> PressedKey<S> 
     /// Convenience passthrough to key_state handle_event.
     pub fn handle_event(
         &mut self,
-        context: Ctx,
+        context: &Ctx,
         event: crate::key::Event<Ev>,
     ) -> crate::key::KeyEvents<Ev> {
         self.key_state

--- a/src/key.rs
+++ b/src/key.rs
@@ -485,7 +485,7 @@ pub trait KeyState: Debug {
     /// Used to update the [KeyState]'s state, and possibly yield event(s).
     fn handle_event(
         &mut self,
-        _context: Self::Context,
+        _context: &Self::Context,
         _keymap_index: u16,
         _event: Event<Self::Event>,
     ) -> KeyEvents<Self::Event> {

--- a/src/key.rs
+++ b/src/key.rs
@@ -170,7 +170,7 @@ pub trait Key: Debug {
     ///  so that holding the key resolves as a hold).
     fn new_pressed_key(
         &self,
-        context: Self::Context,
+        context: &Self::Context,
         key_path: KeyPath,
     ) -> (
         PressedKeyResult<Self::PendingKeyState, Self::KeyState>,
@@ -181,7 +181,7 @@ pub trait Key: Debug {
     fn handle_event(
         &self,
         pending_state: &mut Self::PendingKeyState,
-        context: Self::Context,
+        context: &Self::Context,
         key_path: KeyPath,
         event: Event<Self::Event>,
     ) -> (

--- a/src/key/callback.rs
+++ b/src/key/callback.rs
@@ -26,7 +26,7 @@ impl key::Key for Key {
 
     fn new_pressed_key(
         &self,
-        _context: Self::Context,
+        _context: &Self::Context,
         _key_path: key::KeyPath,
     ) -> (
         key::PressedKeyResult<Self::PendingKeyState, Self::KeyState>,
@@ -42,7 +42,7 @@ impl key::Key for Key {
     fn handle_event(
         &self,
         _pending_state: &mut Self::PendingKeyState,
-        _context: Self::Context,
+        _context: &Self::Context,
         _key_path: key::KeyPath,
         _event: key::Event<Self::Event>,
     ) -> (

--- a/src/key/caps_word.rs
+++ b/src/key/caps_word.rs
@@ -117,7 +117,7 @@ impl Key {
     }
 
     /// Constructs a pressed key state
-    pub fn new_pressed_key(&self, context: Context, keymap_index: u16) -> key::KeyEvents<Event> {
+    pub fn new_pressed_key(&self, context: &Context, keymap_index: u16) -> key::KeyEvents<Event> {
         let key_event = match self {
             Key::ToggleCapsWord => {
                 if context.is_active {
@@ -139,7 +139,7 @@ impl key::Key for Key {
 
     fn new_pressed_key(
         &self,
-        context: Self::Context,
+        context: &Self::Context,
         key_path: key::KeyPath,
     ) -> (
         key::PressedKeyResult<Self::PendingKeyState, Self::KeyState>,
@@ -155,7 +155,7 @@ impl key::Key for Key {
     fn handle_event(
         &self,
         _pending_state: &mut Self::PendingKeyState,
-        _context: Self::Context,
+        _context: &Self::Context,
         _key_path: key::KeyPath,
         _event: key::Event<Self::Event>,
     ) -> (

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -357,7 +357,7 @@ impl key::KeyState for KeyState {
 
     fn handle_event(
         &mut self,
-        context: Self::Context,
+        context: &Self::Context,
         keymap_index: u16,
         event: key::Event<Self::Event>,
     ) -> key::KeyEvents<Self::Event> {
@@ -419,7 +419,7 @@ mod tests {
 
         // Act
         let events = pressed_lmod_key.unwrap_resolved().handle_event(
-            context,
+            &context,
             keymap_index,
             key::Event::Input(input::Event::Release { keymap_index }),
         );
@@ -492,7 +492,7 @@ mod tests {
         let (pressed_lmod_key, _) = keys[keymap_index as usize].new_pressed_key(context, key_path);
         context.layer_context.activate_layer(1);
         let events = pressed_lmod_key.unwrap_resolved().handle_event(
-            context,
+            &context,
             0,
             key::Event::Input(input::Event::Release { keymap_index: 0 }),
         );

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -163,6 +163,36 @@ impl From<Context> for key::tap_hold::Context {
     }
 }
 
+impl<'c> From<&'c Context> for &'c key::caps_word::Context {
+    fn from(ctx: &'c Context) -> Self {
+        &ctx.caps_word_context
+    }
+}
+
+impl<'c> From<&'c Context> for &'c key::chorded::Context {
+    fn from(ctx: &'c Context) -> Self {
+        &ctx.chorded_context
+    }
+}
+
+impl<'c> From<&'c Context> for &'c key::layered::Context {
+    fn from(ctx: &'c Context) -> Self {
+        &ctx.layer_context
+    }
+}
+
+impl<'c> From<&'c Context> for &'c key::sticky::Context {
+    fn from(ctx: &'c Context) -> Self {
+        &ctx.sticky_context
+    }
+}
+
+impl<'c> From<&'c Context> for &'c key::tap_hold::Context {
+    fn from(ctx: &'c Context) -> Self {
+        &ctx.tap_hold_context
+    }
+}
+
 /// Sum type aggregating the [key::Event] types.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Event {

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -415,7 +415,7 @@ mod tests {
         let key_path = key::key_path(keymap_index);
         let key = K::layer_modifier(key::layered::ModifierKey::Hold(1));
         let context: Ctx = DEFAULT_CONTEXT;
-        let (pressed_lmod_key, _) = key.new_pressed_key(context, key_path);
+        let (pressed_lmod_key, _) = key.new_pressed_key(&context, key_path);
 
         // Act
         let events = pressed_lmod_key.unwrap_resolved().handle_event(
@@ -455,7 +455,7 @@ mod tests {
         let keymap_index: u16 = 0;
         let key_path = key::key_path(keymap_index);
         let (_pressed_key, pressed_key_events) =
-            keys[keymap_index as usize].new_pressed_key(context, key_path);
+            keys[keymap_index as usize].new_pressed_key(&context, key_path);
         let maybe_ev = pressed_key_events.into_iter().next();
 
         // Act
@@ -489,7 +489,7 @@ mod tests {
         let mut context: Ctx = DEFAULT_CONTEXT;
         let keymap_index: u16 = 0;
         let key_path = key::key_path(keymap_index);
-        let (pressed_lmod_key, _) = keys[keymap_index as usize].new_pressed_key(context, key_path);
+        let (pressed_lmod_key, _) = keys[keymap_index as usize].new_pressed_key(&context, key_path);
         context.layer_context.activate_layer(1);
         let events = pressed_lmod_key.unwrap_resolved().handle_event(
             &context,
@@ -530,7 +530,7 @@ mod tests {
         // Act
         let keymap_index: u16 = 2;
         let key_path = key::key_path(keymap_index);
-        let (pressed_key, _) = keys[keymap_index as usize].new_pressed_key(context, key_path);
+        let (pressed_key, _) = keys[keymap_index as usize].new_pressed_key(&context, key_path);
         let actual_keycode = pressed_key.unwrap_resolved().key_output();
 
         // Assert
@@ -558,7 +558,7 @@ mod tests {
         // Act
         let keymap_index: u16 = 1;
         let key_path = key::key_path(keymap_index);
-        let (pressed_key, _) = keys[keymap_index as usize].new_pressed_key(context, key_path);
+        let (pressed_key, _) = keys[keymap_index as usize].new_pressed_key(&context, key_path);
         let actual_keycode = pressed_key.unwrap_resolved().key_output();
 
         // Assert

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -128,41 +128,6 @@ impl key::Context for Context {
     }
 }
 
-/// keyboard::Context from composite::Context
-impl From<Context> for () {
-    fn from(_: Context) -> Self {}
-}
-
-impl From<Context> for key::caps_word::Context {
-    fn from(ctx: Context) -> Self {
-        ctx.caps_word_context
-    }
-}
-
-impl From<Context> for key::chorded::Context {
-    fn from(ctx: Context) -> Self {
-        ctx.chorded_context
-    }
-}
-
-impl From<Context> for key::layered::Context {
-    fn from(ctx: Context) -> Self {
-        ctx.layer_context
-    }
-}
-
-impl From<Context> for key::sticky::Context {
-    fn from(ctx: Context) -> Self {
-        ctx.sticky_context
-    }
-}
-
-impl From<Context> for key::tap_hold::Context {
-    fn from(ctx: Context) -> Self {
-        ctx.tap_hold_context
-    }
-}
-
 impl<'c> From<&'c Context> for &'c key::caps_word::Context {
     fn from(ctx: &'c Context) -> Self {
         &ctx.caps_word_context

--- a/src/key/composite/base.rs
+++ b/src/key/composite/base.rs
@@ -38,7 +38,7 @@ impl key::Key for BaseKey {
 
     fn new_pressed_key(
         &self,
-        context: Self::Context,
+        context: &Self::Context,
         key_path: key::KeyPath,
     ) -> (PressedKeyResult, key::KeyEvents<Self::Event>) {
         match self {
@@ -53,7 +53,7 @@ impl key::Key for BaseKey {
     fn handle_event(
         &self,
         _pending_state: &mut Self::PendingKeyState,
-        _context: Self::Context,
+        _context: &Self::Context,
         _key_path: key::KeyPath,
         _event: key::Event<Self::Event>,
     ) -> (

--- a/src/key/composite/chorded.rs
+++ b/src/key/composite/chorded.rs
@@ -50,7 +50,7 @@ impl<K: ChordedNestable> key::Key for ChordedKey<K> {
 
     fn new_pressed_key(
         &self,
-        context: Self::Context,
+        context: &Self::Context,
         key_path: key::KeyPath,
     ) -> (PressedKeyResult, key::KeyEvents<Self::Event>) {
         match self {
@@ -63,7 +63,7 @@ impl<K: ChordedNestable> key::Key for ChordedKey<K> {
     fn handle_event(
         &self,
         pending_state: &mut Self::PendingKeyState,
-        context: Self::Context,
+        context: &Self::Context,
         key_path: key::KeyPath,
         event: key::Event<Self::Event>,
     ) -> (
@@ -102,7 +102,7 @@ impl<K: ChordedNestable> key::Key for Chorded<K> {
 
     fn new_pressed_key(
         &self,
-        context: Self::Context,
+        context: &Self::Context,
         key_path: key::KeyPath,
     ) -> (PressedKeyResult, key::KeyEvents<Self::Event>) {
         let Chorded(key) = self;
@@ -112,7 +112,7 @@ impl<K: ChordedNestable> key::Key for Chorded<K> {
     fn handle_event(
         &self,
         pending_state: &mut Self::PendingKeyState,
-        context: Self::Context,
+        context: &Self::Context,
         key_path: key::KeyPath,
         event: key::Event<Self::Event>,
     ) -> (

--- a/src/key/composite/layered.rs
+++ b/src/key/composite/layered.rs
@@ -47,7 +47,7 @@ impl<K: LayeredNestable> key::Key for LayeredKey<K> {
 
     fn new_pressed_key(
         &self,
-        context: Self::Context,
+        context: &Self::Context,
         key_path: key::KeyPath,
     ) -> (PressedKeyResult, key::KeyEvents<Self::Event>) {
         match self {
@@ -59,7 +59,7 @@ impl<K: LayeredNestable> key::Key for LayeredKey<K> {
     fn handle_event(
         &self,
         pending_state: &mut Self::PendingKeyState,
-        context: Self::Context,
+        context: &Self::Context,
         key_path: key::KeyPath,
         event: key::Event<Self::Event>,
     ) -> (
@@ -96,7 +96,7 @@ impl<K: LayeredNestable> key::Key for Layered<K> {
 
     fn new_pressed_key(
         &self,
-        context: Self::Context,
+        context: &Self::Context,
         key_path: key::KeyPath,
     ) -> (PressedKeyResult, key::KeyEvents<Self::Event>) {
         let Layered(key) = self;
@@ -106,7 +106,7 @@ impl<K: LayeredNestable> key::Key for Layered<K> {
     fn handle_event(
         &self,
         pending_state: &mut Self::PendingKeyState,
-        context: Self::Context,
+        context: &Self::Context,
         key_path: key::KeyPath,
         event: key::Event<Self::Event>,
     ) -> (

--- a/src/key/composite/tap_hold.rs
+++ b/src/key/composite/tap_hold.rs
@@ -50,7 +50,7 @@ impl<K: TapHoldNestable> key::Key for TapHoldKey<K> {
 
     fn new_pressed_key(
         &self,
-        context: Self::Context,
+        context: &Self::Context,
         key_path: key::KeyPath,
     ) -> (PressedKeyResult, key::KeyEvents<Self::Event>) {
         match self {
@@ -62,7 +62,7 @@ impl<K: TapHoldNestable> key::Key for TapHoldKey<K> {
     fn handle_event(
         &self,
         pending_state: &mut Self::PendingKeyState,
-        context: Self::Context,
+        context: &Self::Context,
         key_path: key::KeyPath,
         event: key::Event<Self::Event>,
     ) -> (
@@ -99,7 +99,7 @@ impl<K: TapHoldNestable> key::Key for TapHold<K> {
 
     fn new_pressed_key(
         &self,
-        context: Self::Context,
+        context: &Self::Context,
         key_path: key::KeyPath,
     ) -> (PressedKeyResult, key::KeyEvents<Self::Event>) {
         let TapHold(key) = self;
@@ -109,7 +109,7 @@ impl<K: TapHoldNestable> key::Key for TapHold<K> {
     fn handle_event(
         &self,
         pending_state: &mut Self::PendingKeyState,
-        context: Self::Context,
+        context: &Self::Context,
         key_path: key::KeyPath,
         event: key::Event<Self::Event>,
     ) -> (

--- a/src/key/keyboard.rs
+++ b/src/key/keyboard.rs
@@ -81,7 +81,7 @@ impl key::Key for Key {
 
     fn new_pressed_key(
         &self,
-        _context: Self::Context,
+        _context: &Self::Context,
         _key_path: key::KeyPath,
     ) -> (
         key::PressedKeyResult<Self::PendingKeyState, Self::KeyState>,
@@ -96,7 +96,7 @@ impl key::Key for Key {
     fn handle_event(
         &self,
         _pending_state: &mut Self::PendingKeyState,
-        _context: Self::Context,
+        _context: &Self::Context,
         _key_path: key::KeyPath,
         _event: key::Event<Self::Event>,
     ) -> (

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -60,7 +60,7 @@ impl key::Key for ModifierKey {
 
     fn new_pressed_key(
         &self,
-        _context: Self::Context,
+        _context: &Self::Context,
         key_path: key::KeyPath,
     ) -> (
         key::PressedKeyResult<Self::PendingKeyState, Self::KeyState>,
@@ -76,7 +76,7 @@ impl key::Key for ModifierKey {
     fn handle_event(
         &self,
         _pending_state: &mut Self::PendingKeyState,
-        _context: Self::Context,
+        _context: &Self::Context,
         _key_path: key::KeyPath,
         _event: key::Event<Self::Event>,
     ) -> (
@@ -303,25 +303,25 @@ impl<K: key::Key + Copy + PartialEq> LayeredKey<K> {
 
 impl<K: key::Key + Copy + PartialEq> LayeredKey<K>
 where
-    K::Context: Into<Context>,
+    for<'c> &'c K::Context: Into<&'c Context>,
 {
     /// Presses the key, using the highest active key, if any.
     fn new_pressed_key(
         &self,
-        context: K::Context,
+        context: &K::Context,
         key_path: key::KeyPath,
     ) -> (
         key::PressedKeyResult<K::PendingKeyState, K::KeyState>,
         key::KeyEvents<K::Event>,
     ) {
-        let layer_context: Context = context.into();
+        let layer_context: &Context = context.into();
         let (layer, passthrough_key) = self
             .layered
             .highest_active_key(layer_context.layer_state(), layer_context.default_layer)
             .unwrap_or((0, &self.base));
 
         // PRESSED KEY PATH: add Layer (0 = base, n = layer_index)
-        let (pkr, pke) = passthrough_key.new_pressed_key(context, key_path);
+        let (pkr, pke) = passthrough_key.new_pressed_key(&context, key_path);
         (pkr.add_path_item(layer as u16), pke)
     }
 }
@@ -343,7 +343,7 @@ impl<
 
     fn new_pressed_key(
         &self,
-        context: Self::Context,
+        context: &Self::Context,
         key_path: key::KeyPath,
     ) -> (
         key::PressedKeyResult<Self::PendingKeyState, Self::KeyState>,
@@ -355,7 +355,7 @@ impl<
     fn handle_event(
         &self,
         _pending_state: &mut Self::PendingKeyState,
-        _context: Self::Context,
+        _context: &Self::Context,
         _key_path: key::KeyPath,
         _event: key::Event<Self::Event>,
     ) -> (
@@ -531,7 +531,7 @@ mod tests {
         // Act: without activating a layer, press the layered key
         let keymap_index = 9; // arbitrary
         let key_path = key::key_path(keymap_index);
-        let (actual_key_state, _actual_event) = layered_key.new_pressed_key(context, key_path);
+        let (actual_key_state, _actual_event) = layered_key.new_pressed_key(&context, key_path);
 
         // Assert
         let expected_key_state: KeyState = KeyState::Keyboard(expected_key.new_pressed_key());
@@ -557,7 +557,7 @@ mod tests {
         // Act: without activating a layer, press the layered key
         let keymap_index = 9; // arbitrary
         let key_path = key::key_path(keymap_index);
-        let (actual_pressed_key, _event) = layered_key.new_pressed_key(context, key_path);
+        let (actual_pressed_key, _event) = layered_key.new_pressed_key(&context, key_path);
 
         let actual_key_output = actual_pressed_key.unwrap_resolved().key_output();
 
@@ -596,7 +596,7 @@ mod tests {
         ));
         let keymap_index = 9; // arbitrary
         let key_path = key::key_path(keymap_index);
-        let (actual_pressed_key, _actual_event) = layered_key.new_pressed_key(context, key_path);
+        let (actual_pressed_key, _actual_event) = layered_key.new_pressed_key(&context, key_path);
 
         // Assert
         let expected_pressed_key = KeyState::Keyboard(expected_key.new_pressed_key());
@@ -634,7 +634,7 @@ mod tests {
         ));
         let keymap_index = 9; // arbitrary
         let key_path = key::key_path(keymap_index);
-        let (actual_pressed_key, _actual_event) = layered_key.new_pressed_key(context, key_path);
+        let (actual_pressed_key, _actual_event) = layered_key.new_pressed_key(&context, key_path);
 
         // Assert
         let expected_pressed_key = KeyState::Keyboard(expected_key.new_pressed_key());
@@ -664,7 +664,7 @@ mod tests {
         ));
         let keymap_index = 9; // arbitrary
         let key_path = key::key_path(keymap_index);
-        let (actual_pressed_key, _actual_event) = layered_key.new_pressed_key(context, key_path);
+        let (actual_pressed_key, _actual_event) = layered_key.new_pressed_key(&context, key_path);
 
         // Assert
         let expected_pressed_key = KeyState::Keyboard(expected_key.new_pressed_key());

--- a/src/key/sticky.rs
+++ b/src/key/sticky.rs
@@ -216,7 +216,7 @@ impl key::Key for Key {
 
     fn new_pressed_key(
         &self,
-        _context: Self::Context,
+        _context: &Self::Context,
         _key_path: key::KeyPath,
     ) -> (
         key::PressedKeyResult<Self::PendingKeyState, Self::KeyState>,
@@ -231,7 +231,7 @@ impl key::Key for Key {
     fn handle_event(
         &self,
         _pending_state: &mut Self::PendingKeyState,
-        _context: Self::Context,
+        _context: &Self::Context,
         _key_path: key::KeyPath,
         _event: key::Event<Self::Event>,
     ) -> (

--- a/src/key/sticky.rs
+++ b/src/key/sticky.rs
@@ -284,7 +284,7 @@ impl KeyState {
     /// Handle the given event.
     pub fn handle_event(
         &mut self,
-        context: Context,
+        context: &Context,
         keymap_index: u16,
         event: key::Event<Event>,
     ) -> key::KeyEvents<Event> {
@@ -305,7 +305,7 @@ impl KeyState {
                     keymap_index: released_index,
                 }) if released_index == keymap_index => {
                     // The sticky key has been released.
-                    let sticky_ctx: Context = context.into();
+                    let sticky_ctx: &Context = context.into();
                     match sticky_ctx.config.activation {
                         StickyKeyActivation::OnStickyKeyRelease => {
                             let sticky_ev = Event::ActivateModifiers(self.sticky_modifiers);

--- a/src/key/tap_hold.rs
+++ b/src/key/tap_hold.rs
@@ -73,7 +73,7 @@ impl<K: key::Key> Key<K> {
     /// Constructs a new pressed key state and a scheduled event for the tap-hold key.
     fn new_pressed_key(
         &self,
-        context: Context,
+        context: &Context,
         key_path: key::KeyPath,
     ) -> (PendingKeyState, key::ScheduledEvent<Event>) {
         let keymap_index: u16 = key_path[0];
@@ -104,7 +104,7 @@ impl<
 
     fn new_pressed_key(
         &self,
-        context: Self::Context,
+        context: &Self::Context,
         key_path: key::KeyPath,
     ) -> (
         key::PressedKeyResult<Self::PendingKeyState, Self::KeyState>,
@@ -120,7 +120,7 @@ impl<
     fn handle_event(
         &self,
         pending_state: &mut Self::PendingKeyState,
-        context: Self::Context,
+        context: &Self::Context,
         key_path: key::KeyPath,
         event: key::Event<Self::Event>,
     ) -> (
@@ -301,7 +301,7 @@ impl PendingKeyState {
     /// Returns at most 2 events
     pub fn handle_event(
         &mut self,
-        context: Context,
+        context: &Context,
         keymap_index: u16,
         event: key::Event<Event>,
     ) -> Option<TapHoldState> {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -558,7 +558,7 @@ impl<
             self.pressed_inputs.iter_mut().for_each(|pi| {
                 if let input::PressedInput::Key(pressed_key) = pi {
                     pressed_key
-                        .handle_event(self.context, ev.into())
+                        .handle_event(&self.context, ev.into())
                         .into_iter()
                         .for_each(|sch_ev| self.event_scheduler.schedule_event(sch_ev));
                 }
@@ -690,7 +690,7 @@ impl<
             }) = pi
             {
                 key_state
-                    .handle_event(self.context, *keymap_index, ev)
+                    .handle_event(&self.context, *keymap_index, ev)
                     .into_iter()
                     .for_each(|sch_ev| self.event_scheduler.schedule_event(sch_ev));
             }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -535,7 +535,7 @@ impl<
             let pending_key = pending_key.lookup(&key_path[1..]);
             let (ks, pke) = pending_key.handle_event(
                 pending_key_state,
-                self.context,
+                &self.context,
                 key_path.clone(),
                 ev.into(),
             );
@@ -575,7 +575,7 @@ impl<
 
                     let mut key_path = key::KeyPath::new();
                     key_path.push(keymap_index).unwrap();
-                    let (pk, pke) = key.new_pressed_key(self.context, key_path);
+                    let (pk, pke) = key.new_pressed_key(&self.context, key_path);
 
                     pke.into_iter()
                         .for_each(|sch_ev| self.event_scheduler.schedule_event(sch_ev));
@@ -665,7 +665,7 @@ impl<
             let pending_key = &self.key_definitions[key_path[0] as usize];
             let pending_key = pending_key.lookup(&key_path[1..]);
             let (ks, pke) =
-                pending_key.handle_event(pending_key_state, self.context, key_path.clone(), ev);
+                pending_key.handle_event(pending_key_state, &self.context, key_path.clone(), ev);
 
             pke.into_iter()
                 .for_each(|sch_ev| self.event_scheduler.schedule_event(sch_ev));


### PR DESCRIPTION
Previously, #89 had gone and passed Context as values.

Since then, `key::dynamic` has been taken out from the codebase. The codebase better supports passing `Context` around by reference.