### PR TITLE
usbd-smart-keyboard: allow access to keymap output

### DIFF
--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -30,7 +30,7 @@ const MAX_QUEUED_INPUT_EVENTS: usize = 32;
 pub const INPUT_QUEUE_TICK_DELAY: u8 = 1;
 
 /// Constructs an HID report or a sequence of key codes from the given sequence of [key::KeyOutput].
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct KeymapOutput {
     pressed_key_codes: heapless::Vec<key::KeyOutput, { MAX_PRESSED_KEYS }>,
 }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -35,6 +35,14 @@ pub struct KeymapOutput {
     pressed_key_codes: heapless::Vec<key::KeyOutput, { MAX_PRESSED_KEYS }>,
 }
 
+impl Default for KeymapOutput {
+    fn default() -> Self {
+        Self {
+            pressed_key_codes: heapless::Vec::new(),
+        }
+    }
+}
+
 impl KeymapOutput {
     /// Constructs a new keymap output.
     pub fn new(pressed_key_codes: heapless::Vec<key::KeyOutput, { MAX_PRESSED_KEYS }>) -> Self {


### PR DESCRIPTION
Currently, the `KeyboardBackend` in `usbd-smart-keyboard` supports `usbd-human-interface-device`.

`embassy`'s USB is separate from `usb_device`. -- Still, `KeyboardBackend` seems like a useful abstraction.

This PR enhances `smart_keymap::keymap::KeymapOutput`, and adjusts `usbd_smart_keyboard::input::smart_keymap::KeyboardBackend` to allow references to the `KeymapOutput`.