### PR TITLE
docs: add `keys.ncl` fields to generated docs

### DIFF
--- a/features/scripts/generate-doc.sh
+++ b/features/scripts/generate-doc.sh
@@ -8,6 +8,8 @@ REPOSITORY_DIR="${SCRIPTS_DIR}/../.."
 FEATURES_DIR="${REPOSITORY_DIR}/features"
 KEYMAP_FEATURES_DIR="${FEATURES_DIR}/keymap"
 
+NCL_DIR="${REPOSITORY_DIR}/ncl"
+
 KEYMAP_FEATURE_MD=""
 
 keymap_key_features=(
@@ -32,6 +34,13 @@ keymap_ncl_features=(
     "layer_string"
     "chords"
 )
+
+KEY_FIELDS_MD="${NCL_DIR}/key-docs.md"
+nickel export \
+    --field=keys_md \
+    --format=text \
+    "${NCL_DIR}/key-docs.ncl" \
+    > "${KEY_FIELDS_MD}"
 
 KEYMAP_KEY_FEATURES_DIR="${KEYMAP_FEATURES_DIR}/key"
 KEYMAP_FEATURE_MD="${KEYMAP_FEATURE_MD} ${KEYMAP_KEY_FEATURES_DIR}/readme.md"
@@ -65,4 +74,5 @@ pandoc \
   --toc-depth=4 \
   --metadata=title="Smart Keymap Features" \
   ${KEYMAP_FEATURE_MD} \
+  ${KEY_FIELDS_MD} \
   --output="${FEATURES_DIR}/generated-features.html"

--- a/ncl/key-docs.ncl
+++ b/ncl/key-docs.ncl
@@ -1,0 +1,40 @@
+{
+  key_extensions = (import "key-extensions.ncl") |> std.record.remove "extend_keys",
+
+  grouped_key_fields =
+    std.record.map_values
+      (fun key_extension =>
+        key_extension
+        |> std.record.fields
+        |> std.array.filter ((!=) "keys")
+      )
+      key_extensions,
+
+  keys_md = m%"
+    # `keys.ncl` Fields
+
+    `keys.ncl` provides the values for key definitions
+     used in `keymap.ncl`.
+
+    See the documentation for [keymap.ncl](#keymap.ncl)
+     for examples of using `keys.ncl`.
+
+    The fields available in `keys.ncl`:
+
+    %{
+      grouped_key_fields
+      |> std.record.map
+           (fun extension_group_name key_extension_fields =>
+             m%"
+                ### %{extension_group_name}
+                %{
+                  key_extension_fields
+                  |> std.array.map (fun field_name => "- `` %{field_name} ``")
+                  |> std.string.join "\n"
+                }
+                "%)
+      |> std.record.values
+      |> std.string.join "\n\n"
+    }
+    "%,
+}

--- a/ncl/ncl.mk
+++ b/ncl/ncl.mk
@@ -32,6 +32,7 @@ ncl-format:
 	   ncl/import-keymap-json.ncl \
 	   ncl/inputs-to-json.ncl \
 	   ncl/inputs.ncl \
+       ncl/key-docs.ncl  \
        ncl/key-extensions.ncl  \
        ncl/keymap-ncl-to-json.ncl \
 	   ncl/keymap-codegen.ncl \


### PR DESCRIPTION
Currently, there's no reference documentation for the `keys.ncl` fields. So, when writing a keymap, use of `let K = import "keys.ncl" in ...` requires either copying other working code, or reading the `key-extensions` file.

I want to move the `key-extensions` out from a single file, which would make it harder to write keymaps.

This PR follows on from #402, and adds rudimentary reference documentation to the generated HTML docs.

It's not pretty, but it shows the full list of `keys.ncl` fields. It also groups e.g. "aliases" and "literals" separately from e.g. "layered" key fields.

There's room for improvement, such as:
- formatting the list of fields differently for the different groups (e.g. the `symbols` group would be clearer as just a plain string of the symbols; the `keyboard` group might need bespoke formatting, or to be sorted by HID code somehow).
- linking to the generated feature specs for each keys.