### PR TITLE
Keyberon smart keyboard: use actual types in doctests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,7 +916,7 @@ dependencies = [
  "frunk",
  "fugit",
  "generic-array",
- "heapless 0.7.17",
+ "heapless 0.8.0",
  "keyberon",
  "nb 1.1.0",
  "panic-halt",

--- a/keyberon-smart-keyboard/Cargo.toml
+++ b/keyberon-smart-keyboard/Cargo.toml
@@ -14,7 +14,7 @@ embedded-hal = "1.0"
 fugit = "0.3.7"
 frunk = { version = "0.4", default-features = false }
 generic-array = "0.14"
-heapless = "0.7"
+heapless = "0.8"
 nb = "1.1"
 panic-halt = "0.2.0"
 panic-rtt-target = { version = "0.1.2", features = ["cortex-m"] }

--- a/keyberon-smart-keyboard/src/lib.rs
+++ b/keyberon-smart-keyboard/src/lib.rs
@@ -10,17 +10,48 @@
 //!
 //! Roughly, where Keyberon code is typically:
 //!
-//! ```ignore
+//! ```
+//! use embedded_hal::digital::{InputPin, OutputPin};
+//! use keyberon::chording::Chording;
+//! use keyberon::debounce::Debouncer;
+//! use keyberon::layout::CustomEvent;
+//! use keyberon::layout::Event;
+//! use keyberon::layout::Layout;
+//! use keyberon::matrix::Matrix;
+//!
 //! // Gather events from keyboard matrix
-//! let key_presses = matrix.get().unwrap();
-//! let debounced_events = debouncer.events(key_presses).collect();
-//! chording.tick(debounced_events)
+//! fn keyboard_events<C, R, E, const COLS: usize, const ROWS: usize, const CHORD_COUNT: usize>(
+//!     matrix: &mut Matrix<C, R, COLS, ROWS>,
+//!     debouncer: &mut Debouncer<[[bool; COLS]; ROWS]>,
+//!     chording: &mut Chording<CHORD_COUNT>,
+//! ) -> heapless::Vec<Event, 8>
+//! where
+//!     C: InputPin<Error = E>,
+//!     R: OutputPin<Error = E>,
+//!     E: core::fmt::Debug,
+//! {
+//!     let key_presses: [[bool; COLS]; ROWS] = matrix.get().unwrap();
+//!     let debounced_events: heapless::Vec<Event, 8> = debouncer.events(key_presses).collect();
+//!     chording.tick(debounced_events)
+//! }
 //!
 //! // Compute key codes from those events
-//! for event in chording.events() {
-//!     layout.event(event);
+//! fn key_codes_from_events<
+//!     T: 'static,
+//!     K: Copy + 'static,
+//!     const COLS: usize,
+//!     const ROWS: usize,
+//!     const LAYER_COUNT: usize,
+//! >(
+//!     events: heapless::Vec<Event, 8>,
+//!     layout: &mut Layout<COLS, ROWS, LAYER_COUNT, T, K>,
+//! ) -> heapless::Vec<K, 8> {
+//!     for event in events {
+//!         layout.event(event);
+//!     }
+//!     let _custom_event: CustomEvent<T> = layout.tick();
+//!     layout.keycodes().collect()
 //! }
-//! let keycodes = layout.keycodes();
 //! ```
 //!
 //! With this crate, [input::Keyboard] manages scanning/debouncing events
@@ -28,17 +59,37 @@
 //!
 //! For computing the key codes, this uses [input::smart_keymap::KeyboardBackend]:
 //!
-//! ```ignore
-//! // Compute key codes from those events
-//! for event in keyboard.events() {
-//!     if let Some(event) = keymap_index_of(&KEYMAP_INDICES, event) {
-//!         backend.event(event);
-//!     }
+//! ```
+//! use keyberon::layout::Event;
+//!
+//! use keyberon_smart_keyboard::input::Keyboard;
+//! use keyberon_smart_keyboard::input::MatrixScanner;
+//! use keyberon_smart_keyboard::input::PressedKeys;
+//! use keyberon_smart_keyboard::input::smart_keymap::KeyboardBackend;
+//! use keyberon_smart_keyboard::input::smart_keymap::keymap_index_of;
+//!
+//! // Gather events from keyboard matrix
+//! fn keyboard_events<M: MatrixScanner<COLS, ROWS>, const COLS: usize, const ROWS: usize>(
+//!     keyboard: &mut Keyboard<COLS, ROWS, M>,
+//! ) -> heapless::Vec<Event, 8>
+//! {
+//!     keyboard.events()
 //! }
-//! backend.tick();
-//! let key_codes = backend
-//!   .keymap_output()
-//!   .pressed_key_codes();
+//!
+//! // Compute key codes from those events
+//! fn key_codes_from_events<const COLS: usize, const ROWS: usize>(
+//!     keymap_indices: &[[Option<u16>; COLS]; ROWS],
+//!     events: heapless::Vec<Event, 8>,
+//!     backend: &mut KeyboardBackend,
+//! ) -> heapless::Vec<u8, 24> {
+//!     for event in events {
+//!         if let Some(event) = keymap_index_of(keymap_indices, event) {
+//!             backend.event(event);
+//!         }
+//!     }
+//!     backend.tick();
+//!     backend.keymap_output().pressed_key_codes()
+//! }
 //! ```
 
 #![no_main]

--- a/keyberon-smart-keyboard/src/lib.rs
+++ b/keyberon-smart-keyboard/src/lib.rs
@@ -1,4 +1,4 @@
-//! # USBD Smart Keyboard
+//! # Keyberon Smart Keyboard
 //!
 //! This crate provides functionality for using [smart_keymap]
 //!  as part of Rust keyboard firmware.


### PR DESCRIPTION
The `keyberon-smart-keyboard`'s `lib.rs` has some doctest snippets illustrating the main types used to go from "matrix scanning" to "reportable key codes".

Rust supports running these code snippets as doctests.

It's somewhat more polished to provide the actual Rust types used.

(Since keyberon uses heapless v0.8, `keyberon-smart-keymap` needs to update its `heapless` to track that).