### PR TITLE
Sticky Layer Modifier

### DIFF
--- a/features/keymap/key/layer_modifier-sticky.feature
+++ b/features/keymap/key/layer_modifier-sticky.feature
@@ -1,0 +1,79 @@
+Feature: Layer Modifier: Sticky
+
+  The `K.layer_mod.sticky` key activates a layer in a similar manner to sticky key modifiers:
+
+  - tapping the sticky layer modifier activates the layer for the next key press.
+  - holding the sticky layer modifier activates the layer, similar to `K.layer_mod.hold`.
+
+  For examples of this feature in other smart keyboard firmware, see e.g.:
+
+  - [QMK's OSL(layer)](https://docs.qmk.fm/feature_layers#switching-and-toggling-layers),
+
+  - [ZMK's "sticky layer" behaviour](https://zmk.dev/docs/keymaps/behaviors/sticky-layer)
+
+  Background:
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+          layers = [
+              [K.layer_mod.sticky 1, K.A, K.B],
+              [K.TTTT, K.X, K.Y],
+          ],
+      }
+      """
+
+  Example: tapping sticky layer modifier activates the later for the next pressed key
+
+    When the keymap registers the following input
+      """
+      [
+        tap (K.layer_mod.sticky 1),
+        tap_keymap_index 1,
+        tap_keymap_index 2,
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        tap (K.X),
+        tap (K.B),
+      ]
+      """
+
+  Example: tapping sticky layer modifier activates the layer only for the next pressed key
+
+    When the keymap registers the following input
+      """
+      [
+        tap (K.layer_mod.sticky 1),
+        press_keymap_index 1,
+        press_keymap_index 2,
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        press (K.X),
+        press (K.B),
+      ]
+      """
+
+  Example: pressing sticky layer modifier activates the layer
+
+    When the keymap registers the following input
+      """
+      [
+        press (K.layer_mod.sticky 1),
+        tap_keymap_index 1,
+        tap_keymap_index 2,
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        tap (K.X),
+        tap (K.Y),
+      ]
+      """

--- a/features/scripts/generate-doc.sh
+++ b/features/scripts/generate-doc.sh
@@ -23,6 +23,7 @@ keymap_key_features=(
     "layer_modifier-default"
     "layer_modifier-hold"
     "layer_modifier-set_active_layers"
+    "layer_modifier-sticky"
     "layer_modifier-toggle"
     "mouse"
     "sticky_modifiers"

--- a/ncl/smart_keys/layered/key-extensions.ncl
+++ b/ncl/smart_keys/layered/key-extensions.ncl
@@ -13,6 +13,10 @@
         {
           layer_modifier = { toggle = layer_num }
         },
+      sticky = fun layer_num =>
+        {
+          layer_modifier = { sticky = layer_num }
+        },
       set_active_layers_to = fun active_layers =>
         {
           layer_modifier = { set_active_layers_to = active_layers }

--- a/ncl/smart_keys/layered/keymap-codegen.ncl
+++ b/ncl/smart_keys/layered/keymap-codegen.ncl
@@ -90,12 +90,13 @@
           validators.record.validator {
             fields_validator =
               validators.all_of [
-                validators.record.has_any_field_of ["Default", "Hold", "SetActiveLayers", "Toggle"],
-                validators.record.has_only_fields ["Default", "Hold", "SetActiveLayers", "Toggle"],
+                validators.record.has_any_field_of ["Default", "Hold", "Sticky", "SetActiveLayers", "Toggle"],
+                validators.record.has_only_fields ["Default", "Hold", "Sticky", "SetActiveLayers", "Toggle"],
               ],
             field_validators = {
               Hold = validators.is_number,
               Toggle = validators.is_number,
+              Sticky = validators.is_number,
               SetActiveLayers = validators.is_number,
             },
           },
@@ -128,6 +129,14 @@
                 include key_type,
                 variant = "Toggle",
                 rust_expr = "%{module}::ModifierKey::toggle(%{std.to_string layer_index})",
+              },
+            { Sticky = layer_index } =>
+              {
+                include json,
+                include module,
+                include key_type,
+                variant = "Sticky",
+                rust_expr = "%{module}::ModifierKey::sticky(%{std.to_string layer_index})",
               },
             { SetActiveLayers = active_layers_bitset } =>
               {

--- a/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
@@ -35,6 +35,7 @@
         |> match {
           { layer_modifier = { default_ } } => validators.is_number default_,
           { layer_modifier = { hold } } => validators.is_number hold,
+          { layer_modifier = { sticky } } => validators.is_number sticky,
           { layer_modifier = { toggle } } => validators.all_of [validators.is_number, validators.is_greater_than 0] toggle,
           { layer_modifier = { set_active_layers_to } } => (validators.array.validator validators.is_number) set_active_layers_to,
           _ => 'Error { message = "expected { layer_modifier = { default_ } } or { layer_modifier = { hold } } or { layer_modifier = { toggle } }" },
@@ -51,6 +52,8 @@
             { Hold = hold_layer },
           { layer_modifier = { toggle = toggle_layer } } =>
             { Toggle = toggle_layer },
+          { layer_modifier = { sticky = sticky_layer } } =>
+            { Sticky = sticky_layer },
           { layer_modifier = { set_active_layers_to = active_layers } } =>
             let active_layers_bitset =
               active_layers

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -207,6 +207,9 @@ impl<const LAYER_COUNT: usize> Context<LAYER_COUNT> {
             LayerEvent::Deactivated(layer) => {
                 self.active_layers.deactivate(layer);
             }
+            LayerEvent::StickyActivated(layer) => {
+                self.active_layers.activate(layer, ActivationStyle::Sticky);
+            }
             LayerEvent::Toggled(layer) => {
                 if self.active_layers[layer as usize - 1].is_active() {
                     self.active_layers.deactivate(layer);
@@ -377,6 +380,8 @@ pub enum LayerEvent {
     Deactivated(LayerIndex),
     /// Toggles the given layer.
     Toggled(LayerIndex),
+    /// Activates the given layer.
+    StickyActivated(LayerIndex),
     /// Sets the active layers to the given set of layers.
     Set(LayerBitset),
     /// Changes the default layer.

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -85,12 +85,14 @@ impl ModifierKey {
     /// Pressing a [ModifierKey::Hold] emits a [LayerEvent::Activated] event.
     pub fn new_pressed_key(&self) -> (ModifierKeyState, LayerEvent) {
         match self {
-            ModifierKey::Hold(layer) => (ModifierKeyState, LayerEvent::Activated(*layer)),
-            ModifierKey::Toggle(layer) => (ModifierKeyState, LayerEvent::Toggled(*layer)),
+            ModifierKey::Hold(layer) => (ModifierKeyState::new(), LayerEvent::Activated(*layer)),
+            ModifierKey::Toggle(layer) => (ModifierKeyState::new(), LayerEvent::Toggled(*layer)),
             ModifierKey::SetActiveLayers(layer_set) => {
-                (ModifierKeyState, LayerEvent::Set(*layer_set))
+                (ModifierKeyState::new(), LayerEvent::Set(*layer_set))
             }
-            ModifierKey::Default(layer) => (ModifierKeyState, LayerEvent::SetDefault(*layer)),
+            ModifierKey::Default(layer) => {
+                (ModifierKeyState::new(), LayerEvent::SetDefault(*layer))
+            }
         }
     }
 }
@@ -392,11 +394,36 @@ pub enum LayerEvent {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PendingKeyState;
 
+/// Whether the pressed Sticky modifier key is "sticky" or "regular".
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum Behavior {
+    /// Key state is "sticky". (Will activate sticky modifier when released).
+    Sticky,
+    /// Key state is "regular". (No sticky modifiers activated when released).
+    Regular,
+}
+
 /// [crate::key::KeyState] of [ModifierKey].
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct ModifierKeyState;
+pub struct ModifierKeyState {
+    behavior: Behavior,
+}
 
 impl ModifierKeyState {
+    /// Constructs a regular ModifierKeyState
+    pub fn new() -> Self {
+        Self {
+            behavior: Behavior::Regular,
+        }
+    }
+
+    /// Constructs a sticky ModifierKeyState
+    pub fn sticky() -> Self {
+        Self {
+            behavior: Behavior::Sticky,
+        }
+    }
+
     /// Handle the given event for the given key.
     pub fn handle_event(
         &mut self,

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -104,6 +104,11 @@ impl From<LayerEvent> for () {
 pub enum ActivationStyle {
     /// Regular layer activation.
     Regular,
+    /// Sticky layer activation.
+    ///
+    /// Sticky layer activation is similar to sticky key modifiers.
+    /// The sticky layer activation is implemented using the sticky layer modifier key.
+    Sticky,
 }
 
 /// State of an individual layer: active or inactive.

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -50,6 +50,11 @@ impl ModifierKey {
         ModifierKey::Hold(layer)
     }
 
+    /// Create a new [ModifierKey] that activates the layer when held, or makes it sticky when tapped.
+    pub const fn sticky(layer: LayerIndex) -> Self {
+        ModifierKey::Sticky(layer)
+    }
+
     /// Create a new [ModifierKey] that toggles the given layer.
     pub const fn toggle(layer: LayerIndex) -> Self {
         ModifierKey::Toggle(layer)

--- a/tests/rust/layered.rs
+++ b/tests/rust/layered.rs
@@ -1,4 +1,5 @@
 mod set_active_layers;
+mod sticky;
 mod tap_hold;
 mod toggle;
 

--- a/tests/rust/layered/sticky.rs
+++ b/tests/rust/layered/sticky.rs
@@ -1,0 +1,186 @@
+use smart_keymap::input;
+use smart_keymap::keymap::ObservedKeymap;
+
+use smart_keymap_macros::keymap;
+
+#[test]
+fn next_press_after_tapping_sticky_layer_press_is_modified() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                layers = [
+                    [K.layer_mod.sticky 1, K.A, K.B],
+                    [K.TTTT, K.K, K.L],
+                ],
+            }
+        "#
+    ));
+
+    // Act
+    // Tap Sticky Layer Modifier
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+
+    // Press second key
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert
+    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0x0E, 0, 0, 0, 0, 0]];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn only_next_press_after_tapping_sticky_layer_press_is_modified() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                layers = [
+                    [K.layer_mod.sticky 1, K.A, K.B],
+                    [K.TTTT, K.K, K.L],
+                ],
+            }
+        "#
+    ));
+
+    // Act
+    // Tap Sticky Layer Modifier
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+
+    // Tap second key
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+
+    // Press second key, again
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x0E, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x04, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn interrupting_sticky_layer_press_acts_as_hold_modifier() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                layers = [
+                    [K.layer_mod.sticky 1, K.A, K.B],
+                    [K.TTTT, K.K, K.L],
+                ],
+            }
+        "#
+    ));
+
+    // Act
+    // Press Sticky Layer Modifier
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+
+    // Interrupt it by pressing second key
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert
+    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0x0E, 0, 0, 0, 0, 0]];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn interrupting_sticky_layer_press_acts_as_hold_modifier_while_held() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                layers = [
+                    [K.layer_mod.sticky 1, K.A, K.B],
+                    [K.TTTT, K.K, K.L],
+                ],
+            }
+        "#
+    ));
+
+    // Act
+    // Press Sticky Layer Modifier
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+
+    // Interrupt it by tapping second key
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+
+    // Sticky modifier still held, press third key.
+    keymap.handle_input(input::Event::Press { keymap_index: 2 });
+
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x0E, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x0F, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn interrupting_sticky_layer_press_acts_as_hold_modifier_until_released() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                layers = [
+                    [K.layer_mod.sticky 1, K.A, K.B],
+                    [K.TTTT, K.K, K.L],
+                ],
+            }
+        "#
+    ));
+
+    // Act
+    // Press Sticky Layer Modifier
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+
+    // Interrupt it by tapping second key
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+
+    // Release Sticky Layer Modifier
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+
+    // Press third key.
+    keymap.handle_input(input::Event::Press { keymap_index: 2 });
+
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x0E, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0x05, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}


### PR DESCRIPTION
Some other keyboard firmwares implement "sticky layer" functionality. Similar to sticky modifier keys: tap activates the modifier for the next key press, holding it acts as a regular (hold) modifier.

This PR implements this functionality for `smart-keymap`.