### PR TITLE
Fix resolve chorded to pendingkeystate

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -136,7 +136,7 @@ impl<PKS, KS> PressedKeyResult<PKS, KS> {
     pub fn add_path_item(self, item: u16) -> Self {
         match self {
             PressedKeyResult::Pending(mut key_path, pks) => {
-                key_path.push(item).unwrap();
+                key_path.insert(1, item).unwrap();
                 PressedKeyResult::Pending(key_path, pks)
             }
             pkr => pkr,

--- a/src/key.rs
+++ b/src/key.rs
@@ -107,6 +107,7 @@ impl<E: Debug, const M: usize> IntoIterator for KeyEvents<E, M> {
 }
 
 /// Pressed Key which may be pending, or a resolved key state.
+#[derive(Debug)]
 pub enum PressedKeyResult<PKS, KS> {
     /// Unresolved key state. (e.g. tap-hold or chorded keys when first pressed).
     Pending(KeyPath, PKS),

--- a/src/key/chorded.rs
+++ b/src/key/chorded.rs
@@ -325,7 +325,7 @@ where
                                 .iter()
                                 .find(|(ch_id, _)| *ch_id == resolved_chord_id)
                             {
-                                Some((resolved_chord_id, k))
+                                Some((1 + resolved_chord_id, k))
                             } else {
                                 panic!("check_resolution has invalid chord id")
                             }
@@ -342,7 +342,7 @@ where
             if let Some((i, k)) = maybe_pathel_key {
                 let (pkr, pke) = k.new_pressed_key(context, key_path);
                 // PRESSED KEY PATH: add Chord (0 = passthrough, 1 = 1+chord_id)
-                (pkr.add_path_item(1 + i as u16), pke)
+                (pkr.add_path_item(i as u16), pke)
             } else {
                 let pkr = key::PressedKeyResult::Resolved(key::NoOpKeyState::new().into());
                 let pke = key::KeyEvents::no_events();

--- a/tests/rust/chorded.rs
+++ b/tests/rust/chorded.rs
@@ -1,3 +1,4 @@
+mod over_layered_tap_hold;
 mod overlapping;
 mod overlapping_aux;
 mod overlapping_simultaneous;

--- a/tests/rust/chorded.rs
+++ b/tests/rust/chorded.rs
@@ -2,6 +2,7 @@ mod overlapping;
 mod overlapping_aux;
 mod overlapping_simultaneous;
 mod tap_hold;
+mod tap_hold_over_tap_hold;
 
 use smart_keymap::input;
 use smart_keymap::key;

--- a/tests/rust/chorded/over_layered_tap_hold.rs
+++ b/tests/rust/chorded/over_layered_tap_hold.rs
@@ -1,0 +1,190 @@
+use smart_keymap::input;
+use smart_keymap::key;
+use smart_keymap::keymap;
+use smart_keymap::slice::Slice;
+use smart_keymap::tuples;
+
+use keymap::DistinctReports;
+use keymap::Keymap;
+
+use key::{chorded, composite, keyboard, layered, tap_hold};
+use tuples::Keys4;
+
+type Ctx = composite::Context;
+type Ev = composite::Event;
+type PKS = composite::PendingKeyState;
+type KS = composite::KeyState;
+type CK = composite::ChordedKey<composite::LayeredKey<composite::TapHoldKey<keyboard::Key>>>;
+type AK = composite::ChordedKey<composite::Layered<composite::TapHold<keyboard::Key>>>;
+type LK = composite::Chorded<composite::LayeredKey<composite::TapHold<keyboard::Key>>>;
+type MK = composite::Chorded<composite::Layered<composite::TapHold<layered::ModifierKey>>>;
+
+// 4 keys:
+//   0: Layers: [{ tap: A, hold: lctrl }, { tap: F, hold: lshift }],
+//   1: B
+//   2: Layers: [C, D]
+//   3: Set Default (Layer 1)
+// chord [01] = { E }
+const KEYS: Keys4<CK, AK, LK, MK, Ctx, Ev, PKS, KS> = tuples::Keys4::new((
+    composite::ChordedKey::Chorded(chorded::Key::new(
+        &[(
+            0,
+            composite::LayeredKey::Pass(composite::TapHoldKey::Pass(keyboard::Key::new(0x08))),
+        )],
+        composite::LayeredKey::Layered(layered::LayeredKey::new(
+            composite::TapHoldKey::TapHold(tap_hold::Key::new(
+                keyboard::Key::new(0x04),
+                keyboard::Key::new(0xE2),
+            )),
+            [Some(composite::TapHoldKey::TapHold(tap_hold::Key::new(
+                keyboard::Key::new(0x09),
+                keyboard::Key::new(0xE2),
+            )))],
+        )),
+    )),
+    composite::ChordedKey::Auxiliary(chorded::AuxiliaryKey::new(composite::Layered(
+        composite::TapHold(keyboard::Key::new(0x05)),
+    ))),
+    composite::Chorded(composite::LayeredKey::Layered(layered::LayeredKey::new(
+        composite::TapHold(keyboard::Key::new(0x06)),
+        [Some(composite::TapHold(keyboard::Key::new(0x07)))],
+    ))),
+    composite::Chorded(composite::Layered(composite::TapHold(
+        layered::ModifierKey::Default(1),
+    ))),
+));
+
+const CONTEXT: Ctx = key::composite::Context::from_config(composite::Config {
+    chorded: chorded::Config {
+        chords: Slice::from_slice(&[chorded::ChordIndices::from_slice(&[0, 1])]),
+        ..chorded::DEFAULT_CONFIG
+    },
+    ..composite::DEFAULT_CONFIG
+});
+
+#[test]
+fn tap_key_after_tapping_chord_on_default_layer() {
+    // Assemble
+    let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
+
+    // Act
+    // - Default layer,
+    // - Press chord (01), release chord.
+    // - Press letter.
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Press { keymap_index: 2 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Release { keymap_index: 2 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    while keymap.has_scheduled_events() {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    // Assert
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x08, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x06, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn tap_key_after_tapping_chord_on_layer_1() {
+    // Assemble
+    let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
+
+    // Act
+    // - Set default layer to 1
+    // - Press chord (01), release chord.
+    // - Press letter.
+    keymap.handle_input(input::Event::Press { keymap_index: 3 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Press { keymap_index: 3 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Press { keymap_index: 2 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Release { keymap_index: 2 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    while keymap.has_scheduled_events() {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    // Assert
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x08, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x07, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn tap_chorded_key_passes_through_as_tap() {
+    // Assemble
+    let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
+
+    // Act
+    // - Default layer,
+    // - Press chord (01), release chord.
+    // - Press letter.
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    while keymap.has_scheduled_events() {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    // Assert
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
+}

--- a/tests/rust/chorded/over_layered_tap_hold.rs
+++ b/tests/rust/chorded/over_layered_tap_hold.rs
@@ -188,3 +188,48 @@ fn tap_chorded_key_passes_through_as_tap() {
     ];
     assert_eq!(expected_reports, actual_reports.reports());
 }
+
+#[test]
+fn tap_key_after_tapping_chorded_key_on_layer_1() {
+    // Assemble
+    let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
+
+    // Act
+    // - Set default layer to 1
+    // - Press chord (01), release chord.
+    // - Press letter.
+    keymap.handle_input(input::Event::Press { keymap_index: 3 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Press { keymap_index: 3 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Press { keymap_index: 2 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Release { keymap_index: 2 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    while keymap.has_scheduled_events() {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    // Assert
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x09, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x07, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
+}

--- a/tests/rust/chorded/tap_hold_over_tap_hold.rs
+++ b/tests/rust/chorded/tap_hold_over_tap_hold.rs
@@ -1,0 +1,217 @@
+use smart_keymap::input;
+use smart_keymap::key;
+use smart_keymap::keymap;
+use smart_keymap::slice::Slice;
+use smart_keymap::tuples;
+
+use keymap::DistinctReports;
+use keymap::Keymap;
+
+use key::{chorded, composite, keyboard, tap_hold};
+use tuples::Keys2;
+
+type Ctx = composite::Context;
+type Ev = composite::Event;
+type PKS = composite::PendingKeyState;
+type KS = composite::KeyState;
+type CK = composite::ChordedKey<composite::Layered<composite::TapHoldKey<keyboard::Key>>>;
+type AK = composite::ChordedKey<composite::Layered<composite::TapHoldKey<keyboard::Key>>>;
+
+// 2 keys:
+//   0: { tap: a, hold: lctrl },
+//   1: { tap: b, hold: lshift },
+// chord [01] = { tap: c, hold: lalt }
+const KEYS: Keys2<CK, AK, Ctx, Ev, PKS, KS> = tuples::Keys2::new((
+    composite::ChordedKey::Chorded(chorded::Key::new(
+        &[(
+            0,
+            composite::Layered(composite::TapHoldKey::TapHold(tap_hold::Key::new(
+                keyboard::Key::new(0x06),
+                keyboard::Key::new(0xE2),
+            ))),
+        )],
+        composite::Layered(composite::TapHoldKey::TapHold(tap_hold::Key::new(
+            keyboard::Key::new(0x04),
+            keyboard::Key::new(0xE0),
+        ))),
+    )),
+    composite::ChordedKey::Auxiliary(chorded::AuxiliaryKey::new(composite::Layered(
+        composite::TapHoldKey::TapHold(tap_hold::Key::new(
+            keyboard::Key::new(0x05),
+            keyboard::Key::new(0xE1),
+        )),
+    ))),
+));
+
+const CONTEXT: Ctx = key::composite::Context::from_config(composite::Config {
+    chorded: chorded::Config {
+        chords: Slice::from_slice(&[chorded::ChordIndices::from_slice(&[0, 1])]),
+        ..chorded::DEFAULT_CONFIG
+    },
+    ..composite::DEFAULT_CONFIG
+});
+
+#[test]
+fn tap_chord_acts_as_chorded_tap() {
+    // Assemble
+    let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
+
+    // Act
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    while keymap.has_scheduled_events() {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    // Assert
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x06, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn hold_chord_acts_as_chorded_hold() {
+    // Assemble
+    let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
+
+    // Act
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    while keymap.has_scheduled_events() {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    // Assert
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [4, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn tap_chorded_key_acts_as_passthrough_tap() {
+    // Assemble
+    let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
+
+    // Act
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    while keymap.has_scheduled_events() {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    // Assert
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn hold_chorded_key_acts_as_passthrough_hold() {
+    // Assemble
+    let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
+
+    // Act
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    while keymap.has_scheduled_events() {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    // Assert
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [1, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn tap_auxiliary_key_acts_as_passthrough_tap() {
+    // Assemble
+    let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
+
+    // Act
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    while keymap.has_scheduled_events() {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    // Assert
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn hold_auxiliary_key_acts_as_passthrough_hold() {
+    // Assemble
+    let mut keymap = Keymap::new(KEYS, CONTEXT);
+    let mut actual_reports = DistinctReports::new();
+
+    // Act
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+
+    while keymap.has_scheduled_events() {
+        keymap.tick();
+        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    }
+
+    // Assert
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [2, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, actual_reports.reports());
+}


### PR DESCRIPTION
Same as #356.

I observed bugs when testing this with my keymap. (Using the "AF" tap-dance keys, it failed to switch layers).