### PR TITLE
rust: keymap: don't cancel events for resolved key release

### DIFF
--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -590,9 +590,6 @@ where
                             _ => false,
                         })
                         .map(|i| self.pressed_inputs.remove(i));
-
-                    self.event_scheduler
-                        .cancel_events_for_keymap_index(keymap_index);
                 }
 
                 input::Event::VirtualKeyPress { key_output } => {


### PR DESCRIPTION
In support of #444.

Not *sure* about this.

The intention is so that e.g. timeout events don't affect the next key press. But, that's taken care of in the code for handling the keymap pending state.

For macro key / automation key, I *do* want the events which were scheduled by a previous key press to persist. Either with this, or with some other `key::Event` variant.