### PR TITLE
firmware: ch58x: set ms per tick for BLE firmware

### DIFF
--- a/firmware/ch58x-ble-hid-keyboard-c/APP/hidkbd.c
+++ b/firmware/ch58x-ble-hid-keyboard-c/APP/hidkbd.c
@@ -263,6 +263,9 @@ void HidEmu_Init() {
   // SmartKeymap
   keyboard_init();
   keymap_init();
+  // keymap_tick is called in HidEmu_ProcessEvent's START_KEYMAP_TICK_EVT,
+  // which is invoked by TMOS every 13 * 625 microseconds = 8.125ms.
+  keymap_set_ms_per_tick(8);
 }
 
 /*********************************************************************


### PR DESCRIPTION
The CH58x firmware calls `keymap_tick` every 8ms (as explained in the comment).

So, the keymap should be configured with `keymap_set_ms_per_tick`.