### PR TITLE
Simplify key::composite::Context::handle_event Boilerplate

### DIFF
--- a/src/key/caps_word.rs
+++ b/src/key/caps_word.rs
@@ -19,11 +19,7 @@ pub const DEFAULT_CONTEXT: Context = Context { is_active: false };
 
 impl Context {
     /// Updates the context with the given event.
-    pub fn handle_event<E>(&mut self, event: key::Event<E>) -> key::KeyEvents<E>
-    where
-        Event: TryFrom<E>,
-        E: core::fmt::Debug + core::marker::Copy,
-    {
+    fn handle_event(&mut self, event: key::Event<Event>) -> key::KeyEvents<Event> {
         match event {
             key::Event::Keymap(keymap::KeymapEvent::ResolvedKeyOutput {
                 key_output:
@@ -65,32 +61,26 @@ impl Context {
                     key::KeyEvents::no_events()
                 }
             }
-            key::Event::Key { key_event, .. } => {
-                if let Ok(ev) = key_event.try_into() {
-                    match ev {
-                        Event::EnableCapsWord => {
-                            self.is_active = true;
+            key::Event::Key { key_event, .. } => match key_event {
+                Event::EnableCapsWord => {
+                    self.is_active = true;
 
-                            let key_code = 0xE1;
-                            let vk_ev = input::Event::VirtualKeyPress {
-                                key_output: key::KeyOutput::from_key_code(key_code),
-                            };
-                            key::KeyEvents::event(key::Event::Input(vk_ev))
-                        }
-                        Event::DisableCapsWord => {
-                            self.is_active = false;
-
-                            let key_code = 0xE1;
-                            let vk_ev = input::Event::VirtualKeyRelease {
-                                key_output: key::KeyOutput::from_key_code(key_code),
-                            };
-                            key::KeyEvents::event(key::Event::Input(vk_ev))
-                        }
-                    }
-                } else {
-                    key::KeyEvents::no_events()
+                    let key_code = 0xE1;
+                    let vk_ev = input::Event::VirtualKeyPress {
+                        key_output: key::KeyOutput::from_key_code(key_code),
+                    };
+                    key::KeyEvents::event(key::Event::Input(vk_ev))
                 }
-            }
+                Event::DisableCapsWord => {
+                    self.is_active = false;
+
+                    let key_code = 0xE1;
+                    let vk_ev = input::Event::VirtualKeyRelease {
+                        key_output: key::KeyOutput::from_key_code(key_code),
+                    };
+                    key::KeyEvents::event(key::Event::Input(vk_ev))
+                }
+            },
             _ => key::KeyEvents::no_events(),
         }
     }

--- a/src/key/caps_word.rs
+++ b/src/key/caps_word.rs
@@ -86,6 +86,14 @@ impl Context {
     }
 }
 
+impl key::Context for Context {
+    type Event = Event;
+
+    fn handle_event(&mut self, event: key::Event<Self::Event>) -> key::KeyEvents<Self::Event> {
+        self.handle_event(event)
+    }
+}
+
 /// Caps Word events.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Event {

--- a/src/key/chorded.rs
+++ b/src/key/chorded.rs
@@ -252,7 +252,7 @@ impl Context {
     }
 
     /// Updates the context for the given key event.
-    pub fn handle_event(&mut self, event: key::Event<Event>) {
+    fn handle_event(&mut self, event: key::Event<Event>) {
         match event {
             key::Event::Input(input::Event::Press { keymap_index }) => {
                 self.press_index(keymap_index);
@@ -280,6 +280,15 @@ impl Context {
             }
             _ => {}
         }
+    }
+}
+
+impl key::Context for Context {
+    type Event = Event;
+
+    fn handle_event(&mut self, event: key::Event<Self::Event>) -> key::KeyEvents<Self::Event> {
+        self.handle_event(event);
+        key::KeyEvents::no_events()
     }
 }
 

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -112,25 +112,19 @@ impl key::Context for Context {
         let mut pke = key::KeyEvents::no_events();
 
         if let Ok(e) = event.try_into_key_event() {
-            let caps_word_ev = self.caps_word.handle_event(e);
-            pke.extend(caps_word_ev.into_events());
+            pke.extend(self.caps_word.handle_event(e).into_events());
         }
 
         if let Ok(e) = event.try_into_key_event() {
-            self.chorded.handle_event(e);
+            pke.extend(self.chorded.handle_event(e).into_events());
         }
 
         if let Ok(e) = event.try_into_key_event() {
-            let sticky_ev = self.sticky.handle_event(e);
-            pke.extend(sticky_ev.into_events());
+            pke.extend(self.layered.handle_event(e).into_events());
         }
 
-        if let key::Event::Key {
-            key_event: Event::Layered(ev),
-            ..
-        } = event
-        {
-            self.layered.handle_event(ev);
+        if let Ok(e) = event.try_into_key_event() {
+            pke.extend(self.sticky.handle_event(e).into_events());
         }
 
         pke

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -111,8 +111,10 @@ impl key::Context for Context {
     fn handle_event(&mut self, event: key::Event<Self::Event>) -> key::KeyEvents<Self::Event> {
         let mut pke = key::KeyEvents::no_events();
 
-        let caps_word_ev = self.caps_word.handle_event(event);
-        pke.extend(caps_word_ev);
+        if let Ok(e) = event.try_into_key_event() {
+            let caps_word_ev = self.caps_word.handle_event(e);
+            pke.extend(caps_word_ev.into_events());
+        }
 
         if let Ok(e) = event.try_into_key_event() {
             self.chorded.handle_event(e);

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -178,7 +178,7 @@ impl Context {
     }
 
     /// Updates the context with the [LayerEvent].
-    pub fn handle_event(&mut self, event: LayerEvent) {
+    fn handle_event(&mut self, event: LayerEvent) {
         match event {
             LayerEvent::LayerActivated(layer) => {
                 self.active_layers.activate(layer);
@@ -200,6 +200,20 @@ impl Context {
             }
             LayerEvent::DefaultLayerSet(0) => self.default_layer = None,
             LayerEvent::DefaultLayerSet(layer) => self.default_layer = Some(layer),
+        }
+    }
+}
+
+impl key::Context for Context {
+    type Event = LayerEvent;
+
+    fn handle_event(&mut self, event: key::Event<Self::Event>) -> key::KeyEvents<Self::Event> {
+        match event {
+            key::Event::Key { key_event, .. } => {
+                self.handle_event(key_event);
+                key::KeyEvents::no_events()
+            }
+            _ => key::KeyEvents::no_events(),
         }
     }
 }

--- a/src/key/sticky.rs
+++ b/src/key/sticky.rs
@@ -96,7 +96,7 @@ impl Context {
     }
 
     /// Updates the context with the given event.
-    pub fn handle_event(&mut self, event: key::Event<Event>) -> key::KeyEvents<Event> {
+    fn handle_event(&mut self, event: key::Event<Event>) -> key::KeyEvents<Event> {
         // Cases:
         //
         // - No sticky key has been pressed.
@@ -230,6 +230,14 @@ impl Context {
             }
             _ => key::KeyEvents::no_events(),
         }
+    }
+}
+
+impl key::Context for Context {
+    type Event = Event;
+
+    fn handle_event(&mut self, event: key::Event<Self::Event>) -> key::KeyEvents<Self::Event> {
+        self.handle_event(event)
     }
 }
 


### PR DESCRIPTION
This PR implements `key::Context` for various `Context` impls, so that `key::composite::Context::handle_event`'s implementation can be simplified to be more "obviously correct".