### PR TITLE
stm32f4-rtic: be consistent about custom_board cfg flag

### DIFF
--- a/stm32f4-rtic-smart-keyboard/examples/minif4_36-rev2021_4-lhs.rs
+++ b/stm32f4-rtic-smart-keyboard/examples/minif4_36-rev2021_4-lhs.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 
-#[cfg(not(custom_board))]
 mod board {
     pub use stm32f4_rtic_smart_keyboard::input::Input;
 

--- a/stm32f4-rtic-smart-keyboard/examples/minif4_36-rev2021_4-rhs.rs
+++ b/stm32f4-rtic-smart-keyboard/examples/minif4_36-rev2021_4-rhs.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 
-#[cfg(not(custom_board))]
 mod board {
     pub use stm32f4_rtic_smart_keyboard::input::Input;
 

--- a/stm32f4-rtic-smart-keyboard/src/main.rs
+++ b/stm32f4-rtic-smart-keyboard/src/main.rs
@@ -50,6 +50,9 @@ mod board {
     pub(crate) use keyboard;
 }
 
+#[cfg(custom_board)]
+include!(concat!(env!("OUT_DIR"), "/board.rs"));
+
 #[rtic::app(device = stm32f4xx_hal::pac, peripherals = true)]
 mod app {
     // set the panic handler


### PR DESCRIPTION
I don't have any Nickel written to support custom `mod board`; but, the stm32f4-rtic code should still be consistent about its support. (`main.rs` should allow *using* it; the MiniF4 LHS/RHS shouldn't regard it, since they have specific `mod board` implementations).