### PR TITLE
Nickel: codegen support key MouseOutput, KeyUsage, KeyOutput structs

### DIFF
--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -110,6 +110,39 @@
       "%,
   },
 
+  checks.check_key_usage = {
+    check_json_validation = {
+      actual = key_usage.json_validator { Keyboard = 4 },
+      expected = 'Ok,
+    },
+  },
+
+  key_usage = {
+    Json = std.contract.from_validator json_validator,
+
+    json_validator =
+      validators.record.validator {
+        fields_validator = validators.record.has_any_field_of ["Keyboard", "Consumer", "Custom", "MouseOutput"],
+        field_validators = {
+          Keyboard = validators.is_number,
+          Consumer = validators.is_number,
+          Custom = validators.is_number,
+          MouseOutput = mouse_output.json_validator,
+        },
+      },
+
+    is_json = fun json => 'Ok == json_validator json,
+
+    rust_expr = fun json =>
+      json
+      |> match {
+        { Keyboard } => "smart_keymap::key::KeyUsage::Keyboard(%{std.to_string Keyboard})",
+        { Consumer } => "smart_keymap::key::KeyUsage::Consumer(%{std.to_string Consumer})",
+        { Custom } => "smart_keymap::key::KeyUsage::Custom(%{std.to_string Custom})",
+        { MouseOutput } => "smart_keymap::key::KeyUsage::Mouse(%{mouse_output.rust_expr MouseOutput})",
+      },
+  },
+
   composite = {
     ref = {
       wrap = fun ref @ { module, json, rust_expr, .. } =>

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -143,6 +143,43 @@
       },
   },
 
+  checks.check_key_output = {
+    check_json_validation_of_key_code = {
+      actual = key_output.json_validator { key_code = { Keyboard = 4 } },
+      expected = 'Ok,
+    },
+  },
+
+  key_output = {
+    Json = std.contract.from_validator json_validator,
+
+    json_validator =
+      validators.record.validator {
+        fields_validator = validators.record.has_only_fields ["key_code", "modifiers"],
+        field_validators = {
+          key_code = key_usage.json_validator,
+          modifiers = keyboard_modifiers.json_validator,
+        },
+      },
+
+    is_json = fun json => 'Ok == json_validator json,
+
+    rust_expr = fun json =>
+      json
+      |> match {
+        { key_code } => "smart_keymap::key::KeyOutput::from_usage(%{key_usage.rust_expr key_code})",
+        { modifiers } =>
+          m%"smart_keymap::key::KeyOutput::from_key_modifiers(
+          %{keyboard_modifiers.rust_expr modifiers}
+        )"%,
+        { key_code, modifiers } =>
+          m%"smart_keymap::key::KeyOutput::from_usage_with_modifiers(
+              %{key_usage.rust_expr key_code},
+              %{keyboard_modifiers.rust_expr modifiers}
+            )"%,
+      },
+  },
+
   composite = {
     ref = {
       wrap = fun ref @ { module, json, rust_expr, .. } =>

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -71,6 +71,45 @@
     rust_expr = fun b => "smart_keymap::key::KeyboardModifiers::from_byte(%{std.to_string b})",
   },
 
+  mouse_output = {
+    Json = std.contract.from_validator json_validator,
+
+    json_validator =
+      validators.record.validator {
+        fields_validator = validators.record.has_only_fields ["pressed_buttons", "x", "y", "vertical_scroll", "horizontal_scroll"],
+        field_validators = {
+          pressed_buttons = validators.is_number,
+          x = validators.is_number,
+          y = validators.is_number,
+          vertical_scroll = validators.is_number,
+          horizontal_scroll = validators.is_number,
+        },
+      },
+
+    is_json = fun json => 'Ok == json_validator json,
+
+    rust_expr = fun json =>
+      let { pressed_buttons, x, y, vertical_scroll, horizontal_scroll } =
+        json
+        & {
+          pressed_buttons | default = 0,
+          x | default = 0,
+          y | default = 0,
+          vertical_scroll | default = 0,
+          horizontal_scroll | default = 0
+        }
+      in
+      m%"
+        smart_keymap::key::MouseOutput {
+          pressed_buttons: %{std.to_string json.pressed_buttons},
+          x: %{std.to_string json.x},
+          y: %{std.to_string json.y},
+          vertical_scroll: %{std.to_string json.vertical_scroll},
+          horizontal_scroll: %{std.to_string json.horizontal_scroll},
+        }
+      "%,
+  },
+
   composite = {
     ref = {
       wrap = fun ref @ { module, json, rust_expr, .. } =>


### PR DESCRIPTION
In support of #444.

Implements code with json validators, `rust_expr` for `key::MouseOutput`, `KeyUsage` and `KeyOutput`.