### PR TITLE
ncl: layouts: generalize remapping from 36keys

### DIFF
--- a/ncl/layouts/remap-36keys.ncl
+++ b/ncl/layouts/remap-36keys.ncl
@@ -1,0 +1,1 @@
+{ source_key_count = 36 } & (import "remap.ncl")

--- a/ncl/layouts/remap.ncl
+++ b/ncl/layouts/remap.ncl
@@ -1,9 +1,10 @@
 {
-  into_layout = fun from_split_3x5_3 split_3x5_3_keymap =>
+  source_key_count | Number,
+  into_layout = fun from_layout source_keymap =>
     let remapped_indices # Array { target_index : Number, source_index : Number }
     =
-      let split_3x5_3_indices = std.array.range 0 36 in
-      let target_indices = from_split_3x5_3 { no_key = false, from_layout = split_3x5_3_indices } in
+      let source_indices = std.array.range 0 source_key_count in
+      let target_indices = from_layout { no_key = false, from_layout = source_indices } in
       target_indices
       |> std.array.map_with_index (fun ti si => { target_index = ti, source_index = si })
       |> std.array.filter (fun { target_index, .. } => target_index != false)
@@ -24,13 +25,13 @@
       in
       chords |> std.array.map remap_chord
     in
-    let split_3x5_3_layers =
+    let source_layers =
       let km_aug = import "keymap-ncl-to-json.ncl" in
-      split_3x5_3_keymap.layers
-      |> std.array.map (split_3x5_3_keymap & km_aug).layer_as_array_of_keys
+      source_keymap.layers
+      |> std.array.map (source_keymap & km_aug).layer_as_array_of_keys
     in
     (
-      split_3x5_3_keymap
+      source_keymap
       |> (match {
         { chords = source_chords, ..km } => { chords = remap_chords source_chords } & km,
         km => km,
@@ -44,6 +45,6 @@
           let K = import "keys.ncl" in
           K.NO
         in
-        std.array.map (fun l => from_split_3x5_3 { no_key = NO_KEY, from_layout = l }) split_3x5_3_layers
+        std.array.map (fun l => from_layout { no_key = NO_KEY, from_layout = l }) source_layers
     },
 }

--- a/ncl/ncl.mk
+++ b/ncl/ncl.mk
@@ -24,7 +24,8 @@ test-ncl-checks:
 .PHONY: ncl-format
 ncl-format:
 	nickel format \
-	   ncl/layouts/split_3x5+3.ncl \
+	   ncl/layouts/remap.ncl \
+	   ncl/layouts/remap-36keys.ncl \
 	   ncl/checks.ncl \
 	   ncl/hid-report.ncl \
 	   ncl/import-keymap-json.ncl \

--- a/tests/ncl/keymap-42key-rgoulter/keymap.ncl
+++ b/tests/ncl/keymap-42key-rgoulter/keymap.ncl
@@ -1,4 +1,4 @@
-let split_3x5_3 = import "layouts/split_3x5+3.ncl" in
+let remap_36keys = import "layouts/remap-36keys.ncl" in
 
 let from_3x5_3 = fun
   {
@@ -18,4 +18,4 @@ let from_3x5_3 = fun
   ]
 in
 (import "../keymap-36key-rgoulter/keymap.ncl")
-  |> split_3x5_3.into_layout from_3x5_3
+  |> remap_36keys.into_layout from_3x5_3

--- a/tests/ncl/keymap-48key-rgoulter/keymap.ncl
+++ b/tests/ncl/keymap-48key-rgoulter/keymap.ncl
@@ -1,4 +1,4 @@
-let split_3x5_3 = import "layouts/split_3x5+3.ncl" in
+let remap_36keys = import "layouts/remap-36keys.ncl" in
 
 let from_3x5_3 = fun
   {
@@ -18,4 +18,4 @@ let from_3x5_3 = fun
   ]
 in
 (import "../keymap-36key-rgoulter/keymap.ncl")
-  |> split_3x5_3.into_layout from_3x5_3
+  |> remap_36keys.into_layout from_3x5_3


### PR DESCRIPTION
The `ncl/layouts/split_3x5_3.ncl` provided a function for remapping from a "split 3x5+3" layout, into whatever layout the caller provided. (e.g. the Pico42 rgoulter keymap uses this).

Two problems:
- smart keymap's keymaps are a linear sequence (in contrast to rows/cols). So, "layout" is a physical interpretation of a keymap.
- the remapping functionality isn't particularly coupled to "split 3x5+3".

This PR addresses this:
- Renames the module to "remap.ncl", taking in a `source_key_count` field.
- Defines a `remap-36keys.ncl`.
- Updates some of the naming in the remapping. (from/into, source/target).