### PR TITLE
Firmware: STM32-Embassy: add consumer, mouse support

### DIFF
--- a/stm32-embassy-smart-keyboard/examples/minif4_36-rev2021_5-lhs.rs
+++ b/stm32-embassy-smart-keyboard/examples/minif4_36-rev2021_5-lhs.rs
@@ -25,6 +25,7 @@ use usbd_hid::descriptor::{
 use keyberon_smart_keyboard::input::smart_keymap::keymap_index_of;
 use keyberon_smart_keyboard::input::smart_keymap::KeyboardBackend;
 use keyberon_smart_keyboard::input::MatrixScanner;
+use keyberon_smart_keyboard::smart_keymap::key;
 use keyberon_smart_keyboard::split::BackendMessage;
 
 use smart_keymap::input::Event;
@@ -330,11 +331,7 @@ async fn main(spawner: Spawner) {
     };
 
     spawner
-        .spawn(keyboard_backend(
-            writer_kbd,
-            writer_mouse,
-            writer_consumer,
-        ))
+        .spawn(keyboard_backend(writer_kbd, writer_mouse, writer_consumer))
         .unwrap();
     spawner
         .spawn(keyboard_matrix_scan(matrix_scan_sender, keyboard))
@@ -393,12 +390,7 @@ async fn keyboard_backend(
                     wheel: mouse_output.vertical_scroll,
                     pan: mouse_output.horizontal_scroll,
                 };
-                if mouse_report.buttons != last_mouse_report.buttons
-                    || mouse_report.x != last_mouse_report.x
-                    || mouse_report.y != last_mouse_report.y
-                    || mouse_report.wheel != last_mouse_report.wheel
-                    || mouse_report.pan != last_mouse_report.pan
-                {
+                if mouse_report != last_mouse_report || mouse_output != key::MouseOutput::NO_OUTPUT {
                     let buf = [
                         mouse_report.buttons,
                         mouse_report.x as u8,

--- a/stm32-embassy-smart-keyboard/src/main.rs
+++ b/stm32-embassy-smart-keyboard/src/main.rs
@@ -21,6 +21,7 @@ use {defmt_rtt as _, panic_probe as _};
 
 use keyberon_smart_keyboard::input::smart_keymap::keymap_index_of;
 use keyberon_smart_keyboard::input::smart_keymap::KeyboardBackend;
+use keyberon_smart_keyboard::smart_keymap::key;
 
 use board::KEYMAP_INDICES;
 
@@ -228,12 +229,7 @@ async fn main(_spawner: Spawner) {
                 wheel: mouse_output.vertical_scroll,
                 pan: mouse_output.horizontal_scroll,
             };
-            if mouse_report.buttons != last_mouse_report.buttons
-                || mouse_report.x != last_mouse_report.x
-                || mouse_report.y != last_mouse_report.y
-                || mouse_report.wheel != last_mouse_report.wheel
-                || mouse_report.pan != last_mouse_report.pan
-            {
+            if mouse_report != last_mouse_report || mouse_output != key::MouseOutput::NO_OUTPUT {
                 let buf = [
                     mouse_report.buttons,
                     mouse_report.x as u8,


### PR DESCRIPTION
And, finally, following #428, #427, #420, #419 and others, this PR updates the STM32-embassy examples with consumer, mouse support.

As with the stm32F4-rtic examples.. note that STM32F4 has 4 endpoints, so control + 3 interfaces. So, not enough endpoints to also add e.g. serial, or other interfaces with this approach. (Could perhaps share the endpoint with a compound HID device).