### PR TITLE
Nickel: keymap-ncl-to-json: implement `key.map_accum`

### DIFF
--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -113,6 +113,8 @@
     is_key = fun k => 'Ok == key_validator k,
 
     to_json_value = fun k => null,
+
+    map_accum = fun f acc k => f acc k,
   },
 
   keymap_ncl.key = {
@@ -151,6 +153,10 @@
     to_json_value = fun k =>
       let km = key_module_for_value k in
       km.to_json_value k,
+
+    map_accum = fun f acc k =>
+      let km = key_module_for_value k in
+      km.map_accum f acc k,
   },
 
   keymap_ncl.nullable_key = {
@@ -170,6 +176,13 @@
       k if keymap_ncl.null_.is_key k => keymap_ncl.null_.to_json_value k,
       _ => std.fail_with "unsupported nullable_key item in keymap.ncl",
     },
+
+    map_accum = fun f acc k =>
+      match {
+        k if keymap_ncl.key.is_key k => keymap_ncl.key.map_accum f acc k,
+        k if keymap_ncl.null_.is_key k => keymap_ncl.null_.map_accum f acc k,
+        _ => std.fail_with "unsupported nullable_key item in keymap.ncl",
+      },
   },
 
   checks.check_words_from_whitespace_delimited_string = {

--- a/ncl/smart_keys/callback/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/callback/keymap-ncl-to-json.ncl
@@ -18,5 +18,7 @@
       is_key = fun k => 'Ok == key_validator k,
 
       to_json_value = fun key => key,
+
+      map_accum = fun f acc k => f acc k,
     },
 }

--- a/ncl/smart_keys/caps_word/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/caps_word/keymap-ncl-to-json.ncl
@@ -16,5 +16,7 @@
       is_key = fun k => 'Ok == key_validator k,
 
       to_json_value = fun key => key,
+
+      map_accum = fun f acc k => f acc k,
     },
 }

--- a/ncl/smart_keys/chorded/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/chorded/keymap-ncl-to-json.ncl
@@ -32,6 +32,20 @@
           chords = chords_ |> std.array.map (fun [i, chord_key] => [i, keymap_ncl.key.to_json_value chord_key]),
           passthrough = keymap_ncl.key.to_json_value passthrough_key,
         },
+
+      map_accum = fun f acc k @ { chords, passthrough } =>
+        let { acc, chords } =
+          chords
+          |> std.array.fold_left
+            (fun { acc, chords } [i, k] =>
+              let { acc, k } = f acc k in
+              let chords = chords @ [[i, k]] in
+              { include acc, include chords }
+            )
+            { include acc, chords = [] }
+        in
+        let { acc, k = passthrough } = f acc passthrough in
+        { include acc, k = { include chords, include passthrough, }, },
     },
 
   keymap_ncl.chorded_aux
@@ -52,5 +66,9 @@
         {
           passthrough = keymap_ncl.key.to_json_value passthrough_key,
         },
+
+      map_accum = fun f acc k @ { passthrough } =>
+        let { acc, k = passthrough } = f acc passthrough in
+        { include acc, k = { include passthrough }, },
     },
 }

--- a/ncl/smart_keys/consumer/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/consumer/keymap-ncl-to-json.ncl
@@ -18,5 +18,7 @@
       is_key = fun k => 'Ok == key_validator k,
 
       to_json_value = fun k => k,
+
+      map_accum = fun f acc k => f acc k,
     },
 }

--- a/ncl/smart_keys/custom/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/custom/keymap-ncl-to-json.ncl
@@ -16,5 +16,7 @@
       is_key = fun k => 'Ok == key_validator k,
 
       to_json_value = fun key => key,
+
+      map_accum = fun f acc k => f acc k,
     },
 }

--- a/ncl/smart_keys/keyboard/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/keyboard/keymap-ncl-to-json.ncl
@@ -41,5 +41,7 @@
         { modifiers = km, ..k } => k & { modifiers = keyboard_modifiers.to_json_value km },
         k => k,
       },
+
+      map_accum = fun f acc k => f acc k,
     },
 }

--- a/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
@@ -59,7 +59,9 @@
             in
             { SetActiveLayers = active_layers_bitset },
           _ => 'Error { message = "expected { layer_modifier = { default_ } } or { layer_modifier = { hold } } or { layer_modifier = { toggle } }" },
-        }
+        },
+
+      map_accum = fun f acc k => f acc k,
     },
 
   checks.layered =
@@ -132,5 +134,20 @@
               (fun k => if k != null then keymap_ncl.key.to_json_value k else null)
               layered_keys,
         },
+
+      map_accum = fun f acc k @ { layered, ..base_key } =>
+        let { acc, layered } =
+          layered
+          |> std.array.fold_left
+            (fun { acc, layered } k =>
+              let { acc, k } = f acc k in
+              let layered = layered @ [k] in
+              { include acc, include layered }
+            )
+            { include acc, layered = [] }
+        in
+        let { acc, k = base_key } = f acc base_key in
+        # n.b.: `.. base_key` results in format error.
+        { include acc, k = { include layered, } & base_key, },
     },
 }

--- a/ncl/smart_keys/mouse/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/mouse/keymap-ncl-to-json.ncl
@@ -25,5 +25,7 @@
       is_key = fun k => 'Ok == key_validator k,
 
       to_json_value = fun k => k,
+
+      map_accum = fun f acc k => f acc k,
     },
 }

--- a/ncl/smart_keys/sticky/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/sticky/keymap-ncl-to-json.ncl
@@ -44,5 +44,7 @@
       is_key = fun k => 'Ok == key_validator k,
 
       to_json_value = fun { sticky_modifiers = sm } => { sticky_modifiers = keyboard_modifiers.to_json_value sm },
+
+      map_accum = fun f acc k => f acc k,
     },
 }

--- a/ncl/smart_keys/tap_dance/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/tap_dance/keymap-ncl-to-json.ncl
@@ -31,5 +31,26 @@
         {
           definitions = [keymap_ncl.key.to_json_value tap_key] @ (std.array.map keymap_ncl.key.to_json_value tap_dances),
         },
-    },
+
+      map_accum = fun f acc k @ { tap_dances, ..tap_key } =>
+        let { acc, tap_dances } =
+          tap_dances
+          |> std.array.fold_left
+            (fun { acc, tap_dances } k =>
+              let { acc, k } = f acc k in
+              let tap_dances = tap_dances @ [k] in
+              { include acc, include tap_dances }
+            )
+            { include acc, tap_dances = [] }
+        in
+        let { acc, k = tap_key } = f acc tap_key in
+        {
+          include acc,
+          k =
+            {
+              include tap_dances,
+            }
+            & tap_key,
+        },
+    }
 }

--- a/ncl/smart_keys/tap_hold/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/tap_hold/keymap-ncl-to-json.ncl
@@ -71,5 +71,17 @@
           hold = keymap_ncl.key.to_json_value hold_key,
           tap = keymap_ncl.key.to_json_value tap_key,
         },
+
+      map_accum = fun f acc k @ { hold = hold_key, ..tap_key } =>
+        let { acc, k = tap_key } = f acc tap_key in
+        let { acc, k = hold_key } = f acc hold_key in
+        {
+          include acc,
+          k =
+            {
+              hold = hold_key,
+            }
+            & tap_key,
+        },
     },
 }


### PR DESCRIPTION
In support of #444.

This PR adds a `map_accum` function to the key modules for `keymap_ncl`.

"map accum" is a stateful map: it maps both the value, as well as an accumulated value.

The use case in #444 is to accumulate the automation key instructions from the keymap_ncl automation keys (and map the automation keys with the instruction executions start+length).