### PR TITLE
Indirection on new_pressed_key

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -129,11 +129,34 @@ impl<E: Debug, const M: usize> IntoIterator for KeyEvents<E, M> {
     }
 }
 
+/// Newtype for invoking new_pressed_key on the key at the given [KeyPath].
+#[derive(Debug)]
+pub enum NewPressedKey {
+    /// Invoke new_pressed_key on the key at the given [KeyPath].
+    Key(KeyPath),
+    /// For keys which do nothing when pressed.
+    NoOp,
+}
+
+impl NewPressedKey {
+    /// Constructs a NewPressedKey value.
+    pub fn key_path(key_path: KeyPath) -> Self {
+        NewPressedKey::Key(key_path)
+    }
+
+    /// Constructs a NoOp NewPressedKey value.
+    pub fn no_op() -> Self {
+        NewPressedKey::NoOp
+    }
+}
+
 /// Pressed Key which may be pending, or a resolved key state.
 #[derive(Debug)]
 pub enum PressedKeyResult<PKS, KS> {
     /// Unresolved key state. (e.g. tap-hold or chorded keys when first pressed).
     Pending(KeyPath, PKS),
+    /// Resolved as a new pressed key.
+    NewPressedKey(NewPressedKey),
     /// Resolved key state.
     Resolved(KS),
 }
