### PR TITLE
Nickel: key-extensions: add " " as literal alias to Space

### DIFF
--- a/ncl/smart_keys/keyboard/key-extensions.ncl
+++ b/ncl/smart_keys/keyboard/key-extensions.ncl
@@ -191,6 +191,8 @@
       "<" = keys.LeftAngleBracket,
       "." = keys.Dot,
       ">" = keys.RightAngleBracket,
+
+      " " = keys.Space,
     },
 
     shifted = {


### PR DESCRIPTION
In support of #444.

It's useful to have `" "` as a literal alias for string macros.