### PR TITLE
ncl: keymap-codegen: describe keymap_json.config with Contracts

### DIFF
--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -1,8 +1,56 @@
 let validators = import "validators.ncl" in
 {
+  ChordIndicesJson = Array Number,
+
+  ChordedConfigJson = {
+    chords | optional | Array ChordIndicesJson,
+    timeout | optional | Number,
+  },
+
+  StickyActivationJson =
+    std.contract.from_validator (
+      validators.is_elem_of [
+        "OnStickyKeyRelease"
+      ]
+    ),
+
+  StickyConfigJson = {
+    activation
+      | optional
+      | StickyActivationJson,
+  },
+
+  TapHoldInterruptResponseJson =
+    std.contract.from_validator (
+      validators.is_elem_of [
+        "HoldOnKeyPress",
+        "HoldOnKeyTap",
+        "Ignore",
+      ]
+    ),
+
+  TapHoldConfigJson = {
+    timeout | optional | Number,
+    interrupt_response | optional | TapHoldInterruptResponseJson,
+  },
+
+  ConfigJson = {
+    chorded | optional | ChordedConfigJson,
+    sticky | optional | StickyConfigJson,
+    tap_hold | optional | TapHoldConfigJson,
+  },
+
+  KeymapJson
+    | doc "Contract for the keymap.json value"
+    = {
+      keys | Array key.JsonValue,
+      config | optional | ConfigJson,
+      ..
+    },
+
   json_keymap
     | doc "The 'JSON' value of the keymap. e.g. imported from keymap.json."
-    | { keys | Array key.JsonValue, .. },
+    | KeymapJson,
 
   # Given an array of codegen_values,
   #  return the 'wrapper type' that unifies all the values.


### PR DESCRIPTION
Blocked on #296.

Adding contracts on `keymap-codegen.ncl` is somewhat less useful than for `keymap-ncl-to-json`. But, it clarifies assumptions being made, so there's more benefit than risk to adding it.

Also: currently, `keymap.ncl`'s `config` is largely just passed-through to `keymap-codegen`; but, it may be that e.g. `keymap-ncl-to-json` uses Nickel enum tags (e.g. `'HoldOnInterruptTap` or so. -- If Nickel LSP could help with writing keymap.ncl, that'd be great.