### PR TITLE
RP2040-rtic: deprecate usbd smart keyboard common

### DIFF
--- a/rp2040-rtic-smart-keyboard/src/app_prelude.rs
+++ b/rp2040-rtic-smart-keyboard/src/app_prelude.rs
@@ -1,5 +1,3 @@
-pub use usbd_smart_keyboard::app_prelude::VID;
-
 pub use core::convert::Infallible;
 
 pub use keyberon::debounce::Debouncer;
@@ -19,5 +17,5 @@ pub use usbd_human_interface_device::usb_class::UsbHidClassBuilder;
 pub use usbd_human_interface_device::UsbHidError;
 
 pub use crate::app_init;
-pub use crate::common::{usb_poll, UsbClass, UsbDevice};
+pub use crate::common::{usb_poll, UsbClass, UsbDevice, VID};
 pub use crate::input::{Input, Output};

--- a/rp2040-rtic-smart-keyboard/src/app_prelude.rs
+++ b/rp2040-rtic-smart-keyboard/src/app_prelude.rs
@@ -1,4 +1,4 @@
-pub use usbd_smart_keyboard::app_prelude::{usb_poll, VID};
+pub use usbd_smart_keyboard::app_prelude::VID;
 
 pub use core::convert::Infallible;
 
@@ -19,5 +19,5 @@ pub use usbd_human_interface_device::usb_class::UsbHidClassBuilder;
 pub use usbd_human_interface_device::UsbHidError;
 
 pub use crate::app_init;
-pub use crate::common::{UsbClass, UsbDevice};
+pub use crate::common::{usb_poll, UsbClass, UsbDevice};
 pub use crate::input::{Input, Output};

--- a/rp2040-rtic-smart-keyboard/src/app_prelude.rs
+++ b/rp2040-rtic-smart-keyboard/src/app_prelude.rs
@@ -1,4 +1,4 @@
-pub use usbd_smart_keyboard::app_prelude::*;
+pub use usbd_smart_keyboard::app_prelude::{usb_poll, VID};
 
 pub use core::convert::Infallible;
 

--- a/rp2040-rtic-smart-keyboard/src/common.rs
+++ b/rp2040-rtic-smart-keyboard/src/common.rs
@@ -2,9 +2,13 @@ use rp2040_hal as hal;
 
 use frunk::HList;
 
+use usb_device::UsbError;
+
 use usbd_human_interface_device::device::consumer::ConsumerControl;
 use usbd_human_interface_device::device::keyboard::NKROBootKeyboard;
 use usbd_human_interface_device::usb_class::UsbHidClass;
+
+use usbd_serial::SerialPort;
 
 use hal::usb::UsbBus;
 
@@ -27,4 +31,28 @@ pub type UsbSerial = usbd_serial::SerialPort<'static, UsbBus>;
 /// Enters the bootloader.
 pub fn keyboard_reset_to_bootloader() {
     rp2040_hal::rom_data::reset_to_usb_boot(0, 0);
+}
+
+/// Polls the given [UsbDevice] with the [UsbHidClass] that has a [NKROBootKeyboard]. (e.g. [UsbClass]).
+pub fn usb_poll(
+    usb_dev: &mut UsbDevice,
+    usb_serial: &mut SerialPort<'static, UsbBus>,
+    keyboard: &mut UsbClass,
+) {
+    if usb_dev.poll(&mut [keyboard, usb_serial]) {
+        let mut buf = [0u8; 64];
+        match usb_serial.read(&mut buf) {
+            Err(_e) => {}
+            Ok(_count) => {}
+        }
+
+        let interface = keyboard.device::<NKROBootKeyboard<'static, UsbBus>, _>();
+        match interface.read_report() {
+            Err(UsbError::WouldBlock) => {}
+            Err(e) => {
+                core::panic!("Failed to read keyboard report: {:?}", e)
+            }
+            Ok(_leds) => {}
+        }
+    }
 }

--- a/rp2040-rtic-smart-keyboard/src/common.rs
+++ b/rp2040-rtic-smart-keyboard/src/common.rs
@@ -1,8 +1,22 @@
-use hal::usb::UsbBus;
 use rp2040_hal as hal;
 
-/// Alias for [usbd_smart_keyboard::common::UsbClass] using the RP2040 [UsbBus].
-pub type UsbClass = usbd_smart_keyboard::common::UsbClass<UsbBus>;
+use frunk::HList;
+
+use usbd_human_interface_device::device::consumer::ConsumerControl;
+use usbd_human_interface_device::device::keyboard::NKROBootKeyboard;
+use usbd_human_interface_device::usb_class::UsbHidClass;
+
+use hal::usb::UsbBus;
+
+/// A [usb_device::class::UsbClass] impl. with HID Keyboard, HID consumer devices.
+pub type UsbClass = UsbHidClass<
+    'static,
+    UsbBus,
+    HList!(
+        ConsumerControl<'static, UsbBus>,
+        NKROBootKeyboard<'static, UsbBus>,
+    ),
+>;
 
 /// Alias for [usb_device::device::UsbDevice] using the RP2040 [UsbBus].
 pub type UsbDevice = usb_device::device::UsbDevice<'static, UsbBus>;

--- a/rp2040-rtic-smart-keyboard/src/common.rs
+++ b/rp2040-rtic-smart-keyboard/src/common.rs
@@ -1,8 +1,6 @@
 use hal::usb::UsbBus;
 use rp2040_hal as hal;
 
-pub use usbd_smart_keyboard::common::*;
-
 /// Alias for [usbd_smart_keyboard::common::UsbClass] using the RP2040 [UsbBus].
 pub type UsbClass = usbd_smart_keyboard::common::UsbClass<UsbBus>;
 

--- a/rp2040-rtic-smart-keyboard/src/common.rs
+++ b/rp2040-rtic-smart-keyboard/src/common.rs
@@ -28,6 +28,9 @@ pub type UsbDevice = usb_device::device::UsbDevice<'static, UsbBus>;
 /// Alias for [usbd_serial::SerialPort] using the RP2040 [UsbBus].
 pub type UsbSerial = usbd_serial::SerialPort<'static, UsbBus>;
 
+/// A USB Vendor ID.
+pub const VID: u16 = 0xcafe;
+
 /// Enters the bootloader.
 pub fn keyboard_reset_to_bootloader() {
     rp2040_hal::rom_data::reset_to_usb_boot(0, 0);


### PR DESCRIPTION
While working on a keyboard firmware using embassy, I noticed an awkwardness with `usbd-smart-keyboard`:

- `usbd-smart-keyboard` is still useful for writing keyboard firmware with embassy, even though embassy doesn't use `usb-device`. (i.e. it's useful for bridging keyberon and `smart-keymap`).
- `usbd-smart-keyboard`'s `usb-device` items aren't all that useful.

This PR removes rp2040-rtic-smart-keyboard's dependency on usbd-smart-keyboard's "not all that useful" items: the USB device/class type aliases, VID constant, and usb_poll implementation.