### PR TITLE
ncl: keymap-codegen: provide json_deserializable_keymap

### DIFF
--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -69,6 +69,8 @@ let validators = import "validators.ncl" in
     | doc "The 'JSON' value of the keymap. e.g. imported from keymap.json."
     | KeymapJson,
 
+  json_deserializable_keymap = json_keymap,
+
   # Given an array of codegen_values,
   #  return the 'wrapper type' that unifies all the values.
   #

--- a/smart-keymap-nickel-helper/src/lib.rs
+++ b/smart-keymap-nickel-helper/src/lib.rs
@@ -212,7 +212,7 @@ pub fn nickel_json_value_for_keymap(ncl_import_path: String, keymap_ncl: &str) -
             "export",
             "--format=json",
             format!("--import-path={}", ncl_import_path).as_ref(),
-            "--field=json_keymap",
+            "--field=json_deserializable_keymap",
         ])
         .stdin(Stdio::piped())
         .stderr(Stdio::piped())
@@ -228,7 +228,7 @@ pub fn nickel_json_value_for_keymap(ncl_import_path: String, keymap_ncl: &str) -
             let child_stdin = nickel_command.stdin.as_mut().unwrap();
             child_stdin
                 .write_all(
-                    format!(r#"(import "keymap-ncl-to-json.ncl") & ({})"#, keymap_ncl).as_bytes(),
+                    format!(r#"(import "keymap-ncl-to-json.ncl") & (import "keymap-codegen.ncl") & ({})"#, keymap_ncl).as_bytes(),
                 )
                 .unwrap_or_else(|e| panic!("Failed to write to stdin: {:?}", e));
 


### PR DESCRIPTION
#381 rewrites the implementation, such that "keymap.json" is no longer the deserialized value. 

I *think* the right way to do it is to keep keymap.json as an intermediate representation, and use keymap-codegen to take the "keymap.json" value, and transform it to how the Rust code expects it (either as a deserializable json value, or by constructing rust expressions which get compiled by build.rs).

So, this PR introduces a new field for keymap-codegen, and updates the smart keymap nickel helper to use that.