### PR TITLE
Smart keymap nickel helper: refactor common functionality

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,51 +1,15 @@
 use std::env;
-use std::fs;
-use std::io::Write;
-use std::path::Path;
 
 use smart_keymap_nickel_helper::{
-    nickel_keymap_rs_for_keymap_path, rustfmt, NickelError, NickelEvalInputs,
+    codegen_rust_module, nickel_keymap_rs_for_keymap_path, CodegenInputs,
 };
 
 fn main() {
-    println!("cargo:rerun-if-env-changed=SMART_KEYMAP_CUSTOM_KEYMAP");
-    println!("cargo::rustc-check-cfg=cfg(custom_keymap)");
-    if let Some(custom_keymap_path) = env::var("SMART_KEYMAP_CUSTOM_KEYMAP")
-        .ok()
-        .filter(|s| !s.is_empty())
-    {
-        let out_dir = env::var("OUT_DIR").unwrap();
-        let dest_path = Path::new(&out_dir).join("keymap.rs");
-        println!("cargo:rerun-if-changed={}", dest_path.to_str().unwrap());
-
-        if custom_keymap_path.ends_with(".rs") {
-            println!("cargo:rustc-cfg=custom_keymap");
-
-            // Copy the custom keymap file to the output directory
-            fs::copy(custom_keymap_path, &dest_path).unwrap();
-        } else if custom_keymap_path.ends_with(".ncl") {
-            println!("cargo:rustc-cfg=custom_keymap");
-
-            // Evaluate the custom keymap file with Nickel
-            let keymap_path = Path::new(&custom_keymap_path);
-            match nickel_keymap_rs_for_keymap_path(NickelEvalInputs {
-                ncl_import_path: format!("{}/ncl", env!("CARGO_MANIFEST_DIR")).as_str(),
-                input_path: keymap_path,
-            }) {
-                Ok(keymap_rs) => {
-                    let mut file = fs::File::create(&dest_path).unwrap();
-                    let formatted = rustfmt(keymap_rs);
-                    file.write_all(formatted.as_bytes()).unwrap();
-                }
-                Err(NickelError::NickelNotFound) => {
-                    panic!("`nickel` not found in PATH");
-                }
-                Err(NickelError::EvalError(e)) => {
-                    panic!("Nickel evaluation failed: {}", e);
-                }
-            }
-        } else {
-            panic!("Unsupported custom keymap path: {}", custom_keymap_path);
-        }
-    }
+    codegen_rust_module(CodegenInputs {
+        env_var: "SMART_KEYMAP_CUSTOM_KEYMAP",
+        cfg_name: "custom_keymap",
+        module_basename: "keymap.rs",
+        ncl_import_path: format!("{}/ncl", env!("CARGO_MANIFEST_DIR")).as_str(),
+        nickel_eval_fn: nickel_keymap_rs_for_keymap_path,
+    });
 }

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,9 @@ use std::fs;
 use std::io::Write;
 use std::path::Path;
 
