### PR TITLE
chorded tap-hold over tap-hold keys

### DIFF
--- a/src/key/chorded.rs
+++ b/src/key/chorded.rs
@@ -544,8 +544,11 @@ where
 
                     (pkr, pke)
                 }
-                // n.b. no need to add to key path; chorded aux_key only nests the passthrough key.
-                ChordResolution::Passthrough => self.passthrough.new_pressed_key(context, key_path),
+                ChordResolution::Passthrough => {
+                    let (pkr, pke) = self.passthrough.new_pressed_key(context, key_path);
+                    let pkr = pkr.add_path_item(0); // 0 = passthrough key
+                    (pkr, pke)
+                }
             }
         } else {
             let pkr = key::PressedKeyResult::Pending(key_path, pks.into());
@@ -613,8 +616,7 @@ impl<
                 if let Some(ChordResolution::Passthrough) = ch_state {
                     let nk = &self.passthrough;
                     let (pkr, mut pke) = nk.new_pressed_key(context, key_path);
-
-                    // n.b. no need to add to key path; chorded aux_key only nests the passthrough key.
+                    let pkr = pkr.add_path_item(0); // 0 = passthrough key
 
                     let ch_r_ev = Event::ChordResolved(ChordResolution::Passthrough);
                     let sch_ev = key::ScheduledEvent::immediate(key::Event::key_event(
@@ -657,7 +659,8 @@ impl<
     > {
         match path {
             [] => self,
-            _ => self.passthrough.lookup(path),
+            [0, path @ ..] => self.passthrough.lookup(path),
+            _ => panic!("illegal path"),
         }
     }
 }

--- a/src/key/chorded.rs
+++ b/src/key/chorded.rs
@@ -433,7 +433,7 @@ impl<
                                         .iter()
                                         .find(|(ch_id, _)| *ch_id == resolved_chord_id)
                                     {
-                                        Some((resolved_chord_id, k))
+                                        Some((1 + resolved_chord_id, k))
                                     } else {
                                         panic!("event's chord resolution has invalid chord id")
                                     }
@@ -456,7 +456,7 @@ impl<
                     if let Some((i, nk)) = maybe_pathel_and_key {
                         let (pkr, mut pke) = nk.new_pressed_key(context, key_path);
                         // PRESSED KEY PATH: add Chord (0 = passthrough, 1 = 1+chord_id)
-                        let pkr = pkr.add_path_item(1 + i as u16);
+                        let pkr = pkr.add_path_item(i as u16);
 
                         pke.add_event(sch_ev);
 

--- a/tests/rust/chorded.rs
+++ b/tests/rust/chorded.rs
@@ -2,6 +2,7 @@ mod overlapping;
 mod overlapping_aux;
 mod overlapping_simultaneous;
 mod tap_hold;
+mod tap_hold_over_tap_hold;
 
 use smart_keymap::input;
 use smart_keymap::key;

--- a/tests/rust/chorded/tap_hold_over_tap_hold.rs
+++ b/tests/rust/chorded/tap_hold_over_tap_hold.rs
@@ -1,0 +1,217 @@
+use smart_keymap::input;
+use smart_keymap::key;
+use smart_keymap::keymap;
+use smart_keymap::slice::Slice;
+use smart_keymap::tuples;
+
+use keymap::DistinctReports;
+use keymap::Keymap;
+
+use key::{chorded, composite, keyboard, tap_hold};
+use tuples::Keys2;
+
+type Ctx = composite::Context;
+type Ev = composite::Event;
+type PKS = composite::PendingKeyState;
+type KS = composite::KeyState;
+type CK = composite::ChordedKey<composite::Layered<composite::TapHoldKey<keyboard::Key>>>;
+type AK = composite::ChordedKey<composite::Layered<composite::TapHoldKey<keyboard::Key>>>;
+
+// 2 keys:
+//   0: { tap: a, hold: lctrl },
+//   1: { tap: b, hold: lshift },
+// chord [01] = { tap: c, hold: lalt }
+const KEYS: Keys2<CK, AK, Ctx, Ev, PKS, KS> = tuples::Keys2::new((
+    composite::ChordedKey::Chorded(chorded::Key::new(
+        &[(
+            0,
+            composite::Layered(composite::TapHoldKey::TapHold(tap_hold::Key::new(
+                keyboard::Key::new(0x06),
+                keyboard::Key::new(0xE2),
+            ))),
+        )],
+        composite::Layered(composite::TapHoldKey::TapHold(tap_hold::Key::new(
+            keyboard::Key::new(0x04),
+            keyboard::Key::new(0xE0),
+        ))),
+    )),
+    composite::ChordedKey::Auxiliary(chorded::AuxiliaryKey::new(composite::Layered(
+        composite::TapHoldKey::TapHold(tap_hold::Key::new(
+            keyboard::Key::new(0x05),
+            keyboard::Key::new(0xE1),
+        )),
+    ))),
+));
+
+const CONTEXT: Ctx = key::composite::Context::from_config(composite::Config {
+    chorded: chorded::Config {
+        chords: Slice::from_slice(&[chorded::ChordIndices::from_slice(&[0, 1])]),
+        ..chorded::DEFAULT_CONFIG
+    },
+    ..composite::DEFAULT_CONFIG
+});
+
+#[test]
+fn tap_chord_acts_as_chorded_tap() {
+    // Assemble
+    let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
+
+    // Act
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    while keymap.has_scheduled_events() {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    // Assert
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x06, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn hold_chord_acts_as_chorded_hold() {
+    // Assemble
+    let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
+
+    // Act
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    while keymap.has_scheduled_events() {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    // Assert
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [4, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn tap_chorded_key_acts_as_passthrough_tap() {
+    // Assemble
+    let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
+
+    // Act
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    while keymap.has_scheduled_events() {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    // Assert
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn hold_chorded_key_acts_as_passthrough_hold() {
+    // Assemble
+    let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
+
+    // Act
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    while keymap.has_scheduled_events() {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    // Assert
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [1, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn tap_auxiliary_key_acts_as_passthrough_tap() {
+    // Assemble
+    let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
+
+    // Act
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    while keymap.has_scheduled_events() {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    // Assert
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn hold_auxiliary_key_acts_as_passthrough_hold() {
+    // Assemble
+    let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
+
+    // Act
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    while keymap.has_scheduled_events() {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    // Assert
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [2, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
+}


### PR DESCRIPTION
One use case which smart-keymap should be able to support: a chord which is a tap-hold key, where the chorded keys are themselves tap-hold keys.

This could be useful for making expressive use of tap-hold keys, such as tap-hold home-row modifiers, or tap-hold thumb keys.