### PR TITLE
Firmware: CH32X: Add HID mouse report output

### DIFF
--- a/firmware/ch32x035-usb-device-compositekm-c/User/main.c
+++ b/firmware/ch32x035-usb-device-compositekm-c/User/main.c
@@ -36,6 +36,8 @@ extern uint8_t KB_Data_Pack[8];
 extern uint8_t PREV_KB_Data_Pack[8];
 extern uint8_t Consumer_Data_Pack[KEYMAP_HID_REPORT_CONSUMER_LEN];
 extern uint8_t PREV_Consumer_Data_Pack[KEYMAP_HID_REPORT_CONSUMER_LEN];
+extern uint8_t Mouse_Data_Pack[4];
+extern uint8_t PREV_Mouse_Data_Pack[4];
 
 /*********************************************************************
  * @fn      main
@@ -63,6 +65,7 @@ int main(void) {
   printf("TIM3 Init OK!\r\n");
 
   static uint8_t sending_kb = 0;
+  static uint8_t sending_mouse = 0;
   static uint8_t sending_consumer = 0;
 
   /* Usb Init */
@@ -79,6 +82,19 @@ int main(void) {
         } else if (USBFS_Endp_Busy[DEF_UEP1] == 0) {
           memcpy(PREV_KB_Data_Pack, KB_Data_Pack, sizeof(KB_Data_Pack));
           sending_kb = 0;
+        }
+      }
+
+      if (memcmp(Mouse_Data_Pack, PREV_Mouse_Data_Pack,
+                 sizeof(Mouse_Data_Pack)) != 0) {
+        if (sending_mouse == 0) {
+          USBFS_Endp_DataUp(DEF_UEP2, Mouse_Data_Pack, sizeof(Mouse_Data_Pack),
+                            DEF_UEP_CPY_LOAD);
+          sending_mouse = 1;
+        } else if (USBFS_Endp_Busy[DEF_UEP2] == 0) {
+          memcpy(PREV_Mouse_Data_Pack, Mouse_Data_Pack,
+                 sizeof(Mouse_Data_Pack));
+          sending_mouse = 0;
         }
       }
 

--- a/firmware/ch32x035-usb-device-compositekm-c/User/usbd_composite_km.c
+++ b/firmware/ch32x035-usb-device-compositekm-c/User/usbd_composite_km.c
@@ -52,6 +52,8 @@ uint8_t Consumer_Data_Pack[KEYMAP_HID_REPORT_CONSUMER_LEN] = {
     0x00}; // Consumer IN Data Packet
 uint8_t PREV_Consumer_Data_Pack[KEYMAP_HID_REPORT_CONSUMER_LEN] = {
     0x00};                                  // Consumer IN Data Packet
+uint8_t Mouse_Data_Pack[4] = {0x00};        // Mouse IN Data Packet
+uint8_t PREV_Mouse_Data_Pack[4] = {0x00};   // Mouse IN Data Packet
 volatile uint8_t KB_LED_Last_Status = 0x00; // Keyboard LED Last Result
 volatile uint8_t KB_LED_Cur_Status = 0x00;  // Keyboard LED Current Result
 
@@ -117,11 +119,17 @@ void TIM3_IRQHandler(void) {
 
     if (memcmp(KB_Data_Pack, PREV_KB_Data_Pack, sizeof(KB_Data_Pack)) == 0 &&
         memcmp(Consumer_Data_Pack, PREV_Consumer_Data_Pack,
-               sizeof(Consumer_Data_Pack)) == 0) {
+               sizeof(Consumer_Data_Pack)) == 0 &&
+        memcmp(Mouse_Data_Pack, PREV_Mouse_Data_Pack,
+               sizeof(Mouse_Data_Pack)) == 0) {
       keymap_tick(&hid_report);
       memcpy(KB_Data_Pack, hid_report.keyboard, sizeof(KB_Data_Pack));
       memcpy(Consumer_Data_Pack, hid_report.consumer,
              sizeof(Consumer_Data_Pack));
+      Mouse_Data_Pack[0] = hid_report.mouse.pressed_buttons;
+      Mouse_Data_Pack[1] = hid_report.mouse.x;
+      Mouse_Data_Pack[2] = hid_report.mouse.y;
+      Mouse_Data_Pack[3] = hid_report.mouse.vertical_scroll;
     }
 
     /* Clear interrupt flag */


### PR DESCRIPTION
It's crude, but I am able to observe mouse movement (and mouse scrolling, mouse buttons) on the CH32X using this.

I think it's out of smart-keymap's scope to improve on the mouse input much more than that... although, sure, providing a crate or something to help create smooth mouse output is an idea.