### PR TITLE
Rust edition alignment

### DIFF
--- a/rp2040-rtic-smart-keyboard/Cargo.toml
+++ b/rp2040-rtic-smart-keyboard/Cargo.toml
@@ -3,7 +3,7 @@ name = "rp2040-rtic-smart-keyboard"
 version = "0.7.0-dev"
 license = "MIT OR Apache-2.0"
 authors = ["Richard Goulter <richard.goulter@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 rp-pico = "0.9"

--- a/stm32f4-rtic-smart-keyboard/Cargo.toml
+++ b/stm32f4-rtic-smart-keyboard/Cargo.toml
@@ -3,7 +3,7 @@ name = "stm32f4-rtic-smart-keyboard"
 version = "0.7.0-dev"
 license = "MIT OR Apache-2.0"
 authors = ["Richard Goulter <richard.goulter@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 embedded-hal = "1.0"

--- a/usbd-smart-keyboard/Cargo.toml
+++ b/usbd-smart-keyboard/Cargo.toml
@@ -3,7 +3,7 @@ name = "usbd-smart-keyboard"
 version = "0.7.0-dev"
 license = "MIT OR Apache-2.0"
 authors = ["Richard Goulter <richard.goulter@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [features]
 usbd-serial = []


### PR DESCRIPTION
Some workspace members had `edition = 2018`. `edition`s might as well all be the same edition.