@@ -211,10 +234,7 @@ pub trait Key: Debug {
         context: &Self::Context,
         key_path: KeyPath,
         event: Event<Self::Event>,
-    ) -> (
-        Option<PressedKeyResult<Self::PendingKeyState, Self::KeyState>>,
-        KeyEvents<Self::Event>,
-    );
+    ) -> (Option<NewPressedKey>, KeyEvents<Self::Event>);
 
     /// Return a reference to the key for the given path.
     fn lookup(

--- a/src/key.rs
+++ b/src/key.rs
@@ -46,7 +46,7 @@ impl KeyPath {
     /// Adds an item to the KeyPath.
     pub fn add_path_item(&self, item: u16) -> KeyPath {
         let mut kp = self.clone();
-        kp.0.insert(1, item).unwrap();
+        kp.0.push(item).unwrap();
         kp
     }
 }

--- a/src/key.rs
+++ b/src/key.rs
@@ -44,8 +44,10 @@ impl KeyPath {
     }
 
     /// Adds an item to the KeyPath.
-    pub fn add_path_item(&mut self, item: u16) {
-        self.0.insert(1, item).unwrap();
+    pub fn add_path_item(&self, item: u16) -> KeyPath {
+        let mut kp = self.clone();
+        kp.0.insert(1, item).unwrap();
+        kp
     }
 }
 
@@ -156,9 +158,8 @@ impl<PKS, KS> PressedKeyResult<PKS, KS> {
     /// Adds an item to the KeyPath if the pressed key result is pending.
     pub fn add_path_item(self, item: u16) -> Self {
         match self {
-            PressedKeyResult::Pending(mut key_path, pks) => {
-                key_path.add_path_item(item);
-                PressedKeyResult::Pending(key_path, pks)
+            PressedKeyResult::Pending(key_path, pks) => {
+                PressedKeyResult::Pending(key_path.add_path_item(item), pks)
             }
             pkr => pkr,
         }

--- a/src/key.rs
+++ b/src/key.rs
@@ -44,7 +44,7 @@ impl KeyPath {
     }
 
     /// Adds an item to the KeyPath.
-    pub fn add_path_item(&self, item: u16) -> KeyPath {
+    pub fn append_path_item(&self, item: u16) -> KeyPath {
         let mut kp = self.clone();
         kp.0.push(item).unwrap();
         kp
@@ -179,10 +179,10 @@ impl<PKS, KS> PressedKeyResult<PKS, KS> {
     }
 
     /// Adds an item to the KeyPath if the pressed key result is pending.
-    pub fn add_path_item(self, item: u16) -> Self {
+    pub fn append_path_item(self, item: u16) -> Self {
         match self {
             PressedKeyResult::Pending(key_path, pks) => {
-                PressedKeyResult::Pending(key_path.add_path_item(item), pks)
+                PressedKeyResult::Pending(key_path.append_path_item(item), pks)
             }
             pkr => pkr,
         }

--- a/src/key/callback.rs
+++ b/src/key/callback.rs
@@ -47,10 +47,7 @@ impl key::Key for Key {
         _context: &Self::Context,
         _key_path: key::KeyPath,
         _event: key::Event<Self::Event>,
-    ) -> (
-        Option<key::PressedKeyResult<Self::PendingKeyState, Self::KeyState>>,
-        key::KeyEvents<Self::Event>,
-    ) {
+    ) -> (Option<key::NewPressedKey>, key::KeyEvents<Self::Event>) {
         panic!()
     }
 

--- a/src/key/callback.rs
+++ b/src/key/callback.rs
@@ -35,10 +35,10 @@ impl key::Key for Key {
         key::KeyEvents<Self::Event>,
     ) {
         let &Key { keymap_callback } = self;
-        let pks = key::PressedKeyResult::Resolved(key::NoOpKeyState::new().into());
+        let pkr = key::PressedKeyResult::NewPressedKey(key::NewPressedKey::NoOp);
         let km_ev = crate::keymap::KeymapEvent::Callback(keymap_callback);
         let pke = key::KeyEvents::event(key::Event::Keymap(km_ev));
-        (pks, pke)
+        (pkr, pke)
     }
 
     fn handle_event(

--- a/src/key/caps_word.rs
+++ b/src/key/caps_word.rs
@@ -148,8 +148,8 @@ impl key::Key for Key {
         let caps_word_context = context.into();
         let keymap_index: u16 = key_path.keymap_index();
         let pke = self.new_pressed_key(caps_word_context, keymap_index);
-        let pks = key::PressedKeyResult::Resolved(key::NoOpKeyState::new().into());
-        (pks, pke.into_events())
+        let pkr = key::PressedKeyResult::NewPressedKey(key::NewPressedKey::NoOp);
+        (pkr, pke.into_events())
     }
 
     fn handle_event(

--- a/src/key/caps_word.rs
+++ b/src/key/caps_word.rs
@@ -158,10 +158,7 @@ impl key::Key for Key {
         _context: &Self::Context,
         _key_path: key::KeyPath,
         _event: key::Event<Self::Event>,
-    ) -> (
-        Option<key::PressedKeyResult<Self::PendingKeyState, Self::KeyState>>,
-        key::KeyEvents<Self::Event>,
-    ) {
+    ) -> (Option<key::NewPressedKey>, key::KeyEvents<Self::Event>) {
         panic!()
     }
 

--- a/src/key/chorded.rs
+++ b/src/key/chorded.rs
@@ -293,7 +293,6 @@ where
     K::Event: TryInto<Event>,
     K::Event: From<Event>,
     K::PendingKeyState: From<PendingKeyState>,
-    K::KeyState: From<key::NoOpKeyState<K::Context, K::Event>>,
 {
     /// Constructs new pressed key.
     pub fn new_pressed_key(
@@ -349,7 +348,7 @@ where
 
                 (pkr, pke)
             } else {
-                let pkr = key::PressedKeyResult::Resolved(key::NoOpKeyState::new().into());
+                let pkr = key::PressedKeyResult::NewPressedKey(key::NewPressedKey::NoOp);
                 let pke = key::KeyEvents::no_events();
                 (pkr, pke)
             }
@@ -520,7 +519,6 @@ where
     K::Event: TryInto<Event>,
     K::Event: From<Event>,
     K::PendingKeyState: From<PendingKeyState>,
-    K::KeyState: From<key::NoOpKeyState<K::Context, K::Event>>,
 {
     /// Constructs new pressed key.
     pub fn new_pressed_key(
@@ -539,7 +537,7 @@ where
         if let PendingChordState::Resolved(resolution) = chord_resolution {
             match resolution {
                 ChordResolution::Chord(_resolved_chord_id) => {
-                    let pkr = key::PressedKeyResult::Resolved(key::NoOpKeyState::new().into());
+                    let pkr = key::PressedKeyResult::NewPressedKey(key::NewPressedKey::NoOp);
                     let pke = key::KeyEvents::no_events();
 
                     (pkr, pke)

--- a/src/key/chorded.rs
+++ b/src/key/chorded.rs
@@ -341,7 +341,7 @@ where
 
             if let Some(i) = maybe_pathel_key {
                 // PRESSED KEY PATH: add Chord (0 = passthrough, 1 = 1+chord_id)
-                let new_key_path = key_path.add_path_item(i as u16);
+                let new_key_path = key_path.append_path_item(i as u16);
                 let pkr = key::PressedKeyResult::NewPressedKey(key::NewPressedKey::key_path(
                     new_key_path,
                 ));
@@ -457,7 +457,7 @@ impl<
 
                     if let Some(i) = maybe_pathel_and_key {
                         // PRESSED KEY PATH: add Chord (0 = passthrough, 1 = 1+chord_id)
-                        let new_key_path = key_path.add_path_item(i as u16);
+                        let new_key_path = key_path.append_path_item(i as u16);
 
                         let pke = key::KeyEvents::scheduled_event(sch_ev);
 
@@ -545,7 +545,7 @@ where
                     (pkr, pke)
                 }
                 ChordResolution::Passthrough => {
-                    let new_key_path = key_path.add_path_item(0); // 0 = passthrough key
+                    let new_key_path = key_path.append_path_item(0); // 0 = passthrough key
                     let pkr = key::PressedKeyResult::NewPressedKey(key::NewPressedKey::key_path(
                         new_key_path,
                     ));
@@ -614,7 +614,7 @@ impl<
             if let Ok(ch_ev) = event.try_into_key_event(|e| e.try_into()) {
                 let ch_state = ch_pks.handle_event(keymap_index, ch_ev);
                 if let Some(ChordResolution::Passthrough) = ch_state {
-                    let new_key_path = key_path.add_path_item(0); // 0 = passthrough key
+                    let new_key_path = key_path.append_path_item(0); // 0 = passthrough key
 
                     let ch_r_ev = Event::ChordResolved(ChordResolution::Passthrough);
                     let sch_ev = key::ScheduledEvent::immediate(key::Event::key_event(

--- a/src/key/composite/base.rs
+++ b/src/key/composite/base.rs
@@ -60,10 +60,7 @@ impl key::Key for BaseKey {
         _context: &Self::Context,
         _key_path: key::KeyPath,
         _event: key::Event<Self::Event>,
-    ) -> (
-        Option<key::PressedKeyResult<Self::PendingKeyState, Self::KeyState>>,
-        key::KeyEvents<Self::Event>,
-    ) {
+    ) -> (Option<key::NewPressedKey>, key::KeyEvents<Self::Event>) {
         panic!()
     }
 

--- a/src/key/composite/chorded.rs
+++ b/src/key/composite/chorded.rs
@@ -66,10 +66,7 @@ impl<K: ChordedNestable> key::Key for ChordedKey<K> {
         context: &Self::Context,
         key_path: key::KeyPath,
         event: key::Event<Self::Event>,
-    ) -> (
-        Option<key::PressedKeyResult<Self::PendingKeyState, Self::KeyState>>,
-        key::KeyEvents<Self::Event>,
-    ) {
+    ) -> (Option<key::NewPressedKey>, key::KeyEvents<Self::Event>) {
         match self {
             ChordedKey::Chorded(key) => key.handle_event(pending_state, context, key_path, event),
             ChordedKey::Auxiliary(key) => key.handle_event(pending_state, context, key_path, event),
@@ -115,10 +112,7 @@ impl<K: ChordedNestable> key::Key for Chorded<K> {
         context: &Self::Context,
         key_path: key::KeyPath,
         event: key::Event<Self::Event>,
-    ) -> (
-        Option<key::PressedKeyResult<Self::PendingKeyState, Self::KeyState>>,
-        key::KeyEvents<Self::Event>,
-    ) {
+    ) -> (Option<key::NewPressedKey>, key::KeyEvents<Self::Event>) {
         let Chorded(key) = self;
         key.handle_event(pending_state, context, key_path, event)
     }

--- a/src/key/composite/layered.rs
+++ b/src/key/composite/layered.rs
@@ -62,10 +62,7 @@ impl<K: LayeredNestable> key::Key for LayeredKey<K> {
         context: &Self::Context,
         key_path: key::KeyPath,
         event: key::Event<Self::Event>,
-    ) -> (
-        Option<key::PressedKeyResult<Self::PendingKeyState, Self::KeyState>>,
-        key::KeyEvents<Self::Event>,
-    ) {
+    ) -> (Option<key::NewPressedKey>, key::KeyEvents<Self::Event>) {
         match self {
             LayeredKey::Layered(key) => key.handle_event(pending_state, context, key_path, event),
             LayeredKey::Pass(key) => key.handle_event(pending_state, context, key_path, event),
@@ -109,10 +106,7 @@ impl<K: LayeredNestable> key::Key for Layered<K> {
         context: &Self::Context,
         key_path: key::KeyPath,
         event: key::Event<Self::Event>,
-    ) -> (
-        Option<key::PressedKeyResult<Self::PendingKeyState, Self::KeyState>>,
-        key::KeyEvents<Self::Event>,
-    ) {
+    ) -> (Option<key::NewPressedKey>, key::KeyEvents<Self::Event>) {
         let Layered(key) = self;
         key.handle_event(pending_state, context, key_path, event)
     }

--- a/src/key/composite/tap_hold.rs
+++ b/src/key/composite/tap_hold.rs
@@ -69,10 +69,7 @@ impl<K: TapHoldNestable> key::Key for TapHoldKey<K> {
         context: &Self::Context,
         key_path: key::KeyPath,
         event: key::Event<Self::Event>,
-    ) -> (
-        Option<key::PressedKeyResult<Self::PendingKeyState, Self::KeyState>>,
-        key::KeyEvents<Self::Event>,
-    ) {
+    ) -> (Option<key::NewPressedKey>, key::KeyEvents<Self::Event>) {
         match self {
             TapHoldKey::TapDance(key) => key.handle_event(pending_state, context, key_path, event),
             TapHoldKey::TapHold(key) => key.handle_event(pending_state, context, key_path, event),
@@ -118,10 +115,7 @@ impl<K: TapHoldNestable> key::Key for TapHold<K> {
         context: &Self::Context,
         key_path: key::KeyPath,
         event: key::Event<Self::Event>,
-    ) -> (
-        Option<key::PressedKeyResult<Self::PendingKeyState, Self::KeyState>>,
-        key::KeyEvents<Self::Event>,
-    ) {
+    ) -> (Option<key::NewPressedKey>, key::KeyEvents<Self::Event>) {
         let TapHold(key) = self;
         key.handle_event(pending_state, context, key_path, event)
     }

--- a/src/key/custom.rs
+++ b/src/key/custom.rs
@@ -46,10 +46,7 @@ impl key::Key for Key {
         _context: &Self::Context,
         _key_path: key::KeyPath,
         _event: key::Event<Self::Event>,
-    ) -> (
-        Option<key::PressedKeyResult<Self::PendingKeyState, Self::KeyState>>,
-        key::KeyEvents<Self::Event>,
-    ) {
+    ) -> (Option<key::NewPressedKey>, key::KeyEvents<Self::Event>) {
         panic!()
     }
 

--- a/src/key/keyboard.rs
+++ b/src/key/keyboard.rs
@@ -99,10 +99,7 @@ impl key::Key for Key {
         _context: &Self::Context,
         _key_path: key::KeyPath,
         _event: key::Event<Self::Event>,
-    ) -> (
-        Option<key::PressedKeyResult<Self::PendingKeyState, Self::KeyState>>,
-        key::KeyEvents<Self::Event>,
-    ) {
+    ) -> (Option<key::NewPressedKey>, key::KeyEvents<Self::Event>) {
         panic!()
     }
 

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -420,7 +420,7 @@ impl<
         KeyState = Self::KeyState,
     > {
         match path {
-            [] => panic!(),
+            [] => self,
             [0, path @ ..] => self.base.lookup(path),
             [layer_index, path @ ..] => self.layered[(layer_index - 1) as usize]
                 .as_ref()

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -370,7 +370,7 @@ where
 
         // PRESSED KEY PATH: add Layer (0 = base, n = layer_index)
         let (pkr, pke) = passthrough_key.new_pressed_key(context, key_path);
-        (pkr.add_path_item(layer as u16), pke)
+        (pkr.append_path_item(layer as u16), pke)
     }
 }
 

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -118,10 +118,7 @@ impl key::Key for ModifierKey {
         _context: &Self::Context,
         _key_path: key::KeyPath,
         _event: key::Event<Self::Event>,
-    ) -> (
-        Option<key::PressedKeyResult<Self::PendingKeyState, Self::KeyState>>,
-        key::KeyEvents<Self::Event>,
-    ) {
+    ) -> (Option<key::NewPressedKey>, key::KeyEvents<Self::Event>) {
         panic!()
     }
 
@@ -409,10 +406,7 @@ impl<
         _context: &Self::Context,
         _key_path: key::KeyPath,
         _event: key::Event<Self::Event>,
-    ) -> (
-        Option<key::PressedKeyResult<Self::PendingKeyState, Self::KeyState>>,
-        key::KeyEvents<Self::Event>,
-    ) {
+    ) -> (Option<key::NewPressedKey>, key::KeyEvents<Self::Event>) {
         panic!()
     }
 

--- a/src/key/sticky.rs
+++ b/src/key/sticky.rs
@@ -280,10 +280,7 @@ impl key::Key for Key {
         _context: &Self::Context,
         _key_path: key::KeyPath,
         _event: key::Event<Self::Event>,
-    ) -> (
-        Option<key::PressedKeyResult<Self::PendingKeyState, Self::KeyState>>,
-        key::KeyEvents<Self::Event>,
-    ) {
+    ) -> (Option<key::NewPressedKey>, key::KeyEvents<Self::Event>) {
         panic!()
     }
 

--- a/src/key/tap_dance.rs
+++ b/src/key/tap_dance.rs
@@ -130,7 +130,7 @@ impl<
 
                 if let Some(TapDanceResolution(idx)) = maybe_resolution {
                     // PRESSED KEY PATH: add Tap Dance item (index for the tap-dance definition)
-                    let new_key_path = key_path.add_path_item(idx as u16);
+                    let new_key_path = key_path.append_path_item(idx as u16);
 
                     (
                         Some(key::NewPressedKey::key_path(new_key_path)),
@@ -142,7 +142,7 @@ impl<
                     if td_pks.press_count as usize >= definition_count - 1 {
                         let idx = definition_count - 1;
                         // PRESSED KEY PATH: add Tap Dance item (index for the tap-dance definition)
-                        let new_key_path = key_path.add_path_item(idx as u16);
+                        let new_key_path = key_path.append_path_item(idx as u16);
 
                         (
                             Some(key::NewPressedKey::key_path(new_key_path)),

--- a/src/key/tap_hold.rs
+++ b/src/key/tap_hold.rs
@@ -107,7 +107,7 @@ impl<K: key::Key> Key<K> {
                     // Keymap has not been idle for long enough;
                     // immediately resolve as tap.
                     // PRESSED KEY PATH: add Tap Hold item (0 = tap, 1 = hold)
-                    let tap_key_path = key_path.add_path_item(0);
+                    let tap_key_path = key_path.append_path_item(0);
                     (
                         key::PressedKeyResult::NewPressedKey(key::NewPressedKey::key_path(
                             tap_key_path,
@@ -186,7 +186,7 @@ impl<
                         key::tap_hold::TapHoldState::Hold => 1,
                     };
                     // PRESSED KEY PATH: add Tap Hold item (0 = tap, 1 = hold)
-                    let new_key_path = key_path.add_path_item(i);
+                    let new_key_path = key_path.append_path_item(i);
 
                     (
                         Some(key::NewPressedKey::key_path(new_key_path)),


### PR DESCRIPTION
Towards #381, one blocker is that various `key::Key` implementations themselves invoke `key::Key::new_pressed_key`.

This PR is to rearrange the types so that these invocations instead return some kind of value.