### PR TITLE
ncl: keymap-codegen: use "rust_expr" for Rust expression

### DIFF
--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -68,7 +68,7 @@
 
     is_json = fun json => 'Ok == json_validator json,
 
-    expr = fun b => "smart_keymap::key::KeyboardModifiers::from_byte(%{std.to_string b})",
+    rust_expr = fun b => "smart_keymap::key::KeyboardModifiers::from_byte(%{std.to_string b})",
   },
 
   composite = {

--- a/ncl/smart_keys/keyboard/keymap-codegen.ncl
+++ b/ncl/smart_keys/keyboard/keymap-codegen.ncl
@@ -73,9 +73,9 @@
                 { key_code } =>
                   "smart_keymap::key::keyboard::Key::new(%{std.to_string key_code})",
                 { modifiers } =>
-                  "smart_keymap::key::keyboard::Key::from_modifiers(%{keyboard_modifiers.expr modifiers})",
+                  "smart_keymap::key::keyboard::Key::from_modifiers(%{keyboard_modifiers.rust_expr modifiers})",
                 { key_code, modifiers } =>
-                  "smart_keymap::key::keyboard::Key::new_with_modifiers(%{std.to_string key_code}, %{keyboard_modifiers.expr modifiers})",
+                  "smart_keymap::key::keyboard::Key::new_with_modifiers(%{std.to_string key_code}, %{keyboard_modifiers.rust_expr modifiers})",
               },
           },
 
@@ -115,7 +115,7 @@
                 rust_expr = m%"
                 %{module}::Key {
                   key_code: %{std.to_string key_code},
-                  modifiers: %{keyboard_modifiers.expr modifiers},
+                  modifiers: %{keyboard_modifiers.rust_expr modifiers},
                 }
               "%,
               }

--- a/ncl/smart_keys/sticky/keymap-codegen.ncl
+++ b/ncl/smart_keys/sticky/keymap-codegen.ncl
@@ -41,7 +41,7 @@
               json
               |> match {
                 { sticky_modifiers } =>
-                  "%{module}::Key::new(%{keyboard_modifiers.expr sticky_modifiers})",
+                  "%{module}::Key::new(%{keyboard_modifiers.rust_expr sticky_modifiers})",
               },
           },
 


### PR DESCRIPTION
This PR renames the `keyboard_modifiers` `expr` field to `rust_expr`, bringing it in line with the rest of the code.