### PR TITLE
ncl: keymap-ncl-to-json: add contract for chords

### DIFF
--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -1,5 +1,7 @@
 let validators = import "validators.ncl" in
 {
+  Chord = { indices | Array Number, key | KeymapKey },
+
   KeymapKey =
     std.contract.any_of [
       keyboard.Key,
@@ -28,6 +30,7 @@ let validators = import "validators.ncl" in
     = [keys],
 
   chords
+    | Array Chord
     | default
     = [],
 


### PR DESCRIPTION
Adds a Nickel contract for the `chords` field for `keymap.ncl`.