### PR TITLE
firmware: ch32: remove "WCH-Interrupt-Fast" interrupt param

### DIFF
--- a/firmware/ch32x035-usb-device-compositekm-c/User/ch32x035_it.c
+++ b/firmware/ch32x035-usb-device-compositekm-c/User/ch32x035_it.c
@@ -10,8 +10,8 @@
 
 #include "ch32x035_it.h"
 
-void NMI_Handler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
-void HardFault_Handler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+void NMI_Handler(void) __attribute__((interrupt()));
+void HardFault_Handler(void) __attribute__((interrupt()));
 
 /*********************************************************************
  * @fn      NMI_Handler

--- a/firmware/ch32x035-usb-device-compositekm-c/User/ch32x035_usbfs_device.c
+++ b/firmware/ch32x035-usb-device-compositekm-c/User/ch32x035_usbfs_device.c
@@ -59,7 +59,7 @@ volatile uint8_t USBFS_Endp_Busy[DEF_UEP_NUM];
 
 /******************************************************************************/
 /* Interrupt Service Routine Declaration*/
-void USBFS_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+void USBFS_IRQHandler(void) __attribute__((interrupt()));
 
 /*********************************************************************
  * @fn      USBFS_RCC_Init

--- a/firmware/ch32x035-usb-device-compositekm-c/User/usbd_composite_km.c
+++ b/firmware/ch32x035-usb-device-compositekm-c/User/usbd_composite_km.c
@@ -53,7 +53,7 @@ volatile uint8_t KB_LED_Cur_Status = 0x00;  // Keyboard LED Current Result
 
 /*******************************************************************************/
 /* Interrupt Function Declaration */
-void TIM3_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+void TIM3_IRQHandler(void) __attribute__((interrupt()));
 
 /*********************************************************************
  * @fn      TIM3_Init

--- a/firmware/ch32x035-usb-device-compositekm-c/generated/keyboard_split_rx_dma.c
+++ b/firmware/ch32x035-usb-device-compositekm-c/generated/keyboard_split_rx_dma.c
@@ -24,10 +24,10 @@ static struct {
 };
 
 void KEYBOARD_SPLIT_USART_IRQ_HANDLER(void)
-    __attribute__((interrupt("WCH-Interrupt-fast")));
+    __attribute__((interrupt()));
 
 void KEYBOARD_SPLIT_RX_DMA_IRQ_HANDLER(void)
-    __attribute__((interrupt("WCH-Interrupt-fast")));
+    __attribute__((interrupt()));
 
 void keymap_split_receive_bytes(uint8_t *buf, uint16_t len) {
   KeymapInputEvent ev;

--- a/firmware/ch32x035-usb-device-compositekm-c/generated/keyboard_split_tx_dma.c
+++ b/firmware/ch32x035-usb-device-compositekm-c/generated/keyboard_split_tx_dma.c
@@ -28,7 +28,7 @@ static uint32_t transmit_dma_buffer[MESSAGE_BUFFER_LEN / 4];
 static volatile bool uart_tx_busy = false;
 
 void KEYBOARD_SPLIT_TX_DMA_IRQ_HANDLER(void)
-    __attribute__((interrupt("WCH-Interrupt-fast")));
+    __attribute__((interrupt()));
 void KEYBOARD_SPLIT_TX_DMA_IRQ_HANDLER(void) {
   if (DMA_GetITStatus(KEYBOARD_SPLIT_TX_TC_FLAG)) {
     DMA_ClearITPendingBit(KEYBOARD_SPLIT_TX_TC_FLAG);


### PR DESCRIPTION
I noticed that I'd been unintentionally building the CH32X firmware with the mounriver studio distribution of GCC, whereas the devenv is set to use the xpack distribution of GCC.

I noticed that the CH32X firmware built with the xpack gcc embedded toolchain doesn't work.

This seems to be  due to interrupt handling.

https://gcc.gnu.org/onlinedocs/gcc/RISC-V-Function-Attributes.html

`"WCH-Interrupt-fast"` with the mounriver toolchain seems to make use of features in the CH32X MCU allowing faster interrupt handling.

Removing this attribute, the code works with xpack, and still works with MRS.

I see the CH58x code has this:

```
#ifndef __INTERRUPT
#ifdef INT_SOFT
#define __INTERRUPT   __attribute__((interrupt()))
#else
#define __INTERRUPT   __attribute__((interrupt("WCH-Interrupt-fast")))
#endif
#endif
```

I'm not sure where INT_SOFT comes from.