### PR TITLE
More Consistent key::composite Boilerplate

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -588,13 +588,17 @@ impl<T: Copy> Event<T> {
     }
 
     /// Maps the Event into a new type.
-    pub fn try_into_key_event<U, E>(self, f: fn(T) -> Result<U, E>) -> EventResult<Event<U>> {
+    pub fn try_into_key_event<U, E>(self) -> EventResult<Event<U>>
+    where
+        T: TryInto<U, Error = E>,
+    {
         match self {
             Event::Input(event) => Ok(Event::Input(event)),
             Event::Key {
                 key_event,
                 keymap_index,
-            } => f(key_event)
+            } => key_event
+                .try_into()
                 .map(|key_event| Event::Key {
                     key_event,
                     keymap_index,

--- a/src/key.rs
+++ b/src/key.rs
@@ -161,6 +161,15 @@ impl<R, PKS, KS> PressedKeyResult<R, PKS, KS> {
             PressedKeyResult::Resolved(ks) => PressedKeyResult::Resolved(g(ks)),
         }
     }
+
+    /// Maps the PressedKeyResult into a new type.
+    pub fn into_result<TPKS, TKS>(self) -> PressedKeyResult<R, TPKS, TKS>
+    where
+        PKS: Into<TPKS>,
+        KS: Into<TKS>,
+    {
+        self.map(|pks| pks.into(), |ks| ks.into())
+    }
 }
 
 /// The interface for key `System` behaviour.

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -161,6 +161,12 @@ impl<'c> From<&'c Context> for &'c key::caps_word::Context {
     }
 }
 
+impl<'c> From<&'c Context> for &'c key::callback::Context {
+    fn from(_ctx: &'c Context) -> Self {
+        &key::callback::Context
+    }
+}
+
 impl<'c> From<&'c Context> for &'c key::chorded::Context {
     fn from(ctx: &'c Context) -> Self {
         &ctx.chorded
@@ -176,6 +182,12 @@ impl<'c> From<&'c Context> for &'c key::layered::Context {
 impl<'c> From<&'c Context> for &'c key::sticky::Context {
     fn from(ctx: &'c Context) -> Self {
         &ctx.sticky
+    }
+}
+
+impl<'c> From<&'c Context> for &'c key::custom::Context {
+    fn from(_ctx: &'c Context) -> Self {
+        &key::custom::Context
     }
 }
 
