### PR TITLE
CH32X firmware: debug config

### DIFF
--- a/firmware/ch32x035-usb-device-compositekm-c/CMakeLists.txt
+++ b/firmware/ch32x035-usb-device-compositekm-c/CMakeLists.txt
@@ -27,8 +27,6 @@ target_link_libraries(usb-device-compositekm sdk)
 add_subdirectory(libsmartkeymap smartkeymap)
 target_link_libraries(usb-device-compositekm smartkeymap)
 
-target_compile_definitions(usb-device-compositekm PUBLIC DEBUG=2)
-
 target_compile_features(usb-device-compositekm PUBLIC c_std_99)
 
 target_compile_options(usb-device-compositekm PUBLIC -MMD -MP)

--- a/firmware/ch32x035-usb-device-compositekm-c/generated/CMakeLists.txt
+++ b/firmware/ch32x035-usb-device-compositekm-c/generated/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(keyboard_codegen INTERFACE)
 
 target_include_directories(keyboard_codegen INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 
+include(debug.cmake)
 include(keyboard.cmake)
 include(keyboard_matrix.cmake)
 include(keyboard_led.cmake OPTIONAL)

--- a/firmware/ch32x035-usb-device-compositekm-c/generated/codegen.mk
+++ b/firmware/ch32x035-usb-device-compositekm-c/generated/codegen.mk
@@ -1,5 +1,6 @@
 CODEGEN_DEPS = \
   $(BOARD) \
+  ncl/codegen/debug.ncl \
   ncl/codegen/gpio.ncl \
   ncl/codegen/keyboard.ncl \
   ncl/codegen/keyboard_led.ncl \

--- a/firmware/ch32x035-usb-device-compositekm-c/ncl/boards/ch32x-48.ncl
+++ b/firmware/ch32x035-usb-device-compositekm-c/ncl/boards/ch32x-48.ncl
@@ -39,5 +39,7 @@ let C = import "codegen/contracts.ncl" in
       enabled = true,
       pin = gpio_pins.A5,
     },
+
+    debug.tx = 2,
   },
 }

--- a/firmware/ch32x035-usb-device-compositekm-c/ncl/boards/ch32x-75.ncl
+++ b/firmware/ch32x035-usb-device-compositekm-c/ncl/boards/ch32x-75.ncl
@@ -40,5 +40,7 @@
       enabled = true,
       pin = gpio_pins.B9,
     },
+
+    debug.tx = 2,
   },
 }

--- a/firmware/ch32x035-usb-device-compositekm-c/ncl/codegen/contracts.ncl
+++ b/firmware/ch32x035-usb-device-compositekm-c/ncl/codegen/contracts.ncl
@@ -1,4 +1,5 @@
-(import "gpio.ncl").contracts
+(import "debug.ncl").contracts
+& (import "gpio.ncl").contracts
 & (import "keyboard.ncl").contracts
 & (import "keyboard_led.ncl").contracts
 & (import "keyboard_matrix.ncl").contracts

--- a/firmware/ch32x035-usb-device-compositekm-c/ncl/codegen/debug.ncl
+++ b/firmware/ch32x035-usb-device-compositekm-c/ncl/codegen/debug.ncl
@@ -1,0 +1,43 @@
+let C = import "contracts.ncl" in
+
+{
+  contracts = {
+    UsartTxNumber =
+      std.contract.from_validator (match {
+        1 or 2 or 3 or 4 => 'Ok,
+        _ => 'Error "invalid UART TX pin number",
+      }
+      ),
+
+    UsartAlternateFunction =
+      std.contract.from_validator (match {
+        1 => 'Ok,
+        0 or 2 or 3 => 'Error "USART alternate function remapping not implemented",
+        _ => 'Error "invalid USART alternate function remapping",
+      }
+      ),
+
+    Board = {
+      debug = {
+        tx | default | UsartTxNumber = 1,
+        usart_af | optional | UsartAlternateFunction,
+      },
+
+      ..
+    },
+  },
+
+  board
+    | C.Board,
+
+  cmakelists.debug =
+    let debug_config = board.debug in
+    let debug_def = "target_compile_definitions(keyboard_codegen INTERFACE DEBUG=%{std.to_string debug_config.tx})" in
+    let debug_af_def =
+      if std.record.has_field "usart_af" debug_config then
+        m%"target_compile_definitions(keyboard_codegen INTERFACE DEBUG_AF=%{std.to_string debug_config.usart_af})"%
+      else
+        ""
+    in
+    [debug_def, debug_af_def] |> std.array.filter ((!=) "") |> std.string.join "\n",
+}


### PR DESCRIPTION
Likely there's a way to describe the usart number, AF number from nickel. (e.g. debug.pin = PA2 => tx2, AF0) without too much fuss. But, for now, this will do.