### PR TITLE
Refactor chording chord indices

### DIFF
--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -1408,7 +1408,7 @@ let validators = import "validators.ncl" in
               let chords_fragment =
                 config.chorded.chords
                 |> std.array.map (match {
-                  [i, j] => "Some(crate::key::chorded::ChordIndices::Chord2(%{std.to_string i}, %{std.to_string j}))"
+                  [i, j] => "Some(crate::key::chorded::ChordIndices::from_slice(&[%{std.to_string i}, %{std.to_string j}]))"
                 }
                 )
                 |> std.string.join ","

--- a/src/key/chorded.rs
+++ b/src/key/chorded.rs
@@ -742,7 +742,7 @@ mod tests {
         // Assemble: an Auxilary chorded key, and its PKS, with chord 01.
         let mut context = key::composite::Context::from_config(composite::Config {
             chorded: Config {
-                chords: [Some(ChordIndices::Chord2(0, 1)), None, None, None],
+                chords: [Some(ChordIndices::from_slice(&[0, 1])), None, None, None],
                 ..DEFAULT_CONFIG
             },
             ..composite::DEFAULT_CONFIG

--- a/src/key/chorded.rs
+++ b/src/key/chorded.rs
@@ -35,16 +35,14 @@ impl ChordIndices {
         &self.indices
     }
 
-    /// Returns whether the given index is part of the chord.
+    /// Whether the given index is part of the chord.
     pub fn has_index(&self, index: u16) -> bool {
-        let [i0, i1] = self.indices;
-        i0 == index || i1 == index
+        self.as_slice().iter().any(|&i| i == index)
     }
 
-    /// Returns whether the chord is satisfied by the given indices.
+    /// Whether the chord is satisfied by the given indices.
     pub fn is_satisfied_by(&self, indices: &[u16]) -> bool {
-        let [i0, i1] = &self.indices;
-        indices.contains(i0) && indices.contains(i1)
+        self.as_slice().iter().all(|&i| indices.contains(&i))
     }
 }
 
@@ -94,12 +92,8 @@ where
         v.push(None).unwrap();
     }
 
-    let v_ch: heapless::Vec<Option<ChordIndices>, MAX_CHORDS> = v
-        .iter()
-        .map(|ch_op| ch_op.clone().map(|ch| ch.into()))
-        .collect();
-
-    v_ch.into_array()
+    v.into_array()
+        .map(|a| a.map(|ch_op| ch_op.map(|ch| ch.into())))
         .map_err(|_| serde::de::Error::custom("unable to deserialize"))
 }
 

--- a/src/key/chorded.rs
+++ b/src/key/chorded.rs
@@ -9,7 +9,7 @@ use crate::{input, key};
 pub use crate::init::MAX_CHORDS;
 
 /// The maximum number of keys in a chord.
-const MAX_CHORD_SIZE: usize = 2;
+pub const MAX_CHORD_SIZE: usize = 2;
 
 /// Chords are defined by an (unordered) set of indices into the keymap.
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
@@ -20,6 +20,13 @@ pub enum ChordIndices {
 }
 
 impl ChordIndices {
+    /// Constructs a new [ChordIndices] value from the given slice.
+    ///
+    /// The given slice must be less than [MAX_CHORD_SIZE] in length.
+    pub const fn from_slice(indices: &[u16]) -> ChordIndices {
+        ChordIndices::Chord2(indices[0], indices[1])
+    }
+
     /// Returns whether the given index is part of the chord.
     pub fn has_index(&self, index: u16) -> bool {
         match self {

--- a/src/key/doc_de_chorded.md
+++ b/src/key/doc_de_chorded.md
@@ -54,7 +54,7 @@ use smart_keymap::key::chorded::ChordIndices;
 let json = r#"
   [3, 4]
 "#;
-let expected_chord: ChordIndices = ChordIndices::Chord2(3, 4);
+let expected_chord: ChordIndices = ChordIndices::from_slice(&[3, 4]);
 let actual_chord: ChordIndices = serde_json::from_str(json).unwrap();
 assert_eq!(expected_chord, actual_chord);
 ```

--- a/tests/ncl/keymap-2key-chorded/expected.rs
+++ b/tests/ncl/keymap-2key-chorded/expected.rs
@@ -3,7 +3,7 @@ pub mod init {
     /// Config used by tap-hold keys.
     pub const CONFIG: crate::key::composite::Config = crate::key::composite::Config {
         chorded: crate::key::chorded::Config {
-            chords: [Some(crate::key::chorded::ChordIndices::Chord2(0, 1))],
+            chords: [Some(crate::key::chorded::ChordIndices::from_slice(&[0, 1]))],
             ..crate::key::chorded::DEFAULT_CONFIG
         },
         sticky: crate::key::sticky::DEFAULT_CONFIG,

--- a/tests/ncl/keymap-48key-rgoulter/expected.rs
+++ b/tests/ncl/keymap-48key-rgoulter/expected.rs
@@ -4,8 +4,8 @@ pub mod init {
     pub const CONFIG: crate::key::composite::Config = crate::key::composite::Config {
         chorded: crate::key::chorded::Config {
             chords: [
-                Some(crate::key::chorded::ChordIndices::Chord2(26, 27)),
-                Some(crate::key::chorded::ChordIndices::Chord2(32, 33)),
+                Some(crate::key::chorded::ChordIndices::from_slice(&[26, 27])),
+                Some(crate::key::chorded::ChordIndices::from_slice(&[32, 33])),
             ],
             ..crate::key::chorded::DEFAULT_CONFIG
         },

--- a/tests/rust/chorded.rs
+++ b/tests/rust/chorded.rs
@@ -30,7 +30,12 @@ const KEYS: Keys2<CK, AK, Ctx, Ev, PKS, KS> = tuples::Keys2::new((
 
 const CONTEXT: Ctx = key::composite::Context::from_config(composite::Config {
     chorded: chorded::Config {
-        chords: [Some(chorded::ChordIndices::Chord2(0, 1)), None, None, None],
+        chords: [
+            Some(chorded::ChordIndices::from_slice(&[0, 1])),
+            None,
+            None,
+            None,
+        ],
         ..chorded::DEFAULT_CONFIG
     },
     ..composite::DEFAULT_CONFIG

--- a/tests/rust/chorded/tap_hold.rs
+++ b/tests/rust/chorded/tap_hold.rs
@@ -31,7 +31,12 @@ const KEYS: Keys2<CK, AK, Ctx, Ev, PKS, KS> = tuples::Keys2::new((
 
 const CONTEXT: Ctx = key::composite::Context::from_config(composite::Config {
     chorded: chorded::Config {
-        chords: [Some(chorded::ChordIndices::Chord2(0, 1)), None, None, None],
+        chords: [
+            Some(chorded::ChordIndices::from_slice(&[0, 1])),
+            None,
+            None,
+            None,
+        ],
         ..chorded::DEFAULT_CONFIG
     },
     ..composite::DEFAULT_CONFIG


### PR DESCRIPTION
This PR is to rewrite `ChordIndices` to support chords which have more than 2 chord indices.

That chords only support 2 indices prevents overlapping chords from being implemented.