### PR TITLE
Codegen: add sticky config

### DIFF
--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -1115,6 +1115,9 @@ let validators = import "validators.ncl" in
               chords | default = [],
               timeout | default = 200,
             },
+            sticky = {
+              activation | default = "OnStickyKeyRelease",
+            },
             tap_hold = {
               timeout | default = 200,
               interrupt_response | default = "Ignore",
@@ -1136,6 +1139,13 @@ let validators = import "validators.ncl" in
             timeout: %{std.to_string config.chorded.timeout},
             chords: [%{chords_fragment}],
             ..crate::key::chorded::DEFAULT_CONFIG
+        }
+      "%
+      in
+      let sticky_config_expr = m%"
+        crate::key::sticky::Config {
+            activation: crate::key::sticky::StickyKeyActivation::%{config.sticky.activation},
+            ..crate::key::sticky::DEFAULT_CONFIG
         }
       "%
       in
@@ -1189,6 +1199,7 @@ pub mod init {
     /// Config used by tap-hold keys.
     pub const CONFIG: crate::key::composite::Config = crate::key::composite::Config {
         chorded: %{chorded_config_expr},
+        sticky: %{sticky_config_expr},
         tap_hold: %{tap_hold_config_expr},
         ..crate::key::composite::DEFAULT_CONFIG
     };

--- a/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
+++ b/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
@@ -7,6 +7,10 @@ pub mod init {
             chords: [],
             ..crate::key::chorded::DEFAULT_CONFIG
         },
+        sticky: crate::key::sticky::Config {
+            activation: crate::key::sticky::StickyKeyActivation::OnStickyKeyRelease,
+            ..crate::key::sticky::DEFAULT_CONFIG
+        },
         tap_hold: crate::key::tap_hold::Config {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,

--- a/tests/ncl/keymap-1key-simple/expected.rs
+++ b/tests/ncl/keymap-1key-simple/expected.rs
@@ -7,6 +7,10 @@ pub mod init {
             chords: [],
             ..crate::key::chorded::DEFAULT_CONFIG
         },
+        sticky: crate::key::sticky::Config {
+            activation: crate::key::sticky::StickyKeyActivation::OnStickyKeyRelease,
+            ..crate::key::sticky::DEFAULT_CONFIG
+        },
         tap_hold: crate::key::tap_hold::Config {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,

--- a/tests/ncl/keymap-1key-tap_hold/expected.rs
+++ b/tests/ncl/keymap-1key-tap_hold/expected.rs
@@ -7,6 +7,10 @@ pub mod init {
             chords: [],
             ..crate::key::chorded::DEFAULT_CONFIG
         },
+        sticky: crate::key::sticky::Config {
+            activation: crate::key::sticky::StickyKeyActivation::OnStickyKeyRelease,
+            ..crate::key::sticky::DEFAULT_CONFIG
+        },
         tap_hold: crate::key::tap_hold::Config {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,

--- a/tests/ncl/keymap-2key-2layer-composite/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-composite/expected.rs
@@ -7,6 +7,10 @@ pub mod init {
             chords: [],
             ..crate::key::chorded::DEFAULT_CONFIG
         },
+        sticky: crate::key::sticky::Config {
+            activation: crate::key::sticky::StickyKeyActivation::OnStickyKeyRelease,
+            ..crate::key::sticky::DEFAULT_CONFIG
+        },
         tap_hold: crate::key::tap_hold::Config {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,

--- a/tests/ncl/keymap-2key-2layer-simple/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-simple/expected.rs
@@ -7,6 +7,10 @@ pub mod init {
             chords: [],
             ..crate::key::chorded::DEFAULT_CONFIG
         },
+        sticky: crate::key::sticky::Config {
+            activation: crate::key::sticky::StickyKeyActivation::OnStickyKeyRelease,
+            ..crate::key::sticky::DEFAULT_CONFIG
+        },
         tap_hold: crate::key::tap_hold::Config {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,

--- a/tests/ncl/keymap-2key-chorded/expected.rs
+++ b/tests/ncl/keymap-2key-chorded/expected.rs
@@ -7,6 +7,10 @@ pub mod init {
             chords: [Some(crate::key::chorded::ChordIndices::Chord2(0, 1))],
             ..crate::key::chorded::DEFAULT_CONFIG
         },
+        sticky: crate::key::sticky::Config {
+            activation: crate::key::sticky::StickyKeyActivation::OnStickyKeyRelease,
+            ..crate::key::sticky::DEFAULT_CONFIG
+        },
         tap_hold: crate::key::tap_hold::Config {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,

--- a/tests/ncl/keymap-48key-basic/expected.rs
+++ b/tests/ncl/keymap-48key-basic/expected.rs
@@ -7,6 +7,10 @@ pub mod init {
             chords: [],
             ..crate::key::chorded::DEFAULT_CONFIG
         },
+        sticky: crate::key::sticky::Config {
+            activation: crate::key::sticky::StickyKeyActivation::OnStickyKeyRelease,
+            ..crate::key::sticky::DEFAULT_CONFIG
+        },
         tap_hold: crate::key::tap_hold::Config {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,

--- a/tests/ncl/keymap-48key-rgoulter/expected.rs
+++ b/tests/ncl/keymap-48key-rgoulter/expected.rs
@@ -7,6 +7,10 @@ pub mod init {
             chords: [],
             ..crate::key::chorded::DEFAULT_CONFIG
         },
+        sticky: crate::key::sticky::Config {
+            activation: crate::key::sticky::StickyKeyActivation::OnStickyKeyRelease,
+            ..crate::key::sticky::DEFAULT_CONFIG
+        },
         tap_hold: crate::key::tap_hold::Config {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::HoldOnKeyTap,

--- a/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
@@ -7,6 +7,10 @@ pub mod init {
             chords: [],
             ..crate::key::chorded::DEFAULT_CONFIG
         },
+        sticky: crate::key::sticky::Config {
+            activation: crate::key::sticky::StickyKeyActivation::OnStickyKeyRelease,
+            ..crate::key::sticky::DEFAULT_CONFIG
+        },
         tap_hold: crate::key::tap_hold::Config {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,

--- a/tests/ncl/keymap-60key-dvorak-simple/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple/expected.rs
@@ -7,6 +7,10 @@ pub mod init {
             chords: [],
             ..crate::key::chorded::DEFAULT_CONFIG
         },
+        sticky: crate::key::sticky::Config {
+            activation: crate::key::sticky::StickyKeyActivation::OnStickyKeyRelease,
+            ..crate::key::sticky::DEFAULT_CONFIG
+        },
         tap_hold: crate::key::tap_hold::Config {
             timeout: 200,
             interrupt_response: crate::key::tap_hold::InterruptResponse::Ignore,


### PR DESCRIPTION
Add `key::sticky`'s `Config` to `keymap-codegen.ncl`.

Currently, `keymap-ncl-to-json` doesn't yet offer (many) abstractions for `config`: it translates `chords`, but otherwise `config` in `keymap.json` is just the 'json value' for the Config.