### PR TITLE
Firmware: CH58x: support Mouse, Consumer outputs

### DIFF
--- a/firmware/ch58x-ble-hid-keyboard-c/APP/hidkbd.c
+++ b/firmware/ch58x-ble-hid-keyboard-c/APP/hidkbd.c
@@ -319,7 +319,7 @@ uint16_t HidEmu_ProcessEvent(uint8_t task_id, uint16_t events) {
     return (events ^ START_PHY_UPDATE_EVT);
   }
 
-  if (events & START_REPORT_EVT) {
+  if (events & START_KEYMAP_TICK_EVT) {
     // SmartKeymap
 
     keyboard_matrix_scan();
@@ -330,8 +330,8 @@ uint16_t HidEmu_ProcessEvent(uint8_t task_id, uint16_t events) {
                                   HID_KEYBOARD_IN_RPT_LEN, (unsigned char *)&hid_report.keyboard);
 
     // 13 * 625 microseconds = 8.125ms, approx 125Hz
-    tmos_start_task(hidEmuTaskId, START_REPORT_EVT, 13);
-    return (events ^ START_REPORT_EVT);
+    tmos_start_task(hidEmuTaskId, START_KEYMAP_TICK_EVT, 13);
+    return (events ^ START_KEYMAP_TICK_EVT);
   }
   return 0;
 }
@@ -502,7 +502,7 @@ static uint8_t hidEmuRptCB(uint8_t id, uint8_t type, uint16_t uuid,
   }
   // notifications enabled
   else if (oper == HID_DEV_OPER_ENABLE) {
-    tmos_start_task(hidEmuTaskId, START_REPORT_EVT, 500);
+    tmos_start_task(hidEmuTaskId, START_KEYMAP_TICK_EVT, 500);
   }
   return status;
 }

--- a/firmware/ch58x-ble-hid-keyboard-c/APP/hidkbd.c
+++ b/firmware/ch58x-ble-hid-keyboard-c/APP/hidkbd.c
@@ -326,12 +326,19 @@ uint16_t HidEmu_ProcessEvent(uint8_t task_id, uint16_t events) {
 
     keymap_tick(&hid_report);
 
-    report_status = HidDev_Report(HID_RPT_ID_KEY_IN, HID_REPORT_TYPE_INPUT,
-                                  HID_KEYBOARD_IN_RPT_LEN, (unsigned char *)&hid_report.keyboard);
+    tmos_start_task(hidEmuTaskId, REPORT_KEYBOARD_EVT, 1);
 
     // 13 * 625 microseconds = 8.125ms, approx 125Hz
     tmos_start_task(hidEmuTaskId, START_KEYMAP_TICK_EVT, 13);
     return (events ^ START_KEYMAP_TICK_EVT);
+  }
+  if (events & REPORT_KEYBOARD_EVT) {
+    // SmartKeymap
+    report_status = HidDev_Report(HID_RPT_ID_KEY_IN, HID_REPORT_TYPE_INPUT,
+                                  HID_KEYBOARD_IN_RPT_LEN,
+                                  (unsigned char *)&hid_report.keyboard);
+
+    return (events ^ REPORT_KEYBOARD_EVT);
   }
   return 0;
 }

