### PR TITLE
rust: composite: simplify System syntax

### DIFF
--- a/src/key/callback.rs
+++ b/src/key/callback.rs
@@ -1,4 +1,5 @@
 use core::fmt::Debug;
+use core::marker::PhantomData;
 use core::ops::Index;
 
 use serde::Deserialize;
@@ -43,20 +44,24 @@ pub struct KeyState;
 
 /// The [key::System] implementation for keymap callback keys.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct System<Keys: Index<usize, Output = Key>> {
+pub struct System<R, Keys: Index<usize, Output = Key>> {
     keys: Keys,
+    marker: PhantomData<R>,
 }
 
-impl<Keys: Index<usize, Output = Key>> System<Keys> {
+impl<R, Keys: Index<usize, Output = Key>> System<R, Keys> {
     /// Constructs a new [System] with the given key data.
     ///
     /// The key data is for keys with both key codes and modifiers.
-    pub const fn new(key_data: Keys) -> Self {
-        Self { keys: key_data }
+    pub const fn new(keys: Keys) -> Self {
+        Self {
+            keys,
+            marker: PhantomData,
+        }
     }
 }
 
-impl<R, Keys: Debug + Index<usize, Output = Key>> key::System<R> for System<Keys> {
+impl<R: Debug, Keys: Debug + Index<usize, Output = Key>> key::System<R> for System<R, Keys> {
     type Ref = Ref;
     type Context = Context;
     type Event = Event;

--- a/src/key/caps_word.rs
+++ b/src/key/caps_word.rs
@@ -1,3 +1,6 @@
+use core::fmt::Debug;
+use core::marker::PhantomData;
+
 use serde::Deserialize;
 
 use crate::input;
@@ -147,22 +150,22 @@ pub struct KeyState;
 
 /// The [key::System] implementation for caps word keys.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct System;
+pub struct System<R>(PhantomData<R>);
 
-impl System {
+impl<R> System<R> {
     /// Constructs a new [System] with the given key data.
     pub const fn new() -> Self {
-        Self
+        Self(PhantomData)
     }
 }
 
-impl Default for System {
+impl<R> Default for System<R> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<R> key::System<R> for System {
+impl<R: Debug> key::System<R> for System<R> {
     type Ref = Ref;
     type Context = Context;
     type Event = Event;

--- a/src/key/custom.rs
+++ b/src/key/custom.rs
@@ -1,4 +1,5 @@
 use core::fmt::Debug;
+use core::marker::PhantomData;
 
 use serde::Deserialize;
 
@@ -26,22 +27,22 @@ pub struct KeyState;
 
 /// The [key::System] implementation for custom keys.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct System;
+pub struct System<R>(PhantomData<R>);
 
-impl System {
+impl<R> System<R> {
     /// Constructs a new [System] with the given key data.
     pub const fn new() -> Self {
-        Self
+        Self(PhantomData)
     }
 }
 
-impl Default for System {
+impl<R> Default for System<R> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<R> key::System<R> for System {
+impl<R: Debug> key::System<R> for System<R> {
     type Ref = Ref;
     type Context = Context;
     type Event = Event;

--- a/src/key/keyboard.rs
+++ b/src/key/keyboard.rs
@@ -1,4 +1,5 @@
 use core::fmt::Debug;
+use core::marker::PhantomData;
 use core::ops::Index;
 
 use serde::Deserialize;
@@ -94,20 +95,24 @@ pub struct KeyState;
 
 /// The [key::System] implementation for keyboard keys.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct System<Keys: Index<usize, Output = Key>> {
+pub struct System<R: Debug, Keys: Index<usize, Output = Key>> {
     keys: Keys,
+    marker: PhantomData<R>,
 }
 
-impl<Keys: Index<usize, Output = Key>> System<Keys> {
+impl<R: Debug, Keys: Index<usize, Output = Key>> System<R, Keys> {
     /// Constructs a new [System] with the given key data.
     ///
     /// The key data is for keys with both key codes and modifiers.
-    pub const fn new(key_data: Keys) -> Self {
-        Self { keys: key_data }
+    pub const fn new(keys: Keys) -> Self {
+        Self {
+            keys,
+            marker: PhantomData,
+        }
     }
 }
 
-impl<R, Keys: Debug + Index<usize, Output = Key>> key::System<R> for System<Keys> {
+impl<R: Debug, Keys: Debug + Index<usize, Output = Key>> key::System<R> for System<R, Keys> {
     type Ref = Ref;
     type Context = Context;
     type Event = Event;

--- a/src/key/sticky.rs
+++ b/src/key/sticky.rs
@@ -1,5 +1,6 @@
 use core::fmt::Debug;
 use core::marker::Copy;
+use core::marker::PhantomData;
 use core::ops::Index;
 
 use serde::Deserialize;
@@ -362,18 +363,22 @@ impl KeyState {
 
 /// The [key::System] implementation for keyboard keys.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct System<Keys: Index<usize, Output = Key>> {
+pub struct System<R, Keys: Index<usize, Output = Key>> {
     keys: Keys,
+    marker: PhantomData<R>,
 }
 
-impl<Keys: Index<usize, Output = Key>> System<Keys> {
+impl<R, Keys: Index<usize, Output = Key>> System<R, Keys> {
     /// Constructs a new [System] with the given key data.
-    pub const fn new(key_data: Keys) -> Self {
-        Self { keys: key_data }
+    pub const fn new(keys: Keys) -> Self {
+        Self {
+            keys,
+            marker: PhantomData,
+        }
     }
 }
 
-impl<R, Keys: Debug + Index<usize, Output = Key>> key::System<R> for System<Keys> {
+impl<R: Debug, Keys: Debug + Index<usize, Output = Key>> key::System<R> for System<R, Keys> {
     type Ref = Ref;
     type Context = Context;
     type Event = Event;


### PR DESCRIPTION
By adding `PhantomData` for the various `System` impls, `key::composite`'s `key::System` implementation can avoid fully-qualified syntax.

Unfortunately, can't have `self.into.key_output(..., ...)`.