### PR TITLE
Rewrite KeyboardModifiers as u8 newtype

### DIFF
--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -96,52 +96,11 @@ let validators = import "validators.ncl" in
   keyboard_modifiers = {
     JsonValue = std.contract.from_validator json_value_validator,
 
-    json_value_validator =
-      validators.record.validator {
-        fields_validator =
-          validators.record.has_only_fields [
-            "left_ctrl",
-            "left_shift",
-            "left_alt",
-            "left_gui",
-            "right_ctrl",
-            "right_shift",
-            "right_alt",
-            "right_gui",
-          ],
-        field_validators = {
-          left_ctrl = validators.is_bool,
-          left_shift = validators.is_bool,
-          left_alt = validators.is_bool,
-          left_gui = validators.is_bool,
-          right_ctrl = validators.is_bool,
-          right_shift = validators.is_bool,
-          right_alt = validators.is_bool,
-          right_gui = validators.is_bool,
-        },
-      },
+    json_value_validator = validators.is_number,
 
     is_json_value = fun k => 'Ok == json_value_validator k,
 
-    expr = match {
-      {} => "crate::key::KeyboardModifiers::new()",
-      { left_ctrl, ..modifiers } if left_ctrl =>
-        "crate::key::KeyboardModifiers::LEFT_CTRL.union(&%{keyboard_modifiers.expr modifiers})",
-      { left_alt, ..modifiers } if left_alt =>
-        "crate::key::KeyboardModifiers::LEFT_ALT.union(&%{keyboard_modifiers.expr modifiers})",
-      { left_shift, ..modifiers } if left_shift =>
-        "crate::key::KeyboardModifiers::LEFT_SHIFT.union(&%{keyboard_modifiers.expr modifiers})",
-      { left_gui, ..modifiers } if left_gui =>
-        "crate::key::KeyboardModifiers::LEFT_GUI.union(&%{keyboard_modifiers.expr modifiers})",
-      { right_ctrl, ..modifiers } if right_ctrl =>
-        "crate::key::KeyboardModifiers::RIGHT_CTRL.union(&%{keyboard_modifiers.expr modifiers})",
-      { right_alt, ..modifiers } if right_alt =>
-        "crate::key::KeyboardModifiers::RIGHT_ALT.union(&%{keyboard_modifiers.expr modifiers})",
-      { right_shift, ..modifiers } if right_shift =>
-        "crate::key::KeyboardModifiers::RIGHT_SHIFT.union(&%{keyboard_modifiers.expr modifiers})",
-      { right_gui, ..modifiers } if right_gui =>
-        "crate::key::KeyboardModifiers::RIGHT_GUI.union(&%{keyboard_modifiers.expr modifiers})",
-    },
+    expr = fun b => "crate::key::KeyboardModifiers::from_byte(%{std.to_string b})",
   },
 
   checks.check_keyboard = {
@@ -150,10 +109,10 @@ let validators = import "validators.ncl" in
       let json_value = { key_code = 4 } in
       keyboard.is_json_value json_value,
     check_json_with_modifier_is =
-      let json_value = { key_code = 4, modifiers = { left_ctrl = true } } in
+      let json_value = { key_code = 4, modifiers = 1 } in
       keyboard.is_json_value json_value,
     check_json_modifiers_is =
-      let json_value = { modifiers = { left_ctrl = true } } in
+      let json_value = { modifiers = 1 } in
       keyboard.is_json_value json_value,
 
     check_keyboard_codegen_values = {

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -101,6 +101,31 @@ let validators = import "validators.ncl" in
           right_gui = validators.is_bool,
         },
       },
+
+    # Must agree with consts used in key::KeyboardModifiers
+    to_json_value = fun km =>
+      let km =
+        km
+        & {
+          left_ctrl | default = false,
+          left_shift | default = false,
+          left_alt | default = false,
+          left_gui | default = false,
+          right_ctrl | default = false,
+          right_shift | default = false,
+          right_alt | default = false,
+          right_gui | default = false,
+        }
+      in
+      0
+      + (if km.left_ctrl then 1 else 0)
+      + (if km.left_shift then 2 else 0)
+      + (if km.left_alt then 4 else 0)
+      + (if km.left_gui then 8 else 0)
+      + (if km.right_ctrl then 16 else 0)
+      + (if km.right_shift then 32 else 0)
+      + (if km.right_alt then 64 else 0)
+      + (if km.right_gui then 128 else 0),
   },
 
   checks.keyboard =
@@ -137,7 +162,10 @@ let validators = import "validators.ncl" in
 
       is_key = fun k => 'Ok == key_validator k,
 
-      to_json_value = fun key => key,
+      to_json_value = match {
+        { modifiers = km, ..k } => k & { modifiers = keyboard_modifiers.to_json_value km },
+        k => k,
+      },
     },
 
   checks.layer_modifier =
@@ -230,7 +258,7 @@ let validators = import "validators.ncl" in
 
       is_key = fun k => 'Ok == key_validator k,
 
-      to_json_value = fun key => key,
+      to_json_value = fun { sticky_modifiers = sm } => { sticky_modifiers = keyboard_modifiers.to_json_value sm },
     },
 
   checks.layered =
