### PR TITLE
Increase ChordIndices max chord size

### DIFF
--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -1588,6 +1588,9 @@ pub mod init {
     /// Number of layers supported by the [crate::key::layered] implementation.
     pub const LAYER_COUNT: usize = %{std.to_string num_layers};
 
+    /// The maximum number of keys in a chord.
+    pub const MAX_CHORD_SIZE: usize = 2;
+
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = %{chord_count |> std.to_string};
 

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -1573,6 +1573,12 @@ let validators = import "validators.ncl" in
         else
           0
       in
+      let max_chord_size =
+        if std.record.has_field "chorded" config && std.record.has_field "chords" config.chorded then
+          config.chorded.chords |> std.array.map std.array.length |> std.array.fold_left std.number.max 0
+        else
+          0
+      in
       m%"
 /// Types and initial data used for constructing [KEYMAP].
 pub mod init {
@@ -1589,7 +1595,7 @@ pub mod init {
     pub const LAYER_COUNT: usize = %{std.to_string num_layers};
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 2;
+    pub const MAX_CHORD_SIZE: usize = %{max_chord_size |> std.to_string};
 
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = %{chord_count |> std.to_string};

--- a/src/key/chorded.rs
+++ b/src/key/chorded.rs
@@ -6,10 +6,7 @@ use serde::Deserialize;
 
 use crate::{input, key, slice::Slice};
 
-pub use crate::init::MAX_CHORDS;
-
-/// The maximum number of keys in a chord.
-pub const MAX_CHORD_SIZE: usize = 2;
+pub use crate::init::{MAX_CHORDS, MAX_CHORD_SIZE};
 
 /// Chords are defined by an (unordered) set of indices into the keymap.
 #[derive(Debug, Clone, Copy)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,9 @@ pub mod init {
     /// Number of layers supported by the [crate::key::layered] implementation.
     pub const LAYER_COUNT: usize = 8;
 
+    /// The maximum number of keys in a chord.
+    pub const MAX_CHORD_SIZE: usize = 2;
+
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 4;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub mod init {
     pub const LAYER_COUNT: usize = 8;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 2;
+    pub const MAX_CHORD_SIZE: usize = 16;
 
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 4;

--- a/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
+++ b/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
@@ -16,7 +16,7 @@ pub mod init {
     pub const LAYER_COUNT: usize = 1;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 2;
+    pub const MAX_CHORD_SIZE: usize = 0;
 
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 0;

--- a/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
+++ b/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
@@ -15,6 +15,9 @@ pub mod init {
     /// Number of layers supported by the [crate::key::layered] implementation.
     pub const LAYER_COUNT: usize = 1;
 
+    /// The maximum number of keys in a chord.
+    pub const MAX_CHORD_SIZE: usize = 2;
+
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 0;
 

--- a/tests/ncl/keymap-1key-callback-custom/expected.rs
+++ b/tests/ncl/keymap-1key-callback-custom/expected.rs
@@ -16,7 +16,7 @@ pub mod init {
     pub const LAYER_COUNT: usize = 0;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 2;
+    pub const MAX_CHORD_SIZE: usize = 0;
 
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 0;

--- a/tests/ncl/keymap-1key-callback-custom/expected.rs
+++ b/tests/ncl/keymap-1key-callback-custom/expected.rs
@@ -15,6 +15,9 @@ pub mod init {
     /// Number of layers supported by the [crate::key::layered] implementation.
     pub const LAYER_COUNT: usize = 0;
 
+    /// The maximum number of keys in a chord.
+    pub const MAX_CHORD_SIZE: usize = 2;
+
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 0;
 

--- a/tests/ncl/keymap-1key-custom/expected.rs
+++ b/tests/ncl/keymap-1key-custom/expected.rs
@@ -16,7 +16,7 @@ pub mod init {
     pub const LAYER_COUNT: usize = 0;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 2;
+    pub const MAX_CHORD_SIZE: usize = 0;
 
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 0;

--- a/tests/ncl/keymap-1key-custom/expected.rs
+++ b/tests/ncl/keymap-1key-custom/expected.rs
@@ -15,6 +15,9 @@ pub mod init {
     /// Number of layers supported by the [crate::key::layered] implementation.
     pub const LAYER_COUNT: usize = 0;
 
+    /// The maximum number of keys in a chord.
+    pub const MAX_CHORD_SIZE: usize = 2;
+
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 0;
 

--- a/tests/ncl/keymap-1key-simple/expected.rs
+++ b/tests/ncl/keymap-1key-simple/expected.rs
@@ -12,6 +12,9 @@ pub mod init {
     /// Number of layers supported by the [crate::key::layered] implementation.
     pub const LAYER_COUNT: usize = 0;
 
+    /// The maximum number of keys in a chord.
+    pub const MAX_CHORD_SIZE: usize = 2;
+
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 0;
 

--- a/tests/ncl/keymap-1key-simple/expected.rs
+++ b/tests/ncl/keymap-1key-simple/expected.rs
@@ -13,7 +13,7 @@ pub mod init {
     pub const LAYER_COUNT: usize = 0;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 2;
+    pub const MAX_CHORD_SIZE: usize = 0;
 
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 0;

--- a/tests/ncl/keymap-1key-tap_dance/expected.rs
+++ b/tests/ncl/keymap-1key-tap_dance/expected.rs
@@ -12,6 +12,9 @@ pub mod init {
     /// Number of layers supported by the [crate::key::layered] implementation.
     pub const LAYER_COUNT: usize = 0;
 
+    /// The maximum number of keys in a chord.
+    pub const MAX_CHORD_SIZE: usize = 2;
+
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 0;
 

--- a/tests/ncl/keymap-1key-tap_dance/expected.rs
+++ b/tests/ncl/keymap-1key-tap_dance/expected.rs
@@ -13,7 +13,7 @@ pub mod init {
     pub const LAYER_COUNT: usize = 0;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 2;
+    pub const MAX_CHORD_SIZE: usize = 0;
 
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 0;

--- a/tests/ncl/keymap-1key-tap_hold/expected.rs
+++ b/tests/ncl/keymap-1key-tap_hold/expected.rs
@@ -12,6 +12,9 @@ pub mod init {
     /// Number of layers supported by the [crate::key::layered] implementation.
     pub const LAYER_COUNT: usize = 0;
 
+    /// The maximum number of keys in a chord.
+    pub const MAX_CHORD_SIZE: usize = 2;
+
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 0;
 

--- a/tests/ncl/keymap-1key-tap_hold/expected.rs
+++ b/tests/ncl/keymap-1key-tap_hold/expected.rs
@@ -13,7 +13,7 @@ pub mod init {
     pub const LAYER_COUNT: usize = 0;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 2;
+    pub const MAX_CHORD_SIZE: usize = 0;
 
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 0;

--- a/tests/ncl/keymap-2key-2layer-composite/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-composite/expected.rs
@@ -16,7 +16,7 @@ pub mod init {
     pub const LAYER_COUNT: usize = 1;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 2;
+    pub const MAX_CHORD_SIZE: usize = 0;
 
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 0;

--- a/tests/ncl/keymap-2key-2layer-composite/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-composite/expected.rs
@@ -15,6 +15,9 @@ pub mod init {
     /// Number of layers supported by the [crate::key::layered] implementation.
     pub const LAYER_COUNT: usize = 1;
 
+    /// The maximum number of keys in a chord.
+    pub const MAX_CHORD_SIZE: usize = 2;
+
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 0;
 

--- a/tests/ncl/keymap-2key-2layer-simple/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-simple/expected.rs
@@ -16,7 +16,7 @@ pub mod init {
     pub const LAYER_COUNT: usize = 1;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 2;
+    pub const MAX_CHORD_SIZE: usize = 0;
 
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 0;

--- a/tests/ncl/keymap-2key-2layer-simple/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-simple/expected.rs
@@ -15,6 +15,9 @@ pub mod init {
     /// Number of layers supported by the [crate::key::layered] implementation.
     pub const LAYER_COUNT: usize = 1;
 
+    /// The maximum number of keys in a chord.
+    pub const MAX_CHORD_SIZE: usize = 2;
+
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 0;
 

--- a/tests/ncl/keymap-2key-chorded/expected.rs
+++ b/tests/ncl/keymap-2key-chorded/expected.rs
@@ -15,6 +15,9 @@ pub mod init {
     /// Number of layers supported by the [crate::key::layered] implementation.
     pub const LAYER_COUNT: usize = 0;
 
+    /// The maximum number of keys in a chord.
+    pub const MAX_CHORD_SIZE: usize = 2;
+
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 1;
 

--- a/tests/ncl/keymap-34key-seniply/expected.rs
+++ b/tests/ncl/keymap-34key-seniply/expected.rs
@@ -15,6 +15,9 @@ pub mod init {
     /// Number of layers supported by the [crate::key::layered] implementation.
     pub const LAYER_COUNT: usize = 5;
 
+    /// The maximum number of keys in a chord.
+    pub const MAX_CHORD_SIZE: usize = 2;
+
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 0;
 

--- a/tests/ncl/keymap-34key-seniply/expected.rs
+++ b/tests/ncl/keymap-34key-seniply/expected.rs
@@ -16,7 +16,7 @@ pub mod init {
     pub const LAYER_COUNT: usize = 5;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 2;
+    pub const MAX_CHORD_SIZE: usize = 0;
 
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 0;

--- a/tests/ncl/keymap-48key-basic/expected.rs
+++ b/tests/ncl/keymap-48key-basic/expected.rs
@@ -15,6 +15,9 @@ pub mod init {
     /// Number of layers supported by the [crate::key::layered] implementation.
     pub const LAYER_COUNT: usize = 3;
 
+    /// The maximum number of keys in a chord.
+    pub const MAX_CHORD_SIZE: usize = 2;
+
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 0;
 

--- a/tests/ncl/keymap-48key-basic/expected.rs
+++ b/tests/ncl/keymap-48key-basic/expected.rs
@@ -16,7 +16,7 @@ pub mod init {
     pub const LAYER_COUNT: usize = 3;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 2;
+    pub const MAX_CHORD_SIZE: usize = 0;
 
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 0;

--- a/tests/ncl/keymap-48key-rgoulter/expected.rs
+++ b/tests/ncl/keymap-48key-rgoulter/expected.rs
@@ -22,6 +22,9 @@ pub mod init {
     /// Number of layers supported by the [crate::key::layered] implementation.
     pub const LAYER_COUNT: usize = 6;
 
+    /// The maximum number of keys in a chord.
+    pub const MAX_CHORD_SIZE: usize = 2;
+
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 2;
 

--- a/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
@@ -16,7 +16,7 @@ pub mod init {
     pub const LAYER_COUNT: usize = 0;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 2;
+    pub const MAX_CHORD_SIZE: usize = 0;
 
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 0;

--- a/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
@@ -15,6 +15,9 @@ pub mod init {
     /// Number of layers supported by the [crate::key::layered] implementation.
     pub const LAYER_COUNT: usize = 0;
 
+    /// The maximum number of keys in a chord.
+    pub const MAX_CHORD_SIZE: usize = 2;
+
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 0;
 

--- a/tests/ncl/keymap-60key-dvorak-simple/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple/expected.rs
@@ -16,7 +16,7 @@ pub mod init {
     pub const LAYER_COUNT: usize = 0;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 2;
+    pub const MAX_CHORD_SIZE: usize = 0;
 
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 0;

--- a/tests/ncl/keymap-60key-dvorak-simple/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple/expected.rs
@@ -15,6 +15,9 @@ pub mod init {
     /// Number of layers supported by the [crate::key::layered] implementation.
     pub const LAYER_COUNT: usize = 0;
 
+    /// The maximum number of keys in a chord.
+    pub const MAX_CHORD_SIZE: usize = 2;
+
     /// The maximum number of chords.
     pub const MAX_CHORDS: usize = 0;
 


### PR DESCRIPTION
Following #361 and #362, this PR increases the chord max size from 2.

The chord size is 16 (used by tests), and is computed by codegen for `keymap.ncl`.

A Rust integration test demonstrating a 4-key chord has been added.