### PR TITLE
firmware: ch32: use mounriver riscv embedded gcc

### DIFF
--- a/firmware/ch32x035-usb-device-compositekm-c/devenv.nix
+++ b/firmware/ch32x035-usb-device-compositekm-c/devenv.nix
@@ -22,6 +22,7 @@ let ch32 = inputs.rgoulter-ch32.packages.${pkgs.stdenv.system}; in
     pkgs.nls
 
     ch32.wchisp
-    ch32.xpack-riscv-none-elf-gcc
+    # ch32.xpack-riscv-none-elf-gcc
+    ch32.mrs-riscv-embedded-gcc12
   ];
 }


### PR DESCRIPTION
Hmm.

The code *builds* with the XPack disribution of GCC.

I thought it would also run.

However, I've been using a `build` configured to use mounriver's GCC, so never noticed that building with xpack, the ISRs don't seem to work.

(Fortunately, the keyboard can still enter the bootloader by holding SW_1_1).
