### PR TITLE
cargo: config: fix thumbv7em-none-eabihf

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,7 @@
 runner = "gdb -q -x openocd.gdb"
 
 rustflags = [
-  "-C", "link-arg=--library-path=ld/stm32f4xx-tinyuf2"
+  "-C", "link-arg=--library-path=ld/stm32f4xx-tinyuf2",
 ]
 
 [target.thumbv6m-none-eabi]
@@ -11,13 +11,18 @@ rustflags = [
 runner = "elf2uf2-rs -d"
 
 rustflags = [
-  "-C", "link-arg=-Tlink.x",
   "-C", "link-arg=--library-path=ld/rp2040",
 
   # Code-size optimizations.
   #   trap unreachable can save a lot of space, but requires nightly compiler.
   #   uncomment the next line if you wish to enable it
   # "-Z", "trap-unreachable=no",
+]
+
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+
+rustflags = [
+  "-C", "link-arg=-Tlink.x",
   "-C", "llvm-args=--inline-threshold=5",
   "-C", "no-vectorize-loops",
 ]

--- a/.github/workflows/rust-stm32f4.yaml
+++ b/.github/workflows/rust-stm32f4.yaml
@@ -50,19 +50,19 @@ jobs:
         run: rustup target add thumbv7em-none-eabihf
 
       - name: Run Cargo Build
-        run: cargo build --target=thumbv7em-none-eabihf --no-default-features
+        run: cargo build --release --target=thumbv7em-none-eabihf --no-default-features
 
       - name: Run Cargo Build (usbd-smart-keymap)
-        run: cargo build --target=thumbv7em-none-eabihf --package=usbd-smart-keyboard
+        run: cargo build --release --target=thumbv7em-none-eabihf --package=usbd-smart-keyboard
 
       - name: Run Cargo Build (stm32f4-rtic-smart-keyboard)
-        run: cargo build --target=thumbv7em-none-eabihf --package=stm32f4-rtic-smart-keyboard
+        run: cargo build --release --target=thumbv7em-none-eabihf --package=stm32f4-rtic-smart-keyboard
 
       - name: Run Cargo Build (stm32f4-rtic-smart-keyboard, ex=minif4_36-rev2021_4-lhs)
-        run: cargo build --target=thumbv7em-none-eabihf --package=stm32f4-rtic-smart-keyboard --example=minif4_36-rev2021_4-lhs
+        run: cargo build --release --target=thumbv7em-none-eabihf --package=stm32f4-rtic-smart-keyboard --example=minif4_36-rev2021_4-lhs
 
       - name: Run Cargo Build (stm32f4-rtic-smart-keyboard, ex=minif4_36-rev2021_4-rhs)
-        run: cargo build --target=thumbv7em-none-eabihf --package=stm32f4-rtic-smart-keyboard --example=minif4_36-rev2021_4-rhs
+        run: cargo build --release --target=thumbv7em-none-eabihf --package=stm32f4-rtic-smart-keyboard --example=minif4_36-rev2021_4-rhs
 
       - name: Run Cargo Doc
         run: |


### PR DESCRIPTION
Last change to `.cargo/config.toml` broke linking on the STM32F4, and CI wasn't catching this problem. Oops.

Per https://docs.rs/cortex-m-rt/latest/cortex_m_rt/ `cortex_m_rt` provides the `link.x`, and the user is  supply the `memory.x`.