### PR TITLE
More Key outputs

### DIFF
--- a/smart_keymap/src/lib.rs
+++ b/smart_keymap/src/lib.rs
@@ -105,16 +105,10 @@ impl From<input::Event> for KeymapInputEvent {
                 event_type: KeymapInputEventType::KeymapEventRelease,
                 value,
             },
-            // LIMITATION: split transport for virtual keys only works for basic key codes.
-            input::Event::VirtualKeyPress { key_output } => KeymapInputEvent {
-                event_type: KeymapInputEventType::KeymapEventVirtualPress,
-                value: key_output.key_code() as u16,
-            },
-            // LIMITATION: split transport for virtual keys only works for basic key codes.
-            input::Event::VirtualKeyRelease { key_output } => KeymapInputEvent {
-                event_type: KeymapInputEventType::KeymapEventVirtualRelease,
-                value: key_output.key_code() as u16,
-            },
+            // LIMITATION: split transport for virtual keys not implemented
+            input::Event::VirtualKeyPress { .. } => todo!(),
+            // LIMITATION: split transport for virtual keys not implemented
+            input::Event::VirtualKeyRelease { .. } => todo!(),
         }
     }
 }

--- a/src/key.rs
+++ b/src/key.rs
@@ -387,10 +387,17 @@ impl KeyboardModifiers {
     }
 }
 
+/// Enum for the different types of key codes.
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyUsage {
+    /// Key usage code.
+    Keyboard(u8),
+}
+
 /// Struct for the output from [KeyState].
 #[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct KeyOutput {
-    key_code: u8,
+    key_code: KeyUsage,
     key_modifiers: KeyboardModifiers,
 }
 
@@ -399,12 +406,12 @@ impl KeyOutput {
     pub fn from_key_code(key_code: u8) -> Self {
         if let Some(key_modifiers) = KeyboardModifiers::from_key_code(key_code) {
             KeyOutput {
-                key_code: 0x00,
+                key_code: KeyUsage::Keyboard(0x00),
                 key_modifiers,
             }
         } else {
             KeyOutput {
-                key_code,
+                key_code: KeyUsage::Keyboard(key_code),
                 key_modifiers: KeyboardModifiers::new(),
             }
         }
@@ -425,13 +432,13 @@ impl KeyOutput {
     /// Constructs a [KeyOutput] for just the given keyboard modifiers.
     pub fn from_key_modifiers(key_modifiers: KeyboardModifiers) -> Self {
         KeyOutput {
-            key_code: 0x00,
+            key_code: KeyUsage::Keyboard(0x00),
             key_modifiers,
         }
     }
 
     /// Returns the key code value.
-    pub fn key_code(&self) -> u8 {
+    pub fn key_code(&self) -> KeyUsage {
         self.key_code
     }
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -439,6 +439,14 @@ impl KeyOutput {
         }
     }
 
+    /// Constructs a [KeyOutput] from a custom code.
+    pub fn from_custom_code(custom_code: u8) -> Self {
+        KeyOutput {
+            key_code: KeyUsage::Custom(custom_code),
+            key_modifiers: KeyboardModifiers::new(),
+        }
+    }
+
     /// Returns the key code value.
     pub fn key_code(&self) -> KeyUsage {
         self.key_code

--- a/src/key.rs
+++ b/src/key.rs
@@ -392,6 +392,8 @@ impl KeyboardModifiers {
 pub enum KeyUsage {
     /// Key usage code.
     Keyboard(u8),
+    /// Custom code. (Behaviour defined by firmware implementation).
+    Custom(u8),
 }
 
 /// Struct for the output from [KeyState].

--- a/src/key/caps_word.rs
+++ b/src/key/caps_word.rs
@@ -26,7 +26,7 @@ impl Context {
             key::Event::Keymap(keymap::KeymapEvent::ResolvedKeyOutput {
                 key_output:
                     key::KeyOutput {
-                        key_code,
+                        key_code: key::KeyUsage::Keyboard(key_code),
                         key_modifiers,
                     },
                 ..

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -67,6 +67,7 @@ impl KeymapOutput {
                 .iter()
                 .flat_map(|ko| match ko.key_code() {
                     key::KeyUsage::Keyboard(kc) => Some(kc),
+                    _ => None,
                 }),
         );
 
@@ -91,6 +92,7 @@ impl KeymapOutput {
             .iter()
             .flat_map(|ko| match ko.key_code() {
                 key::KeyUsage::Keyboard(kc) => Some(kc),
+                _ => None,
             })
             .filter(|&kc| kc != 0);
 

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -102,6 +102,17 @@ impl KeymapOutput {
 
         report
     }
+
+    /// Returns the pressed custom codes.
+    pub fn pressed_custom_codes(&self) -> heapless::Vec<u8, 24> {
+        self.pressed_key_codes
+            .iter()
+            .flat_map(|ko| match ko.key_code() {
+                key::KeyUsage::Custom(kc) => Some(kc),
+                _ => None,
+            })
+            .collect()
+    }
 }
 
 #[derive(Debug)]

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -62,7 +62,13 @@ impl KeymapOutput {
 
         result.extend(modifiers.as_key_codes());
 
-        result.extend(self.pressed_key_codes.iter().map(|ko| ko.key_code()));
+        result.extend(
+            self.pressed_key_codes
+                .iter()
+                .flat_map(|ko| match ko.key_code() {
+                    key::KeyUsage::Keyboard(kc) => Some(kc),
+                }),
+        );
 
         result
     }
@@ -83,7 +89,9 @@ impl KeymapOutput {
         let key_codes = self
             .pressed_key_codes
             .iter()
-            .map(|ko| ko.key_code())
+            .flat_map(|ko| match ko.key_code() {
+                key::KeyUsage::Keyboard(kc) => Some(kc),
+            })
             .filter(|&kc| kc != 0);
 
         for (i, key_code) in key_codes.take(6).enumerate() {


### PR DESCRIPTION
It's common for keyboard firmware to support key outputs other than keyboard codes. -- e.g. media keys (consumer), mouse keys, or maybe custom key codes.

I think many use cases for custom keys can be covered with the `Custom(i, j)` callback key; but, may be useful to support `Custom(i, j)` keys for arbitrary custom pressed key behaviour.