@@ -324,12 +352,12 @@ let validators = import "validators.ncl" in
 
       check_tap_keyboard_hold_keyboard_to_json_json_value_keyboard = {
         actual = K.A & K.hold K.LeftCtrl |> tap_hold.to_json_value,
-        expected = { tap = { key_code = 4 }, hold = { modifiers = { left_ctrl = true } } },
+        expected = { tap = { key_code = 4 }, hold = { modifiers = 1 } },
       },
 
       check_json_value_tap_keyboard_hold_keyboard = {
         actual = K.A & K.hold K.LeftCtrl |> key.to_json_value,
-        expected = { tap = { key_code = 4 }, hold = { modifiers = { left_ctrl = true } } },
+        expected = { tap = { key_code = 4 }, hold = { modifiers = 1 } },
       },
     },
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -279,6 +279,11 @@ impl KeyboardModifiers {
         KeyboardModifiers(0x00)
     }
 
+    /// Constructs with modifiers with the given byte.
+    pub const fn from_byte(b: u8) -> Self {
+        KeyboardModifiers(b)
+    }
+
     /// Constructs with the given key_code.
     ///
     /// Returns None if the key_code is not a modifier key code.

--- a/src/key.rs
+++ b/src/key.rs
@@ -215,50 +215,41 @@ pub trait Context: Clone + Copy {
 
 /// Bool flags for each of the modifier keys (left ctrl, etc.).
 #[derive(Deserialize, Serialize, Default, Clone, Copy, PartialEq, Eq)]
-pub struct KeyboardModifiers {
-    #[serde(default)]
-    left_ctrl: bool,
-    #[serde(default)]
-    left_shift: bool,
-    #[serde(default)]
-    left_alt: bool,
-    #[serde(default)]
-    left_gui: bool,
-    #[serde(default)]
-    right_ctrl: bool,
-    #[serde(default)]
-    right_shift: bool,
-    #[serde(default)]
-    right_alt: bool,
-    #[serde(default)]
-    right_gui: bool,
+pub struct KeyboardModifiers(u8);
+
+impl core::ops::Deref for KeyboardModifiers {
+    type Target = u8;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl core::fmt::Debug for KeyboardModifiers {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut ds = f.debug_struct("KeyboardModifiers");
-        if self.left_ctrl {
+        if self.0 & Self::LEFT_CTRL_U8 != 0 {
             ds.field("left_ctrl", &true);
         }
-        if self.left_shift {
+        if self.0 & Self::LEFT_SHIFT_U8 != 0 {
             ds.field("left_shift", &true);
         }
-        if self.left_alt {
+        if self.0 & Self::LEFT_ALT_U8 != 0 {
             ds.field("left_alt", &true);
         }
-        if self.left_gui {
+        if self.0 & Self::LEFT_GUI_U8 != 0 {
             ds.field("left_gui", &true);
         }
-        if self.right_ctrl {
+        if self.0 & Self::RIGHT_CTRL_U8 != 0 {
             ds.field("right_ctrl", &true);
         }
-        if self.right_shift {
+        if self.0 & Self::RIGHT_SHIFT_U8 != 0 {
             ds.field("right_shift", &true);
         }
-        if self.right_alt {
+        if self.0 & Self::RIGHT_ALT_U8 != 0 {
             ds.field("right_alt", &true);
         }
-        if self.right_gui {
+        if self.0 & Self::RIGHT_GUI_U8 != 0 {
             ds.field("right_gui", &true);
         }
         ds.finish_non_exhaustive()
@@ -266,18 +257,26 @@ impl core::fmt::Debug for KeyboardModifiers {
 }
 
 impl KeyboardModifiers {
+    /// Byte value for left ctrl.
+    pub const LEFT_CTRL_U8: u8 = 0x01;
+    /// Byte value for left shift.
+    pub const LEFT_SHIFT_U8: u8 = 0x02;
+    /// Byte value for left alt.
+    pub const LEFT_ALT_U8: u8 = 0x04;
+    /// Byte value for left gui.
+    pub const LEFT_GUI_U8: u8 = 0x08;
+    /// Byte value for right ctrl.
+    pub const RIGHT_CTRL_U8: u8 = 0x10;
+    /// Byte value for right shift.
+    pub const RIGHT_SHIFT_U8: u8 = 0x20;
+    /// Byte value for right alt.
+    pub const RIGHT_ALT_U8: u8 = 0x40;
+    /// Byte value for right gui.
+    pub const RIGHT_GUI_U8: u8 = 0x80;
+
     /// Constructs with modifiers defaulting to false.
     pub const fn new() -> Self {
-        KeyboardModifiers {
-            left_ctrl: false,
-            left_shift: false,
-            left_alt: false,
-            left_gui: false,
-            right_ctrl: false,
-            right_shift: false,
-            right_alt: false,
-            right_gui: false,
-        }
+        KeyboardModifiers(0x00)
     }
 
     /// Constructs with the given key_code.
@@ -303,52 +302,28 @@ impl KeyboardModifiers {
     };
 
     /// Const for left ctrl.
-    pub const LEFT_CTRL: KeyboardModifiers = KeyboardModifiers {
-        left_ctrl: true,
-        ..KeyboardModifiers::new()
-    };
+    pub const LEFT_CTRL: KeyboardModifiers = KeyboardModifiers(Self::LEFT_CTRL_U8);
 
     /// Const for left shift.
-    pub const LEFT_SHIFT: KeyboardModifiers = KeyboardModifiers {
-        left_shift: true,
-        ..KeyboardModifiers::new()
-    };
+    pub const LEFT_SHIFT: KeyboardModifiers = KeyboardModifiers(Self::LEFT_SHIFT_U8);
 
     /// Const for left alt.
-    pub const LEFT_ALT: KeyboardModifiers = KeyboardModifiers {
-        left_alt: true,
-        ..KeyboardModifiers::new()
-    };
+    pub const LEFT_ALT: KeyboardModifiers = KeyboardModifiers(Self::LEFT_ALT_U8);
 
     /// Const for left gui.
-    pub const LEFT_GUI: KeyboardModifiers = KeyboardModifiers {
-        left_gui: true,
-        ..KeyboardModifiers::new()
-    };
+    pub const LEFT_GUI: KeyboardModifiers = KeyboardModifiers(Self::LEFT_GUI_U8);
 
     /// Const for right ctrl.
-    pub const RIGHT_CTRL: KeyboardModifiers = KeyboardModifiers {
-        right_ctrl: true,
-        ..KeyboardModifiers::new()
-    };
+    pub const RIGHT_CTRL: KeyboardModifiers = KeyboardModifiers(Self::RIGHT_CTRL_U8);
 
     /// Const for right shift.
-    pub const RIGHT_SHIFT: KeyboardModifiers = KeyboardModifiers {
-        right_shift: true,
-        ..KeyboardModifiers::new()
-    };
+    pub const RIGHT_SHIFT: KeyboardModifiers = KeyboardModifiers(Self::RIGHT_SHIFT_U8);
 
     /// Const for right alt.
-    pub const RIGHT_ALT: KeyboardModifiers = KeyboardModifiers {
-        right_alt: true,
-        ..KeyboardModifiers::new()
-    };
+    pub const RIGHT_ALT: KeyboardModifiers = KeyboardModifiers(Self::RIGHT_ALT_U8);
 
     /// Const for right gui.
-    pub const RIGHT_GUI: KeyboardModifiers = KeyboardModifiers {
-        right_gui: true,
-        ..KeyboardModifiers::new()
-    };
+    pub const RIGHT_GUI: KeyboardModifiers = KeyboardModifiers(Self::RIGHT_GUI_U8);
 
     /// Predicate for whether the key code is a modifier key code.
     pub const fn is_modifier_key_code(key_code: u8) -> bool {
@@ -359,28 +334,28 @@ impl KeyboardModifiers {
     pub fn as_key_codes(&self) -> heapless::Vec<u8, 8> {
         let mut key_codes = heapless::Vec::new();
 
-        if self.left_ctrl {
+        if self.0 & Self::LEFT_CTRL_U8 != 0 {
             key_codes.push(0xE0).unwrap();
         }
-        if self.left_shift {
+        if self.0 & Self::LEFT_SHIFT_U8 != 0 {
             key_codes.push(0xE1).unwrap();
         }
-        if self.left_alt {
+        if self.0 & Self::LEFT_ALT_U8 != 0 {
             key_codes.push(0xE2).unwrap();
         }
-        if self.left_gui {
+        if self.0 & Self::LEFT_GUI_U8 != 0 {
             key_codes.push(0xE3).unwrap();
         }
-        if self.right_ctrl {
+        if self.0 & Self::RIGHT_CTRL_U8 != 0 {
             key_codes.push(0xE4).unwrap();
         }
-        if self.right_shift {
+        if self.0 & Self::RIGHT_SHIFT_U8 != 0 {
             key_codes.push(0xE5).unwrap();
         }
-        if self.right_alt {
+        if self.0 & Self::RIGHT_ALT_U8 != 0 {
             key_codes.push(0xE6).unwrap();
         }
-        if self.right_gui {
+        if self.0 & Self::RIGHT_GUI_U8 != 0 {
             key_codes.push(0xE7).unwrap();
         }
 
@@ -396,28 +371,12 @@ impl KeyboardModifiers {
 
     /// Union of two KeyboardModifiers, taking "or" of each modifier.
     pub const fn union(&self, other: &KeyboardModifiers) -> KeyboardModifiers {
-        KeyboardModifiers {
-            left_ctrl: self.left_ctrl || other.left_ctrl,
-            left_shift: self.left_shift || other.left_shift,
-            left_alt: self.left_alt || other.left_alt,
-            left_gui: self.left_gui || other.left_gui,
-            right_ctrl: self.right_ctrl || other.right_ctrl,
-            right_shift: self.right_shift || other.right_shift,
-            right_alt: self.right_alt || other.right_alt,
-            right_gui: self.right_gui || other.right_gui,
-        }
+        KeyboardModifiers(self.0 | other.0)
     }
 
     /// Whether this keyboard modifiers includes all the other modifiers.
     pub const fn has_modifiers(&self, other: &KeyboardModifiers) -> bool {
-        (!other.left_ctrl || self.left_ctrl)
-            && (!other.left_shift || self.left_shift)
-            && (!other.left_alt || self.left_alt)
-            && (!other.left_gui || self.left_gui)
-            && (!other.right_ctrl || self.right_ctrl)
-            && (!other.right_shift || self.right_shift)
-            && (!other.right_alt || self.right_alt)
-            && (!other.right_gui || self.right_gui)
+        self.0 & other.0 != 0
     }
 }
 

--- a/src/key/doc_de_keyboard.md
+++ b/src/key/doc_de_keyboard.md
@@ -18,7 +18,7 @@ Modifiers:
 use smart_keymap::key::keyboard::Key;
 use smart_keymap::key::KeyboardModifiers;
 let json = r#"
-  { "modifiers": { "left_ctrl": true } }
+  { "modifiers": 1 }
 "#;
 let expected_key: Key = Key::from_modifiers(
     KeyboardModifiers::LEFT_CTRL,
@@ -33,7 +33,7 @@ Key code with modifiers:
 use smart_keymap::key::keyboard::Key;
 use smart_keymap::key::KeyboardModifiers;
 let json = r#"
-  { "key_code": 4, "modifiers": { "left_ctrl": true } }
+  { "key_code": 4, "modifiers": 1 }
 "#;
 let expected_key: Key = Key::new_with_modifiers(
     0x04,

--- a/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
+++ b/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
@@ -56,8 +56,7 @@ pub mod init {
                 crate::key::composite::BaseKey::Keyboard(crate::key::keyboard::Key::new(4)),
                 crate::key::composite::BaseKey::Keyboard(
                     crate::key::keyboard::Key::from_modifiers(
-                        crate::key::KeyboardModifiers::LEFT_CTRL
-                            .union(&crate::key::KeyboardModifiers::new()),
+                        crate::key::KeyboardModifiers::from_byte(1),
                     ),
                 ),
             )),

--- a/tests/ncl/keymap-48key-basic/expected.rs
+++ b/tests/ncl/keymap-48key-basic/expected.rs
@@ -296,8 +296,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             53,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     None,
@@ -314,8 +313,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             30,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     None,
@@ -332,8 +330,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             31,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     None,
@@ -350,8 +347,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             32,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     None,
@@ -368,8 +364,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             33,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     None,
@@ -386,8 +381,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             34,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     None,
@@ -404,8 +398,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             35,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     None,
@@ -422,8 +415,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             36,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     Some(crate::key::composite::TapHold(
@@ -442,8 +434,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             37,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     Some(crate::key::composite::TapHold(
@@ -462,8 +453,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             38,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     Some(crate::key::composite::TapHold(
@@ -482,8 +472,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             39,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     None,
@@ -500,8 +489,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             49,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     None,
@@ -618,8 +606,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             45,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     None,
@@ -636,8 +623,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             46,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     None,
@@ -654,8 +640,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             47,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     None,
@@ -672,8 +657,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             48,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     None,
@@ -690,8 +674,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             56,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     None,
@@ -700,8 +683,7 @@ pub mod init {
         )),
         crate::key::composite::Chorded(crate::key::composite::Layered(
             crate::key::composite::TapHold(crate::key::keyboard::Key::from_modifiers(
-                crate::key::KeyboardModifiers::LEFT_SHIFT
-                    .union(&crate::key::KeyboardModifiers::new()),
+                crate::key::KeyboardModifiers::from_byte(2),
             )),
         )),
         crate::key::composite::Chorded(crate::key::composite::LayeredKey::Layered(
@@ -830,8 +812,7 @@ pub mod init {
         crate::key::composite::Chorded(crate::key::composite::LayeredKey::Layered(
             crate::key::layered::LayeredKey::new(
                 crate::key::composite::TapHold(crate::key::keyboard::Key::from_modifiers(
-                    crate::key::KeyboardModifiers::RIGHT_SHIFT
-                        .union(&crate::key::KeyboardModifiers::new()),
+                    crate::key::KeyboardModifiers::from_byte(32),
                 )),
                 [
                     None,
@@ -844,20 +825,17 @@ pub mod init {
         )),
         crate::key::composite::Chorded(crate::key::composite::Layered(
             crate::key::composite::TapHold(crate::key::keyboard::Key::from_modifiers(
-                crate::key::KeyboardModifiers::LEFT_CTRL
-                    .union(&crate::key::KeyboardModifiers::new()),
+                crate::key::KeyboardModifiers::from_byte(1),
             )),
         )),
         crate::key::composite::Chorded(crate::key::composite::Layered(
             crate::key::composite::TapHold(crate::key::keyboard::Key::from_modifiers(
-                crate::key::KeyboardModifiers::LEFT_GUI
-                    .union(&crate::key::KeyboardModifiers::new()),
+                crate::key::KeyboardModifiers::from_byte(8),
             )),
         )),
         crate::key::composite::Chorded(crate::key::composite::Layered(
             crate::key::composite::TapHold(crate::key::keyboard::Key::from_modifiers(
-                crate::key::KeyboardModifiers::LEFT_ALT
-                    .union(&crate::key::KeyboardModifiers::new()),
+                crate::key::KeyboardModifiers::from_byte(4),
             )),
         )),
         crate::key::composite::Chorded(crate::key::composite::Layered(
@@ -908,8 +886,7 @@ pub mod init {
         crate::key::composite::Chorded(crate::key::composite::LayeredKey::Layered(
             crate::key::layered::LayeredKey::new(
                 crate::key::composite::TapHold(crate::key::keyboard::Key::from_modifiers(
-                    crate::key::KeyboardModifiers::RIGHT_ALT
-                        .union(&crate::key::KeyboardModifiers::new()),
+                    crate::key::KeyboardModifiers::from_byte(64),
                 )),
                 [
                     None,
@@ -923,8 +900,7 @@ pub mod init {
         crate::key::composite::Chorded(crate::key::composite::LayeredKey::Layered(
             crate::key::layered::LayeredKey::new(
                 crate::key::composite::TapHold(crate::key::keyboard::Key::from_modifiers(
-                    crate::key::KeyboardModifiers::RIGHT_GUI
-                        .union(&crate::key::KeyboardModifiers::new()),
+                    crate::key::KeyboardModifiers::from_byte(128),
                 )),
                 [
                     None,
@@ -938,8 +914,7 @@ pub mod init {
         crate::key::composite::Chorded(crate::key::composite::LayeredKey::Layered(
             crate::key::layered::LayeredKey::new(
                 crate::key::composite::TapHold(crate::key::keyboard::Key::from_modifiers(
-                    crate::key::KeyboardModifiers::RIGHT_CTRL
-                        .union(&crate::key::KeyboardModifiers::new()),
+                    crate::key::KeyboardModifiers::from_byte(16),
                 )),
                 [
                     None,

--- a/tests/ncl/keymap-48key-rgoulter/expected.rs
+++ b/tests/ncl/keymap-48key-rgoulter/expected.rs
@@ -299,8 +299,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             47,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     Some(crate::key::composite::TapHold(
@@ -326,8 +325,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             36,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     Some(crate::key::composite::TapHold(
@@ -353,8 +351,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             37,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     Some(crate::key::composite::TapHold(
@@ -380,8 +377,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             38,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     Some(crate::key::composite::TapHold(
@@ -407,8 +403,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             48,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     Some(crate::key::composite::TapHold(
@@ -564,8 +559,7 @@ pub mod init {
                 crate::key::composite::TapHoldKey::TapHold(crate::key::tap_hold::Key::new(
                     crate::key::keyboard::Key::new(4),
                     crate::key::keyboard::Key::from_modifiers(
-                        crate::key::KeyboardModifiers::LEFT_ALT
-                            .union(&crate::key::KeyboardModifiers::new()),
+                        crate::key::KeyboardModifiers::from_byte(4),
                     ),
                 )),
                 [
@@ -575,8 +569,7 @@ pub mod init {
                     Some(crate::key::composite::TapHoldKey::Pass(
                         crate::key::keyboard::Key::new_with_modifiers(
                             53,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     Some(crate::key::composite::TapHoldKey::Pass(
@@ -597,8 +590,7 @@ pub mod init {
                 crate::key::composite::TapHoldKey::TapHold(crate::key::tap_hold::Key::new(
                     crate::key::keyboard::Key::new(18),
                     crate::key::keyboard::Key::from_modifiers(
-                        crate::key::KeyboardModifiers::LEFT_GUI
-                            .union(&crate::key::KeyboardModifiers::new()),
+                        crate::key::KeyboardModifiers::from_byte(8),
                     ),
                 )),
                 [
@@ -608,8 +600,7 @@ pub mod init {
                     Some(crate::key::composite::TapHoldKey::Pass(
                         crate::key::keyboard::Key::new_with_modifiers(
                             33,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     Some(crate::key::composite::TapHoldKey::Pass(
@@ -630,8 +621,7 @@ pub mod init {
                 crate::key::composite::TapHoldKey::TapHold(crate::key::tap_hold::Key::new(
                     crate::key::keyboard::Key::new(8),
                     crate::key::keyboard::Key::from_modifiers(
-                        crate::key::KeyboardModifiers::LEFT_CTRL
-                            .union(&crate::key::KeyboardModifiers::new()),
+                        crate::key::KeyboardModifiers::from_byte(1),
                     ),
                 )),
                 [
@@ -641,8 +631,7 @@ pub mod init {
                     Some(crate::key::composite::TapHoldKey::Pass(
                         crate::key::keyboard::Key::new_with_modifiers(
                             34,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     Some(crate::key::composite::TapHoldKey::Pass(
@@ -663,8 +652,7 @@ pub mod init {
                 crate::key::composite::TapHoldKey::TapHold(crate::key::tap_hold::Key::new(
                     crate::key::keyboard::Key::new(24),
                     crate::key::keyboard::Key::from_modifiers(
-                        crate::key::KeyboardModifiers::LEFT_SHIFT
-                            .union(&crate::key::KeyboardModifiers::new()),
+                        crate::key::KeyboardModifiers::from_byte(2),
                     ),
                 )),
                 [
@@ -674,8 +662,7 @@ pub mod init {
                     Some(crate::key::composite::TapHoldKey::Pass(
                         crate::key::keyboard::Key::new_with_modifiers(
                             35,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     Some(crate::key::composite::TapHoldKey::Pass(
@@ -701,8 +688,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             46,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     Some(crate::key::composite::TapHold(
@@ -792,8 +778,7 @@ pub mod init {
                 crate::key::composite::TapHoldKey::TapHold(crate::key::tap_hold::Key::new(
                     crate::key::keyboard::Key::new(11),
                     crate::key::keyboard::Key::from_modifiers(
-                        crate::key::KeyboardModifiers::RIGHT_SHIFT
-                            .union(&crate::key::KeyboardModifiers::new()),
+                        crate::key::KeyboardModifiers::from_byte(32),
                     ),
                 )),
                 [
@@ -817,8 +802,7 @@ pub mod init {
                 crate::key::composite::TapHoldKey::TapHold(crate::key::tap_hold::Key::new(
                     crate::key::keyboard::Key::new(23),
                     crate::key::keyboard::Key::from_modifiers(
-                        crate::key::KeyboardModifiers::LEFT_CTRL
-                            .union(&crate::key::KeyboardModifiers::new()),
+                        crate::key::KeyboardModifiers::from_byte(1),
                     ),
                 )),
                 [
@@ -842,8 +826,7 @@ pub mod init {
                 crate::key::composite::TapHoldKey::TapHold(crate::key::tap_hold::Key::new(
                     crate::key::keyboard::Key::new(17),
                     crate::key::keyboard::Key::from_modifiers(
-                        crate::key::KeyboardModifiers::RIGHT_GUI
-                            .union(&crate::key::KeyboardModifiers::new()),
+                        crate::key::KeyboardModifiers::from_byte(128),
                     ),
                 )),
                 [
@@ -867,8 +850,7 @@ pub mod init {
                 crate::key::composite::TapHoldKey::TapHold(crate::key::tap_hold::Key::new(
                     crate::key::keyboard::Key::new(22),
                     crate::key::keyboard::Key::from_modifiers(
-                        crate::key::KeyboardModifiers::LEFT_ALT
-                            .union(&crate::key::KeyboardModifiers::new()),
+                        crate::key::KeyboardModifiers::from_byte(4),
                     ),
                 )),
                 [
@@ -897,8 +879,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             56,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     Some(crate::key::composite::TapHold(
@@ -924,8 +905,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             30,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     Some(crate::key::composite::TapHold(
@@ -951,8 +931,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             31,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     Some(crate::key::composite::TapHold(
@@ -978,8 +957,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             32,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     Some(crate::key::composite::TapHold(
@@ -1005,8 +983,7 @@ pub mod init {
                     Some(crate::key::composite::TapHold(
                         crate::key::keyboard::Key::new_with_modifiers(
                             49,
-                            crate::key::KeyboardModifiers::LEFT_SHIFT
-                                .union(&crate::key::KeyboardModifiers::new()),
+                            crate::key::KeyboardModifiers::from_byte(2),
                         ),
                     )),
                     Some(crate::key::composite::TapHold(
@@ -1266,8 +1243,7 @@ pub mod init {
                         crate::key::composite::BaseKey::Keyboard(
                             crate::key::keyboard::Key::new_with_modifiers(
                                 55,
-                                crate::key::KeyboardModifiers::LEFT_SHIFT
-                                    .union(&crate::key::KeyboardModifiers::new()),
+                                crate::key::KeyboardModifiers::from_byte(2),
                             ),
                         ),
                     )),
@@ -1300,8 +1276,7 @@ pub mod init {
                         crate::key::composite::BaseKey::Keyboard(
                             crate::key::keyboard::Key::new_with_modifiers(
                                 39,
-                                crate::key::KeyboardModifiers::LEFT_SHIFT
-                                    .union(&crate::key::KeyboardModifiers::new()),
+                                crate::key::KeyboardModifiers::from_byte(2),
                             ),
                         ),
                     )),
@@ -1334,8 +1309,7 @@ pub mod init {
                         crate::key::composite::BaseKey::Keyboard(
                             crate::key::keyboard::Key::new_with_modifiers(
                                 45,
-                                crate::key::KeyboardModifiers::LEFT_SHIFT
-                                    .union(&crate::key::KeyboardModifiers::new()),
+                                crate::key::KeyboardModifiers::from_byte(2),
                             ),
                         ),
                     )),

--- a/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
@@ -425,8 +425,7 @@ pub mod init {
             crate::key::composite::TapHoldKey::TapHold(crate::key::tap_hold::Key::new(
                 crate::key::keyboard::Key::new(4),
                 crate::key::keyboard::Key::from_modifiers(
-                    crate::key::KeyboardModifiers::LEFT_ALT
-                        .union(&crate::key::KeyboardModifiers::new()),
+                    crate::key::KeyboardModifiers::from_byte(4),
                 ),
             )),
         )),
@@ -434,8 +433,7 @@ pub mod init {
             crate::key::composite::TapHoldKey::TapHold(crate::key::tap_hold::Key::new(
                 crate::key::keyboard::Key::new(18),
                 crate::key::keyboard::Key::from_modifiers(
-                    crate::key::KeyboardModifiers::LEFT_GUI
-                        .union(&crate::key::KeyboardModifiers::new()),
+                    crate::key::KeyboardModifiers::from_byte(8),
                 ),
             )),
         )),
@@ -443,8 +441,7 @@ pub mod init {
             crate::key::composite::TapHoldKey::TapHold(crate::key::tap_hold::Key::new(
                 crate::key::keyboard::Key::new(8),
                 crate::key::keyboard::Key::from_modifiers(
-                    crate::key::KeyboardModifiers::LEFT_CTRL
-                        .union(&crate::key::KeyboardModifiers::new()),
+                    crate::key::KeyboardModifiers::from_byte(1),
                 ),
             )),
         )),
@@ -452,8 +449,7 @@ pub mod init {
             crate::key::composite::TapHoldKey::TapHold(crate::key::tap_hold::Key::new(
                 crate::key::keyboard::Key::new(24),
                 crate::key::keyboard::Key::from_modifiers(
-                    crate::key::KeyboardModifiers::LEFT_SHIFT
-                        .union(&crate::key::KeyboardModifiers::new()),
+                    crate::key::KeyboardModifiers::from_byte(2),
                 ),
             )),
         )),
@@ -467,8 +463,7 @@ pub mod init {
             crate::key::composite::TapHoldKey::TapHold(crate::key::tap_hold::Key::new(
                 crate::key::keyboard::Key::new(11),
                 crate::key::keyboard::Key::from_modifiers(
-                    crate::key::KeyboardModifiers::RIGHT_SHIFT
-                        .union(&crate::key::KeyboardModifiers::new()),
+                    crate::key::KeyboardModifiers::from_byte(32),
                 ),
             )),
         )),
@@ -476,8 +471,7 @@ pub mod init {
             crate::key::composite::TapHoldKey::TapHold(crate::key::tap_hold::Key::new(
                 crate::key::keyboard::Key::new(23),
                 crate::key::keyboard::Key::from_modifiers(
-                    crate::key::KeyboardModifiers::RIGHT_CTRL
-                        .union(&crate::key::KeyboardModifiers::new()),
+                    crate::key::KeyboardModifiers::from_byte(16),
                 ),
             )),
         )),
@@ -485,8 +479,7 @@ pub mod init {
             crate::key::composite::TapHoldKey::TapHold(crate::key::tap_hold::Key::new(
                 crate::key::keyboard::Key::new(17),
                 crate::key::keyboard::Key::from_modifiers(
-                    crate::key::KeyboardModifiers::RIGHT_GUI
-                        .union(&crate::key::KeyboardModifiers::new()),
+                    crate::key::KeyboardModifiers::from_byte(128),
                 ),
             )),
         )),
@@ -494,8 +487,7 @@ pub mod init {
             crate::key::composite::TapHoldKey::TapHold(crate::key::tap_hold::Key::new(
                 crate::key::keyboard::Key::new(22),
                 crate::key::keyboard::Key::from_modifiers(
-                    crate::key::KeyboardModifiers::RIGHT_ALT
-                        .union(&crate::key::KeyboardModifiers::new()),
+                    crate::key::KeyboardModifiers::from_byte(64),
                 ),
             )),
         )),
@@ -504,8 +496,7 @@ pub mod init {
         )),
         crate::key::composite::Chorded(crate::key::composite::Layered(
             crate::key::composite::TapHold(crate::key::keyboard::Key::from_modifiers(
-                crate::key::KeyboardModifiers::LEFT_SHIFT
-                    .union(&crate::key::KeyboardModifiers::new()),
+                crate::key::KeyboardModifiers::from_byte(2),
             )),
         )),
         crate::key::composite::Chorded(crate::key::composite::Layered(
@@ -540,26 +531,22 @@ pub mod init {
         )),
         crate::key::composite::Chorded(crate::key::composite::Layered(
             crate::key::composite::TapHold(crate::key::keyboard::Key::from_modifiers(
-                crate::key::KeyboardModifiers::RIGHT_SHIFT
-                    .union(&crate::key::KeyboardModifiers::new()),
+                crate::key::KeyboardModifiers::from_byte(32),
             )),
         )),
         crate::key::composite::Chorded(crate::key::composite::Layered(
             crate::key::composite::TapHold(crate::key::keyboard::Key::from_modifiers(
-                crate::key::KeyboardModifiers::LEFT_CTRL
-                    .union(&crate::key::KeyboardModifiers::new()),
+                crate::key::KeyboardModifiers::from_byte(1),
             )),
         )),
         crate::key::composite::Chorded(crate::key::composite::Layered(
             crate::key::composite::TapHold(crate::key::keyboard::Key::from_modifiers(
-                crate::key::KeyboardModifiers::LEFT_GUI
-                    .union(&crate::key::KeyboardModifiers::new()),
+                crate::key::KeyboardModifiers::from_byte(8),
             )),
         )),
         crate::key::composite::Chorded(crate::key::composite::Layered(
             crate::key::composite::TapHold(crate::key::keyboard::Key::from_modifiers(
-                crate::key::KeyboardModifiers::LEFT_ALT
-                    .union(&crate::key::KeyboardModifiers::new()),
+                crate::key::KeyboardModifiers::from_byte(4),
             )),
         )),
         crate::key::composite::Chorded(crate::key::composite::Layered(
@@ -582,20 +569,17 @@ pub mod init {
         )),
         crate::key::composite::Chorded(crate::key::composite::Layered(
             crate::key::composite::TapHold(crate::key::keyboard::Key::from_modifiers(
-                crate::key::KeyboardModifiers::RIGHT_ALT
-                    .union(&crate::key::KeyboardModifiers::new()),
+                crate::key::KeyboardModifiers::from_byte(64),
             )),
         )),
         crate::key::composite::Chorded(crate::key::composite::Layered(
             crate::key::composite::TapHold(crate::key::keyboard::Key::from_modifiers(
-                crate::key::KeyboardModifiers::RIGHT_GUI
-                    .union(&crate::key::KeyboardModifiers::new()),
+                crate::key::KeyboardModifiers::from_byte(128),
             )),
         )),
         crate::key::composite::Chorded(crate::key::composite::Layered(
             crate::key::composite::TapHold(crate::key::keyboard::Key::from_modifiers(
-                crate::key::KeyboardModifiers::RIGHT_CTRL
-                    .union(&crate::key::KeyboardModifiers::new()),
+                crate::key::KeyboardModifiers::from_byte(16),
             )),
         )),
     ));

--- a/tests/ncl/keymap-60key-dvorak-simple/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple/expected.rs
@@ -456,8 +456,7 @@ pub mod init {
         )),
         crate::key::composite::Chorded(crate::key::composite::Layered(
             crate::key::composite::TapHold(crate::key::keyboard::Key::from_modifiers(
-                crate::key::KeyboardModifiers::LEFT_SHIFT
-                    .union(&crate::key::KeyboardModifiers::new()),
+                crate::key::KeyboardModifiers::from_byte(2),
             )),
         )),
         crate::key::composite::Chorded(crate::key::composite::Layered(
@@ -492,26 +491,22 @@ pub mod init {
         )),
         crate::key::composite::Chorded(crate::key::composite::Layered(
             crate::key::composite::TapHold(crate::key::keyboard::Key::from_modifiers(
-                crate::key::KeyboardModifiers::RIGHT_SHIFT
-                    .union(&crate::key::KeyboardModifiers::new()),
+                crate::key::KeyboardModifiers::from_byte(32),
             )),
         )),
         crate::key::composite::Chorded(crate::key::composite::Layered(
             crate::key::composite::TapHold(crate::key::keyboard::Key::from_modifiers(
-                crate::key::KeyboardModifiers::LEFT_CTRL
-                    .union(&crate::key::KeyboardModifiers::new()),
+                crate::key::KeyboardModifiers::from_byte(1),
             )),
         )),
         crate::key::composite::Chorded(crate::key::composite::Layered(
             crate::key::composite::TapHold(crate::key::keyboard::Key::from_modifiers(
-                crate::key::KeyboardModifiers::LEFT_GUI
-                    .union(&crate::key::KeyboardModifiers::new()),
+                crate::key::KeyboardModifiers::from_byte(8),
             )),
         )),
         crate::key::composite::Chorded(crate::key::composite::Layered(
             crate::key::composite::TapHold(crate::key::keyboard::Key::from_modifiers(
-                crate::key::KeyboardModifiers::LEFT_ALT
-                    .union(&crate::key::KeyboardModifiers::new()),
+                crate::key::KeyboardModifiers::from_byte(4),
             )),
         )),
         crate::key::composite::Chorded(crate::key::composite::Layered(
@@ -534,20 +529,17 @@ pub mod init {
         )),
         crate::key::composite::Chorded(crate::key::composite::Layered(
             crate::key::composite::TapHold(crate::key::keyboard::Key::from_modifiers(
-                crate::key::KeyboardModifiers::RIGHT_ALT
-                    .union(&crate::key::KeyboardModifiers::new()),
+                crate::key::KeyboardModifiers::from_byte(64),
             )),
         )),
         crate::key::composite::Chorded(crate::key::composite::Layered(
             crate::key::composite::TapHold(crate::key::keyboard::Key::from_modifiers(
-                crate::key::KeyboardModifiers::RIGHT_GUI
-                    .union(&crate::key::KeyboardModifiers::new()),
+                crate::key::KeyboardModifiers::from_byte(128),
             )),
         )),
         crate::key::composite::Chorded(crate::key::composite::Layered(
             crate::key::composite::TapHold(crate::key::keyboard::Key::from_modifiers(
-                crate::key::KeyboardModifiers::RIGHT_CTRL
-                    .union(&crate::key::KeyboardModifiers::new()),
+                crate::key::KeyboardModifiers::from_byte(16),
             )),
         )),
     ));


### PR DESCRIPTION
Firmware size: 67.81%, down from 78.08%