### PR TITLE
firmware: ch58x: define DEBUG to UART1

### DIFF
--- a/firmware/ch58x-ble-hid-keyboard-c/CMakeLists.txt
+++ b/firmware/ch58x-ble-hid-keyboard-c/CMakeLists.txt
@@ -25,6 +25,7 @@ add_subdirectory(generated)
 target_link_libraries(HID_Keyboard keyboard_codegen)
 
 add_subdirectory(sdk sdk)
+target_compile_definitions(sdk INTERFACE DEBUG Debug_UART1)
 
 target_link_libraries(HID_Keyboard sdk)
 


### PR DESCRIPTION
The CH58x firmware seems to assume `DEBUG` is `uart1`. The WABBLE-60 uses uart1.

```
#ifdef DEBUG
  GPIOA_SetBits(bTXD1);
  GPIOA_ModeCfg(bTXD1, GPIO_ModeOut_PP_5mA);
  UART1_DefInit();
#endif
```

Ideally, I'd like to use the same ncl codegen technique as used by the ch32x firmware.. but, it doesn't work here: in the ch32x firmware, `sdk` reads an `#include` from `User/`, but here `sdk` does not; so, setting the define for the codegen'd code does not affect `sdk`.

I'm not sure what a better solution is to allow different uart as debug tx; but, this is enough for now.