### PR TITLE
Assert sizeof Event

### DIFF
--- a/src/key/callback.rs
+++ b/src/key/callback.rs
@@ -123,4 +123,9 @@ mod tests {
     fn test_sizeof_ref() {
         assert_eq!(1, core::mem::size_of::<Ref>());
     }
+
+    #[test]
+    fn test_sizeof_event() {
+        assert_eq!(0, core::mem::size_of::<Event>());
+    }
 }

--- a/src/key/caps_word.rs
+++ b/src/key/caps_word.rs
@@ -227,4 +227,9 @@ mod tests {
     fn test_sizeof_ref() {
         assert_eq!(0, core::mem::size_of::<Ref>());
     }
+
+    #[test]
+    fn test_sizeof_event() {
+        assert_eq!(1, core::mem::size_of::<Event>());
+    }
 }

--- a/src/key/chorded.rs
+++ b/src/key/chorded.rs
@@ -959,6 +959,11 @@ mod tests {
     }
 
     #[test]
+    fn test_sizeof_event() {
+        assert_eq!(2, core::mem::size_of::<Event>());
+    }
+
+    #[test]
     fn test_timeout_resolves_unsatisfied_aux_state_as_passthrough_key() {
         // Assemble: an Auxilary chorded key, and its PKS.
         let context = DEFAULT_CONTEXT;

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -1114,4 +1114,9 @@ mod tests {
     fn test_sizeof_ref() {
         assert_eq!(3, core::mem::size_of::<Ref>());
     }
+
+    #[test]
+    fn test_sizeof_event() {
+        assert_eq!(16, core::mem::size_of::<Event>());
+    }
 }

--- a/src/key/consumer.rs
+++ b/src/key/consumer.rs
@@ -105,4 +105,9 @@ mod tests {
     fn test_sizeof_ref() {
         assert_eq!(1, core::mem::size_of::<Ref>());
     }
+
+    #[test]
+    fn test_sizeof_event() {
+        assert_eq!(0, core::mem::size_of::<Event>());
+    }
 }

--- a/src/key/custom.rs
+++ b/src/key/custom.rs
@@ -102,4 +102,9 @@ mod tests {
     fn test_sizeof_ref() {
         assert_eq!(1, core::mem::size_of::<Ref>());
     }
+
+    #[test]
+    fn test_sizeof_event() {
+        assert_eq!(0, core::mem::size_of::<Event>());
+    }
 }

--- a/src/key/keyboard.rs
+++ b/src/key/keyboard.rs
@@ -177,4 +177,9 @@ mod tests {
     fn test_sizeof_ref() {
         assert_eq!(2, core::mem::size_of::<Ref>());
     }
+
+    #[test]
+    fn test_sizeof_event() {
+        assert_eq!(0, core::mem::size_of::<Event>());
+    }
 }

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -524,6 +524,11 @@ mod tests {
     }
 
     #[test]
+    fn test_sizeof_event() {
+        assert_eq!(16, core::mem::size_of::<LayerEvent>());
+    }
+
+    #[test]
     fn test_pressing_hold_modifier_key_emits_event_activate_layer() {
         let layer = 1;
         let key = ModifierKey::Hold(layer);

--- a/src/key/mouse.rs
+++ b/src/key/mouse.rs
@@ -158,4 +158,9 @@ mod tests {
     fn test_sizeof_ref() {
         assert_eq!(2, core::mem::size_of::<Ref>());
     }
+
+    #[test]
+    fn test_sizeof_event() {
+        assert_eq!(0, core::mem::size_of::<Event>());
+    }
 }

--- a/src/key/sticky.rs
+++ b/src/key/sticky.rs
@@ -449,4 +449,9 @@ mod tests {
     fn test_sizeof_ref() {
         assert_eq!(1, core::mem::size_of::<Ref>());
     }
+
+    #[test]
+    fn test_sizeof_event() {
+        assert_eq!(1, core::mem::size_of::<Event>());
+    }
 }

--- a/src/key/tap_dance.rs
+++ b/src/key/tap_dance.rs
@@ -295,4 +295,9 @@ mod tests {
     fn test_sizeof_ref() {
         assert_eq!(1, core::mem::size_of::<Ref>());
     }
+
+    #[test]
+    fn test_sizeof_event() {
+        assert_eq!(1, core::mem::size_of::<Event>());
+    }
 }

--- a/src/key/tap_hold.rs
+++ b/src/key/tap_hold.rs
@@ -391,4 +391,9 @@ mod tests {
     fn test_sizeof_ref() {
         assert_eq!(1, core::mem::size_of::<Ref>());
     }
+
+    #[test]
+    fn test_sizeof_event() {
+        assert_eq!(0, core::mem::size_of::<Event>());
+    }
 }


### PR DESCRIPTION
Same as #430, but for Event: this PR adds trivial unit tests asserting the size of various `Event` items.

That is: rationale for #430 is that `Ref` needs to be small. Rational for this PR is to clarify what the size of `Event` is, so that other impls. don't increase this unless they need to.