@@ -642,7 +654,7 @@ impl<K: Debug + Keys> key::System<Ref> for System<K> {
             Ref::Keyboard(key_ref) => {
                 let (pkr, pke) =
                     self.keyboard
-                        .new_pressed_key(keymap_index, &key::keyboard::Context, key_ref);
+                        .new_pressed_key(keymap_index, context.into(), key_ref);
                 (
                     pkr.map(|_| panic!(), KeyState::Keyboard),
                     pke.map_events(|_| panic!()),
@@ -651,7 +663,7 @@ impl<K: Debug + Keys> key::System<Ref> for System<K> {
             Ref::Callback(key_ref) => {
                 let (pkr, pke) =
                     self.callback
-                        .new_pressed_key(keymap_index, &key::callback::Context, key_ref);
+                        .new_pressed_key(keymap_index, context.into(), key_ref);
                 (
                     pkr.map(|_| panic!(), |_| panic!()),
                     pke.map_events(|_| panic!()),
@@ -676,9 +688,9 @@ impl<K: Debug + Keys> key::System<Ref> for System<K> {
                 )
             }
             Ref::Custom(key_ref) => {
-                let (pkr, pke) =
-                    self.custom
-                        .new_pressed_key(keymap_index, &key::custom::Context, key_ref);
+                let (pkr, pke) = self
+                    .custom
+                    .new_pressed_key(keymap_index, context.into(), key_ref);
                 (
                     pkr.map(|_| panic!(), Into::into),
                     pke.map_events(|_| panic!()),

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -220,9 +220,27 @@ pub enum Event {
     LayerModification(key::layered::LayerEvent),
 }
 
+impl From<key::keyboard::Event> for Event {
+    fn from(_ev: key::keyboard::Event) -> Self {
+        panic!()
+    }
+}
+
 impl From<key::caps_word::Event> for Event {
     fn from(ev: key::caps_word::Event) -> Self {
         Event::CapsWord(ev)
+    }
+}
+
+impl From<key::callback::Event> for Event {
+    fn from(_ev: key::callback::Event) -> Self {
+        panic!()
+    }
+}
+
+impl From<key::custom::Event> for Event {
+    fn from(_ev: key::custom::Event) -> Self {
+        panic!()
     }
 }
 
@@ -342,6 +360,36 @@ pub enum PendingKeyState {
     Chorded(key::chorded::PendingKeyState),
 }
 
+impl From<key::keyboard::PendingKeyState> for PendingKeyState {
+    fn from(_pks: key::keyboard::PendingKeyState) -> Self {
+        panic!()
+    }
+}
+
+impl From<key::caps_word::PendingKeyState> for PendingKeyState {
+    fn from(_pks: key::caps_word::PendingKeyState) -> Self {
+        panic!()
+    }
+}
+
+impl From<key::callback::PendingKeyState> for PendingKeyState {
+    fn from(_pks: key::callback::PendingKeyState) -> Self {
+        panic!()
+    }
+}
+
+impl From<key::sticky::PendingKeyState> for PendingKeyState {
+    fn from(_pks: key::sticky::PendingKeyState) -> Self {
+        panic!()
+    }
+}
+
+impl From<key::custom::PendingKeyState> for PendingKeyState {
+    fn from(_pks: key::custom::PendingKeyState) -> Self {
+        panic!()
+    }
+}
+
 impl From<key::tap_dance::PendingKeyState> for PendingKeyState {
     fn from(pks: key::tap_dance::PendingKeyState) -> Self {
         PendingKeyState::TapDance(pks)
@@ -351,6 +399,12 @@ impl From<key::tap_dance::PendingKeyState> for PendingKeyState {
 impl From<key::tap_hold::PendingKeyState> for PendingKeyState {
     fn from(pks: key::tap_hold::PendingKeyState) -> Self {
         PendingKeyState::TapHold(pks)
+    }
+}
+
+impl From<key::layered::PendingKeyState> for PendingKeyState {
+    fn from(_pks: key::layered::PendingKeyState) -> Self {
+        panic!()
     }
 }
 
@@ -420,9 +474,39 @@ impl From<key::keyboard::KeyState> for KeyState {
     }
 }
 
+impl From<key::caps_word::KeyState> for KeyState {
+    fn from(_ks: key::caps_word::KeyState) -> Self {
+        panic!()
+    }
+}
+
+impl From<key::callback::KeyState> for KeyState {
+    fn from(_ks: key::callback::KeyState) -> Self {
+        panic!()
+    }
+}
+
+impl From<key::tap_dance::KeyState> for KeyState {
+    fn from(_ks: key::tap_dance::KeyState) -> Self {
+        panic!()
+    }
+}
+
+impl From<key::tap_hold::KeyState> for KeyState {
+    fn from(_ks: key::tap_hold::KeyState) -> Self {
+        panic!()
+    }
+}
+
 impl From<key::layered::ModifierKeyState> for KeyState {
     fn from(ks: key::layered::ModifierKeyState) -> Self {
         KeyState::LayerModifier(ks)
+    }
+}
+
+impl From<key::chorded::KeyState> for KeyState {
+    fn from(_ks: key::chorded::KeyState) -> Self {
+        panic!()
     }
 }
 
@@ -655,82 +739,55 @@ impl<K: Debug + Keys> key::System<Ref> for System<K> {
                 let (pkr, pke) =
                     self.keyboard
                         .new_pressed_key(keymap_index, context.into(), key_ref);
-                (
-                    pkr.map(|_| panic!(), KeyState::Keyboard),
-                    pke.map_events(|_| panic!()),
-                )
+                (pkr.map(Into::into, Into::into), pke.map_events(Into::into))
             }
             Ref::Callback(key_ref) => {
                 let (pkr, pke) =
                     self.callback
                         .new_pressed_key(keymap_index, context.into(), key_ref);
-                (
-                    pkr.map(|_| panic!(), |_| panic!()),
-                    pke.map_events(|_| panic!()),
-                )
+                (pkr.map(Into::into, Into::into), pke.map_events(Into::into))
             }
             Ref::CapsWord(key_ref) => {
                 let (pkr, pke) =
                     self.caps_word
                         .new_pressed_key(keymap_index, context.into(), key_ref);
-                (
-                    pkr.map(|_| panic!(), |_| panic!()),
-                    pke.map_events(Into::into),
-                )
+                (pkr.map(Into::into, Into::into), pke.map_events(Into::into))
             }
             Ref::Sticky(key_ref) => {
                 let (pkr, pke) = self
                     .sticky
                     .new_pressed_key(keymap_index, context.into(), key_ref);
-                (
-                    pkr.map(|_| panic!(), Into::into),
-                    pke.map_events(Into::into),
-                )
+                (pkr.map(Into::into, Into::into), pke.map_events(Into::into))
             }
             Ref::Custom(key_ref) => {
                 let (pkr, pke) = self
                     .custom
                     .new_pressed_key(keymap_index, context.into(), key_ref);
-                (
-                    pkr.map(|_| panic!(), Into::into),
-                    pke.map_events(|_| panic!()),
-                )
+                (pkr.map(Into::into, Into::into), pke.map_events(Into::into))
             }
             Ref::TapDance(key_ref) => {
                 let (pkr, pke) =
                     self.tap_dance
                         .new_pressed_key(keymap_index, context.into(), key_ref);
-                (
-                    pkr.map(Into::into, |_| panic!()),
-                    pke.map_events(Into::into),
-                )
+                (pkr.map(Into::into, Into::into), pke.map_events(Into::into))
             }
             Ref::TapHold(key_ref) => {
                 let (pkr, pke) =
                     self.tap_hold
                         .new_pressed_key(keymap_index, context.into(), key_ref);
-                (
-                    pkr.map(Into::into, |_| panic!()),
-                    pke.map_events(Into::into),
-                )
+                (pkr.map(Into::into, Into::into), pke.map_events(Into::into))
             }
             Ref::Layered(key_ref) => {
                 let (pkr, pke) =
                     self.layered
                         .new_pressed_key(keymap_index, context.into(), key_ref);
-                (
-                    pkr.map(|_| panic!(), Into::into),
-                    pke.map_events(Into::into),
-                )
+                (pkr.map(Into::into, Into::into), pke.map_events(Into::into))
             }
             Ref::Chorded(key_ref) => {
                 let (pkr, pke) =
                     self.chorded
                         .new_pressed_key(keymap_index, context.into(), key_ref);
-                (
-                    pkr.map(Into::into, |_| panic!()),
-                    pke.map_events(Into::into),
-                )
+                (pkr.map(Into::into, Into::into), pke.map_events(Into::into))
             }
         }
     }
@@ -810,7 +867,7 @@ impl<K: Debug + Keys> key::System<Ref> for System<K> {
                             keymap_index,
                             event,
                         );
-                    pke.map_events(|_| panic!())
+                    pke.map_events(Into::into)
                 } else {
                     key::KeyEvents::no_events()
                 }

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -114,12 +114,12 @@ impl key::Context for Context {
         let caps_word_ev = self.caps_word_context.handle_event(event);
         pke.extend(caps_word_ev);
 
-        if let Ok(e) = event.try_into_key_event(|e| e.try_into()) {
+        if let Ok(e) = event.try_into_key_event() {
             let sticky_ev = self.sticky.handle_event(e);
             pke.extend(sticky_ev.into_events());
         }
 
-        if let Ok(e) = event.try_into_key_event(|e| e.try_into()) {
+        if let Ok(e) = event.try_into_key_event() {
             self.chorded.handle_event(e);
         }
 
@@ -739,55 +739,55 @@ impl<K: Debug + Keys> key::System<Ref> for System<K> {
                 let (pkr, pke) =
                     self.keyboard
                         .new_pressed_key(keymap_index, context.into(), key_ref);
-                (pkr.map(Into::into, Into::into), pke.map_events(Into::into))
+                (pkr.into_result(), pke.into_events())
             }
             Ref::Callback(key_ref) => {
                 let (pkr, pke) =
                     self.callback
                         .new_pressed_key(keymap_index, context.into(), key_ref);
-                (pkr.map(Into::into, Into::into), pke.map_events(Into::into))
+                (pkr.into_result(), pke.into_events())
             }
             Ref::CapsWord(key_ref) => {
                 let (pkr, pke) =
                     self.caps_word
                         .new_pressed_key(keymap_index, context.into(), key_ref);
-                (pkr.map(Into::into, Into::into), pke.map_events(Into::into))
+                (pkr.into_result(), pke.into_events())
             }
             Ref::Sticky(key_ref) => {
                 let (pkr, pke) = self
                     .sticky
                     .new_pressed_key(keymap_index, context.into(), key_ref);
-                (pkr.map(Into::into, Into::into), pke.map_events(Into::into))
+                (pkr.into_result(), pke.into_events())
             }
             Ref::Custom(key_ref) => {
                 let (pkr, pke) = self
                     .custom
                     .new_pressed_key(keymap_index, context.into(), key_ref);
-                (pkr.map(Into::into, Into::into), pke.map_events(Into::into))
+                (pkr.into_result(), pke.into_events())
             }
             Ref::TapDance(key_ref) => {
                 let (pkr, pke) =
                     self.tap_dance
                         .new_pressed_key(keymap_index, context.into(), key_ref);
-                (pkr.map(Into::into, Into::into), pke.map_events(Into::into))
+                (pkr.into_result(), pke.into_events())
             }
             Ref::TapHold(key_ref) => {
                 let (pkr, pke) =
                     self.tap_hold
                         .new_pressed_key(keymap_index, context.into(), key_ref);
-                (pkr.map(Into::into, Into::into), pke.map_events(Into::into))
+                (pkr.into_result(), pke.into_events())
             }
             Ref::Layered(key_ref) => {
                 let (pkr, pke) =
                     self.layered
                         .new_pressed_key(keymap_index, context.into(), key_ref);
-                (pkr.map(Into::into, Into::into), pke.map_events(Into::into))
+                (pkr.into_result(), pke.into_events())
             }
             Ref::Chorded(key_ref) => {
                 let (pkr, pke) =
                     self.chorded
                         .new_pressed_key(keymap_index, context.into(), key_ref);
-                (pkr.map(Into::into, Into::into), pke.map_events(Into::into))
+                (pkr.into_result(), pke.into_events())
             }
         }
     }
@@ -802,7 +802,7 @@ impl<K: Debug + Keys> key::System<Ref> for System<K> {
     ) -> (Option<key::NewPressedKey<Ref>>, key::KeyEvents<Self::Event>) {
         match (key_ref, pending_state) {
             (Ref::TapDance(key_ref), PendingKeyState::TapDance(pending_state)) => {
-                if let Ok(event) = event.try_into_key_event(TryInto::try_into) {
+                if let Ok(event) = event.try_into_key_event() {
                     let (maybe_npk, pke) = self.tap_dance.update_pending_state(
                         pending_state,
                         keymap_index,
@@ -810,13 +810,13 @@ impl<K: Debug + Keys> key::System<Ref> for System<K> {
                         key_ref,
                         event,
                     );
-                    (maybe_npk, pke.map_events(Into::into))
+                    (maybe_npk, pke.into_events())
                 } else {
                     (None, key::KeyEvents::no_events())
                 }
             }
             (Ref::TapHold(key_ref), PendingKeyState::TapHold(pending_state)) => {
-                if let Ok(event) = event.try_into_key_event(TryInto::try_into) {
+                if let Ok(event) = event.try_into_key_event() {
                     let (maybe_npk, pke) = self.tap_hold.update_pending_state(
                         pending_state,
                         keymap_index,
@@ -824,13 +824,13 @@ impl<K: Debug + Keys> key::System<Ref> for System<K> {
                         key_ref,
                         event,
                     );
-                    (maybe_npk, pke.map_events(Into::into))
+                    (maybe_npk, pke.into_events())
                 } else {
                     (None, key::KeyEvents::no_events())
                 }
             }
             (Ref::Chorded(key_ref), PendingKeyState::Chorded(pending_state)) => {
-                if let Ok(event) = event.try_into_key_event(TryInto::try_into) {
+                if let Ok(event) = event.try_into_key_event() {
                     let (maybe_npk, pke) = self.chorded.update_pending_state(
                         pending_state,
                         keymap_index,
@@ -838,7 +838,7 @@ impl<K: Debug + Keys> key::System<Ref> for System<K> {
                         key_ref,
                         event,
                     );
-                    (maybe_npk, pke.map_events(Into::into))
+                    (maybe_npk, pke.into_events())
                 } else {
                     (None, key::KeyEvents::no_events())
                 }
@@ -857,7 +857,7 @@ impl<K: Debug + Keys> key::System<Ref> for System<K> {
     ) -> key::KeyEvents<Self::Event> {
         match (key_ref, key_state) {
             (Ref::Keyboard(key_ref), KeyState::Keyboard(key_state)) => {
-                if let Ok(event) = event.try_into_key_event(TryInto::try_into) {
+                if let Ok(event) = event.try_into_key_event() {
                     let pke =
                         <key::keyboard::System<K::Keyboard> as key::System<Ref>>::update_state(
                             &self.keyboard,
@@ -867,13 +867,13 @@ impl<K: Debug + Keys> key::System<Ref> for System<K> {
                             keymap_index,
                             event,
                         );
-                    pke.map_events(Into::into)
+                    pke.into_events()
                 } else {
                     key::KeyEvents::no_events()
                 }
             }
             (Ref::Sticky(key_ref), KeyState::Sticky(key_state)) => {
-                if let Ok(event) = event.try_into_key_event(TryInto::try_into) {
+                if let Ok(event) = event.try_into_key_event() {
                     let pke = <key::sticky::System<K::Sticky> as key::System<Ref>>::update_state(
                         &self.sticky,
                         key_state,
@@ -882,13 +882,13 @@ impl<K: Debug + Keys> key::System<Ref> for System<K> {
                         keymap_index,
                         event,
                     );
-                    pke.map_events(Into::into)
+                    pke.into_events()
                 } else {
                     key::KeyEvents::no_events()
                 }
             }
             (Ref::Layered(key_ref), KeyState::LayerModifier(key_state)) => {
-                if let Ok(event) = event.try_into_key_event(TryInto::try_into) {
+                if let Ok(event) = event.try_into_key_event() {
                     let pke =
                         <key::layered::System<Ref, K::LayerModifiers, K::Layered> as key::System<
                             Ref,
@@ -900,7 +900,7 @@ impl<K: Debug + Keys> key::System<Ref> for System<K> {
                             keymap_index,
                             event,
                         );
-                    pke.map_events(Into::into)
+                    pke.into_events()
                 } else {
                     key::KeyEvents::no_events()
                 }


### PR DESCRIPTION
I've been considering different ways of shifting the complexity of `key::composite` around.

`key::composite` aggregates all the other key implementations so that `keymap::Keymap` has access to all the keys. The logic in `key::composite` is very straightforward: it has sum types (enum of `Keyboard(x)`, `TapHold(x)`, ...) for Ref, Event, PendingKeyState, KeyState, and product types for Context, System. -- The logic is 'just' dispatching the methods of `key::System` appropriately.

If all the code in `key::composite`'s `key::system` implementation is dead simple to maintain, this reduces the maintenance burden of adding keys.

This PR adds more `From` impls, and changes the PKR/PKE uses to implicitly make use of these.