### PR TITLE
Tap Hold: required_idle_time

### DIFF
--- a/features/keymap/key/tap_hold-config-required_idle_time.feature
+++ b/features/keymap/key/tap_hold-config-required_idle_time.feature
@@ -1,0 +1,116 @@
+Feature: TapHold Key (configure required_idle_time)
+
+  The `required_idle_time` config for tap hold keys means that
+   tap hold keys act as 'tap' if they are pressed before the required
+   idle time has passed since the previous keymap input event (press/release).
+
+  This helps prevent accidental 'resolved-as-hold' tap-hold key presses
+   when typing quickly.
+
+  For examples of this key in other smart keyboard firmware, see e.g.:
+
+  - [ZMK's hold-tap keymap behaviors, require-prior-idle-ms](https://zmk.dev/docs/keymaps/behaviors/hold-tap#require-prior-idle-ms)
+
+  - [FAK's complex hold-tap behaviors, Global quick tap](https://github.com/semickolon/fak?tab=readme-ov-file#complex-hold-tap-behaviors)
+
+  Background:
+
+    Let's demonstrate tap-hold "required_idle_time" behaviour
+    using a keymap with a keyboard key, and a tap-hold key:
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        config.tap_hold.required_idle_time = 100,
+        keys = [
+          K.A,
+          K.B & K.hold K.LeftCtrl,
+        ]
+      }
+      """
+
+  Example: tap hold resolves as tap when pressed before required idle time
+
+    Pressing a tap-hold key immediately resolves it as 'tap' when
+     it's pressed after another key, within the required idle time.
+
+    When the keymap registers the following input
+      """
+      [
+        press (K.A),
+        release (K.A),
+      ]
+      """
+    And the keymap ticks 50 times
+    And the keymap registers the following input
+      """
+      [
+        press (K.B & K.hold K.LeftCtrl),
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        press (K.A),
+        release (K.A),
+        press (K.B),
+      ]
+      """
+
+  Example: tap hold resolves as tap when tapped after required idle time
+
+    Whereas, the tap-hold key behaves as usual if the keymap is
+     idle for the required time.
+
+    When the keymap registers the following input
+      """
+      [
+        press (K.A),
+        release (K.A),
+      ]
+      """
+    And the keymap ticks 110 times
+    And the keymap registers the following input
+      """
+      [
+        press (K.B & K.hold K.LeftCtrl),
+        release (K.B & K.hold K.LeftCtrl),
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        press (K.A),
+        release (K.A),
+        press (K.B),
+        release (K.B),
+      ]
+      """
+
+
+  Example: tap hold resolves as tap when tapped after required idle time
+
+    When the keymap registers the following input
+      """
+      [
+        press (K.A),
+        release (K.A),
+      ]
+      """
+    And the keymap ticks 110 times
+    And the keymap registers the following input
+      """
+      [
+        press (K.B & K.hold K.LeftCtrl),
+      ]
+      """
+    And the keymap ticks 250 times
+    Then the output should be equivalent to output from
+      """
+      [
+        press (K.A),
+        release (K.A),
+        press (K.LeftCtrl),
+      ]
+      """

--- a/features/scripts/generate-doc.sh
+++ b/features/scripts/generate-doc.sh
@@ -17,6 +17,7 @@ keymap_key_features=(
     "tap_hold-config-interrupt-ignore"
     "tap_hold-config-interrupt-presses"
     "tap_hold-config-interrupt-tap"
+    "tap_hold-config-required_idle_time"
     "layered"
     "caps_word"
     "sticky_modifiers"

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -32,6 +32,7 @@ let validators = import "validators.ncl" in
   TapHoldConfigJson = {
     timeout | optional | Number,
     interrupt_response | optional | TapHoldInterruptResponseJson,
+    required_idle_time | optional | Number,
   },
 
   ConfigJson = {

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -1183,10 +1183,17 @@ let validators = import "validators.ncl" in
             else
               ""
           in
+          let required_idle_time_field_fragment =
+            if std.record.has_field "required_idle_time" config.tap_hold then
+              "required_idle_time: Some(%{std.to_string config.tap_hold.required_idle_time}),"
+            else
+              ""
+          in
           m%"
             crate::key::tap_hold::Config {
                 %{timeout_field_fragment}
                 %{interrupt_response_field_fragment}
+                %{required_idle_time_field_fragment}
                 ..crate::key::tap_hold::DEFAULT_CONFIG
             }
           "%

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -31,6 +31,7 @@ let validators = import "validators.ncl" in
   TapHoldConfig = {
     timeout | optional | Number,
     interrupt_response | optional | TapHoldInterruptResponse,
+    required_idle_time | optional | Number,
   },
 
   Config = {

--- a/src/key/tap_hold.rs
+++ b/src/key/tap_hold.rs
@@ -30,6 +30,13 @@ pub struct Config {
     /// How the tap-hold key should respond to interruptions.
     #[serde(default = "default_interrupt_response")]
     pub interrupt_response: InterruptResponse,
+
+    /// Amount of time (in milliseconds) the keymap must have been idle
+    ///  in order for tap hold to support 'hold' functionality.
+    ///
+    /// This reduces disruption from unexpected hold resolutions
+    ///  when typing quickly.
+    pub required_idle_time: Option<u16>,
 }
 
 fn default_timeout() -> u16 {
@@ -44,6 +51,7 @@ fn default_interrupt_response() -> InterruptResponse {
 pub const DEFAULT_CONFIG: Config = Config {
     timeout: 200,
     interrupt_response: InterruptResponse::Ignore,
+    required_idle_time: None,
 };
 
 impl Default for Config {

--- a/tests/ncl/keymap-48key-rgoulter/expected.rs
+++ b/tests/ncl/keymap-48key-rgoulter/expected.rs
@@ -12,6 +12,7 @@ pub mod init {
         sticky: crate::key::sticky::DEFAULT_CONFIG,
         tap_hold: crate::key::tap_hold::Config {
             interrupt_response: crate::key::tap_hold::InterruptResponse::HoldOnKeyTap,
+
             ..crate::key::tap_hold::DEFAULT_CONFIG
         },
         ..crate::key::composite::DEFAULT_CONFIG

--- a/tests/rust/tap_hold.rs
+++ b/tests/rust/tap_hold.rs
@@ -2,6 +2,7 @@ mod hold_on_interrupt_press;
 mod hold_on_interrupt_tap;
 mod interrupt_ignore;
 mod layered;
+mod required_idle_time;
 
 use smart_keymap::input;
 use smart_keymap::key;

--- a/tests/rust/tap_hold/required_idle_time.rs
+++ b/tests/rust/tap_hold/required_idle_time.rs
@@ -1,0 +1,154 @@
+use smart_keymap::input;
+use smart_keymap::key;
+use smart_keymap::keymap;
+use smart_keymap::tuples;
+
+use keymap::DistinctReports;
+use keymap::Keymap;
+
+use key::composite::{Context, Event, KeyState, PendingKeyState};
+use key::{composite, keyboard, tap_hold};
+use tuples::Keys2;
+
+type K = composite::Chorded<composite::Layered<composite::TapHold<keyboard::Key>>>;
+type THK = composite::Chorded<composite::Layered<composite::TapHoldKey<keyboard::Key>>>;
+const KEYS: Keys2<K, THK, Context, Event, PendingKeyState, KeyState> = Keys2::new((
+    composite::Chorded(composite::Layered(composite::TapHold(keyboard::Key::new(
+        0x04,
+    )))),
+    composite::Chorded(composite::Layered(composite::TapHoldKey::TapHold(
+        tap_hold::Key {
+            tap: keyboard::Key::new(0x05),
+            hold: keyboard::Key::new(0xE0),
+        },
+    ))),
+));
+const CONTEXT: Context = composite::Context::from_config(composite::Config {
+    tap_hold: tap_hold::Config {
+        required_idle_time: Some(100),
+        timeout: 200,
+        ..tap_hold::DEFAULT_CONFIG
+    },
+    ..composite::DEFAULT_CONFIG
+});
+
+#[test]
+fn tap_hold_resolves_as_tap_when_pressed_before_required_idle_time() {
+    // Assemble
+    let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
+
+    // Act -- tap 'a', then soon after, tap the tap-hold key
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    for _ in 0..50 {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    while keymap.has_scheduled_events() {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    // Assert -- tap-hold key immediately resolves as 'tap'
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn tap_hold_resolves_as_tap_when_tapped_after_required_idle_time() {
+    // Assemble
+    let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
+
+    // Act -- tap 'a', then soon after, tap the tap-hold key
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    for _ in 0..101 {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    while keymap.has_scheduled_events() {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    // Assert -- tap-hold key immediately resolves as 'tap'
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn tap_hold_resolves_as_hold_when_held_after_required_idle_time() {
+    // Assemble
+    let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
+
+    // Act -- tap 'a', then soon after, tap the tap-hold key
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    for _ in 0..101 {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    for _ in 0..201 {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    while keymap.has_scheduled_events() {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    // Assert -- tap-hold key immediately resolves as 'tap'
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [1, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
+}


### PR DESCRIPTION
Builds on #337.

With disciplined typing, it's possible to use tap-hold home-row modifiers even with fast typing. But, sometimes when typing quickly, TH-HRMs unintentionally resolve as 'hold', which is quite an interruption!

The `required_idle_time` option means that tap-hold keys behave as 'tap' when they're pressed within the given time of another key press/release.