### PR TITLE
Cucumber: support more inputs

### DIFF
--- a/ncl/inputs-to-json.ncl
+++ b/ncl/inputs-to-json.ncl
@@ -42,6 +42,11 @@
       |> match {
         'Press k => { Press = { keymap_index = (lookup_keymap_index layer_state k) } },
         'Release k => { Release = { keymap_index = (lookup_keymap_index layer_state k) } },
+        'Tap k => { Tap = { keymap_index = (lookup_keymap_index layer_state k) } },
+        'PressKeymapIndex keymap_index => { Press = { include keymap_index } },
+        'ReleaseKeymapIndex keymap_index => { Press = { include keymap_index } },
+        'TapKeymapIndex keymap_index => { Tap = { include keymap_index } },
+        'Wait duration => { Wait = { include duration } },
       }
     in
     let initial_layer_state =

--- a/ncl/inputs.ncl
+++ b/ncl/inputs.ncl
@@ -1,4 +1,9 @@
 {
   press = fun k => 'Press k,
   release = fun k => 'Release k,
+  tap = fun k => 'Tap k,
+  press_keymap_index = fun kmi => 'PressKeymapIndex kmi,
+  release_keymap_index = fun kmi => 'ReleaseKeymapIndex kmi,
+  tap_keymap_index = fun kmi => 'TapKeymapIndex kmi,
+  wait = fun duration => 'Wait duration,
 }

--- a/smart-keymap-nickel-helper/src/lib.rs
+++ b/smart-keymap-nickel-helper/src/lib.rs
@@ -288,7 +288,16 @@ pub fn nickel_json_value_for_inputs(
                            & ({{
                                  inputs =
                                     let K = import "keys.ncl" in
-                                    let {{ press, release, .. }} = import "inputs.ncl" in
+                                    let {{
+                                      press,
+                                      press_keymap_index,
+                                      release,
+                                      release_keymap_index,
+                                      tap,
+                                      tap_keymap_index,
+                                      wait,
+                                      ..
+                                    }} = import "inputs.ncl" in
                                     {},
                               }})
                         "#,

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -203,6 +203,8 @@ fn load_keymap(keymap_ncl: &str) -> Keymap {
 enum Input {
     Press { keymap_index: u16 },
     Release { keymap_index: u16 },
+    Tap { keymap_index: u16 },
+    Wait { duration: u16 },
 }
 
 fn handle_inputs(keymap: &mut ObservedKeymap, inputs: &[Input]) {
@@ -213,6 +215,15 @@ fn handle_inputs(keymap: &mut ObservedKeymap, inputs: &[Input]) {
             }
             Input::Release { keymap_index } => {
                 keymap.handle_input(input::Event::Release { keymap_index })
+            }
+            Input::Tap { keymap_index } => {
+                keymap.handle_input(input::Event::Press { keymap_index });
+                keymap.handle_input(input::Event::Release { keymap_index });
+            }
+            Input::Wait { duration } => {
+                for _ in 0..duration {
+                    keymap.tick();
+                }
             }
         }
     }


### PR DESCRIPTION
Following #464 and #465 refactoring, this PR adds more inputs to the Cucumber test suite.

This will support writing more concise Cucumber specs, such as using 'tap' instead of 'press, release', and using 'wait' (rather than having a separate step to tick the keymap).