### PR TITLE
Sticky Key: add config option to release on next press

### DIFF
--- a/features/keymap/key/sticky_modifiers-config-release_on_next_press.feature
+++ b/features/keymap/key/sticky_modifiers-config-release_on_next_press.feature
@@ -1,0 +1,44 @@
+Feature: Sticky Modifiers Key (config release: OnNextKeyPress)
+
+  The `config.sticky.release` can be set to `"OnNextKeyPress"`
+   so that the sticky key releases when the next key is pressed
+   after the modified key.
+
+  This helps with rolling key presses.
+
+  Background:
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        config.sticky.release = "OnNextKeyPress",
+        keys = [
+          (K.sticky K.LeftShift),
+          (K.sticky K.LeftCtrl),
+          K.A,
+          K.B,
+        ]
+      }
+      """
+
+  Example: the sticky modifier releases when the next key is pressed
+    When the keymap registers the following input
+      """
+      [
+        press (K.sticky K.LeftShift),
+        release (K.sticky K.LeftShift),
+        press K.A,
+        press K.B,
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        press (K.LeftShift),
+        press K.A,
+        release (K.LeftShift),
+        press K.B,
+      ]
+      """
+

--- a/features/scripts/generate-doc.sh
+++ b/features/scripts/generate-doc.sh
@@ -22,6 +22,7 @@ keymap_key_features=(
     "caps_word"
     "tap_dance"
     "sticky_modifiers"
+    "sticky_modifiers-config-release_on_next_press"
 )
 
 keymap_ncl_features=(

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -14,10 +14,21 @@ let validators = import "validators.ncl" in
       ]
     ),
 
+  StickyReleaseJson =
+    std.contract.from_validator (
+      validators.is_elem_of [
+        "OnModifiedKeyRelease",
+        "OnNextKeyPress",
+      ]
+    ),
+
   StickyConfigJson = {
     activation
       | optional
       | StickyActivationJson,
+    release
+      | optional
+      | StickyReleaseJson,
   },
 
   TapDanceConfigJson = {
@@ -1424,10 +1435,24 @@ let validators = import "validators.ncl" in
             else
               ""
           in
+          let release_field_fragment =
+            if std.record.has_field "release" config.sticky then
+              "release: crate::key::sticky::StickyKeyRelease::%{config.sticky.release},"
+            else
+              ""
+          in
+          let config_fragment =
+            [
+              activation_field_fragment,
+              release_field_fragment,
+              "..crate::key::sticky::DEFAULT_CONFIG"
+            ]
+            |> std.array.filter ((!=) "")
+            |> std.string.join "\n"
+          in
           m%"
             crate::key::sticky::Config {
-                %{activation_field_fragment}
-                ..crate::key::sticky::DEFAULT_CONFIG
+                %{config_fragment}
             }
           "%
         else

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -13,10 +13,21 @@ let validators = import "validators.ncl" in
       ]
     ),
 
+  StickyReleaseJson =
+    std.contract.from_validator (
+      validators.is_elem_of [
+        "OnModifiedKeyRelease",
+        "OnNextKeyPress",
+      ]
+    ),
+
   StickyConfig = {
     activation
       | optional
       | StickyActivation,
+    release
+      | optional
+      | StickyReleaseJson,
   },
 
   TapHoldInterruptResponse =

--- a/src/key/sticky.rs
+++ b/src/key/sticky.rs
@@ -18,17 +18,30 @@ pub enum StickyKeyActivation {
     // OnNextKeyPress,
 }
 
+/// When the sticky modifiers release.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "std", derive(Deserialize))]
+pub enum StickyKeyRelease {
+    /// Sticky modifiers release when the modified key is released.
+    OnModifiedKeyRelease,
+    /// Sticky modifiers release when a key is pressed after the modified key.
+    OnNextKeyPress,
+}
+
 /// Sticky Key configuration.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "std", derive(Deserialize))]
 pub struct Config {
     /// The sticky key activation mode.
     pub activation: StickyKeyActivation,
+    /// When the sticky modifiers release.
+    pub release: StickyKeyRelease,
 }
 
 /// The default [Config].
 pub const DEFAULT_CONFIG: Config = Config {
     activation: StickyKeyActivation::OnStickyKeyRelease,
+    release: StickyKeyRelease::OnModifiedKeyRelease,
 };
 
 impl Default for Config {

--- a/src/key/sticky.rs
+++ b/src/key/sticky.rs
@@ -33,9 +33,19 @@ pub enum StickyKeyRelease {
 #[cfg_attr(feature = "std", derive(Deserialize))]
 pub struct Config {
     /// The sticky key activation mode.
+    #[cfg_attr(feature = "std", serde(default = "default_activation"))]
     pub activation: StickyKeyActivation,
     /// When the sticky modifiers release.
+    #[cfg_attr(feature = "std", serde(default = "default_release"))]
     pub release: StickyKeyRelease,
+}
+
+fn default_activation() -> StickyKeyActivation {
+    DEFAULT_CONFIG.activation
+}
+
+fn default_release() -> StickyKeyRelease {
+    DEFAULT_CONFIG.release
 }
 
 /// The default [Config].


### PR DESCRIPTION
When I tried sticky key modifiers, I noticed it had issues with rolling key presses. e.g. "sticky shift, press a, press b" would shift both a, b rather than just a.

This config option allows releasing on next press.