### PR TITLE
Add stm32-embassy-smart-keyboard firmware example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2213,6 +2213,7 @@ dependencies = [
  "embassy-usb",
  "keyberon",
  "keyberon-smart-keyboard",
+ "panic-halt",
  "panic-probe",
  "smart-keymap",
  "smart-keymap-nickel-helper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,6 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fea5ef5bed4d3468dfd44f5c9fa4cda8f54c86d4fb4ae683eacf9d39e2ea12"
 dependencies = [
- "defmt 0.3.100",
  "embassy-futures",
  "embassy-sync",
  "embassy-time",
@@ -620,7 +619,6 @@ checksum = "90327bcc66333a507f89ecc4e2d911b265c45f5c9bc241f98eee076752d35ac6"
 dependencies = [
  "cortex-m",
  "critical-section",
- "defmt 0.3.100",
  "document-features",
  "embassy-executor-macros",
 ]
@@ -651,7 +649,6 @@ checksum = "0ef3bac31ec146321248a169e9c7b5799f1e0b3829c7a9b324cb4600a7438f59"
 dependencies = [
  "cortex-m",
  "critical-section",
- "defmt 0.3.100",
  "num-traits",
 ]
 
@@ -660,9 +657,6 @@ name = "embassy-net-driver"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524eb3c489760508f71360112bca70f6e53173e6fe48fc5f0efd0f5ab217751d"
-dependencies = [
- "defmt 0.3.100",
-]
 
 [[package]]
 name = "embassy-net-driver-channel"
@@ -690,7 +684,6 @@ dependencies = [
  "cortex-m",
  "cortex-m-rt",
  "critical-section",
- "defmt 0.3.100",
  "document-features",
  "embassy-embedded-hal",
  "embassy-futures",
@@ -732,7 +725,6 @@ checksum = "8d2c8cdff05a7a51ba0087489ea44b0b1d97a296ca6b1d6d1a33ea7423d34049"
 dependencies = [
  "cfg-if",
  "critical-section",
- "defmt 0.3.100",
  "embedded-io-async",
  "futures-sink",
  "futures-util",
@@ -747,7 +739,6 @@ checksum = "f820157f198ada183ad62e0a66f554c610cdcd1a9f27d4b316358103ced7a1f8"
 dependencies = [
  "cfg-if",
  "critical-section",
- "defmt 0.3.100",
  "document-features",
  "embassy-time-driver",
  "embedded-hal 0.2.7",
@@ -781,7 +772,6 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e651b9b7b47b514e6e6d1940a6e2e300891a2c33641917130643602a0cb6386"
 dependencies = [
- "defmt 0.3.100",
  "embassy-futures",
  "embassy-net-driver-channel",
  "embassy-sync",
@@ -796,9 +786,6 @@ name = "embassy-usb-driver"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fc247028eae04174b6635104a35b1ed336aabef4654f5e87a8f32327d231970"
-dependencies = [
- "defmt 0.3.100",
-]
 
 [[package]]
 name = "embassy-usb-synopsys-otg"
@@ -807,7 +794,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08e753b23799329780c7ac434264026d0422044d6649ed70a73441b14a6436d7"
 dependencies = [
  "critical-section",
- "defmt 0.3.100",
  "embassy-sync",
  "embassy-usb-driver",
 ]
@@ -870,9 +856,6 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
-dependencies = [
- "defmt 0.3.100",
-]
 
 [[package]]
 name = "embedded-io-async"
@@ -880,7 +863,6 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
 dependencies = [
- "defmt 0.3.100",
  "embedded-io",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2201,6 +2201,7 @@ dependencies = [
  "embassy-stm32",
  "embassy-time",
  "embassy-usb",
+ "keyberon",
  "keyberon-smart-keyboard",
  "panic-probe",
  "smart-keymap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2189,6 +2189,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "static_cell"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89b0684884a883431282db1e4343f34afc2ff6996fe1f4a1664519b66e14c1e"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "stm32-embassy-smart-keyboard"
 version = "0.7.0-dev"
 dependencies = [
@@ -2206,6 +2215,7 @@ dependencies = [
  "panic-probe",
  "smart-keymap",
  "smart-keymap-nickel-helper",
+ "static_cell",
  "usbd-hid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2208,6 +2208,7 @@ dependencies = [
  "embassy-executor",
  "embassy-futures",
  "embassy-stm32",
+ "embassy-sync",
  "embassy-time",
  "embassy-usb",
  "keyberon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2201,7 +2201,10 @@ dependencies = [
  "embassy-stm32",
  "embassy-time",
  "embassy-usb",
+ "keyberon-smart-keyboard",
  "panic-probe",
+ "smart-keymap",
+ "smart-keymap-nickel-helper",
  "usbd-hid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,33 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aligned"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "377e4c0ba83e4431b10df45c1d4666f178ea9c552cac93e60c3a88bf32785923"
+dependencies = [
+ "as-slice",
 ]
 
 [[package]]
@@ -79,6 +100,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +145,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "bit_field"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
+
+[[package]]
 name = "bitfield"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +161,12 @@ name = "bitfield"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -148,6 +190,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-device-driver"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c051592f59fe68053524b4c4935249b806f72c1f544cfb7abe4f57c3be258e"
+dependencies = [
+ "aligned",
+]
+
+[[package]]
 name = "bstr"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +219,21 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "clap"
@@ -228,7 +294,7 @@ version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
 dependencies = [
- "encode_unicode",
+ "encode_unicode 1.0.0",
  "libc",
  "once_cell",
  "unicode-width 0.2.0",
@@ -396,10 +462,96 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.91",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.91",
+]
+
+[[package]]
 name = "debug-helper"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e"
+
+[[package]]
+name = "defmt"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0963443817029b2024136fc4dd07a5107eb8f977eaf18fcd1fdeb11306b64ad"
+dependencies = [
+ "defmt 1.0.1",
+]
+
+[[package]]
+name = "defmt"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "548d977b6da32fa1d1fda2876453da1e7df63ad0304c8b3dae4dbe7b96f39b78"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d4fc12a85bcf441cfe44344c4b72d58493178ce635338a3f3b78943aceb258e"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "defmt-rtt"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6eca0aae8aa2cf8333200ecbd236274697bc0a394765c858b3d9372eb1abcfa"
+dependencies = [
+ "critical-section",
+ "defmt 0.3.100",
+]
 
 [[package]]
 name = "deranged"
@@ -441,6 +593,233 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "embassy-embedded-hal"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fea5ef5bed4d3468dfd44f5c9fa4cda8f54c86d4fb4ae683eacf9d39e2ea12"
+dependencies = [
+ "defmt 0.3.100",
+ "embassy-futures",
+ "embassy-sync",
+ "embassy-time",
+ "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "embedded-storage",
+ "embedded-storage-async",
+ "nb 1.1.0",
+]
+
+[[package]]
+name = "embassy-executor"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90327bcc66333a507f89ecc4e2d911b265c45f5c9bc241f98eee076752d35ac6"
+dependencies = [
+ "cortex-m",
+ "critical-section",
+ "defmt 0.3.100",
+ "document-features",
+ "embassy-executor-macros",
+]
+
+[[package]]
+name = "embassy-executor-macros"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3577b1e9446f61381179a330fc5324b01d511624c55f25e3c66c9e3c626dbecf"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
+]
+
+[[package]]
+name = "embassy-futures"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f878075b9794c1e4ac788c95b728f26aa6366d32eeb10c7051389f898f7d067"
+
+[[package]]
+name = "embassy-hal-internal"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef3bac31ec146321248a169e9c7b5799f1e0b3829c7a9b324cb4600a7438f59"
+dependencies = [
+ "cortex-m",
+ "critical-section",
+ "defmt 0.3.100",
+ "num-traits",
+]
+
+[[package]]
+name = "embassy-net-driver"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524eb3c489760508f71360112bca70f6e53173e6fe48fc5f0efd0f5ab217751d"
+dependencies = [
+ "defmt 0.3.100",
+]
+
+[[package]]
+name = "embassy-net-driver-channel"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4818c32afec43e3cae234f324bad9a976c9aa7501022d26ff60a4017a1a006b7"
+dependencies = [
+ "embassy-futures",
+ "embassy-net-driver",
+ "embassy-sync",
+]
+
+[[package]]
+name = "embassy-stm32"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e0bb733acdddbc7097765a47ce80bde2385647cf1d8427331931e06cff9a87"
+dependencies = [
+ "aligned",
+ "bit_field",
+ "bitflags 2.6.0",
+ "block-device-driver",
+ "cfg-if",
+ "chrono",
+ "cortex-m",
+ "cortex-m-rt",
+ "critical-section",
+ "defmt 0.3.100",
+ "document-features",
+ "embassy-embedded-hal",
+ "embassy-futures",
+ "embassy-hal-internal",
+ "embassy-net-driver",
+ "embassy-sync",
+ "embassy-time",
+ "embassy-time-driver",
+ "embassy-time-queue-utils",
+ "embassy-usb-driver",
+ "embassy-usb-synopsys-otg",
+ "embedded-can",
+ "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "embedded-hal-nb",
+ "embedded-io",
+ "embedded-io-async",
+ "embedded-storage",
+ "embedded-storage-async",
+ "futures-util",
+ "nb 1.1.0",
+ "proc-macro2",
+ "quote",
+ "rand_core",
+ "sdio-host",
+ "static_assertions",
+ "stm32-fmc",
+ "stm32-metapac",
+ "vcell",
+ "volatile-register",
+]
+
+[[package]]
+name = "embassy-sync"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d2c8cdff05a7a51ba0087489ea44b0b1d97a296ca6b1d6d1a33ea7423d34049"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "defmt 0.3.100",
+ "embedded-io-async",
+ "futures-sink",
+ "futures-util",
+ "heapless 0.8.0",
+]
+
+[[package]]
+name = "embassy-time"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f820157f198ada183ad62e0a66f554c610cdcd1a9f27d4b316358103ced7a1f8"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "defmt 0.3.100",
+ "document-features",
+ "embassy-time-driver",
+ "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "futures-util",
+]
+
+[[package]]
+name = "embassy-time-driver"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d45f5d833b6d98bd2aab0c2de70b18bfaa10faf661a1578fd8e5dfb15eb7eba"
+dependencies = [
+ "document-features",
+]
+
+[[package]]
+name = "embassy-time-queue-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc55c748d16908a65b166d09ce976575fb8852cf60ccd06174092b41064d8f83"
+dependencies = [
+ "embassy-executor",
+ "heapless 0.8.0",
+]
+
+[[package]]
+name = "embassy-usb"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e651b9b7b47b514e6e6d1940a6e2e300891a2c33641917130643602a0cb6386"
+dependencies = [
+ "defmt 0.3.100",
+ "embassy-futures",
+ "embassy-net-driver-channel",
+ "embassy-sync",
+ "embassy-usb-driver",
+ "heapless 0.8.0",
+ "ssmarshal",
+ "usbd-hid",
+]
+
+[[package]]
+name = "embassy-usb-driver"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc247028eae04174b6635104a35b1ed336aabef4654f5e87a8f32327d231970"
+dependencies = [
+ "defmt 0.3.100",
+]
+
+[[package]]
+name = "embassy-usb-synopsys-otg"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08e753b23799329780c7ac434264026d0422044d6649ed70a73441b14a6436d7"
+dependencies = [
+ "critical-section",
+ "defmt 0.3.100",
+ "embassy-sync",
+ "embassy-usb-driver",
+]
+
+[[package]]
+name = "embedded-can"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d2e857f87ac832df68fa498d18ddc679175cf3d2e4aa893988e5601baf9438"
+dependencies = [
+ "nb 1.1.0",
+]
 
 [[package]]
 name = "embedded-dma"
@@ -491,12 +870,40 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+dependencies = [
+ "defmt 0.3.100",
+]
+
+[[package]]
+name = "embedded-io-async"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
+dependencies = [
+ "defmt 0.3.100",
+ "embedded-io",
+]
 
 [[package]]
 name = "embedded-storage"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a21dea9854beb860f3062d10228ce9b976da520a73474aed3171ec276bc0c032"
+
+[[package]]
+name = "embedded-storage-async"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1763775e2323b7d5f0aa6090657f5e21cfa02ede71f5dc40eead06d64dcd15cc"
+dependencies = [
+ "embedded-storage",
+]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encode_unicode"
@@ -533,6 +940,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "frunk"
@@ -716,7 +1129,7 @@ dependencies = [
  "serde_json",
  "syn 2.0.91",
  "textwrap",
- "thiserror",
+ "thiserror 1.0.69",
  "typed-builder",
 ]
 
@@ -739,7 +1152,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "ignore",
  "walkdir",
 ]
@@ -767,6 +1180,15 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "heapless"
@@ -812,6 +1234,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "ignore"
 version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,7 +1262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1043,6 +1471,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,6 +1557,16 @@ name = "panic-halt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de96540e0ebde571dc55c73d60ef407c653844e6f9a1e2fdbd40c07b9252d812"
+
+[[package]]
+name = "panic-probe"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4047d9235d1423d66cc97da7d07eddb54d4f154d6c13805c6d0793956f4f25b0"
+dependencies = [
+ "cortex-m",
+ "defmt 0.3.100",
+]
 
 [[package]]
 name = "panic-rtt-target"
@@ -1255,6 +1702,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,7 +1795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64",
- "bitflags",
+ "bitflags 2.6.0",
  "serde",
  "serde_derive",
 ]
@@ -1523,7 +1992,7 @@ version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1556,6 +2025,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdio-host"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93c025f9cfe4c388c328ece47d11a54a823da3b5ad0370b22d95ad47137f85a"
 
 [[package]]
 name = "sealed"
@@ -1692,10 +2167,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "ssmarshal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3e6ad23b128192ed337dfa4f1b8099ced0c2bf30d61e551b65fda5916dbb850"
+dependencies = [
+ "encode_unicode 0.3.6",
+ "serde",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stm32-embassy-smart-keyboard"
+version = "0.7.0-dev"
+dependencies = [
+ "cortex-m",
+ "cortex-m-rt",
+ "defmt 0.3.100",
+ "defmt-rtt",
+ "embassy-executor",
+ "embassy-futures",
+ "embassy-stm32",
+ "embassy-usb",
+ "panic-probe",
+ "usbd-hid",
+]
+
+[[package]]
+name = "stm32-fmc"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f0639399e2307c2446c54d91d4f1596343a1e1d5cab605b9cce11d0ab3858c"
+dependencies = [
+ "embedded-hal 0.2.7",
+]
+
+[[package]]
+name = "stm32-metapac"
+version = "16.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc520f60f6653a32479a95b9180b33908f0cbbdf106609465ee7dea98f4f5b37"
+dependencies = [
+ "cortex-m",
+ "cortex-m-rt",
+]
 
 [[package]]
 name = "stm32f4-rtic-smart-keyboard"
@@ -1885,7 +2411,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -1893,6 +2428,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1981,6 +2527,43 @@ checksum = "98816b1accafbb09085168b90f27e93d790b4bfa19d883466b5e53315b5f06a6"
 dependencies = [
  "heapless 0.8.0",
  "portable-atomic",
+]
+
+[[package]]
+name = "usbd-hid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6f291ab53d428685cc780f08a2eb9d5d6ff58622db2b36e239a4f715f1e184c"
+dependencies = [
+ "serde",
+ "ssmarshal",
+ "usb-device",
+ "usbd-hid-macros",
+]
+
+[[package]]
+name = "usbd-hid-descriptors"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee54712c5d778d2fb2da43b1ce5a7b5060886ef7b09891baeb4bf36910a3ed"
+dependencies = [
+ "bitfield 0.14.0",
+]
+
+[[package]]
+name = "usbd-hid-macros"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb573c76e7884035ac5e1ab4a81234c187a82b6100140af0ab45757650ccda38"
+dependencies = [
+ "byteorder",
+ "hashbrown 0.13.2",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 1.0.109",
+ "usbd-hid-descriptors",
 ]
 
 [[package]]
@@ -2142,4 +2725,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,6 +2199,7 @@ dependencies = [
  "embassy-executor",
  "embassy-futures",
  "embassy-stm32",
+ "embassy-time",
  "embassy-usb",
  "panic-probe",
  "usbd-hid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "rp2040-rtic-smart-keyboard",
     "smart-keymap-nickel-helper",
     "smart_keymap",
+    "stm32-embassy-smart-keyboard",
     "stm32f4-rtic-smart-keyboard",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ STM32F4_RELEASE_TARGET_DIR ?= $(STM32F4_TARGET_DIR)/release
 DEST_DIR ?= .
 
 STM32F4_RTIC_EXAMPLES := $(notdir $(basename $(wildcard stm32f4-rtic-smart-keyboard/examples/*.rs)))
-STM32F4_EXAMPLES := $(STM32F4_RTIC_EXAMPLES)
+STM32F4_EMBASSY_EXAMPLES := $(notdir $(basename $(wildcard stm32f4-embassy-smart-keyboard/examples/*.rs)))
+STM32F4_EXAMPLES := $(STM32F4_RTIC_EXAMPLES) $(STM32F4_EMBASSY_EXAMPLES )
 
 EXAMPLES := $(STM32F4_EXAMPLES)
 EXAMPLES_BIN := $(addprefix example-, $(addsuffix .bin,$(EXAMPLES)))
@@ -91,6 +92,9 @@ $(STM32F4_RELEASE_TARGET_DIR)/examples/%: stm32f4-rtic-smart-keyboard/examples/%
 
 $(STM32F4_RELEASE_TARGET_DIR)/%: stm32f4-rtic-smart-keyboard/src/bin/%.rs
 	cargo build --target=$(STM32F4_TARGET) --package=stm32f4-rtic-smart-keyboard --release --bin="$*"
+
+$(STM32F4_RELEASE_TARGET_DIR)/examples/%: stm32-embassy-smart-keyboard/examples/%.rs
+	cargo build --target=$(STM32F4_TARGET) --package=stm32-embassy-smart-keyboard --release --example="$*"
 
 $(DEST_DIR)/%.bin: $(STM32F4_RELEASE_TARGET_DIR)/examples/%
 	rust-objcopy $(STM32F4_RELEASE_TARGET_DIR)/examples/$* --output-target "binary" $(DEST_DIR)/$*.bin

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,10 @@ $(STM32F4_RELEASE_TARGET_DIR)/examples/minif4_36-rev2021_4-lhs: SMART_KEYMAP_CUS
 
 $(STM32F4_RELEASE_TARGET_DIR)/examples/minif4_36-rev2021_4-rhs: SMART_KEYMAP_CUSTOM_KEYMAP=$(shell pwd)/tests/ncl/keymap-36key-rgoulter/keymap.ncl
 
+$(STM32F4_RELEASE_TARGET_DIR)/examples/minif4_36-rev2021_5-lhs: SMART_KEYMAP_CUSTOM_KEYMAP=$(shell pwd)/tests/ncl/keymap-36key-rgoulter/keymap.ncl
+
+$(STM32F4_RELEASE_TARGET_DIR)/examples/minif4_36-rev2021_5-rhs: SMART_KEYMAP_CUSTOM_KEYMAP=$(shell pwd)/tests/ncl/keymap-36key-rgoulter/keymap.ncl
+
 $(STM32F4_RELEASE_TARGET_DIR)/examples/%: stm32f4-rtic-smart-keyboard/examples/%.rs
 	cargo build --target=$(STM32F4_TARGET) --package=stm32f4-rtic-smart-keyboard --release --example="$*"
 

--- a/stm32-embassy-smart-keyboard/Cargo.toml
+++ b/stm32-embassy-smart-keyboard/Cargo.toml
@@ -20,6 +20,7 @@ cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-sing
 cortex-m-rt = "0.7.0"
 keyberon = { git = "https://github.com/TeXitoi/keyberon", branch = "master" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
+panic-halt = "0.2.0"
 static_cell = "2.1.0"
 usbd-hid = "0.8.1"
 

--- a/stm32-embassy-smart-keyboard/Cargo.toml
+++ b/stm32-embassy-smart-keyboard/Cargo.toml
@@ -5,12 +5,12 @@ version = "0.7.0-dev"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-stm32 = { version = "0.2.0", features = ["defmt", "stm32f401cc", "unstable-pac", "time-driver-tim4", "exti", "chrono"] }
-embassy-executor = { version = "0.7.0", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
-embassy-sync = { version = "0.6.2", features = ["defmt"] }
-embassy-time = { version = "0.4.0", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+embassy-stm32 = { version = "0.2.0", features = ["stm32f401cc", "unstable-pac", "time-driver-tim4", "exti", "chrono"] }
+embassy-executor = { version = "0.7.0", features = ["arch-cortex-m", "executor-thread", "executor-interrupt"] }
+embassy-sync = { version = "0.6.2" }
+embassy-time = { version = "0.4.0", features = ["tick-hz-32_768"] }
 
-embassy-usb = { version = "0.4.0", features = ["defmt" ] }
+embassy-usb = { version = "0.4.0" }
 embassy-futures = { version = "0.1.0" }
 
 defmt = "0.3"

--- a/stm32-embassy-smart-keyboard/Cargo.toml
+++ b/stm32-embassy-smart-keyboard/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.7.0-dev"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-stm32 = { version = "0.2.0", features = ["defmt", "stm32f401cc", "unstable-pac", "memory-x", "time-driver-tim4", "exti", "chrono"] }
+embassy-stm32 = { version = "0.2.0", features = ["defmt", "stm32f401cc", "unstable-pac", "time-driver-tim4", "exti", "chrono"] }
 embassy-executor = { version = "0.7.0", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.4.0", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 

--- a/stm32-embassy-smart-keyboard/Cargo.toml
+++ b/stm32-embassy-smart-keyboard/Cargo.toml
@@ -17,6 +17,7 @@ defmt-rtt = "0.4"
 
 cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
+keyberon = { git = "https://github.com/TeXitoi/keyberon", branch = "master" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 usbd-hid = "0.8.1"
 

--- a/stm32-embassy-smart-keyboard/Cargo.toml
+++ b/stm32-embassy-smart-keyboard/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 embassy-stm32 = { version = "0.2.0", features = ["defmt", "stm32f401cc", "unstable-pac", "time-driver-tim4", "exti", "chrono"] }
 embassy-executor = { version = "0.7.0", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-sync = { version = "0.6.2", features = ["defmt"] }
 embassy-time = { version = "0.4.0", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
 
 embassy-usb = { version = "0.4.0", features = ["defmt" ] }

--- a/stm32-embassy-smart-keyboard/Cargo.toml
+++ b/stm32-embassy-smart-keyboard/Cargo.toml
@@ -20,3 +20,9 @@ cortex-m-rt = "0.7.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 usbd-hid = "0.8.1"
 
+keyberon-smart-keyboard = { path = "../keyberon-smart-keyboard" }
+# smart-keymap = { git = "https://github.com/rgoulter/smart-keymap.git" }
+smart-keymap = { path = "..", default-features = false }
+
+[build-dependencies]
+smart-keymap-nickel-helper = { path = "../smart-keymap-nickel-helper" }

--- a/stm32-embassy-smart-keyboard/Cargo.toml
+++ b/stm32-embassy-smart-keyboard/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+edition = "2021"
+name = "stm32-embassy-smart-keyboard"
+version = "0.7.0-dev"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+embassy-stm32 = { version = "0.2.0", features = ["defmt", "stm32f401cc", "unstable-pac", "memory-x", "time-driver-tim4", "exti", "chrono"] }
+embassy-executor = { version = "0.7.0", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-usb = { version = "0.4.0", features = ["defmt" ] }
+embassy-futures = { version = "0.1.0" }
+
+defmt = "0.3"
+defmt-rtt = "0.4"
+
+cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
+cortex-m-rt = "0.7.0"
+panic-probe = { version = "0.3", features = ["print-defmt"] }
+usbd-hid = "0.8.1"
+

--- a/stm32-embassy-smart-keyboard/Cargo.toml
+++ b/stm32-embassy-smart-keyboard/Cargo.toml
@@ -19,6 +19,7 @@ cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-sing
 cortex-m-rt = "0.7.0"
 keyberon = { git = "https://github.com/TeXitoi/keyberon", branch = "master" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
+static_cell = "2.1.0"
 usbd-hid = "0.8.1"
 
 keyberon-smart-keyboard = { path = "../keyberon-smart-keyboard" }

--- a/stm32-embassy-smart-keyboard/Cargo.toml
+++ b/stm32-embassy-smart-keyboard/Cargo.toml
@@ -7,6 +7,8 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 embassy-stm32 = { version = "0.2.0", features = ["defmt", "stm32f401cc", "unstable-pac", "memory-x", "time-driver-tim4", "exti", "chrono"] }
 embassy-executor = { version = "0.7.0", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-time = { version = "0.4.0", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }
+
 embassy-usb = { version = "0.4.0", features = ["defmt" ] }
 embassy-futures = { version = "0.1.0" }
 

--- a/stm32-embassy-smart-keyboard/build.rs
+++ b/stm32-embassy-smart-keyboard/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+}

--- a/stm32-embassy-smart-keyboard/build.rs
+++ b/stm32-embassy-smart-keyboard/build.rs
@@ -1,4 +1,18 @@
+use std::env;
+
+use smart_keymap_nickel_helper::{
+    codegen_rust_module, nickel_board_rs_for_board_path, CodegenInputs,
+};
+
 fn main() {
     println!("cargo:rustc-link-arg-bins=--nmagic");
     println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+
+    codegen_rust_module(CodegenInputs {
+        env_var: "SMART_KEYBOARD_CUSTOM_BOARD",
+        cfg_name: "custom_board",
+        module_basename: "board.rs",
+        ncl_import_path: format!("{}/ncl", env!("CARGO_MANIFEST_DIR")).as_str(),
+        nickel_eval_fn: nickel_board_rs_for_board_path,
+    });
 }

--- a/stm32-embassy-smart-keyboard/build.rs
+++ b/stm32-embassy-smart-keyboard/build.rs
@@ -7,6 +7,8 @@ use smart_keymap_nickel_helper::{
 fn main() {
     println!("cargo:rustc-link-arg-bins=--nmagic");
     println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+    println!("cargo:rustc-link-arg-examples=--nmagic");
+    println!("cargo:rustc-link-arg-examples=-Tdefmt.x");
 
     codegen_rust_module(CodegenInputs {
         env_var: "SMART_KEYBOARD_CUSTOM_BOARD",

--- a/stm32-embassy-smart-keyboard/examples/minif4_36-rev2021_5-lhs.rs
+++ b/stm32-embassy-smart-keyboard/examples/minif4_36-rev2021_5-lhs.rs
@@ -1,0 +1,418 @@
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_futures::join::join;
+use embassy_stm32::mode::Async;
+use embassy_stm32::time::Hertz;
+use embassy_stm32::usart::{HalfDuplexConfig, HalfDuplexReadback, Uart};
+use embassy_stm32::usb::Driver;
+use embassy_stm32::{bind_interrupts, peripherals, usart, usb, Config};
+use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex;
+use embassy_sync::channel::{Channel, Sender};
+use embassy_time::Timer;
+use embassy_usb::class::hid::{
+    HidReader, HidReaderWriter, HidWriter, ReportId, RequestHandler, State,
+};
+use embassy_usb::control::OutResponse;
+use embassy_usb::Builder;
+use panic_halt as _;
+use static_cell::StaticCell;
+use usbd_hid::descriptor::{KeyboardReport, SerializedDescriptor};
+
+use keyberon_smart_keyboard::input::smart_keymap::keymap_index_of;
+use keyberon_smart_keyboard::input::smart_keymap::KeyboardBackend;
+use keyberon_smart_keyboard::input::MatrixScanner;
+use keyberon_smart_keyboard::split::BackendMessage;
+
+use smart_keymap::input::Event;
+use smart_keymap::split::{Message, BUFFER_SIZE};
+
+use board::KEYMAP_INDICES;
+
+use core::ptr::write_volatile;
+use cortex_m::peripheral::SCB;
+
+// Constants derived from the TinyUF2 source for stm32f4
+// Address: From linker script (_board_dfu_dbl_tap = _estack = end of RAM - 4)
+//          RAM Base = 0x20000000, Size = 64KB = 0x10000
+//          Address = 0x20000000 + 0x10000 - 4 = 0x2000FFFC
+const BOOTLOADER_MAGIC_ADDR: u32 = 0x2000FFFC;
+
+// Value: From board_api.h (DBL_TAP_MAGIC for 32-bit reg size)
+const BOOTLOADER_MAGIC_VALUE: u32 = 0xf01669ef;
+
+static EP_OUT_BUFFER: StaticCell<[u8; 256]> = StaticCell::new();
+
+static CONFIG_DESCRIPTOR: StaticCell<[u8; 256]> = StaticCell::new();
+static BOS_DESCRIPTOR: StaticCell<[u8; 256]> = StaticCell::new();
+static MS_OS_DESCRIPTOR: StaticCell<[u8; 256]> = StaticCell::new();
+static CONTROL_BUF: StaticCell<[u8; 64]> = StaticCell::new();
+
+static HID_STATE: StaticCell<State> = StaticCell::new();
+
+static KEYBOARD_BACKEND: StaticCell<KeyboardBackend> = StaticCell::new();
+
+static BACKEND_CHANNEL: Channel<ThreadModeRawMutex, BackendMessage, 8> = Channel::new();
+
+bind_interrupts!(struct Irqs {
+    OTG_FS => usb::InterruptHandler<peripherals::USB_OTG_FS>;
+    USART1 => usart::InterruptHandler<peripherals::USART1>;
+});
+
+/// Enters the TinyUF2 bootloader by writing the DBL_TAP_MAGIC value to RAM
+/// and triggering a system reset.
+///
+/// # Safety
+///
+/// - This function writes to a specific memory address (`0x2000FFFC`).
+///   Ensure this address is correct and accessible RAM for your target's
+///   TinyUF2 configuration. It must not conflict with essential application data
+///   that needs to persist across a soft reset (which is unlikely).
+/// - This function triggers a system reset, abruptly terminating the
+///   current application execution. Ensure system state is safe for a reset.
+/// - Relies on the TinyUF2 bootloader flashed on the device correctly
+///   checking this specific address and value upon startup.
+pub unsafe fn enter_bootloader_tinyuf2() {
+    write_volatile(BOOTLOADER_MAGIC_ADDR as *mut u32, BOOTLOADER_MAGIC_VALUE);
+    SCB::sys_reset();
+}
+
+#[cfg(not(custom_board))]
+mod board {
+    use embassy_stm32::gpio::Input;
+
+    pub const COLS: usize = 5;
+    pub const ROWS: usize = 4;
+
+    #[rustfmt::skip]
+    pub const KEYMAP_INDICES: [[Option<u16>; COLS]; ROWS] = [
+        [ Some(0),  Some(1),  Some(2),  Some(3),  Some(4)],
+        [Some(10), Some(11), Some(12), Some(13), Some(14)],
+        [Some(20), Some(21), Some(22), Some(23), Some(24)],
+        [Some(30), Some(31), Some(32),     None,     None],
+    ];
+
+    pub type Keyboard<'d> = keyberon_smart_keyboard::input::Keyboard<COLS, ROWS, DirectPins<'d>>;
+
+    pub type PressedKeys = keyberon_smart_keyboard::input::PressedKeys<COLS, ROWS>;
+
+    #[rustfmt::skip]
+    pub struct DirectPins<'d>(
+        pub Input<'d>,
+        pub Input<'d>,
+        pub Input<'d>,
+        pub Input<'d>,
+        pub Input<'d>,
+
+        pub Input<'d>,
+        pub Input<'d>,
+        pub Input<'d>,
+        pub Input<'d>,
+        pub Input<'d>,
+
+        pub Input<'d>,
+        pub Input<'d>,
+        pub Input<'d>,
+        pub Input<'d>,
+        pub Input<'d>,
+
+        pub Input<'d>,
+        pub Input<'d>,
+        pub Input<'d>,
+    );
+
+    impl<'d> keyberon_smart_keyboard::input::MatrixScanner<COLS, ROWS> for DirectPins<'d> {
+        fn is_boot_key_pressed(&mut self) -> bool {
+            self.0.is_low()
+        }
+
+        fn get(&mut self) -> Result<[[bool; COLS]; ROWS], core::convert::Infallible> {
+            Ok([
+                [
+                    self.0.is_low(),
+                    self.1.is_low(),
+                    self.2.is_low(),
+                    self.3.is_low(),
+                    self.4.is_low(),
+                ],
+                [
+                    self.5.is_low(),
+                    self.6.is_low(),
+                    self.7.is_low(),
+                    self.8.is_low(),
+                    self.9.is_low(),
+                ],
+                [
+                    self.10.is_low(),
+                    self.11.is_low(),
+                    self.12.is_low(),
+                    self.13.is_low(),
+                    self.14.is_low(),
+                ],
+                [
+                    self.15.is_low(),
+                    self.16.is_low(),
+                    self.17.is_low(),
+                    false,
+                    false,
+                ],
+            ])
+        }
+    }
+
+    macro_rules! keyboard {
+        ($p:ident) => {
+            crate::board::Keyboard {
+                matrix: crate::board::DirectPins(
+                    embassy_stm32::gpio::Input::new($p.PB12, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PB15, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PA9, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PA5, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PB3, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PB13, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PA8, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PA10, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PA15, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PB10, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PB14, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PB1, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PA6, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PA4, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PB5, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PA2, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PA0, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PC13, embassy_stm32::gpio::Pull::Up),
+                ),
+                debouncer: keyberon::debounce::Debouncer::new(
+                    crate::board::PressedKeys::default(),
+                    crate::board::PressedKeys::default(),
+                    25,
+                ),
+            }
+        };
+    }
+
+    pub(crate) use keyboard;
+}
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let mut config = Config::default();
+    {
+        use embassy_stm32::rcc::*;
+        config.rcc.hse = Some(Hse {
+            freq: Hertz(25_000_000),
+            mode: HseMode::Oscillator,
+        });
+        config.rcc.pll_src = PllSource::HSE;
+        config.rcc.pll = Some(Pll {
+            prediv: PllPreDiv::DIV25,  // PLL Input: 25MHz / 25 = 1MHz
+            mul: PllMul::MUL336,       // VCO Output: 1MHz * 336 = 336MHz
+            divp: Some(PllPDiv::DIV4), // System Clock (PLL_P): 336MHz / 4 = 84MHz.
+            divq: Some(PllQDiv::DIV7), // USB/SDIO/RNG Clock (PLL_Q): 336MHz / 7 = 48MHz
+            divr: None,
+        });
+        config.rcc.ahb_pre = AHBPrescaler::DIV1;
+        config.rcc.apb1_pre = APBPrescaler::DIV2;
+        config.rcc.apb2_pre = APBPrescaler::DIV1;
+        config.rcc.sys = Sysclk::PLL1_P;
+        config.rcc.mux.clk48sel = mux::Clk48sel::PLL1_Q;
+    }
+    let p = embassy_stm32::init(config);
+
+    let ep_out_buffer: &'static mut [u8; 256] = EP_OUT_BUFFER.init([0u8; 256]);
+    let mut config = embassy_stm32::usb::Config::default();
+
+    config.vbus_detection = false;
+
+    let driver: Driver<'static, _> =
+        Driver::new_fs(p.USB_OTG_FS, Irqs, p.PA12, p.PA11, ep_out_buffer, config);
+
+    let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
+    config.manufacturer = Some("Embassy");
+    config.product = Some("STM32F4 rev2021.5 LHS");
+    config.serial_number = Some("12345678");
+    config.max_power = 100;
+    config.max_packet_size_0 = 64;
+
+    let config_descriptor = CONFIG_DESCRIPTOR.init([0; 256]);
+    let bos_descriptor = BOS_DESCRIPTOR.init([0; 256]);
+    let ms_os_descriptor = MS_OS_DESCRIPTOR.init([0; 256]);
+    let control_buf = CONTROL_BUF.init([0; 64]);
+
+    let mut request_handler = MyRequestHandler {};
+
+    let state = HID_STATE.init(State::new());
+
+    let mut builder = Builder::new(
+        driver,
+        config,
+        config_descriptor,
+        bos_descriptor,
+        ms_os_descriptor,
+        control_buf,
+    );
+
+    let config = embassy_usb::class::hid::Config {
+        report_descriptor: KeyboardReport::desc(),
+        request_handler: None,
+        poll_ms: 1,
+        max_packet_size: 8,
+    };
+
+    let hid = HidReaderWriter::<_, 1, 8>::new(&mut builder, state, config);
+
+    let mut usb = builder.build();
+
+    let usb_fut = usb.run();
+
+    let (reader, writer): (
+        HidReader<'static, Driver<'static, _>, 1>,
+        HidWriter<'static, Driver<'static, _>, 8>,
+    ) = hid.split();
+
+    let mut keyboard = board::keyboard!(p);
+
+    if keyboard.matrix.is_boot_key_pressed() {
+        unsafe {
+            enter_bootloader_tinyuf2();
+        }
+    }
+
+    let matrix_scan_sender: Sender<'static, ThreadModeRawMutex, BackendMessage, 8> =
+        BACKEND_CHANNEL.sender();
+
+    let config = usart::Config::default();
+    let uart = Uart::new_half_duplex(
+        p.USART1,
+        p.PB6,
+        Irqs,
+        p.DMA2_CH7,
+        p.DMA2_CH5,
+        config,
+        HalfDuplexReadback::NoReadback,
+        HalfDuplexConfig::OpenDrainExternal,
+    )
+    .unwrap();
+
+    let out_fut = async {
+        reader.run(false, &mut request_handler).await;
+    };
+
+    spawner.spawn(keyboard_backend(writer)).unwrap();
+    spawner
+        .spawn(keyboard_matrix_scan(matrix_scan_sender, keyboard))
+        .unwrap();
+    spawner
+        .spawn(keyboard_split_rx(matrix_scan_sender, uart))
+        .unwrap();
+
+    join(usb_fut, out_fut).await;
+}
+
+#[embassy_executor::task]
+async fn keyboard_backend(
+    mut writer: HidWriter<'static, Driver<'static, peripherals::USB_OTG_FS>, 8>,
+) {
+    let backend = KEYBOARD_BACKEND.init({
+        use smart_keymap::init;
+        use smart_keymap::keymap::Keymap;
+        let keymap = Keymap::new(init::KEY_DEFINITIONS, init::CONTEXT);
+        KeyboardBackend::new(keymap)
+    });
+
+    let mut report_success = true;
+
+    loop {
+        match BACKEND_CHANNEL.receive().await {
+            BackendMessage::Event(event) => {
+                backend.event(event);
+            }
+            BackendMessage::Tick => {
+                if report_success {
+                    backend.tick();
+                }
+
+                let report = backend.keymap_output().as_hid_boot_keyboard_report();
+                match writer.write(&report).await {
+                    Ok(()) => {
+                        report_success = true;
+                    }
+                    Err(_e) => {
+                        report_success = false;
+                    }
+                };
+            }
+        }
+    }
+}
+
+#[embassy_executor::task]
+async fn keyboard_matrix_scan(
+    matrix_scan_sender: Sender<'static, ThreadModeRawMutex, BackendMessage, 8>,
+    mut keyboard: board::Keyboard<'static>,
+) {
+    loop {
+        Timer::after_millis(1).await;
+
+        for event in keyboard.events() {
+            if let Some(event) = keymap_index_of(&KEYMAP_INDICES, event) {
+                matrix_scan_sender.send(BackendMessage::Event(event)).await;
+            }
+        }
+        matrix_scan_sender.send(BackendMessage::Tick).await;
+    }
+}
+
+#[embassy_executor::task]
+async fn keyboard_split_rx(
+    matrix_scan_sender: Sender<'static, ThreadModeRawMutex, BackendMessage, 8>,
+    uart: Uart<'static, Async>,
+) {
+    let mut transport_reader = TransportReader::new(uart);
+    loop {
+        if let Some(event) = transport_reader.read().await {
+            matrix_scan_sender.send(BackendMessage::Event(event)).await;
+        }
+    }
+}
+
+struct MyRequestHandler {}
+
+impl RequestHandler for MyRequestHandler {
+    fn get_report(&mut self, _id: ReportId, _buf: &mut [u8]) -> Option<usize> {
+        None
+    }
+
+    fn set_report(&mut self, _id: ReportId, _data: &[u8]) -> OutResponse {
+        OutResponse::Accepted
+    }
+
+    fn set_idle_ms(&mut self, _id: Option<ReportId>, _dur: u32) {}
+
+    fn get_idle_ms(&mut self, _id: Option<ReportId>) -> Option<u32> {
+        None
+    }
+}
+
+struct TransportReader<'d> {
+    pub uart: usart::Uart<'d, Async>,
+}
+
+impl<'d> TransportReader<'d> {
+    pub fn new(rx: usart::Uart<'d, Async>) -> Self {
+        TransportReader { uart: rx }
+    }
+
+    pub async fn read(&mut self) -> Option<Event> {
+        let mut buf: [u8; BUFFER_SIZE] = [0; BUFFER_SIZE];
+        if let Ok(_) = self.uart.read(&mut buf).await {
+            Message::deserialize(&buf)
+                .ok()
+                .map(|Message { input_event }: Message| input_event)
+        } else {
+            None
+        }
+    }
+}

--- a/stm32-embassy-smart-keyboard/examples/minif4_36-rev2021_5-rhs.rs
+++ b/stm32-embassy-smart-keyboard/examples/minif4_36-rev2021_5-rhs.rs
@@ -1,0 +1,230 @@
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_stm32::time::Hertz;
+use embassy_stm32::usart::{HalfDuplexConfig, HalfDuplexReadback, Uart};
+use embassy_stm32::{bind_interrupts, peripherals, usart, usb, Config};
+use embassy_time::Timer;
+use panic_halt as _;
+
+use keyberon_smart_keyboard::input::smart_keymap::keymap_index_of;
+use keyberon_smart_keyboard::input::MatrixScanner;
+
+use smart_keymap::split::Message;
+
+use board::KEYMAP_INDICES;
+
+use core::ptr::write_volatile;
+use cortex_m::peripheral::SCB;
+
+// Constants derived from the TinyUF2 source for stm32f4
+// Address: From linker script (_board_dfu_dbl_tap = _estack = end of RAM - 4)
+//          RAM Base = 0x20000000, Size = 64KB = 0x10000
+//          Address = 0x20000000 + 0x10000 - 4 = 0x2000FFFC
+const BOOTLOADER_MAGIC_ADDR: u32 = 0x2000FFFC;
+
+// Value: From board_api.h (DBL_TAP_MAGIC for 32-bit reg size)
+const BOOTLOADER_MAGIC_VALUE: u32 = 0xf01669ef;
+
+bind_interrupts!(struct Irqs {
+    OTG_FS => usb::InterruptHandler<peripherals::USB_OTG_FS>;
+    USART1 => usart::InterruptHandler<peripherals::USART1>;
+});
+
+/// Enters the TinyUF2 bootloader by writing the DBL_TAP_MAGIC value to RAM
+/// and triggering a system reset.
+///
+/// # Safety
+///
+/// - This function writes to a specific memory address (`0x2000FFFC`).
+///   Ensure this address is correct and accessible RAM for your target's
+///   TinyUF2 configuration. It must not conflict with essential application data
+///   that needs to persist across a soft reset (which is unlikely).
+/// - This function triggers a system reset, abruptly terminating the
+///   current application execution. Ensure system state is safe for a reset.
+/// - Relies on the TinyUF2 bootloader flashed on the device correctly
+///   checking this specific address and value upon startup.
+pub unsafe fn enter_bootloader_tinyuf2() {
+    write_volatile(BOOTLOADER_MAGIC_ADDR as *mut u32, BOOTLOADER_MAGIC_VALUE);
+    SCB::sys_reset();
+}
+
+#[cfg(not(custom_board))]
+mod board {
+    use embassy_stm32::gpio::Input;
+
+    pub const COLS: usize = 5;
+    pub const ROWS: usize = 4;
+
+    #[rustfmt::skip]
+    pub const KEYMAP_INDICES: [[Option<u16>; COLS]; ROWS] = [
+        [Some(5),  Some(6),  Some(7),  Some(8),  Some(9)],
+        [Some(15), Some(16), Some(17), Some(18), Some(19)],
+        [Some(25), Some(26), Some(27), Some(28), Some(29)],
+        [Some(33), Some(34), Some(35),     None,     None],
+    ];
+
+    pub type Keyboard<'d> = keyberon_smart_keyboard::input::Keyboard<COLS, ROWS, DirectPins<'d>>;
+
+    pub type PressedKeys = keyberon_smart_keyboard::input::PressedKeys<COLS, ROWS>;
+
+    #[rustfmt::skip]
+    pub struct DirectPins<'d>(
+        pub Input<'d>,
+        pub Input<'d>,
+        pub Input<'d>,
+        pub Input<'d>,
+        pub Input<'d>,
+
+        pub Input<'d>,
+        pub Input<'d>,
+        pub Input<'d>,
+        pub Input<'d>,
+        pub Input<'d>,
+
+        pub Input<'d>,
+        pub Input<'d>,
+        pub Input<'d>,
+        pub Input<'d>,
+        pub Input<'d>,
+
+        pub Input<'d>,
+        pub Input<'d>,
+        pub Input<'d>,
+    );
+
+    impl<'d> keyberon_smart_keyboard::input::MatrixScanner<COLS, ROWS> for DirectPins<'d> {
+        fn is_boot_key_pressed(&mut self) -> bool {
+            self.0.is_low()
+        }
+
+        fn get(&mut self) -> Result<[[bool; COLS]; ROWS], core::convert::Infallible> {
+            Ok([
+                [
+                    self.0.is_low(),
+                    self.1.is_low(),
+                    self.2.is_low(),
+                    self.3.is_low(),
+                    self.4.is_low(),
+                ],
+                [
+                    self.5.is_low(),
+                    self.6.is_low(),
+                    self.7.is_low(),
+                    self.8.is_low(),
+                    self.9.is_low(),
+                ],
+                [
+                    self.10.is_low(),
+                    self.11.is_low(),
+                    self.12.is_low(),
+                    self.13.is_low(),
+                    self.14.is_low(),
+                ],
+                [
+                    self.15.is_low(),
+                    self.16.is_low(),
+                    self.17.is_low(),
+                    false,
+                    false,
+                ],
+            ])
+        }
+    }
+
+    macro_rules! keyboard {
+        ($p:ident) => {
+            crate::board::Keyboard {
+                matrix: crate::board::DirectPins(
+                    embassy_stm32::gpio::Input::new($p.PB3, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PA5, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PA9, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PB15, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PB12, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PB10, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PA15, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PA10, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PA8, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PB13, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PB5, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PA4, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PA6, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PB1, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PB14, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PC13, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PA0, embassy_stm32::gpio::Pull::Up),
+                    embassy_stm32::gpio::Input::new($p.PA2, embassy_stm32::gpio::Pull::Up),
+                ),
+                debouncer: keyberon::debounce::Debouncer::new(
+                    crate::board::PressedKeys::default(),
+                    crate::board::PressedKeys::default(),
+                    25,
+                ),
+            }
+        };
+    }
+
+    pub(crate) use keyboard;
+}
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut config = Config::default();
+    {
+        use embassy_stm32::rcc::*;
+        config.rcc.hse = Some(Hse {
+            freq: Hertz(25_000_000),
+            mode: HseMode::Oscillator,
+        });
+        config.rcc.pll_src = PllSource::HSE;
+        config.rcc.pll = Some(Pll {
+            prediv: PllPreDiv::DIV25,  // PLL Input: 25MHz / 25 = 1MHz
+            mul: PllMul::MUL336,       // VCO Output: 1MHz * 336 = 336MHz
+            divp: Some(PllPDiv::DIV4), // System Clock (PLL_P): 336MHz / 4 = 84MHz.
+            divq: Some(PllQDiv::DIV7), // USB/SDIO/RNG Clock (PLL_Q): 336MHz / 7 = 48MHz
+            divr: None,
+        });
+        config.rcc.ahb_pre = AHBPrescaler::DIV1;
+        config.rcc.apb1_pre = APBPrescaler::DIV2;
+        config.rcc.apb2_pre = APBPrescaler::DIV1;
+        config.rcc.sys = Sysclk::PLL1_P;
+        config.rcc.mux.clk48sel = mux::Clk48sel::PLL1_Q;
+    }
+    let p = embassy_stm32::init(config);
+
+    let mut keyboard = board::keyboard!(p);
+
+    if keyboard.matrix.is_boot_key_pressed() {
+        unsafe {
+            enter_bootloader_tinyuf2();
+        }
+    }
+
+    let config = usart::Config::default();
+    let usart = Uart::new_half_duplex(
+        p.USART1,
+        p.PB6,
+        Irqs,
+        p.DMA2_CH7,
+        p.DMA2_CH5,
+        config,
+        HalfDuplexReadback::NoReadback,
+        HalfDuplexConfig::OpenDrainExternal,
+    )
+    .unwrap();
+    let (mut tx, _) = usart.split();
+
+    loop {
+        Timer::after_millis(1).await;
+
+        for event in keyboard.events() {
+            if let Some(input_event) = keymap_index_of(&KEYMAP_INDICES, event) {
+                let message = Message { input_event };
+                let buf = message.serialize();
+                tx.write(&buf).await.unwrap();
+                tx.flush().await.unwrap();
+            }
+        }
+    }
+}

--- a/stm32-embassy-smart-keyboard/src/main.rs
+++ b/stm32-embassy-smart-keyboard/src/main.rs
@@ -1,0 +1,234 @@
+#![no_std]
+#![no_main]
+
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_futures::join::join;
+use embassy_stm32::exti::ExtiInput;
+use embassy_stm32::gpio::Pull;
+use embassy_stm32::time::Hertz;
+use embassy_stm32::usb::Driver;
+use embassy_stm32::{bind_interrupts, peripherals, usb, Config};
+use embassy_usb::class::hid::{HidReaderWriter, ReportId, RequestHandler, State};
+use embassy_usb::control::OutResponse;
+use embassy_usb::{Builder, Handler};
+use usbd_hid::descriptor::{KeyboardReport, SerializedDescriptor};
+use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    OTG_FS => usb::InterruptHandler<peripherals::USB_OTG_FS>;
+});
+
+// If you are trying this and your USB device doesn't connect, the most
+// common issues are the RCC config and vbus_detection
+//
+// See https://embassy.dev/book/#_the_usb_examples_are_not_working_on_my_board_is_there_anything_else_i_need_to_configure
+// for more information.
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut config = Config::default();
+    {
+        use embassy_stm32::rcc::*;
+        config.rcc.hse = Some(Hse {
+            freq: Hertz(8_000_000),
+            mode: HseMode::Bypass,
+        });
+        config.rcc.pll_src = PllSource::HSE;
+        config.rcc.pll = Some(Pll {
+            prediv: PllPreDiv::DIV4,
+            mul: PllMul::MUL168,
+            divp: Some(PllPDiv::DIV2), // 8mhz / 4 * 168 / 2 = 168Mhz.
+            divq: Some(PllQDiv::DIV7), // 8mhz / 4 * 168 / 7 = 48Mhz.
+            divr: None,
+        });
+        config.rcc.ahb_pre = AHBPrescaler::DIV1;
+        config.rcc.apb1_pre = APBPrescaler::DIV4;
+        config.rcc.apb2_pre = APBPrescaler::DIV2;
+        config.rcc.sys = Sysclk::PLL1_P;
+        config.rcc.mux.clk48sel = mux::Clk48sel::PLL1_Q;
+    }
+    let p = embassy_stm32::init(config);
+
+    // Create the driver, from the HAL.
+    let mut ep_out_buffer = [0u8; 256];
+    let mut config = embassy_stm32::usb::Config::default();
+
+    // Do not enable vbus_detection. This is a safe default that works in all boards.
+    // However, if your USB device is self-powered (can stay powered on if USB is unplugged), you need
+    // to enable vbus_detection to comply with the USB spec. If you enable it, the board
+    // has to support it or USB won't work at all. See docs on `vbus_detection` for details.
+    config.vbus_detection = false;
+
+    let driver = Driver::new_fs(
+        p.USB_OTG_FS,
+        Irqs,
+        p.PA12,
+        p.PA11,
+        &mut ep_out_buffer,
+        config,
+    );
+
+    // Create embassy-usb Config
+    let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
+    config.manufacturer = Some("Embassy");
+    config.product = Some("HID keyboard example");
+    config.serial_number = Some("12345678");
+    config.max_power = 100;
+    config.max_packet_size_0 = 64;
+
+    // Create embassy-usb DeviceBuilder using the driver and config.
+    // It needs some buffers for building the descriptors.
+    let mut config_descriptor = [0; 256];
+    let mut bos_descriptor = [0; 256];
+    // You can also add a Microsoft OS descriptor.
+    let mut msos_descriptor = [0; 256];
+    let mut control_buf = [0; 64];
+
+    let mut request_handler = MyRequestHandler {};
+    let mut device_handler = MyDeviceHandler::new();
+
+    let mut state = State::new();
+
+    let mut builder = Builder::new(
+        driver,
+        config,
+        &mut config_descriptor,
+        &mut bos_descriptor,
+        &mut msos_descriptor,
+        &mut control_buf,
+    );
+
+    builder.handler(&mut device_handler);
+
+    // Create classes on the builder.
+    let config = embassy_usb::class::hid::Config {
+        report_descriptor: KeyboardReport::desc(),
+        request_handler: None,
+        poll_ms: 60,
+        max_packet_size: 8,
+    };
+
+    let hid = HidReaderWriter::<_, 1, 8>::new(&mut builder, &mut state, config);
+
+    // Build the builder.
+    let mut usb = builder.build();
+
+    // Run the USB device.
+    let usb_fut = usb.run();
+
+    let (reader, mut writer) = hid.split();
+
+    let mut button = ExtiInput::new(p.PC13, p.EXTI13, Pull::Down);
+
+    // Do stuff with the class!
+    let in_fut = async {
+        loop {
+            button.wait_for_rising_edge().await;
+            // signal_pin.wait_for_high().await;
+            info!("Button pressed!");
+            // Create a report with the A key pressed. (no shift modifier)
+            let report = KeyboardReport {
+                keycodes: [4, 0, 0, 0, 0, 0],
+                leds: 0,
+                modifier: 0,
+                reserved: 0,
+            };
+            // Send the report.
+            match writer.write_serialize(&report).await {
+                Ok(()) => {}
+                Err(e) => warn!("Failed to send report: {:?}", e),
+            };
+
+            button.wait_for_falling_edge().await;
+            // signal_pin.wait_for_low().await;
+            info!("Button released!");
+            let report = KeyboardReport {
+                keycodes: [0, 0, 0, 0, 0, 0],
+                leds: 0,
+                modifier: 0,
+                reserved: 0,
+            };
+            match writer.write_serialize(&report).await {
+                Ok(()) => {}
+                Err(e) => warn!("Failed to send report: {:?}", e),
+            };
+        }
+    };
+
+    let out_fut = async {
+        reader.run(false, &mut request_handler).await;
+    };
+
+    // Run everything concurrently.
+    // If we had made everything `'static` above instead, we could do this using separate tasks instead.
+    join(usb_fut, join(in_fut, out_fut)).await;
+}
+
+struct MyRequestHandler {}
+
+impl RequestHandler for MyRequestHandler {
+    fn get_report(&mut self, id: ReportId, _buf: &mut [u8]) -> Option<usize> {
+        info!("Get report for {:?}", id);
+        None
+    }
+
+    fn set_report(&mut self, id: ReportId, data: &[u8]) -> OutResponse {
+        info!("Set report for {:?}: {=[u8]}", id, data);
+        OutResponse::Accepted
+    }
+
+    fn set_idle_ms(&mut self, id: Option<ReportId>, dur: u32) {
+        info!("Set idle rate for {:?} to {:?}", id, dur);
+    }
+
+    fn get_idle_ms(&mut self, id: Option<ReportId>) -> Option<u32> {
+        info!("Get idle rate for {:?}", id);
+        None
+    }
+}
+
+struct MyDeviceHandler {
+    configured: AtomicBool,
+}
+
+impl MyDeviceHandler {
+    fn new() -> Self {
+        MyDeviceHandler {
+            configured: AtomicBool::new(false),
+        }
+    }
+}
+
+impl Handler for MyDeviceHandler {
+    fn enabled(&mut self, enabled: bool) {
+        self.configured.store(false, Ordering::Relaxed);
+        if enabled {
+            info!("Device enabled");
+        } else {
+            info!("Device disabled");
+        }
+    }
+
+    fn reset(&mut self) {
+        self.configured.store(false, Ordering::Relaxed);
+        info!("Bus reset, the Vbus current limit is 100mA");
+    }
+
+    fn addressed(&mut self, addr: u8) {
+        self.configured.store(false, Ordering::Relaxed);
+        info!("USB address set to: {}", addr);
+    }
+
+    fn configured(&mut self, configured: bool) {
+        self.configured.store(configured, Ordering::Relaxed);
+        if configured {
+            info!(
+                "Device configured, it may now draw up to the configured current limit from Vbus."
+            )
+        } else {
+            info!("Device is no longer configured, the Vbus current limit is 100mA.");
+        }
+    }
+}

--- a/stm32-embassy-smart-keyboard/src/main.rs
+++ b/stm32-embassy-smart-keyboard/src/main.rs
@@ -91,7 +91,7 @@ async fn main(_spawner: Spawner) {
     let config = embassy_usb::class::hid::Config {
         report_descriptor: KeyboardReport::desc(),
         request_handler: None,
-        poll_ms: 60,
+        poll_ms: 1,
         max_packet_size: 8,
     };
 

--- a/stm32-embassy-smart-keyboard/src/main.rs
+++ b/stm32-embassy-smart-keyboard/src/main.rs
@@ -21,11 +21,6 @@ bind_interrupts!(struct Irqs {
     OTG_FS => usb::InterruptHandler<peripherals::USB_OTG_FS>;
 });
 
-// If you are trying this and your USB device doesn't connect, the most
-// common issues are the RCC config and vbus_detection
-//
-// See https://embassy.dev/book/#_the_usb_examples_are_not_working_on_my_board_is_there_anything_else_i_need_to_configure
-// for more information.
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let mut config = Config::default();
@@ -51,14 +46,9 @@ async fn main(_spawner: Spawner) {
     }
     let p = embassy_stm32::init(config);
 
-    // Create the driver, from the HAL.
     let mut ep_out_buffer = [0u8; 256];
     let mut config = embassy_stm32::usb::Config::default();
 
-    // Do not enable vbus_detection. This is a safe default that works in all boards.
-    // However, if your USB device is self-powered (can stay powered on if USB is unplugged), you need
-    // to enable vbus_detection to comply with the USB spec. If you enable it, the board
-    // has to support it or USB won't work at all. See docs on `vbus_detection` for details.
     config.vbus_detection = false;
 
     let driver = Driver::new_fs(
@@ -70,7 +60,6 @@ async fn main(_spawner: Spawner) {
         config,
     );
 
-    // Create embassy-usb Config
     let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
     config.manufacturer = Some("Embassy");
     config.product = Some("HID keyboard example");
@@ -78,12 +67,9 @@ async fn main(_spawner: Spawner) {
     config.max_power = 100;
     config.max_packet_size_0 = 64;
 
-    // Create embassy-usb DeviceBuilder using the driver and config.
-    // It needs some buffers for building the descriptors.
     let mut config_descriptor = [0; 256];
     let mut bos_descriptor = [0; 256];
-    // You can also add a Microsoft OS descriptor.
-    let mut msos_descriptor = [0; 256];
+    let mut ms_os_descriptor = [0; 256];
     let mut control_buf = [0; 64];
 
     let mut request_handler = MyRequestHandler {};
@@ -96,13 +82,12 @@ async fn main(_spawner: Spawner) {
         config,
         &mut config_descriptor,
         &mut bos_descriptor,
-        &mut msos_descriptor,
+        &mut ms_os_descriptor,
         &mut control_buf,
     );
 
     builder.handler(&mut device_handler);
 
-    // Create classes on the builder.
     let config = embassy_usb::class::hid::Config {
         report_descriptor: KeyboardReport::desc(),
         request_handler: None,
@@ -112,37 +97,30 @@ async fn main(_spawner: Spawner) {
 
     let hid = HidReaderWriter::<_, 1, 8>::new(&mut builder, &mut state, config);
 
-    // Build the builder.
     let mut usb = builder.build();
 
-    // Run the USB device.
     let usb_fut = usb.run();
 
     let (reader, mut writer) = hid.split();
 
     let mut button = ExtiInput::new(p.PA0, p.EXTI0, Pull::Up);
 
-    // Do stuff with the class!
     let in_fut = async {
         loop {
             button.wait_for_falling_edge().await;
-            // signal_pin.wait_for_high().await;
             info!("Button pressed!");
-            // Create a report with the A key pressed. (no shift modifier)
             let report = KeyboardReport {
                 keycodes: [4, 0, 0, 0, 0, 0],
                 leds: 0,
                 modifier: 0,
                 reserved: 0,
             };
-            // Send the report.
             match writer.write_serialize(&report).await {
                 Ok(()) => {}
                 Err(e) => warn!("Failed to send report: {:?}", e),
             };
 
             button.wait_for_rising_edge().await;
-            // signal_pin.wait_for_low().await;
             info!("Button released!");
             let report = KeyboardReport {
                 keycodes: [0, 0, 0, 0, 0, 0],
@@ -161,8 +139,6 @@ async fn main(_spawner: Spawner) {
         reader.run(false, &mut request_handler).await;
     };
 
-    // Run everything concurrently.
-    // If we had made everything `'static` above instead, we could do this using separate tasks instead.
     join(usb_fut, join(in_fut, out_fut)).await;
 }
 


### PR DESCRIPTION
I want to provide an example firmware for split keyboards which have single-wire serial between split halves.

I have builds of the MiniF4-36 which have TX-TX; this can use half-duplex UART.

`stm32f4xx-hal` doesn't support half-duplex uart at the time of writing. `embassy-stm32` does. So, I'll add an embassy example.