### PR TITLE
rust: rename consts in crate::init

### DIFF
--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -280,19 +280,19 @@ pub mod init {
     use crate as smart_keymap;
 
     /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYER_COUNT: usize = %{std.to_string num_layers};
+    pub const LAYERED_LAYER_COUNT: usize = %{std.to_string num_layers};
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = %{max_chord_size |> std.to_string};
+    pub const CHORDED_MAX_CHORD_SIZE: usize = %{max_chord_size |> std.to_string};
 
     /// The maximum number of chords.
-    pub const MAX_CHORDS: usize = %{chord_count |> std.to_string};
+    pub const CHORDED_MAX_CHORDS: usize = %{chord_count |> std.to_string};
 
     /// The maximum number of overlapping chords for a chorded key.
-    pub const MAX_OVERLAPPING_CHORD_SIZE: usize = %{max_overlapping_chord_size |> std.to_string};
+    pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = %{max_overlapping_chord_size |> std.to_string};
 
     /// The tap-dance definitions.
-    pub const MAX_TAP_DANCE_DEFINITIONS: usize = %{max_tap_dance_definitions |> std.to_string};
+    pub const TAP_DANCE_MAX_DEFINITIONS: usize = %{max_tap_dance_definitions |> std.to_string};
 
     pub use smart_keymap::key::composite::Ref;
 

--- a/src/key/chorded.rs
+++ b/src/key/chorded.rs
@@ -5,7 +5,10 @@ use serde::Deserialize;
 
 use crate::{input, key, slice::Slice};
 
-pub use crate::init::{MAX_CHORDS, MAX_CHORD_SIZE, MAX_OVERLAPPING_CHORD_SIZE};
+pub use crate::init::{
+    CHORDED_MAX_CHORDS as MAX_CHORDS, CHORDED_MAX_CHORD_SIZE as MAX_CHORD_SIZE,
+    CHORDED_MAX_OVERLAPPING_CHORD_SIZE as MAX_OVERLAPPING_CHORD_SIZE,
+};
 
 /// Reference for a chorded key.
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -8,8 +8,8 @@ use serde::Deserialize;
 
 use crate::{key, keymap};
 
-use crate::init::LAYER_COUNT as LAYERED_LAYER_COUNT;
-use crate::init::MAX_TAP_DANCE_DEFINITIONS as TAP_DANCE_MAX_DEF_COUNT;
+use crate::init::LAYERED_LAYER_COUNT;
+use crate::init::TAP_DANCE_MAX_DEFINITIONS as TAP_DANCE_MAX_DEF_COUNT;
 
 /// Aggregate enum for key references.
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,19 +73,19 @@ pub mod init {
     use composite as key_system;
 
     /// Number of layers supported by the [crate::key::layered] implementation.
-    pub const LAYER_COUNT: usize = 8;
+    pub const LAYERED_LAYER_COUNT: usize = 8;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 16;
+    pub const CHORDED_MAX_CHORD_SIZE: usize = 16;
 
     /// The maximum number of chords.
-    pub const MAX_CHORDS: usize = 4;
+    pub const CHORDED_MAX_CHORDS: usize = 4;
 
     /// The maximum number of overlapping chords for a chorded key.
-    pub const MAX_OVERLAPPING_CHORD_SIZE: usize = 16;
+    pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 16;
 
     /// The tap-dance definitions.
-    pub const MAX_TAP_DANCE_DEFINITIONS: usize = 3;
+    pub const TAP_DANCE_MAX_DEFINITIONS: usize = 3;
 
     pub use key_system::Ref;
 

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -16,8 +16,8 @@ use smart_keymap_nickel_helper::{
 
 use smart_keymap::key::composite::{Context, Event, KeyState, PendingKeyState, Ref};
 
-use smart_keymap::init::LAYER_COUNT as LAYERED_LAYER_COUNT;
-use smart_keymap::init::MAX_TAP_DANCE_DEFINITIONS as TAP_DANCE_MAX_DEFS;
+use smart_keymap::init::LAYERED_LAYER_COUNT;
+use smart_keymap::init::TAP_DANCE_MAX_DEFINITIONS as TAP_DANCE_MAX_DEFS;
 
 type System = smart_keymap::key::composite::System<smart_keymap::key::composite::KeyVecs>;
 type Keymap = keymap::Keymap<Vec<Ref>, Ref, Context, Event, PendingKeyState, KeyState, System>;

--- a/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
+++ b/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
@@ -3,19 +3,19 @@ pub mod init {
     use crate as smart_keymap;
 
     /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYER_COUNT: usize = 1;
+    pub const LAYERED_LAYER_COUNT: usize = 1;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 0;
+    pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
     /// The maximum number of chords.
-    pub const MAX_CHORDS: usize = 0;
+    pub const CHORDED_MAX_CHORDS: usize = 0;
 
     /// The maximum number of overlapping chords for a chorded key.
-    pub const MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+    pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
 
     /// The tap-dance definitions.
-    pub const MAX_TAP_DANCE_DEFINITIONS: usize = 0;
+    pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;
 
     pub use smart_keymap::key::composite::Ref;
 

--- a/tests/ncl/keymap-1key-callback-custom/expected.rs
+++ b/tests/ncl/keymap-1key-callback-custom/expected.rs
@@ -3,19 +3,19 @@ pub mod init {
     use crate as smart_keymap;
 
     /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYER_COUNT: usize = 0;
+    pub const LAYERED_LAYER_COUNT: usize = 0;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 0;
+    pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
     /// The maximum number of chords.
-    pub const MAX_CHORDS: usize = 0;
+    pub const CHORDED_MAX_CHORDS: usize = 0;
 
     /// The maximum number of overlapping chords for a chorded key.
-    pub const MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+    pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
 
     /// The tap-dance definitions.
-    pub const MAX_TAP_DANCE_DEFINITIONS: usize = 0;
+    pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;
 
     pub use smart_keymap::key::composite::Ref;
 

--- a/tests/ncl/keymap-1key-custom/expected.rs
+++ b/tests/ncl/keymap-1key-custom/expected.rs
@@ -3,19 +3,19 @@ pub mod init {
     use crate as smart_keymap;
 
     /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYER_COUNT: usize = 0;
+    pub const LAYERED_LAYER_COUNT: usize = 0;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 0;
+    pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
     /// The maximum number of chords.
-    pub const MAX_CHORDS: usize = 0;
+    pub const CHORDED_MAX_CHORDS: usize = 0;
 
     /// The maximum number of overlapping chords for a chorded key.
-    pub const MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+    pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
 
     /// The tap-dance definitions.
-    pub const MAX_TAP_DANCE_DEFINITIONS: usize = 0;
+    pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;
 
     pub use smart_keymap::key::composite::Ref;
 

--- a/tests/ncl/keymap-1key-simple/expected.rs
+++ b/tests/ncl/keymap-1key-simple/expected.rs
@@ -3,19 +3,19 @@ pub mod init {
     use crate as smart_keymap;
 
     /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYER_COUNT: usize = 0;
+    pub const LAYERED_LAYER_COUNT: usize = 0;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 0;
+    pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
     /// The maximum number of chords.
-    pub const MAX_CHORDS: usize = 0;
+    pub const CHORDED_MAX_CHORDS: usize = 0;
 
     /// The maximum number of overlapping chords for a chorded key.
-    pub const MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+    pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
 
     /// The tap-dance definitions.
-    pub const MAX_TAP_DANCE_DEFINITIONS: usize = 0;
+    pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;
 
     pub use smart_keymap::key::composite::Ref;
 

--- a/tests/ncl/keymap-1key-tap_dance/expected.rs
+++ b/tests/ncl/keymap-1key-tap_dance/expected.rs
@@ -3,19 +3,19 @@ pub mod init {
     use crate as smart_keymap;
 
     /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYER_COUNT: usize = 0;
+    pub const LAYERED_LAYER_COUNT: usize = 0;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 0;
+    pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
     /// The maximum number of chords.
-    pub const MAX_CHORDS: usize = 0;
+    pub const CHORDED_MAX_CHORDS: usize = 0;
 
     /// The maximum number of overlapping chords for a chorded key.
-    pub const MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+    pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
 
     /// The tap-dance definitions.
-    pub const MAX_TAP_DANCE_DEFINITIONS: usize = 3;
+    pub const TAP_DANCE_MAX_DEFINITIONS: usize = 3;
 
     pub use smart_keymap::key::composite::Ref;
 

--- a/tests/ncl/keymap-1key-tap_hold/expected.rs
+++ b/tests/ncl/keymap-1key-tap_hold/expected.rs
@@ -3,19 +3,19 @@ pub mod init {
     use crate as smart_keymap;
 
     /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYER_COUNT: usize = 0;
+    pub const LAYERED_LAYER_COUNT: usize = 0;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 0;
+    pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
     /// The maximum number of chords.
-    pub const MAX_CHORDS: usize = 0;
+    pub const CHORDED_MAX_CHORDS: usize = 0;
 
     /// The maximum number of overlapping chords for a chorded key.
-    pub const MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+    pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
 
     /// The tap-dance definitions.
-    pub const MAX_TAP_DANCE_DEFINITIONS: usize = 0;
+    pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;
 
     pub use smart_keymap::key::composite::Ref;
 

--- a/tests/ncl/keymap-2key-2layer-composite/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-composite/expected.rs
@@ -3,19 +3,19 @@ pub mod init {
     use crate as smart_keymap;
 
     /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYER_COUNT: usize = 1;
+    pub const LAYERED_LAYER_COUNT: usize = 1;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 0;
+    pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
     /// The maximum number of chords.
-    pub const MAX_CHORDS: usize = 0;
+    pub const CHORDED_MAX_CHORDS: usize = 0;
 
     /// The maximum number of overlapping chords for a chorded key.
-    pub const MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+    pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
 
     /// The tap-dance definitions.
-    pub const MAX_TAP_DANCE_DEFINITIONS: usize = 0;
+    pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;
 
     pub use smart_keymap::key::composite::Ref;
 

--- a/tests/ncl/keymap-2key-2layer-simple/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-simple/expected.rs
@@ -3,19 +3,19 @@ pub mod init {
     use crate as smart_keymap;
 
     /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYER_COUNT: usize = 1;
+    pub const LAYERED_LAYER_COUNT: usize = 1;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 0;
+    pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
     /// The maximum number of chords.
-    pub const MAX_CHORDS: usize = 0;
+    pub const CHORDED_MAX_CHORDS: usize = 0;
 
     /// The maximum number of overlapping chords for a chorded key.
-    pub const MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+    pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
 
     /// The tap-dance definitions.
-    pub const MAX_TAP_DANCE_DEFINITIONS: usize = 0;
+    pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;
 
     pub use smart_keymap::key::composite::Ref;
 

--- a/tests/ncl/keymap-2key-chorded/expected.rs
+++ b/tests/ncl/keymap-2key-chorded/expected.rs
@@ -3,19 +3,19 @@ pub mod init {
     use crate as smart_keymap;
 
     /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYER_COUNT: usize = 0;
+    pub const LAYERED_LAYER_COUNT: usize = 0;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 2;
+    pub const CHORDED_MAX_CHORD_SIZE: usize = 2;
 
     /// The maximum number of chords.
-    pub const MAX_CHORDS: usize = 1;
+    pub const CHORDED_MAX_CHORDS: usize = 1;
 
     /// The maximum number of overlapping chords for a chorded key.
-    pub const MAX_OVERLAPPING_CHORD_SIZE: usize = 1;
+    pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 1;
 
     /// The tap-dance definitions.
-    pub const MAX_TAP_DANCE_DEFINITIONS: usize = 0;
+    pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;
 
     pub use smart_keymap::key::composite::Ref;
 

--- a/tests/ncl/keymap-34key-seniply/expected.rs
+++ b/tests/ncl/keymap-34key-seniply/expected.rs
@@ -3,19 +3,19 @@ pub mod init {
     use crate as smart_keymap;
 
     /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYER_COUNT: usize = 5;
+    pub const LAYERED_LAYER_COUNT: usize = 5;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 0;
+    pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
     /// The maximum number of chords.
-    pub const MAX_CHORDS: usize = 0;
+    pub const CHORDED_MAX_CHORDS: usize = 0;
 
     /// The maximum number of overlapping chords for a chorded key.
-    pub const MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+    pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
 
     /// The tap-dance definitions.
-    pub const MAX_TAP_DANCE_DEFINITIONS: usize = 0;
+    pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;
 
     pub use smart_keymap::key::composite::Ref;
 

--- a/tests/ncl/keymap-48key-basic/expected.rs
+++ b/tests/ncl/keymap-48key-basic/expected.rs
@@ -3,19 +3,19 @@ pub mod init {
     use crate as smart_keymap;
 
     /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYER_COUNT: usize = 3;
+    pub const LAYERED_LAYER_COUNT: usize = 3;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 0;
+    pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
     /// The maximum number of chords.
-    pub const MAX_CHORDS: usize = 0;
+    pub const CHORDED_MAX_CHORDS: usize = 0;
 
     /// The maximum number of overlapping chords for a chorded key.
-    pub const MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+    pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
 
     /// The tap-dance definitions.
-    pub const MAX_TAP_DANCE_DEFINITIONS: usize = 0;
+    pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;
 
     pub use smart_keymap::key::composite::Ref;
 

--- a/tests/ncl/keymap-48key-rgoulter/expected.rs
+++ b/tests/ncl/keymap-48key-rgoulter/expected.rs
@@ -3,19 +3,19 @@ pub mod init {
     use crate as smart_keymap;
 
     /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYER_COUNT: usize = 8;
+    pub const LAYERED_LAYER_COUNT: usize = 8;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 2;
+    pub const CHORDED_MAX_CHORD_SIZE: usize = 2;
 
     /// The maximum number of chords.
-    pub const MAX_CHORDS: usize = 4;
+    pub const CHORDED_MAX_CHORDS: usize = 4;
 
     /// The maximum number of overlapping chords for a chorded key.
-    pub const MAX_OVERLAPPING_CHORD_SIZE: usize = 1;
+    pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 1;
 
     /// The tap-dance definitions.
-    pub const MAX_TAP_DANCE_DEFINITIONS: usize = 2;
+    pub const TAP_DANCE_MAX_DEFINITIONS: usize = 2;
 
     pub use smart_keymap::key::composite::Ref;
 

--- a/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
@@ -3,19 +3,19 @@ pub mod init {
     use crate as smart_keymap;
 
     /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYER_COUNT: usize = 0;
+    pub const LAYERED_LAYER_COUNT: usize = 0;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 0;
+    pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
     /// The maximum number of chords.
-    pub const MAX_CHORDS: usize = 0;
+    pub const CHORDED_MAX_CHORDS: usize = 0;
 
     /// The maximum number of overlapping chords for a chorded key.
-    pub const MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+    pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
 
     /// The tap-dance definitions.
-    pub const MAX_TAP_DANCE_DEFINITIONS: usize = 0;
+    pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;
 
     pub use smart_keymap::key::composite::Ref;
 

--- a/tests/ncl/keymap-60key-dvorak-simple/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple/expected.rs
@@ -3,19 +3,19 @@ pub mod init {
     use crate as smart_keymap;
 
     /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYER_COUNT: usize = 0;
+    pub const LAYERED_LAYER_COUNT: usize = 0;
 
     /// The maximum number of keys in a chord.
-    pub const MAX_CHORD_SIZE: usize = 0;
+    pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
     /// The maximum number of chords.
-    pub const MAX_CHORDS: usize = 0;
+    pub const CHORDED_MAX_CHORDS: usize = 0;
 
     /// The maximum number of overlapping chords for a chorded key.
-    pub const MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+    pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
 
     /// The tap-dance definitions.
-    pub const MAX_TAP_DANCE_DEFINITIONS: usize = 0;
+    pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;
 
     pub use smart_keymap::key::composite::Ref;
 


### PR DESCRIPTION
Prefix the const with the layer name.