--- a/firmware/ch58x-ble-hid-keyboard-c/APP/include/hidkbd.h
+++ b/firmware/ch58x-ble-hid-keyboard-c/APP/include/hidkbd.h
@@ -31,6 +31,9 @@ extern "C" {
 #define START_PARAM_UPDATE_EVT 0x0002
 #define START_PHY_UPDATE_EVT 0x0004
 #define START_KEYMAP_TICK_EVT 0x0008
+#define REPORT_KEYBOARD_EVT 0x0010
+#define REPORT_MOUSE_EVT 0x0020
+#define REPORT_CONSUMER_EVT 0x0040
 /*********************************************************************
  * MACROS
  */

--- a/firmware/ch58x-ble-hid-keyboard-c/APP/include/hidkbd.h
+++ b/firmware/ch58x-ble-hid-keyboard-c/APP/include/hidkbd.h
@@ -28,9 +28,9 @@ extern "C" {
 
 // Task Events
 #define START_DEVICE_EVT 0x0001
-#define START_REPORT_EVT 0x0002
-#define START_PARAM_UPDATE_EVT 0x0004
-#define START_PHY_UPDATE_EVT 0x0008
+#define START_PARAM_UPDATE_EVT 0x0002
+#define START_PHY_UPDATE_EVT 0x0004
+#define START_KEYMAP_TICK_EVT 0x0008
 /*********************************************************************
  * MACROS
  */

--- a/firmware/ch58x-ble-hid-keyboard-c/CMakeLists.txt
+++ b/firmware/ch58x-ble-hid-keyboard-c/CMakeLists.txt
@@ -25,7 +25,6 @@ add_subdirectory(generated)
 target_link_libraries(HID_Keyboard keyboard_codegen)
 
 add_subdirectory(sdk sdk)
-target_compile_definitions(sdk INTERFACE DEBUG Debug_UART1)
 
 target_link_libraries(HID_Keyboard sdk)
 

--- a/firmware/ch58x-ble-hid-keyboard-c/Profile/hidkbdservice.c
+++ b/firmware/ch58x-ble-hid-keyboard-c/Profile/hidkbdservice.c
@@ -94,6 +94,7 @@ static const uint8_t hidReportMap[] = {
     0x05, 0x01, // Usage Pg (Generic Desktop)
     0x09, 0x06, // Usage (Keyboard)
     0xA1, 0x01, // Collection: (Application)
+    0x85, HID_RPT_ID_KEY_IN, // Report ID (1)
                 //
     0x05, 0x07, // Usage Pg (Key Codes)
     0x19, 0xE0, // Usage Min (224)

--- a/firmware/ch58x-ble-hid-keyboard-c/Profile/hidkbdservice.c
+++ b/firmware/ch58x-ble-hid-keyboard-c/Profile/hidkbdservice.c
@@ -135,7 +135,58 @@ static const uint8_t hidReportMap[] = {
     0x29, 0x65, // Usage Max (101)
     0x81, 0x00, // Input: (Data, Array)
                 //
-    0xC0        // End Collection
+    0xC0,       // End Collection
+
+    // Mouse
+    0x05, 0x01,       // Usage Page (Generic Desktop)
+    0x09, 0x02,       // Usage (Mouse)
+    0xA1, 0x01,       // Collection (Application)
+    0x85, HID_RPT_ID_MOUSE_IN, //   Report ID (2)
+    0x09, 0x01,       //   Usage (Pointer)
+    0xA1, 0x00,       //   Collection (Physical)
+    0x05, 0x09,       //     Usage Page (Buttons)
+    0x19, 0x01,       //     Usage Minimum (1)
+    0x29, 0x03,       //     Usage Maximum (3)
+    0x15, 0x00,       //     Logical Minimum (0)
+    0x25, 0x01,       //     Logical Maximum (1)
+    0x75, 0x01,       //     Report Size (1)
+    0x95, 0x03,       //     Report Count (3)
+    0x81, 0x02,       //     Input (Data, Var, Abs)
+    0x75, 0x05,       //     Report Size (5)
+    0x95, 0x01,       //     Report Count (1)
+    0x81, 0x03,       //     Input (Const, Var, Abs)
+    0x05, 0x01,       //     Usage Page (Generic Desktop)
+    0x09, 0x30,       //     Usage (X)
+    0x09, 0x31,       //     Usage (Y)
+    0x09, 0x38,       //     Usage (Wheel)
+    0x15, 0x81,       //     Logical Minimum (-127)
+    0x25, 0x7F,       //     Logical Maximum (127)
+    0x75, 0x08,       //     Report Size (8)
+    0x95, 0x03,       //     Report Count (3)
+    0x81, 0x06,       //     Input (Data, Var, Rel)
+    0xC0,             //   End Collection
+    0x05, 0x0C,       //   Usage Page (Consumer)
+    0x0A, 0x38, 0x02, //   Usage (AC Pan)
+    0x15, 0x81,       //   Logical Minimum (-127)
+    0x25, 0x7F,       //   Logical Maximum (127)
+    0x75, 0x08,       //   Report Size (8)
+    0x95, 0x01,       //   Report Count (1)
+    0x81, 0x06,       //   Input (Data, Var, Rel)
+    0xC0,             // End Collection
+
+    // Consumer Control
+    0x05, 0x0C,       // Usage Page (Consumer)
+    0x09, 0x01,       // Usage (Consumer Control)
+    0xA1, 0x01,       // Collection (Application)
+    0x85, HID_RPT_ID_CONSUMER_IN, //   Report ID (3)
+    0x19, 0x00,       //   Usage Minimum (0)
+    0x2A, 0xFF, 0x03, //   Usage Maximum (1023)
+    0x15, 0x00,       //   Logical Minimum (0)
+    0x26, 0xFF, 0x03, //   Logical Maximum (1023)
+    0x75, 0x10,       //   Report Size (16)
+    0x95, 0x02,       //   Report Count (2)
+    0x81, 0x00,       //   Input (Data, Array)
+    0xC0              // End Collection
 };
 // clang-format on
 
@@ -181,6 +232,24 @@ static gattCharCfg_t hidReportKeyInClientCharCfg[GATT_MAX_NUM_CONN];
 // HID Report Reference characteristic descriptor, key input
 static uint8_t hidReportRefKeyIn[HID_REPORT_REF_LEN] = {HID_RPT_ID_KEY_IN,
                                                         HID_REPORT_TYPE_INPUT};
+
+// HID Report characteristic, mouse input
+static uint8_t hidReportMouseInProps = GATT_PROP_READ | GATT_PROP_NOTIFY;
+static uint8_t hidReportMouseIn;
+static gattCharCfg_t hidReportMouseInClientCharCfg[GATT_MAX_NUM_CONN];
+
+// HID Report Reference characteristic descriptor, mouse input
+static uint8_t hidReportRefMouseIn[HID_REPORT_REF_LEN] = {
+    HID_RPT_ID_MOUSE_IN, HID_REPORT_TYPE_INPUT};
+
+// HID Report characteristic, consumer input
+static uint8_t hidReportConsumerInProps = GATT_PROP_READ | GATT_PROP_NOTIFY;
+static uint8_t hidReportConsumerIn;
+static gattCharCfg_t hidReportConsumerInClientCharCfg[GATT_MAX_NUM_CONN];
+
+// HID Report Reference characteristic descriptor, consumer input
+static uint8_t hidReportRefConsumerIn[HID_REPORT_REF_LEN] = {
+    HID_RPT_ID_CONSUMER_IN, HID_REPORT_TYPE_INPUT};
 
 // HID Report characteristic, LED output
 static uint8_t hidReportLedOutProps =
@@ -299,6 +368,54 @@ static gattAttribute_t hidAttrTbl[] = {
     // HID Report Reference characteristic descriptor, key input
     {{ATT_BT_UUID_SIZE, reportRefUUID}, GATT_PERMIT_READ, 0, hidReportRefKeyIn},
 
+    // HID Report characteristic, mouse input declaration
+    {{ATT_BT_UUID_SIZE, characterUUID},
+     GATT_PERMIT_READ,
+     0,
+     &hidReportMouseInProps},
+
+    // HID Report characteristic, mouse input
+    {{ATT_BT_UUID_SIZE, hidReportUUID},
+     GATT_PERMIT_ENCRYPT_READ,
+     0,
+     &hidReportMouseIn},
+
+    // HID Report characteristic client characteristic configuration
+    {{ATT_BT_UUID_SIZE, clientCharCfgUUID},
+     GATT_PERMIT_READ | GATT_PERMIT_ENCRYPT_WRITE,
+     0,
+     (uint8_t *)&hidReportMouseInClientCharCfg},
+
+    // HID Report Reference characteristic descriptor, mouse input
+    {{ATT_BT_UUID_SIZE, reportRefUUID},
+     GATT_PERMIT_READ,
+     0,
+     hidReportRefMouseIn},
+
+    // HID Report characteristic, consumer input declaration
+    {{ATT_BT_UUID_SIZE, characterUUID},
+     GATT_PERMIT_READ,
+     0,
+     &hidReportConsumerInProps},
+
+    // HID Report characteristic, consumer input
+    {{ATT_BT_UUID_SIZE, hidReportUUID},
+     GATT_PERMIT_ENCRYPT_READ,
+     0,
+     &hidReportConsumerIn},
+
+    // HID Report characteristic client characteristic configuration
+    {{ATT_BT_UUID_SIZE, clientCharCfgUUID},
+     GATT_PERMIT_READ | GATT_PERMIT_ENCRYPT_WRITE,
+     0,
+     (uint8_t *)&hidReportConsumerInClientCharCfg},
+
+    // HID Report Reference characteristic descriptor, consumer input
+    {{ATT_BT_UUID_SIZE, reportRefUUID},
+     GATT_PERMIT_READ,
+     0,
+     hidReportRefConsumerIn},
+
     // HID Report characteristic, LED output declaration
     {{ATT_BT_UUID_SIZE, characterUUID},
      GATT_PERMIT_READ,
@@ -387,9 +504,23 @@ enum {
                               // configuration
   HID_REPORT_REF_KEY_IN_IDX,  // HID Report Reference characteristic descriptor,
                               // key input
-  HID_REPORT_LED_OUT_DECL_IDX, // HID Report characteristic, LED output
-                               // declaration
-  HID_REPORT_LED_OUT_IDX,      // HID Report characteristic, LED output
+  HID_REPORT_MOUSE_IN_DECL_IDX,    // HID Report characteristic, mouse input
+                                   // declaration
+  HID_REPORT_MOUSE_IN_IDX,         // HID Report characteristic, mouse input
+  HID_REPORT_MOUSE_IN_CCCD_IDX,    // HID Report characteristic client
+                                   // characteristic configuration
+  HID_REPORT_REF_MOUSE_IN_IDX,     // HID Report Reference characteristic
+                                   // descriptor, mouse input
+  HID_REPORT_CONSUMER_IN_DECL_IDX, // HID Report characteristic, consumer input
+                                   // declaration
+  HID_REPORT_CONSUMER_IN_IDX,      // HID Report characteristic, consumer input
+  HID_REPORT_CONSUMER_IN_CCCD_IDX, // HID Report characteristic client
+                                   // characteristic configuration
+  HID_REPORT_REF_CONSUMER_IN_IDX,  // HID Report Reference characteristic
+                                   // descriptor, consumer input
+  HID_REPORT_LED_OUT_DECL_IDX,     // HID Report characteristic, LED output
+                                   // declaration
+  HID_REPORT_LED_OUT_IDX,          // HID Report characteristic, LED output
   HID_REPORT_REF_LED_OUT_IDX, // HID Report Reference characteristic descriptor,
                               // LED output
   HID_BOOT_KEY_IN_DECL_IDX,   // HID Boot Keyboard Input Report declaration
@@ -437,6 +568,8 @@ bStatus_t Hid_AddService(void) {
   // Initialize Client Characteristic Configuration attributes
   GATTServApp_InitCharCfg(INVALID_CONNHANDLE, hidReportKeyInClientCharCfg);
   GATTServApp_InitCharCfg(INVALID_CONNHANDLE, hidReportBootKeyInClientCharCfg);
+  GATTServApp_InitCharCfg(INVALID_CONNHANDLE, hidReportMouseInClientCharCfg);
+  GATTServApp_InitCharCfg(INVALID_CONNHANDLE, hidReportConsumerInClientCharCfg);
 
   // Register GATT attribute list and CBs with GATT Server App
   status = GATTServApp_RegisterService(hidAttrTbl, GATT_NUM_ATTRS(hidAttrTbl),
@@ -487,8 +620,22 @@ bStatus_t Hid_AddService(void) {
   hidRptMap[4].cccdHandle = 0;
   hidRptMap[4].mode = HID_PROTOCOL_MODE_REPORT;
 
+  // Mouse input report
+  hidRptMap[5].id = hidReportRefMouseIn[0];
+  hidRptMap[5].type = hidReportRefMouseIn[1];
+  hidRptMap[5].handle = hidAttrTbl[HID_REPORT_MOUSE_IN_IDX].handle;
+  hidRptMap[5].cccdHandle = hidAttrTbl[HID_REPORT_MOUSE_IN_CCCD_IDX].handle;
+  hidRptMap[5].mode = HID_PROTOCOL_MODE_REPORT;
+
+  // Consumer input report
+  hidRptMap[6].id = hidReportRefConsumerIn[0];
+  hidRptMap[6].type = hidReportRefConsumerIn[1];
+  hidRptMap[6].handle = hidAttrTbl[HID_REPORT_CONSUMER_IN_IDX].handle;
+  hidRptMap[6].cccdHandle = hidAttrTbl[HID_REPORT_CONSUMER_IN_CCCD_IDX].handle;
+  hidRptMap[6].mode = HID_PROTOCOL_MODE_REPORT;
+
   // Battery level input report
-  Batt_GetParameter(BATT_PARAM_BATT_LEVEL_IN_REPORT, &(hidRptMap[5]));
+  Batt_GetParameter(BATT_PARAM_BATT_LEVEL_IN_REPORT, &(hidRptMap[7]));
 
   // Setup report ID map
   HidDev_RegisterReports(HID_NUM_REPORTS, hidRptMap);

--- a/firmware/ch58x-ble-hid-keyboard-c/Profile/include/hidkbdservice.h
+++ b/firmware/ch58x-ble-hid-keyboard-c/Profile/include/hidkbdservice.h
@@ -30,10 +30,11 @@ extern "C" {
 #define HID_NUM_REPORTS 7
 
 // HID Report IDs for the service
-#define HID_RPT_ID_KEY_IN 0   // Keyboard input report ID
-#define HID_RPT_ID_MOUSE_IN 1 // Mouse input report ID
-#define HID_RPT_ID_LED_OUT 0  // LED output report ID
-#define HID_RPT_ID_FEATURE 0  // Feature report ID
+#define HID_RPT_ID_KEY_IN 1      // Keyboard input report ID
+#define HID_RPT_ID_MOUSE_IN 2    // Mouse input report ID
+#define HID_RPT_ID_CONSUMER_IN 3 // Consumer control input report ID
+#define HID_RPT_ID_LED_OUT 0     // LED output report ID
+#define HID_RPT_ID_FEATURE 0     // Feature report ID
 
 // HID feature flags
 #define HID_FEATURE_FLAGS HID_FLAGS_REMOTE_WAKE

--- a/firmware/ch58x-ble-hid-keyboard-c/Profile/include/hidkbdservice.h
+++ b/firmware/ch58x-ble-hid-keyboard-c/Profile/include/hidkbdservice.h
@@ -27,7 +27,7 @@ extern "C" {
  */
 
 // Number of HID reports defined in the service
-#define HID_NUM_REPORTS 7
+#define HID_NUM_REPORTS 8
 
 // HID Report IDs for the service
 #define HID_RPT_ID_KEY_IN 1      // Keyboard input report ID


### PR DESCRIPTION
This PR adds support for Mouse and Consumer keys to the CH58x firmware.

Again, leaning on Aider to provide the code for the BLE HID descriptors used by the GATT services and characteristics.

This one took some time to troubleshoot, because the original value for `HID_RPT_ID_KEY_IN` didn't work. (Also, adding two report kinds brings the total number of reports to `8` from `7`). -- The EVT Example code from WCH is not the most robust or well written.

Confounding my troubleshooting efforts: the WABBLE-60 does expose a TX1 pin; but, you can't have this connected to a USB serial device while using the keyboard, and can't use DEBUG=1 =TX1=PA9 while scanning from Row2=PA9. Oops.

One I was able to add `0x85, HID_RPT_ID_KEY_IN, // Report ID (1)` to the hid report map, enabling the rest of the aider-generated code wasn't too tricky.

Can't send the three reports at once, though; so, code to send the ble notifications in separate tmos tasks (when necessary) was added.