### PR TITLE
Keymap: ignore duplicate key press events

### DIFF
--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -294,6 +294,15 @@ impl<
         }
     }
 
+    fn has_pressed_input_with_keymap_index(&self, keymap_index: u16) -> bool {
+        self.pressed_inputs.iter().any(|pi| match pi {
+            &input::PressedInput::Key(input::PressedKey {
+                keymap_index: ki, ..
+            }) => keymap_index == ki,
+            _ => false,
+        })
+    }
+
     fn process_input(&mut self, ev: input::Event) {
         if let Some(PendingState {
             key_path,
@@ -343,7 +352,9 @@ impl<
                 .for_each(|sch_ev| self.event_scheduler.schedule_event(sch_ev));
 
             match ev {
-                input::Event::Press { keymap_index } => {
+                input::Event::Press { keymap_index }
+                    if !self.has_pressed_input_with_keymap_index(keymap_index) =>
+                {
                     let key = &self.key_definitions[keymap_index as usize];
 
                     let mut key_path = key::KeyPath::new();
@@ -407,6 +418,8 @@ impl<
                         })
                         .map(|i| self.pressed_inputs.remove(i));
                 }
+
+                _ => {}
             }
         }
 

--- a/tests/ceedling/test/test_keymap.c
+++ b/tests/ceedling/test/test_keymap.c
@@ -138,3 +138,23 @@ void test_keyboard_keypress_sequence_da_db_ua(void) {
   keymap_tick(actual_report);
   TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report, 8);
 }
+
+void test_keyboard_double_keypress(void) {
+  uint8_t expected_report[8] = {0, 0, KC_A, 0, 0, 0, 0, 0};
+  uint8_t actual_report[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+  keymap_init();
+
+  keymap_register_input_event(
+      (struct KeymapInputEvent){.event_type = KeymapEventPress,
+                                .value = 2}); // Third key in the keymap is A
+  keymap_tick(actual_report);
+
+  keymap_register_input_event(
+      (struct KeymapInputEvent){.event_type = KeymapEventPress,
+                                .value = 2}); // Third key in the keymap is A
+
+  keymap_tick(actual_report);
+
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report, 8);
+}


### PR DESCRIPTION
Noticed this while working on #239.

Practically, it's helpful to make the keymap robust against the case of duplicate "Press" events for the same keymap index, rather than requiring clients avoid this.