### PR TITLE
rust: remove or replace default_context with const fn

### DIFF
--- a/src/key/caps_word.rs
+++ b/src/key/caps_word.rs
@@ -17,10 +17,12 @@ pub struct Context {
     is_active: bool,
 }
 
-/// The default [Context].
-pub const DEFAULT_CONTEXT: Context = Context { is_active: false };
-
 impl Context {
+    /// Constructs a new [Context].
+    pub const fn new() -> Self {
+        Context { is_active: false }
+    }
+
     /// Updates the context with the given event.
     fn handle_event(&mut self, event: key::Event<Event>) -> key::KeyEvents<Event> {
         match event {

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -79,26 +79,17 @@ pub struct Context {
     tap_hold: key::tap_hold::Context,
 }
 
-/// The default context.
-pub const DEFAULT_CONTEXT: Context = Context {
-    keymap_context: keymap::DEFAULT_KEYMAP_CONTEXT,
-    caps_word: key::caps_word::DEFAULT_CONTEXT,
-    chorded: key::chorded::DEFAULT_CONTEXT,
-    layered: key::layered::DEFAULT_CONTEXT,
-    sticky: key::sticky::DEFAULT_CONTEXT,
-    tap_dance: key::tap_dance::DEFAULT_CONTEXT,
-    tap_hold: key::tap_hold::DEFAULT_CONTEXT,
-};
-
 impl Context {
     /// Constructs a [Context] from the given [Config].
     pub const fn from_config(config: Config) -> Self {
         Self {
+            keymap_context: keymap::KeymapContext::new(),
+            caps_word: key::caps_word::Context::new(),
             chorded: key::chorded::Context::from_config(config.chorded),
+            layered: key::layered::Context::new(),
             sticky: key::sticky::Context::from_config(config.sticky),
             tap_dance: key::tap_dance::Context::from_config(config.tap_dance),
             tap_hold: key::tap_hold::Context::from_config(config.tap_hold),
-            ..DEFAULT_CONTEXT
         }
     }
 }
@@ -106,7 +97,7 @@ impl Context {
 impl Default for Context {
     /// Returns the default context.
     fn default() -> Self {
-        DEFAULT_CONTEXT
+        Self::from_config(DEFAULT_CONFIG)
     }
 }
 

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -145,22 +145,19 @@ pub struct Context {
     active_layers: [bool; LAYER_COUNT],
 }
 
-/// The default [Context] with no active layers.
-pub const DEFAULT_CONTEXT: Context = Context {
-    default_layer: None,
-    active_layers: [false; LAYER_COUNT],
-};
-
 impl Context {
     /// Create a new [Context].
     pub const fn new() -> Self {
-        DEFAULT_CONTEXT
+        Context {
+            default_layer: None,
+            active_layers: [false; LAYER_COUNT],
+        }
     }
 }
 
 impl Default for Context {
     fn default() -> Self {
-        DEFAULT_CONTEXT
+        Self::new()
     }
 }
 

--- a/src/key/sticky.rs
+++ b/src/key/sticky.rs
@@ -79,20 +79,14 @@ pub struct Context {
     pub pressed_keymap_index: Option<u16>,
 }
 
-/// The default [Context].
-pub const DEFAULT_CONTEXT: Context = Context {
-    config: DEFAULT_CONFIG,
-    active_modifiers: [key::KeyboardModifiers::NONE; MAX_STICKY_MODIFIERS as usize],
-    active_modifier_count: 0,
-    pressed_keymap_index: None,
-};
-
 impl Context {
     /// Constructs a context from the given config
     pub const fn from_config(config: Config) -> Context {
         Context {
             config,
-            ..DEFAULT_CONTEXT
+            active_modifiers: [key::KeyboardModifiers::NONE; MAX_STICKY_MODIFIERS as usize],
+            active_modifier_count: 0,
+            pressed_keymap_index: None,
         }
     }
 

--- a/src/key/tap_dance.rs
+++ b/src/key/tap_dance.rs
@@ -66,9 +66,6 @@ pub struct Context {
     config: Config,
 }
 
-/// Default context.
-pub const DEFAULT_CONTEXT: Context = Context::from_config(DEFAULT_CONFIG);
-
 impl Context {
     /// Constructs a context from the given config
     pub const fn from_config(config: Config) -> Context {

--- a/src/key/tap_hold.rs
+++ b/src/key/tap_hold.rs
@@ -98,9 +98,6 @@ pub struct Context {
     idle_time_ms: u32,
 }
 
-/// Default context.
-pub const DEFAULT_CONTEXT: Context = Context::from_config(DEFAULT_CONFIG);
-
 impl Context {
     /// Constructs a context from the given config
     pub const fn from_config(config: Config) -> Context {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -166,11 +166,15 @@ pub struct KeymapContext {
     pub idle_time_ms: u32,
 }
 
-/// Default keymap context.
-pub const DEFAULT_KEYMAP_CONTEXT: KeymapContext = KeymapContext {
-    time_ms: 0,
-    idle_time_ms: 0,
-};
+impl KeymapContext {
+    /// Constructs a new default keymap context.
+    pub const fn new() -> Self {
+        KeymapContext {
+            time_ms: 0,
+            idle_time_ms: 0,
+        }
+    }
+}
 
 /// Trait for setting the keymap context.
 pub trait SetKeymapContext {


### PR DESCRIPTION
`DEFAULT_CONTEXT` can't have generics.

I want to refactor out the `crate::init::MAX_` constants that some `Context`s use, so the `DEFAULT_CONTEXT` should be replaced by calls to `const fn new()` or `from_config`.