-use smart_keymap_nickel_helper::{nickel_keymap_rs_for_keymap_path, rustfmt, NickelError};
+use smart_keymap_nickel_helper::{
+    nickel_keymap_rs_for_keymap_path, rustfmt, NickelError, NickelEvalInputs,
+};
 
 fn main() {
     println!("cargo:rerun-if-env-changed=SMART_KEYMAP_CUSTOM_KEYMAP");
@@ -26,10 +28,10 @@ fn main() {
 
             // Evaluate the custom keymap file with Nickel
             let keymap_path = Path::new(&custom_keymap_path);
-            match nickel_keymap_rs_for_keymap_path(
-                format!("{}/ncl", env!("CARGO_MANIFEST_DIR")),
-                keymap_path,
-            ) {
+            match nickel_keymap_rs_for_keymap_path(NickelEvalInputs {
+                ncl_import_path: format!("{}/ncl", env!("CARGO_MANIFEST_DIR")).as_str(),
+                input_path: keymap_path,
+            }) {
                 Ok(keymap_rs) => {
                     let mut file = fs::File::create(&dest_path).unwrap();
                     let formatted = rustfmt(keymap_rs);

--- a/rp2040-rtic-smart-keyboard/build.rs
+++ b/rp2040-rtic-smart-keyboard/build.rs
@@ -3,7 +3,9 @@ use std::fs;
 use std::io::Write;
 use std::path::Path;
 
-use smart_keymap_nickel_helper::{nickel_board_rs_for_board_path, rustfmt, NickelError};
+use smart_keymap_nickel_helper::{
+    nickel_board_rs_for_board_path, rustfmt, NickelError, NickelEvalInputs,
+};
 
 fn main() {
     println!("cargo:rerun-if-env-changed=SMART_KEYBOARD_CUSTOM_BOARD");
@@ -22,11 +24,11 @@ fn main() {
             println!("cargo:rustc-cfg=custom_board");
 
             // Evaluate the custom keymap file with Nickel
-            let keymap_path = Path::new(&custom_board_path);
-            match nickel_board_rs_for_board_path(
-                format!("{}/ncl", env!("CARGO_MANIFEST_DIR")),
-                keymap_path,
-            ) {
+            let board_path = Path::new(&custom_board_path);
+            match nickel_board_rs_for_board_path(NickelEvalInputs {
+                ncl_import_path: format!("{}/ncl", env!("CARGO_MANIFEST_DIR")).as_str(),
+                input_path: board_path,
+            }) {
                 Ok(board_rs) => {
                     let mut file = fs::File::create(&dest_path).unwrap();
                     let formatted = rustfmt(board_rs);

--- a/rp2040-rtic-smart-keyboard/build.rs
+++ b/rp2040-rtic-smart-keyboard/build.rs
@@ -1,48 +1,15 @@
 use std::env;
-use std::fs;
-use std::io::Write;
-use std::path::Path;
 
 use smart_keymap_nickel_helper::{
-    nickel_board_rs_for_board_path, rustfmt, NickelError, NickelEvalInputs,
+    codegen_rust_module, nickel_board_rs_for_board_path, CodegenInputs,
 };
 
 fn main() {
-    println!("cargo:rerun-if-env-changed=SMART_KEYBOARD_CUSTOM_BOARD");
-    println!("cargo::rustc-check-cfg=cfg(custom_board)");
-    if let Ok(custom_board_path) = env::var("SMART_KEYBOARD_CUSTOM_BOARD") {
-        let out_dir = env::var("OUT_DIR").unwrap();
-        let dest_path = Path::new(&out_dir).join("board.rs");
-        println!("cargo:rerun-if-changed={}", dest_path.to_str().unwrap());
-
-        if custom_board_path.ends_with(".rs") {
-            println!("cargo:rustc-cfg=custom_board");
-
-            // Copy the custom keymap file to the output directory
-            fs::copy(custom_board_path, &dest_path).unwrap();
-        } else if custom_board_path.ends_with(".ncl") {
-            println!("cargo:rustc-cfg=custom_board");
-
-            // Evaluate the custom keymap file with Nickel
-            let board_path = Path::new(&custom_board_path);
-            match nickel_board_rs_for_board_path(NickelEvalInputs {
-                ncl_import_path: format!("{}/ncl", env!("CARGO_MANIFEST_DIR")).as_str(),
-                input_path: board_path,
-            }) {
-                Ok(board_rs) => {
-                    let mut file = fs::File::create(&dest_path).unwrap();
-                    let formatted = rustfmt(board_rs);
-                    file.write_all(formatted.as_bytes()).unwrap();
-                }
-                Err(NickelError::NickelNotFound) => {
-                    panic!("`nickel` not found in PATH");
-                }
-                Err(NickelError::EvalError(e)) => {
-                    panic!("Nickel evaluation failed: {}", e);
-                }
-            }
-        } else {
-            panic!("Unsupported custom board path: {}", custom_board_path);
-        }
-    }
+    codegen_rust_module(CodegenInputs {
+        env_var: "SMART_KEYBOARD_CUSTOM_BOARD",
+        cfg_name: "custom_board",
+        module_basename: "board.rs",
+        ncl_import_path: format!("{}/ncl", env!("CARGO_MANIFEST_DIR")).as_str(),
+        nickel_eval_fn: nickel_board_rs_for_board_path,
+    });
 }

--- a/smart-keymap-nickel-helper/src/lib.rs
+++ b/smart-keymap-nickel-helper/src/lib.rs
@@ -67,7 +67,12 @@ pub fn nickel_keymap_rs_for_keymap_path(
 }
 
 /// Evaluates the Nickel expr for a board, returning the board.rs contents.
-pub fn nickel_board_rs_for_board_path(ncl_import_path: String, board_path: &Path) -> NickelResult {
+pub fn nickel_board_rs_for_board_path(
+    NickelEvalInputs {
+        ncl_import_path,
+        input_path,
+    }: NickelEvalInputs,
+) -> NickelResult {
     let spawn_nickel_result = Command::new("nickel")
         .args([
             "export",
@@ -75,7 +80,7 @@ pub fn nickel_board_rs_for_board_path(ncl_import_path: String, board_path: &Path
             format!("--import-path={}", ncl_import_path).as_ref(),
             "--field=board_rs",
             "codegen.ncl",
-            board_path.to_str().unwrap(),
+            input_path.to_str().unwrap(),
         ])
         .stdin(Stdio::null())
         .stderr(Stdio::piped())

--- a/smart-keymap-nickel-helper/src/lib.rs
+++ b/smart-keymap-nickel-helper/src/lib.rs
@@ -3,6 +3,14 @@ use std::path::Path;
 use std::io::{self, Write};
 use std::process::{Command, Stdio};
 
+/// Inputs for Nickel evaluation.
+pub struct NickelEvalInputs<'a> {
+    /// The Nickel import path to use for the evaluation.
+    pub ncl_import_path: &'a str,
+    /// Path to a Nickel file to evaluate.
+    pub input_path: &'a Path,
+}
+
 /// Likely reasons why running `nickel` may fail.
 pub enum NickelError {
     NickelNotFound,

--- a/smart-keymap-nickel-helper/src/lib.rs
+++ b/smart-keymap-nickel-helper/src/lib.rs
@@ -22,8 +22,10 @@ pub type NickelResult = Result<String, NickelError>;
 
 /// Evaluates the Nickel expr for a keymap, returning the keymap.rs contents.
 pub fn nickel_keymap_rs_for_keymap_path(
-    ncl_import_path: String,
-    keymap_path: &Path,
+    NickelEvalInputs {
+        ncl_import_path,
+        input_path,
+    }: NickelEvalInputs,
 ) -> NickelResult {
     let spawn_nickel_result = Command::new("nickel")
         .args([
@@ -33,7 +35,7 @@ pub fn nickel_keymap_rs_for_keymap_path(
             "--field=keymap_rs",
             "keymap-codegen.ncl",
             "keymap-ncl-to-json.ncl",
-            keymap_path.to_str().unwrap(),
+            input_path.to_str().unwrap(),
         ])
         .stdin(Stdio::null())
         .stderr(Stdio::piped())

--- a/stm32f4-rtic-smart-keyboard/build.rs
+++ b/stm32f4-rtic-smart-keyboard/build.rs
@@ -3,7 +3,9 @@ use std::fs;
 use std::io::Write;
 use std::path::Path;
 
-use smart_keymap_nickel_helper::{nickel_board_rs_for_board_path, rustfmt, NickelError};
+use smart_keymap_nickel_helper::{
+    nickel_board_rs_for_board_path, rustfmt, NickelError, NickelEvalInputs,
+};
 
 fn main() {
     println!("cargo:rerun-if-env-changed=SMART_KEYBOARD_CUSTOM_BOARD");
@@ -22,11 +24,11 @@ fn main() {
             println!("cargo:rustc-cfg=custom_board");
 
             // Evaluate the custom keymap file with Nickel
-            let keymap_path = Path::new(&custom_board_path);
-            match nickel_board_rs_for_board_path(
-                format!("{}/ncl", env!("CARGO_MANIFEST_DIR")),
-                keymap_path,
-            ) {
+            let board_path = Path::new(&custom_board_path);
+            match nickel_board_rs_for_board_path(NickelEvalInputs {
+                ncl_import_path: format!("{}/ncl", env!("CARGO_MANIFEST_DIR")).as_str(),
+                input_path: board_path,
+            }) {
                 Ok(board_rs) => {
                     let mut file = fs::File::create(&dest_path).unwrap();
                     let formatted = rustfmt(board_rs);

--- a/stm32f4-rtic-smart-keyboard/build.rs
+++ b/stm32f4-rtic-smart-keyboard/build.rs
@@ -1,48 +1,15 @@
 use std::env;
-use std::fs;
-use std::io::Write;
-use std::path::Path;
 
 use smart_keymap_nickel_helper::{
-    nickel_board_rs_for_board_path, rustfmt, NickelError, NickelEvalInputs,
+    codegen_rust_module, nickel_board_rs_for_board_path, CodegenInputs,
 };
 
 fn main() {
-    println!("cargo:rerun-if-env-changed=SMART_KEYBOARD_CUSTOM_BOARD");
-    println!("cargo::rustc-check-cfg=cfg(custom_board)");
-    if let Ok(custom_board_path) = env::var("SMART_KEYBOARD_CUSTOM_BOARD") {
-        let out_dir = env::var("OUT_DIR").unwrap();
-        let dest_path = Path::new(&out_dir).join("board.rs");
-        println!("cargo:rerun-if-changed={}", dest_path.to_str().unwrap());
-
-        if custom_board_path.ends_with(".rs") {
-            println!("cargo:rustc-cfg=custom_board");
-
-            // Copy the custom keymap file to the output directory
-            fs::copy(custom_board_path, &dest_path).unwrap();
-        } else if custom_board_path.ends_with(".ncl") {
-            println!("cargo:rustc-cfg=custom_board");
-
-            // Evaluate the custom keymap file with Nickel
-            let board_path = Path::new(&custom_board_path);
-            match nickel_board_rs_for_board_path(NickelEvalInputs {
-                ncl_import_path: format!("{}/ncl", env!("CARGO_MANIFEST_DIR")).as_str(),
-                input_path: board_path,
-            }) {
-                Ok(board_rs) => {
-                    let mut file = fs::File::create(&dest_path).unwrap();
-                    let formatted = rustfmt(board_rs);
-                    file.write_all(formatted.as_bytes()).unwrap();
-                }
-                Err(NickelError::NickelNotFound) => {
-                    panic!("`nickel` not found in PATH");
-                }
-                Err(NickelError::EvalError(e)) => {
-                    panic!("Nickel evaluation failed: {}", e);
-                }
-            }
-        } else {
-            panic!("Unsupported custom board path: {}", custom_board_path);
-        }
-    }
+    codegen_rust_module(CodegenInputs {
+        env_var: "SMART_KEYBOARD_CUSTOM_BOARD",
+        cfg_name: "custom_board",
+        module_basename: "board.rs",
+        ncl_import_path: format!("{}/ncl", env!("CARGO_MANIFEST_DIR")).as_str(),
+        nickel_eval_fn: nickel_board_rs_for_board_path,
+    });
 }


### PR DESCRIPTION
This PR adds input structs for smart keymap nickel helper code, and factors out the common "nickel codegen to rust module" code to a function.

I'm sure the smart-keymap-nickel-helper code could also be refactored further; but, that's more an implementation detail of the code that's being refactored here.

FWIW, STM32F4-RTIC doesn't actually support codegen in any of its binaries.