### PR TITLE
codegen: config defaults

### DIFF
--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -1135,6 +1135,7 @@ let validators = import "validators.ncl" in
         crate::key::chorded::Config {
             timeout: %{std.to_string config.chorded.timeout},
             chords: [%{chords_fragment}],
+            ..crate::key::chorded::DEFAULT_CONFIG
         }
       "%
       in
@@ -1142,6 +1143,7 @@ let validators = import "validators.ncl" in
         crate::key::tap_hold::Config {
             timeout: %{std.to_string config.tap_hold.timeout},
             interrupt_response: crate::key::tap_hold::InterruptResponse::%{config.tap_hold.interrupt_response},
+            ..crate::key::tap_hold::DEFAULT_CONFIG
         }
       "%
       in

--- a/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
+++ b/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
@@ -5,10 +5,12 @@ pub mod init {
         chorded: crate::key::chorded::Config {
             timeout: 200,
             chords: [],
+            ..crate::key::chorded::DEFAULT_CONFIG
         },
         tap_hold: crate::key::tap_hold::Config {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,
+            ..crate::key::tap_hold::DEFAULT_CONFIG
         },
         ..crate::key::composite::DEFAULT_CONFIG
     };

--- a/tests/ncl/keymap-1key-simple/expected.rs
+++ b/tests/ncl/keymap-1key-simple/expected.rs
@@ -5,10 +5,12 @@ pub mod init {
         chorded: crate::key::chorded::Config {
             timeout: 200,
             chords: [],
+            ..crate::key::chorded::DEFAULT_CONFIG
         },
         tap_hold: crate::key::tap_hold::Config {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,
+            ..crate::key::tap_hold::DEFAULT_CONFIG
         },
         ..crate::key::composite::DEFAULT_CONFIG
     };

--- a/tests/ncl/keymap-1key-tap_hold/expected.rs
+++ b/tests/ncl/keymap-1key-tap_hold/expected.rs
@@ -5,10 +5,12 @@ pub mod init {
         chorded: crate::key::chorded::Config {
             timeout: 200,
             chords: [],
+            ..crate::key::chorded::DEFAULT_CONFIG
         },
         tap_hold: crate::key::tap_hold::Config {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,
+            ..crate::key::tap_hold::DEFAULT_CONFIG
         },
         ..crate::key::composite::DEFAULT_CONFIG
     };

--- a/tests/ncl/keymap-2key-2layer-composite/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-composite/expected.rs
@@ -5,10 +5,12 @@ pub mod init {
         chorded: crate::key::chorded::Config {
             timeout: 200,
             chords: [],
+            ..crate::key::chorded::DEFAULT_CONFIG
         },
         tap_hold: crate::key::tap_hold::Config {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,
+            ..crate::key::tap_hold::DEFAULT_CONFIG
         },
         ..crate::key::composite::DEFAULT_CONFIG
     };

--- a/tests/ncl/keymap-2key-2layer-simple/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-simple/expected.rs
@@ -5,10 +5,12 @@ pub mod init {
         chorded: crate::key::chorded::Config {
             timeout: 200,
             chords: [],
+            ..crate::key::chorded::DEFAULT_CONFIG
         },
         tap_hold: crate::key::tap_hold::Config {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,
+            ..crate::key::tap_hold::DEFAULT_CONFIG
         },
         ..crate::key::composite::DEFAULT_CONFIG
     };

--- a/tests/ncl/keymap-2key-chorded/expected.rs
+++ b/tests/ncl/keymap-2key-chorded/expected.rs
@@ -5,10 +5,12 @@ pub mod init {
         chorded: crate::key::chorded::Config {
             timeout: 200,
             chords: [Some(crate::key::chorded::ChordIndices::Chord2(0, 1))],
+            ..crate::key::chorded::DEFAULT_CONFIG
         },
         tap_hold: crate::key::tap_hold::Config {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,
+            ..crate::key::tap_hold::DEFAULT_CONFIG
         },
         ..crate::key::composite::DEFAULT_CONFIG
     };

--- a/tests/ncl/keymap-48key-basic/expected.rs
+++ b/tests/ncl/keymap-48key-basic/expected.rs
@@ -5,10 +5,12 @@ pub mod init {
         chorded: crate::key::chorded::Config {
             timeout: 200,
             chords: [],
+            ..crate::key::chorded::DEFAULT_CONFIG
         },
         tap_hold: crate::key::tap_hold::Config {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,
+            ..crate::key::tap_hold::DEFAULT_CONFIG
         },
         ..crate::key::composite::DEFAULT_CONFIG
     };

--- a/tests/ncl/keymap-48key-rgoulter/expected.rs
+++ b/tests/ncl/keymap-48key-rgoulter/expected.rs
@@ -5,10 +5,12 @@ pub mod init {
         chorded: crate::key::chorded::Config {
             timeout: 200,
             chords: [],
+            ..crate::key::chorded::DEFAULT_CONFIG
         },
         tap_hold: crate::key::tap_hold::Config {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::HoldOnKeyTap,
+            ..crate::key::tap_hold::DEFAULT_CONFIG
         },
         ..crate::key::composite::DEFAULT_CONFIG
     };

--- a/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
@@ -5,10 +5,12 @@ pub mod init {
         chorded: crate::key::chorded::Config {
             timeout: 200,
             chords: [],
+            ..crate::key::chorded::DEFAULT_CONFIG
         },
         tap_hold: crate::key::tap_hold::Config {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,
+            ..crate::key::tap_hold::DEFAULT_CONFIG
         },
         ..crate::key::composite::DEFAULT_CONFIG
     };

--- a/tests/ncl/keymap-60key-dvorak-simple/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple/expected.rs
@@ -5,10 +5,12 @@ pub mod init {
         chorded: crate::key::chorded::Config {
             timeout: 200,
             chords: [],
+            ..crate::key::chorded::DEFAULT_CONFIG
         },
         tap_hold: crate::key::tap_hold::Config {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,
+            ..crate::key::tap_hold::DEFAULT_CONFIG
         },
         ..crate::key::composite::DEFAULT_CONFIG
     };


### PR DESCRIPTION
Using `..DEFAULT_CONFIG` means that fields can be added to config without breaking codegen.