### PR TITLE
Cucumber: refactor input enum

### DIFF
--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -48,7 +48,7 @@ enum LoadedKeymap {
 }
 
 impl LoadedKeymap {
-    pub fn keymap(keymap: Keymap) -> Self {
+    pub fn new(keymap: Keymap) -> Self {
         LoadedKeymap::Keymap {
             keymap: ObservedKeymap::new(keymap),
         }
@@ -205,7 +205,7 @@ fn load_keymap(keymap_ncl: &str) -> Keymap {
 fn setup_nickel_keymap(world: &mut KeymapWorld, step: &Step) {
     let keymap_ncl = step.docstring().unwrap();
     world.keymap_ncl = keymap_ncl.into();
-    world.keymap = LoadedKeymap::keymap(load_keymap(keymap_ncl));
+    world.keymap = LoadedKeymap::new(load_keymap(keymap_ncl));
 }
 
 fn inputs_from_ncl(keymap_ncl: &str, inputs_ncl: &str) -> Vec<input::Event> {

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -61,15 +61,6 @@ impl LoadedKeymap {
         }
     }
 
-    pub fn handle_input(&mut self, ev: input::Event) {
-        match self {
-            LoadedKeymap::Keymap { keymap } => {
-                keymap.handle_input(ev);
-            }
-            _ => panic!("No keymap loaded"),
-        }
-    }
-
     pub fn tick(&mut self) {
         match self {
             LoadedKeymap::Keymap { keymap } => {
@@ -208,6 +199,12 @@ fn load_keymap(keymap_ncl: &str) -> Keymap {
     }
 }
 
+fn handle_inputs(keymap: &mut ObservedKeymap, inputs: &[input::Event]) {
+    for &input in inputs {
+        keymap.handle_input(input);
+    }
+}
+
 #[given("a keymap.ncl:")]
 fn setup_nickel_keymap(world: &mut KeymapWorld, step: &Step) {
     let keymap_ncl = step.docstring().unwrap();
@@ -249,9 +246,7 @@ fn perform_input(world: &mut KeymapWorld, step: &Step) {
     let inputs_ncl = step.docstring().unwrap();
     let inputs = inputs_from_ncl(world.keymap_ncl.as_str(), inputs_ncl);
 
-    for input in inputs {
-        world.keymap.handle_input(input);
-    }
+    handle_inputs(world.keymap.keymap(), &inputs);
 }
 
 #[when(expr = "the keymap ticks {int} times")]
@@ -305,9 +300,7 @@ fn check_report_equivalences(world: &mut KeymapWorld, step: &Step) {
     let inputs_ncl = step.docstring().unwrap();
     let inputs = inputs_from_ncl(TEST_KEYMAP_NCL, inputs_ncl);
 
-    for input in inputs {
-        test_keymap.handle_input(input);
-    }
+    handle_inputs(&mut test_keymap, &inputs);
 
     world.keymap.tick_until_no_scheduled_events();
 

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -205,9 +205,16 @@ enum Input {
     Release { keymap_index: u16 },
 }
 
-fn handle_inputs(keymap: &mut ObservedKeymap, inputs: &[input::Event]) {
+fn handle_inputs(keymap: &mut ObservedKeymap, inputs: &[Input]) {
     for &input in inputs {
-        keymap.handle_input(input);
+        match input {
+            Input::Press { keymap_index } => {
+                keymap.handle_input(input::Event::Press { keymap_index })
+            }
+            Input::Release { keymap_index } => {
+                keymap.handle_input(input::Event::Release { keymap_index })
+            }
+        }
     }
 }
 
@@ -218,14 +225,14 @@ fn setup_nickel_keymap(world: &mut KeymapWorld, step: &Step) {
     world.keymap = LoadedKeymap::new(load_keymap(keymap_ncl));
 }
 
-fn inputs_from_ncl(keymap_ncl: &str, inputs_ncl: &str) -> Vec<input::Event> {
+fn inputs_from_ncl(keymap_ncl: &str, inputs_ncl: &str) -> Vec<Input> {
     match nickel_json_value_for_inputs(
         format!("{}/ncl", env!("CARGO_MANIFEST_DIR")),
         keymap_ncl,
         inputs_ncl,
     ) {
         Ok(json) => {
-            let inputs_result: serde_json::Result<Vec<input::Event>> = serde_json::from_str(&json);
+            let inputs_result: serde_json::Result<Vec<Input>> = serde_json::from_str(&json);
             match inputs_result {
                 Ok(inputs) => inputs,
                 Err(e) => {

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -199,6 +199,12 @@ fn load_keymap(keymap_ncl: &str) -> Keymap {
     }
 }
 
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+enum Input {
+    Press { keymap_index: u16 },
+    Release { keymap_index: u16 },
+}
+
 fn handle_inputs(keymap: &mut ObservedKeymap, inputs: &[input::Event]) {
     for &input in inputs {
         keymap.handle_input(input);

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -54,6 +54,13 @@ impl LoadedKeymap {
         }
     }
 
+    pub fn keymap(&mut self) -> &mut ObservedKeymap {
+        match self {
+            LoadedKeymap::Keymap { keymap, .. } => keymap,
+            _ => panic!("No keymap loaded"),
+        }
+    }
+
     pub fn handle_input(&mut self, ev: input::Event) {
         match self {
             LoadedKeymap::Keymap { keymap } => {


### PR DESCRIPTION
This PR refactors the Cucumber test suite's input enum, using its own `Input` rather than the `smart_keymap::input::Event`.