### PR TITLE
Fix PendingKeyState paths

### DIFF
--- a/src/key/chorded.rs
+++ b/src/key/chorded.rs
@@ -544,8 +544,11 @@ where
 
                     (pkr, pke)
                 }
-                // n.b. no need to add to key path; chorded aux_key only nests the passthrough key.
-                ChordResolution::Passthrough => self.passthrough.new_pressed_key(context, key_path),
+                ChordResolution::Passthrough => {
+                    let (pkr, pke) = self.passthrough.new_pressed_key(context, key_path);
+                    let pkr = pkr.add_path_item(0); // 0 = passthrough key
+                    (pkr, pke)
+                }
             }
         } else {
             let pkr = key::PressedKeyResult::Pending(key_path, pks.into());
@@ -613,8 +616,7 @@ impl<
                 if let Some(ChordResolution::Passthrough) = ch_state {
                     let nk = &self.passthrough;
                     let (pkr, mut pke) = nk.new_pressed_key(context, key_path);
-
-                    // n.b. no need to add to key path; chorded aux_key only nests the passthrough key.
+                    let pkr = pkr.add_path_item(0); // 0 = passthrough key
 
                     let ch_r_ev = Event::ChordResolved(ChordResolution::Passthrough);
                     let sch_ev = key::ScheduledEvent::immediate(key::Event::key_event(
@@ -657,7 +659,8 @@ impl<
     > {
         match path {
             [] => self,
-            _ => self.passthrough.lookup(path),
+            [0, path @ ..] => self.passthrough.lookup(path),
+            _ => panic!("illegal path"),
         }
     }
 }

--- a/src/key/chorded.rs
+++ b/src/key/chorded.rs
@@ -433,7 +433,7 @@ impl<
                                         .iter()
                                         .find(|(ch_id, _)| *ch_id == resolved_chord_id)
                                     {
-                                        Some((resolved_chord_id, k))
+                                        Some((1 + resolved_chord_id, k))
                                     } else {
                                         panic!("event's chord resolution has invalid chord id")
                                     }
@@ -456,7 +456,7 @@ impl<
                     if let Some((i, nk)) = maybe_pathel_and_key {
                         let (pkr, mut pke) = nk.new_pressed_key(context, key_path);
                         // PRESSED KEY PATH: add Chord (0 = passthrough, 1 = 1+chord_id)
-                        let pkr = pkr.add_path_item(1 + i as u16);
+                        let pkr = pkr.add_path_item(i as u16);
 
                         pke.add_event(sch_ev);
 


### PR DESCRIPTION
Taken from #377 (and #356).

Fixes some KeyPath in some of the PendingKeyState.

Only affects cases of e.g. chorded key over tap hold (or tap dance) key; which is broken at the moment anyway.