### PR TITLE
STM32F4-RTIC: deprecate usbd smart keyboard common

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,20 @@ build-rust-thumbv6m-none-eabi:
 	$(CARGO) build --target=thumbv6m-none-eabi --package=usbd-smart-keyboard
 	$(CARGO) build --target=thumbv6m-none-eabi --package=rp2040-rtic-smart-keyboard
 
+.PHONY: build-rust-rp2040
+build-rust-rp2040: build-rust-thumbv6m-none-eabi
+
+.PHONY: build-rust-thumbv7em-none-eabihf
+build-rust-thumbv7em-none-eabihf:
+	$(CARGO) build --target=thumbv7em-none-eabihf --no-default-features
+	$(CARGO) build --target=thumbv7em-none-eabihf --package=usbd-smart-keyboard
+	$(CARGO) build --target=thumbv7em-none-eabihf --package=stm32f4-rtic-smart-keyboard
+	$(CARGO) build --target=thumbv7em-none-eabihf --package=stm32f4-rtic-smart-keyboard --example=minif4_36-rev2021_4-lhs
+	$(CARGO) build --target=thumbv7em-none-eabihf --package=stm32f4-rtic-smart-keyboard --example=minif4_36-rev2021_4-rhs
+
+.PHONY: build-rust-stm32f4
+build-rust-stm32f4: build-rust-thumbv7em-none-eabihf
+
 .PHONY: clean
 clean: clean-generated-keymaps
 	rm -f include/smart_keymap.h

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ all: include/smart_keymap.h
 	$(CARGO) build
 
 .PHONY: test
-test: test-rust test-ncl test-ceedling build-rust-thumbv6m-none-eabi
+test: test-rust test-ncl test-ceedling build-rust-thumbv6m-none-eabi build-rust-stm32f4
 
 .PHONY: test-rust
 test-rust:

--- a/stm32f4-rtic-smart-keyboard/src/app_prelude.rs
+++ b/stm32f4-rtic-smart-keyboard/src/app_prelude.rs
@@ -1,4 +1,4 @@
-pub use usbd_smart_keyboard::app_prelude::*;
+pub use usbd_smart_keyboard::app_prelude::{usb_poll, VID};
 
 pub use stm32f4xx_hal as hal;
 

--- a/stm32f4-rtic-smart-keyboard/src/app_prelude.rs
+++ b/stm32f4-rtic-smart-keyboard/src/app_prelude.rs
@@ -1,5 +1,3 @@
-pub use usbd_smart_keyboard::app_prelude::VID;
-
 pub use stm32f4xx_hal as hal;
 
 pub use hal::{
@@ -14,4 +12,4 @@ pub use hal::{
 };
 
 pub use crate::app_init;
-pub use crate::common::{usb_poll, UsbClass, UsbDevice};
+pub use crate::common::{usb_poll, UsbClass, UsbDevice, VID};

--- a/stm32f4-rtic-smart-keyboard/src/app_prelude.rs
+++ b/stm32f4-rtic-smart-keyboard/src/app_prelude.rs
@@ -1,4 +1,4 @@
-pub use usbd_smart_keyboard::app_prelude::{usb_poll, VID};
+pub use usbd_smart_keyboard::app_prelude::VID;
 
 pub use stm32f4xx_hal as hal;
 
@@ -14,4 +14,4 @@ pub use hal::{
 };
 
 pub use crate::app_init;
-pub use crate::common::{UsbClass, UsbDevice};
+pub use crate::common::{usb_poll, UsbClass, UsbDevice};

--- a/stm32f4-rtic-smart-keyboard/src/common.rs
+++ b/stm32f4-rtic-smart-keyboard/src/common.rs
@@ -1,7 +1,5 @@
 use stm32f4xx_hal::otg_fs::UsbBusType;
 
-pub use usbd_smart_keyboard::common::*;
-
 pub type UsbClass = usbd_smart_keyboard::common::UsbClass<UsbBusType>;
 
 pub type UsbDevice = usb_device::device::UsbDevice<'static, UsbBusType>;

--- a/stm32f4-rtic-smart-keyboard/src/common.rs
+++ b/stm32f4-rtic-smart-keyboard/src/common.rs
@@ -1,5 +1,19 @@
+use frunk::HList;
+
 use stm32f4xx_hal::otg_fs::UsbBusType;
 
-pub type UsbClass = usbd_smart_keyboard::common::UsbClass<UsbBusType>;
+use usbd_human_interface_device::device::consumer::ConsumerControl;
+use usbd_human_interface_device::device::keyboard::NKROBootKeyboard;
+use usbd_human_interface_device::usb_class::UsbHidClass;
+
+/// A [usb_device::class::UsbClass] impl. with HID Keyboard, HID consumer devices.
+pub type UsbClass = UsbHidClass<
+    'static,
+    UsbBusType,
+    HList!(
+        ConsumerControl<'static, UsbBusType>,
+        NKROBootKeyboard<'static, UsbBusType>,
+    ),
+>;
 
 pub type UsbDevice = usb_device::device::UsbDevice<'static, UsbBusType>;

--- a/stm32f4-rtic-smart-keyboard/src/common.rs
+++ b/stm32f4-rtic-smart-keyboard/src/common.rs
@@ -20,6 +20,9 @@ pub type UsbClass = UsbHidClass<
 
 pub type UsbDevice = usb_device::device::UsbDevice<'static, UsbBusType>;
 
+/// A USB Vendor ID.
+pub const VID: u16 = 0xcafe;
+
 /// Polls the given [UsbDevice] with the [UsbHidClass] that has a [NKROBootKeyboard]. (e.g. [UsbClass]).
 pub fn usb_poll(usb_dev: &mut UsbDevice, keyboard: &mut UsbClass) {
     if usb_dev.poll(&mut [keyboard]) {

--- a/stm32f4-rtic-smart-keyboard/src/common.rs
+++ b/stm32f4-rtic-smart-keyboard/src/common.rs
@@ -1,5 +1,7 @@
 use frunk::HList;
 
+use usb_device::UsbError;
+
 use stm32f4xx_hal::otg_fs::UsbBusType;
 
 use usbd_human_interface_device::device::consumer::ConsumerControl;
@@ -17,3 +19,17 @@ pub type UsbClass = UsbHidClass<
 >;
 
 pub type UsbDevice = usb_device::device::UsbDevice<'static, UsbBusType>;
+
+/// Polls the given [UsbDevice] with the [UsbHidClass] that has a [NKROBootKeyboard]. (e.g. [UsbClass]).
+pub fn usb_poll(usb_dev: &mut UsbDevice, keyboard: &mut UsbClass) {
+    if usb_dev.poll(&mut [keyboard]) {
+        let interface = keyboard.device::<NKROBootKeyboard<'static, UsbBusType>, _>();
+        match interface.read_report() {
+            Err(UsbError::WouldBlock) => {}
+            Err(e) => {
+                core::panic!("Failed to read keyboard report: {:?}", e)
+            }
+            Ok(_leds) => {}
+        }
+    }
+}


### PR DESCRIPTION
Same as #318, but for STM32F4:

While working on a keyboard firmware using embassy, I noticed an awkwardness with `usbd-smart-keyboard`:

- `usbd-smart-keyboard` is still useful for writing keyboard firmware with embassy, even though embassy doesn't use `usb-device`. (i.e. it's useful for bridging keyberon and `smart-keymap`).
- `usbd-smart-keyboard`'s `usb-device` items aren't all that useful.

This PR removes stm32f4-rtic-smart-keyboard's dependency on usbd-smart-keyboard's "not all that useful" items: the USB device/class type aliases, VID constant, and usb_poll implementation.