### PR TITLE
Refactor Rust integration tests to use ObservedKeymap

### DIFF
--- a/tests/rust/automation.rs
+++ b/tests/rust/automation.rs
@@ -1,3 +1,5 @@
+use smart_keymap::keymap::ObservedKeymap;
+
 #[test]
 fn test_simple_1char_string_macro() {
     // This test demonstrates using smart_keymap::keymap::Keymap directly,
@@ -5,11 +7,8 @@ fn test_simple_1char_string_macro() {
 
     // Assemble
     use smart_keymap::input;
-    use smart_keymap::keymap;
 
-    use keymap::DistinctReports;
-
-    let mut keymap = smart_keymap_macros::keymap!(
+    let mut keymap = ObservedKeymap::new(smart_keymap_macros::keymap!(
         r#"
         let K = import "keys.ncl" in
 
@@ -20,19 +19,13 @@ fn test_simple_1char_string_macro() {
             ],
         }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act -- tap macro key
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     #[rustfmt::skip]
@@ -41,6 +34,7 @@ fn test_simple_1char_string_macro() {
         [0, 0, 0x04, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
@@ -51,11 +45,8 @@ fn test_simple_string_macro() {
 
     // Assemble
     use smart_keymap::input;
-    use smart_keymap::keymap;
 
-    use keymap::DistinctReports;
-
-    let mut keymap = smart_keymap_macros::keymap!(
+    let mut keymap = ObservedKeymap::new(smart_keymap_macros::keymap!(
         r#"
         let K = import "keys.ncl" in
 
@@ -66,19 +57,13 @@ fn test_simple_string_macro() {
             ],
         }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act -- tap macro key
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     #[rustfmt::skip]
@@ -91,5 +76,6 @@ fn test_simple_string_macro() {
         [0, 0, 0x06, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }

--- a/tests/rust/chorded/over_layered_tap_hold.rs
+++ b/tests/rust/chorded/over_layered_tap_hold.rs
@@ -1,14 +1,12 @@
 use smart_keymap::input;
-use smart_keymap::keymap;
+use smart_keymap::keymap::ObservedKeymap;
 
 use smart_keymap_macros::keymap;
-
-use keymap::DistinctReports;
 
 #[test]
 fn tap_key_after_tapping_chord_on_default_layer() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             let CH = import "chording.ncl" in
@@ -22,35 +20,20 @@ fn tap_key_after_tapping_chord_on_default_layer() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     // - Default layer,
     // - Press chord (01), release chord.
     // - Press letter.
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Release { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Press { keymap_index: 2 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Release { keymap_index: 2 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     #[rustfmt::skip]
@@ -61,13 +44,14 @@ fn tap_key_after_tapping_chord_on_default_layer() {
         [0, 0, 0x06, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn tap_key_after_tapping_chord_on_layer_1() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             let CH = import "chording.ncl" in
@@ -81,41 +65,22 @@ fn tap_key_after_tapping_chord_on_layer_1() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     // - Set default layer to 1
     // - Press chord (01), release chord.
     // - Press letter.
     keymap.handle_input(input::Event::Press { keymap_index: 3 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Press { keymap_index: 3 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Release { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Press { keymap_index: 2 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Release { keymap_index: 2 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     #[rustfmt::skip]
@@ -126,13 +91,14 @@ fn tap_key_after_tapping_chord_on_layer_1() {
         [0, 0, 0x07, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn tap_chorded_key_passes_through_as_tap() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             let CH = import "chording.ncl" in
@@ -146,23 +112,16 @@ fn tap_chorded_key_passes_through_as_tap() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     // - Default layer,
     // - Press chord (01), release chord.
     // - Press letter.
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     #[rustfmt::skip]
@@ -171,13 +130,14 @@ fn tap_chorded_key_passes_through_as_tap() {
         [0, 0, 0x04, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn tap_key_after_tapping_chorded_key_on_layer_1() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             let CH = import "chording.ncl" in
@@ -191,35 +151,20 @@ fn tap_key_after_tapping_chorded_key_on_layer_1() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     // - Set default layer to 1
     // - Press chord (01), release chord.
     // - Press letter.
     keymap.handle_input(input::Event::Press { keymap_index: 3 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Press { keymap_index: 3 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Press { keymap_index: 2 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Release { keymap_index: 2 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     #[rustfmt::skip]
@@ -230,5 +175,6 @@ fn tap_key_after_tapping_chorded_key_on_layer_1() {
         [0, 0, 0x07, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }

--- a/tests/rust/chorded/overlapping_aux.rs
+++ b/tests/rust/chorded/overlapping_aux.rs
@@ -1,14 +1,12 @@
 use smart_keymap::input;
-use smart_keymap::keymap;
+use smart_keymap::keymap::ObservedKeymap;
 
 use smart_keymap_macros::keymap;
-
-use keymap::DistinctReports;
 
 #[test]
 fn overlap_aux_press_ad_results_chord() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             let CH = import "chording.ncl" in
@@ -23,8 +21,7 @@ fn overlap_aux_press_ad_results_chord() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     // Press AD
@@ -32,23 +29,20 @@ fn overlap_aux_press_ad_results_chord() {
 
     for &keymap_index in press_indices {
         keymap.handle_input(input::Event::Press { keymap_index });
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     }
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0x10, 0, 0, 0, 0, 0]];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn overlap_aux_press_cd_results_chord() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             let CH = import "chording.ncl" in
@@ -63,8 +57,7 @@ fn overlap_aux_press_cd_results_chord() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     // Press CD
@@ -72,23 +65,20 @@ fn overlap_aux_press_cd_results_chord() {
 
     for &keymap_index in press_indices {
         keymap.handle_input(input::Event::Press { keymap_index });
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     }
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0x12, 0, 0, 0, 0, 0]];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn overlap_aux_press_abd_results_chord() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             let CH = import "chording.ncl" in
@@ -103,8 +93,7 @@ fn overlap_aux_press_abd_results_chord() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     // Press AD
@@ -112,15 +101,12 @@ fn overlap_aux_press_abd_results_chord() {
 
     for &keymap_index in press_indices {
         keymap.handle_input(input::Event::Press { keymap_index });
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     }
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0x11, 0, 0, 0, 0, 0]];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }

--- a/tests/rust/chorded/overlapping_simultaneous.rs
+++ b/tests/rust/chorded/overlapping_simultaneous.rs
@@ -1,14 +1,12 @@
 use smart_keymap::input;
-use smart_keymap::keymap;
+use smart_keymap::keymap::ObservedKeymap;
 
 use smart_keymap_macros::keymap;
-
-use keymap::DistinctReports;
 
 #[test]
 fn overlap_press_abcd_results_in_chord() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             let CH = import "chording.ncl" in
@@ -23,8 +21,7 @@ fn overlap_press_abcd_results_in_chord() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     // Press ABCD
@@ -32,23 +29,20 @@ fn overlap_press_abcd_results_in_chord() {
 
     for &keymap_index in press_indices {
         keymap.handle_input(input::Event::Press { keymap_index });
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     }
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0x10, 0, 0, 0, 0, 0]];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn overlap_press_ab_results_in_chord() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             let CH = import "chording.ncl" in
@@ -63,8 +57,7 @@ fn overlap_press_ab_results_in_chord() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     // Press AB
@@ -72,23 +65,20 @@ fn overlap_press_ab_results_in_chord() {
 
     for &keymap_index in press_indices {
         keymap.handle_input(input::Event::Press { keymap_index });
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     }
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0x11, 0, 0, 0, 0, 0]];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn overlap_press_cd_results_in_chord() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             let CH = import "chording.ncl" in
@@ -103,8 +93,7 @@ fn overlap_press_cd_results_in_chord() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     // Press CD
@@ -112,23 +101,20 @@ fn overlap_press_cd_results_in_chord() {
 
     for &keymap_index in press_indices {
         keymap.handle_input(input::Event::Press { keymap_index });
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     }
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0x12, 0, 0, 0, 0, 0]];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn overlap_press_ab_then_cd_results_in_chords() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             let CH = import "chording.ncl" in
@@ -143,8 +129,7 @@ fn overlap_press_ab_then_cd_results_in_chords() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     // Press AB
@@ -153,13 +138,9 @@ fn overlap_press_ab_then_cd_results_in_chords() {
 
         for &keymap_index in press_indices {
             keymap.handle_input(input::Event::Press { keymap_index });
-            actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
         }
 
-        while keymap.has_scheduled_events() {
-            keymap.tick();
-            actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-        }
+        keymap.tick_until_no_scheduled_events();
     }
 
     // After timeout, press CD
@@ -168,13 +149,9 @@ fn overlap_press_ab_then_cd_results_in_chords() {
 
         for &keymap_index in press_indices {
             keymap.handle_input(input::Event::Press { keymap_index });
-            actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
         }
 
-        while keymap.has_scheduled_events() {
-            keymap.tick();
-            actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-        }
+        keymap.tick_until_no_scheduled_events();
     }
 
     // Assert
@@ -183,5 +160,6 @@ fn overlap_press_ab_then_cd_results_in_chords() {
         [0, 0, 0x11, 0, 0, 0, 0, 0],
         [0, 0, 0x11, 0x12, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }

--- a/tests/rust/chorded/tap_hold.rs
+++ b/tests/rust/chorded/tap_hold.rs
@@ -1,14 +1,12 @@
 use smart_keymap::input;
-use smart_keymap::keymap;
+use smart_keymap::keymap::ObservedKeymap;
 
 use smart_keymap_macros::keymap;
-
-use keymap::DistinctReports;
 
 #[test]
 fn tap_chord_acts_as_chorded_tap() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -20,26 +18,15 @@ fn tap_chord_acts_as_chorded_tap() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Release { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     #[rustfmt::skip]
@@ -48,13 +35,14 @@ fn tap_chord_acts_as_chorded_tap() {
         [0, 0, 0x06, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn hold_chord_acts_as_chorded_hold() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -66,20 +54,13 @@ fn hold_chord_acts_as_chorded_hold() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     #[rustfmt::skip]
@@ -87,5 +68,6 @@ fn hold_chord_acts_as_chorded_hold() {
         [0, 0, 0, 0, 0, 0, 0, 0],
         [1, 0, 0, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }

--- a/tests/rust/chorded/tap_hold_over_tap_hold.rs
+++ b/tests/rust/chorded/tap_hold_over_tap_hold.rs
@@ -1,14 +1,12 @@
 use smart_keymap::input;
-use smart_keymap::keymap;
+use smart_keymap::keymap::ObservedKeymap;
 
 use smart_keymap_macros::keymap;
-
-use keymap::DistinctReports;
 
 #[test]
 fn tap_chord_acts_as_chorded_tap() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -21,26 +19,15 @@ fn tap_chord_acts_as_chorded_tap() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Release { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     #[rustfmt::skip]
@@ -49,13 +36,14 @@ fn tap_chord_acts_as_chorded_tap() {
         [0, 0, 0x06, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn hold_chord_acts_as_chorded_hold() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -68,20 +56,13 @@ fn hold_chord_acts_as_chorded_hold() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     #[rustfmt::skip]
@@ -89,13 +70,14 @@ fn hold_chord_acts_as_chorded_hold() {
         [0, 0, 0, 0, 0, 0, 0, 0],
         [4, 0, 0, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn tap_chorded_key_acts_as_passthrough_tap() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -108,20 +90,13 @@ fn tap_chorded_key_acts_as_passthrough_tap() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     #[rustfmt::skip]
@@ -130,13 +105,14 @@ fn tap_chorded_key_acts_as_passthrough_tap() {
         [0, 0, 0x04, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn hold_chorded_key_acts_as_passthrough_hold() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -149,17 +125,12 @@ fn hold_chorded_key_acts_as_passthrough_hold() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     #[rustfmt::skip]
@@ -167,13 +138,14 @@ fn hold_chorded_key_acts_as_passthrough_hold() {
         [0, 0, 0, 0, 0, 0, 0, 0],
         [1, 0, 0, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn tap_auxiliary_key_acts_as_passthrough_tap() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -186,20 +158,13 @@ fn tap_auxiliary_key_acts_as_passthrough_tap() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Release { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     #[rustfmt::skip]
@@ -208,13 +173,14 @@ fn tap_auxiliary_key_acts_as_passthrough_tap() {
         [0, 0, 0x05, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn hold_auxiliary_key_acts_as_passthrough_hold() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -227,17 +193,12 @@ fn hold_auxiliary_key_acts_as_passthrough_hold() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     #[rustfmt::skip]
@@ -245,5 +206,6 @@ fn hold_auxiliary_key_acts_as_passthrough_hold() {
         [0, 0, 0, 0, 0, 0, 0, 0],
         [2, 0, 0, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }

--- a/tests/rust/keymap.rs
+++ b/tests/rust/keymap.rs
@@ -11,17 +11,16 @@ mod tap_hold;
 
 mod ms_per_tick;
 
+use smart_keymap::keymap::ObservedKeymap;
+
 #[test]
 fn basic_keymap_expression() {
     // This test demonstrates using smart_keymap::keymap::Keymap directly.
 
     // Assemble
     use smart_keymap::input;
-    use smart_keymap::keymap;
 
-    use keymap::DistinctReports;
-
-    let mut keymap = {
+    let mut keymap = ObservedKeymap::new({
         use key_system::Context;
         use key_system::Ref;
         use smart_keymap::key::composite as key_system;
@@ -45,19 +44,13 @@ fn basic_keymap_expression() {
                 smart_keymap::key::tap_hold::System::new([]),
             ),
         )
-    };
-    let mut actual_reports = DistinctReports::new();
+    });
 
     // Act -- tap 'a'
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     #[rustfmt::skip]
@@ -66,6 +59,7 @@ fn basic_keymap_expression() {
         [0, 0, 0x04, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
@@ -76,11 +70,8 @@ fn basic_keymap_expression_macro() {
 
     // Assemble
     use smart_keymap::input;
-    use smart_keymap::keymap;
 
-    use keymap::DistinctReports;
-
-    let mut keymap = smart_keymap_macros::keymap!(
+    let mut keymap = ObservedKeymap::new(smart_keymap_macros::keymap!(
         r#"
         {
             keys = [
@@ -88,19 +79,13 @@ fn basic_keymap_expression_macro() {
             ],
         }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act -- tap 'a'
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     #[rustfmt::skip]
@@ -109,5 +94,6 @@ fn basic_keymap_expression_macro() {
         [0, 0, 0x04, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }

--- a/tests/rust/layered.rs
+++ b/tests/rust/layered.rs
@@ -3,13 +3,14 @@ mod tap_hold;
 mod toggle;
 
 use smart_keymap::input;
+use smart_keymap::keymap::ObservedKeymap;
 
 use smart_keymap_macros::keymap;
 
 #[test]
 fn press_base_key_when_no_layers_active() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -19,21 +20,21 @@ fn press_base_key_when_no_layers_active() {
                 ],
             }
         "#
-    );
+    ));
 
     // Act
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    let actual_report = keymap.boot_keyboard_report();
 
     // Assert
     let expected_report: [u8; 8] = [0, 0, 0x04, 0, 0, 0, 0, 0];
+    let actual_report = keymap.boot_keyboard_report();
     assert_eq!(expected_report, actual_report,);
 }
 
 #[test]
 fn press_active_layer_when_layer_mod_held() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -43,25 +44,22 @@ fn press_active_layer_when_layer_mod_held() {
                 ],
             }
         "#
-    );
+    ));
 
     // Act
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    for _ in 0..smart_keymap::keymap::INPUT_QUEUE_TICK_DELAY {
-        keymap.tick();
-    }
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    let actual_report = keymap.boot_keyboard_report();
 
     // Assert
     let expected_report: [u8; 8] = [0, 0, 0x05, 0, 0, 0, 0, 0];
+    let actual_report = keymap.boot_keyboard_report();
     assert_eq!(expected_report, actual_report);
 }
 
 #[test]
 fn press_retained_when_layer_mod_released() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -71,29 +69,23 @@ fn press_retained_when_layer_mod_released() {
                 ],
             }
         "#
-    );
+    ));
 
     // Act
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    for _ in 0..smart_keymap::keymap::INPUT_QUEUE_TICK_DELAY {
-        keymap.tick();
-    }
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    for _ in 0..smart_keymap::keymap::INPUT_QUEUE_TICK_DELAY {
-        keymap.tick();
-    }
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    let actual_report = keymap.boot_keyboard_report();
 
     // Assert
     let expected_report: [u8; 8] = [0, 0, 0x05, 0, 0, 0, 0, 0];
+    let actual_report = keymap.boot_keyboard_report();
     assert_eq!(expected_report, actual_report);
 }
 
 #[test]
 fn uses_base_when_pressed_after_layer_mod_released() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -103,21 +95,15 @@ fn uses_base_when_pressed_after_layer_mod_released() {
                 ],
             }
         "#
-    );
+    ));
 
     // Act
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    for _ in 0..smart_keymap::keymap::INPUT_QUEUE_TICK_DELAY {
-        keymap.tick();
-    }
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    for _ in 0..smart_keymap::keymap::INPUT_QUEUE_TICK_DELAY {
-        keymap.tick();
-    }
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    let actual_report = keymap.boot_keyboard_report();
 
     // Assert
     let expected_report: [u8; 8] = [0, 0, 0x04, 0, 0, 0, 0, 0];
+    let actual_report = keymap.boot_keyboard_report();
     assert_eq!(expected_report, actual_report);
 }

--- a/tests/rust/layered/set_active_layers.rs
+++ b/tests/rust/layered/set_active_layers.rs
@@ -1,14 +1,12 @@
 use smart_keymap::input;
-use smart_keymap::keymap;
+use smart_keymap::keymap::ObservedKeymap;
 
 use smart_keymap_macros::keymap;
-
-use keymap::DistinctReports;
 
 #[test]
 fn tap_set_active_layers_activates_layers() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -18,8 +16,7 @@ fn tap_set_active_layers_activates_layers() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     #[rustfmt::skip]
@@ -34,12 +31,7 @@ fn tap_set_active_layers_activates_layers() {
 
     for &keymap_index in tap_indices {
         keymap.handle_input(input::Event::Press { keymap_index });
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
         keymap.handle_input(input::Event::Release { keymap_index });
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     }
 
     // Assert
@@ -55,13 +47,14 @@ fn tap_set_active_layers_activates_layers() {
         [0, 0, 0x07, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn press_set_active_layers_activates_layers() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -71,17 +64,11 @@ fn press_set_active_layers_activates_layers() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    keymap.tick();
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    keymap.tick();
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Assert
     #[rustfmt::skip]
@@ -89,5 +76,6 @@ fn press_set_active_layers_activates_layers() {
         [0, 0, 0, 0, 0, 0, 0, 0],
         [0, 0, 0x05, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }

--- a/tests/rust/layered/toggle.rs
+++ b/tests/rust/layered/toggle.rs
@@ -1,11 +1,12 @@
 use smart_keymap::input;
+use smart_keymap::keymap::ObservedKeymap;
 
 use smart_keymap_macros::keymap;
 
 #[test]
 fn press_active_layer_when_layer_mod_toggle_pressed() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -15,24 +16,22 @@ fn press_active_layer_when_layer_mod_toggle_pressed() {
                 ],
             }
         "#
-    );
+    ));
 
     // Act
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    keymap.tick();
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    keymap.tick();
-    let actual_report = keymap.boot_keyboard_report();
 
     // Assert
     let expected_report: [u8; 8] = [0, 0, 0x05, 0, 0, 0, 0, 0];
+    let actual_report = keymap.boot_keyboard_report();
     assert_eq!(expected_report, actual_report);
 }
 
 #[test]
 fn press_active_layer_when_layer_mod_toggle_tapped() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -42,26 +41,23 @@ fn press_active_layer_when_layer_mod_toggle_tapped() {
                 ],
             }
         "#
-    );
+    ));
 
     // Act
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    keymap.tick();
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    keymap.tick();
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    keymap.tick();
-    let actual_report = keymap.boot_keyboard_report();
 
     // Assert
     let expected_report: [u8; 8] = [0, 0, 0x05, 0, 0, 0, 0, 0];
+    let actual_report = keymap.boot_keyboard_report();
     assert_eq!(expected_report, actual_report);
 }
 
 #[test]
 fn toggle_tapped_twice_deactivates_layer() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -71,22 +67,17 @@ fn toggle_tapped_twice_deactivates_layer() {
                 ],
             }
         "#
-    );
+    ));
 
     // Act
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    keymap.tick();
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    keymap.tick();
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    keymap.tick();
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    keymap.tick();
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    keymap.tick();
-    let actual_report = keymap.boot_keyboard_report();
 
     // Assert
     let expected_report: [u8; 8] = [0, 0, 0x04, 0, 0, 0, 0, 0];
+    let actual_report = keymap.boot_keyboard_report();
     assert_eq!(expected_report, actual_report);
 }

--- a/tests/rust/sticky.rs
+++ b/tests/rust/sticky.rs
@@ -1,16 +1,14 @@
 mod release_on_next_press;
 
 use smart_keymap::input;
-use smart_keymap::keymap;
+use smart_keymap::keymap::ObservedKeymap;
 
 use smart_keymap_macros::keymap;
-
-use keymap::DistinctReports;
 
 #[test]
 fn tap_sticky_mod_modifies_next_keyboard_key() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -22,24 +20,17 @@ fn tap_sticky_mod_modifies_next_keyboard_key() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     // Tap Sticky Modifier
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Press "A"
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     let expected_reports: &[[u8; 8]] = &[
@@ -47,13 +38,14 @@ fn tap_sticky_mod_modifies_next_keyboard_key() {
         [0x02, 0, 0, 0, 0, 0, 0, 0],
         [0x02, 0, 0x04, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn tap_sticky_mod_acts_as_regular_mod_when_interrupted_by_key_slash() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -65,24 +57,17 @@ fn tap_sticky_mod_acts_as_regular_mod_when_interrupted_by_key_slash() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     // Tap Sticky Modifier
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Press "/"
     keymap.handle_input(input::Event::Press { keymap_index: 2 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     let expected_reports: &[[u8; 8]] = &[
@@ -90,13 +75,14 @@ fn tap_sticky_mod_acts_as_regular_mod_when_interrupted_by_key_slash() {
         [0x02, 0, 0, 0, 0, 0, 0, 0],
         [0x02, 0, 0x38, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn tap_sticky_mod_modifies_only_next_keyboard_key() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -108,30 +94,21 @@ fn tap_sticky_mod_modifies_only_next_keyboard_key() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     // Tap Sticky Modifier
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Tap "A"
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     keymap.handle_input(input::Event::Release { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Press "/"
     keymap.handle_input(input::Event::Press { keymap_index: 2 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     let expected_reports: &[[u8; 8]] = &[
@@ -141,13 +118,14 @@ fn tap_sticky_mod_modifies_only_next_keyboard_key() {
         [0, 0, 0, 0, 0, 0, 0, 0],
         [0, 0, 0x38, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn tap_sticky_mod_acts_as_regular_mod_when_interrupted_by_key() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -159,30 +137,22 @@ fn tap_sticky_mod_acts_as_regular_mod_when_interrupted_by_key() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     // Press Sticky Modifier
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Press "A"
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Release Sticky Modifier
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Release "A"
     keymap.handle_input(input::Event::Release { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     let expected_reports: &[[u8; 8]] = &[
@@ -191,13 +161,14 @@ fn tap_sticky_mod_acts_as_regular_mod_when_interrupted_by_key() {
         [0, 0, 0x04, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn tap_multiple_sticky_mod_modifies_next_keyboard_key() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -209,30 +180,20 @@ fn tap_multiple_sticky_mod_modifies_next_keyboard_key() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     // Tap Sticky Modifiers
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     keymap.handle_input(input::Event::Press { keymap_index: 3 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     keymap.handle_input(input::Event::Release { keymap_index: 3 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Tap "A"
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     keymap.handle_input(input::Event::Release { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     let expected_reports: &[[u8; 8]] = &[
@@ -242,13 +203,14 @@ fn tap_multiple_sticky_mod_modifies_next_keyboard_key() {
         [0x03, 0, 0x04, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn tap_sticky_mod_modifies_next_keyboard_key_until_released() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -260,34 +222,24 @@ fn tap_sticky_mod_modifies_next_keyboard_key_until_released() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     // Tap Sticky Modifier
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Press "A"
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Tap "/"
     keymap.handle_input(input::Event::Press { keymap_index: 2 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     keymap.handle_input(input::Event::Release { keymap_index: 2 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Release "A"
     keymap.handle_input(input::Event::Release { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     let expected_reports: &[[u8; 8]] = &[
@@ -298,5 +250,6 @@ fn tap_sticky_mod_modifies_next_keyboard_key_until_released() {
         [0, 0, 0x04, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }

--- a/tests/rust/sticky/release_on_next_press.rs
+++ b/tests/rust/sticky/release_on_next_press.rs
@@ -1,14 +1,12 @@
 use smart_keymap::input;
-use smart_keymap::keymap;
+use smart_keymap::keymap::ObservedKeymap;
 
 use smart_keymap_macros::keymap;
-
-use keymap::DistinctReports;
 
 #[test]
 fn tap_sticky_mod_modifies_next_keyboard_key() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -21,24 +19,17 @@ fn tap_sticky_mod_modifies_next_keyboard_key() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     // Tap Sticky Modifier
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Press "A"
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     let expected_reports: &[[u8; 8]] = &[
@@ -46,13 +37,14 @@ fn tap_sticky_mod_modifies_next_keyboard_key() {
         [0x02, 0, 0, 0, 0, 0, 0, 0],
         [0x02, 0, 0x04, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn tap_sticky_mod_modifies_only_next_keyboard_key() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -65,30 +57,21 @@ fn tap_sticky_mod_modifies_only_next_keyboard_key() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     // Tap Sticky Modifier
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Tap "A"
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     keymap.handle_input(input::Event::Release { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Press "/"
     keymap.handle_input(input::Event::Press { keymap_index: 2 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     let expected_reports: &[[u8; 8]] = &[
@@ -98,13 +81,14 @@ fn tap_sticky_mod_modifies_only_next_keyboard_key() {
         [0, 0, 0, 0, 0, 0, 0, 0],
         [0, 0, 0x38, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn tap_sticky_mod_acts_as_regular_mod_when_interrupted_by_key() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -117,30 +101,22 @@ fn tap_sticky_mod_acts_as_regular_mod_when_interrupted_by_key() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     // Press Sticky Modifier
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Press "A"
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Release Sticky Modifier
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Release "A"
     keymap.handle_input(input::Event::Release { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     let expected_reports: &[[u8; 8]] = &[
@@ -149,13 +125,14 @@ fn tap_sticky_mod_acts_as_regular_mod_when_interrupted_by_key() {
         [0, 0, 0x04, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn tap_multiple_sticky_mod_modifies_next_keyboard_key() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -168,30 +145,20 @@ fn tap_multiple_sticky_mod_modifies_next_keyboard_key() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     // Tap Sticky Modifiers
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     keymap.handle_input(input::Event::Press { keymap_index: 3 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     keymap.handle_input(input::Event::Release { keymap_index: 3 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Tap "A"
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     keymap.handle_input(input::Event::Release { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     let expected_reports: &[[u8; 8]] = &[
@@ -201,13 +168,14 @@ fn tap_multiple_sticky_mod_modifies_next_keyboard_key() {
         [0x03, 0, 0x04, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn tap_sticky_mod_releases_on_next_key_press() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -220,28 +188,20 @@ fn tap_sticky_mod_releases_on_next_key_press() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     // Tap Sticky Modifier
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Press "A"
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Press "/"
     keymap.handle_input(input::Event::Press { keymap_index: 2 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     let expected_reports: &[[u8; 8]] = &[
@@ -250,5 +210,6 @@ fn tap_sticky_mod_releases_on_next_key_press() {
         [0x02, 0, 0x04, 0, 0, 0, 0, 0],
         [0, 0, 0x04, 0x38, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }

--- a/tests/rust/tap_dance.rs
+++ b/tests/rust/tap_dance.rs
@@ -1,14 +1,12 @@
 use smart_keymap::input;
-use smart_keymap::keymap;
+use smart_keymap::keymap::ObservedKeymap;
 
 use smart_keymap_macros::keymap;
-
-use keymap::DistinctReports;
 
 #[test]
 fn key_press_once_and_hold_resolves_as_first_definition() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -18,17 +16,12 @@ fn key_press_once_and_hold_resolves_as_first_definition() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    for _ in 0..250 {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     #[rustfmt::skip]
@@ -36,13 +29,14 @@ fn key_press_once_and_hold_resolves_as_first_definition() {
         [0, 0, 0, 0, 0, 0, 0, 0],
         [0, 0, 0x04, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn key_tap_once_resolves_as_first_definition() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -52,20 +46,14 @@ fn key_tap_once_resolves_as_first_definition() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     #[rustfmt::skip]
@@ -74,13 +62,14 @@ fn key_tap_once_resolves_as_first_definition() {
         [0, 0, 0x04, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn key_tap_once_then_press_and_hold_resolves_as_second_definition() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -90,22 +79,15 @@ fn key_tap_once_then_press_and_hold_resolves_as_second_definition() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     #[rustfmt::skip]
@@ -113,5 +95,6 @@ fn key_tap_once_then_press_and_hold_resolves_as_second_definition() {
         [0, 0, 0, 0, 0, 0, 0, 0],
         [0, 0, 0x05, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }

--- a/tests/rust/tap_hold/interrupt_ignore.rs
+++ b/tests/rust/tap_hold/interrupt_ignore.rs
@@ -1,14 +1,12 @@
 use smart_keymap::input;
-use smart_keymap::keymap;
+use smart_keymap::keymap::ObservedKeymap;
 
 use smart_keymap_macros::keymap;
-
-use keymap::DistinctReports;
 
 #[test]
 fn rolled_presses() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -18,27 +16,16 @@ fn rolled_presses() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     // Roll the keys: press 0, press 1, release 0, release 1
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
     keymap.handle_input(input::Event::Release { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // Assert
     let expected_reports: &[[u8; 8]] = &[
@@ -48,6 +35,7 @@ fn rolled_presses() {
         [0, 0, 0x05, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
@@ -57,7 +45,7 @@ fn rolled_presses_desc_keycodes() {
     const K_G: u8 = 0x0A;
     const K_O: u8 = 0x12;
 
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -67,63 +55,45 @@ fn rolled_presses_desc_keycodes() {
                 ],
             }
         "#
-    );
+    ));
 
-    {
-        let mut actual_reports = DistinctReports::new();
+    // Roll the keys: press 0, press 1, release 0,
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
 
-        // Roll the keys: press 0, press 1, release 0,
-        keymap.handle_input(input::Event::Press { keymap_index: 0 });
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    keymap.tick_until_no_scheduled_events();
 
-        keymap.handle_input(input::Event::Press { keymap_index: 1 });
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
-        keymap.handle_input(input::Event::Release { keymap_index: 0 });
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
-        while keymap.has_scheduled_events() {
-            keymap.tick();
-            actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-        }
-
-        let expected_reports: &[[u8; 8]] = &[
-            [0, 0, 0, 0, 0, 0, 0, 0],
-            [0, 0, K_O, 0, 0, 0, 0, 0],
-            [0, 0, K_O, K_G, 0, 0, 0, 0],
-            [0, 0, K_G, 0, 0, 0, 0, 0],
-        ];
-        assert_eq!(expected_reports, actual_reports.reports());
-    }
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, K_O, 0, 0, 0, 0, 0],
+        [0, 0, K_O, K_G, 0, 0, 0, 0],
+        [0, 0, K_G, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
 
     keymap.handle_input(input::Event::Release { keymap_index: 1 });
 
     // Act
     // Roll a second time
-    {
-        let mut actual_reports = DistinctReports::new();
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
 
-        keymap.handle_input(input::Event::Press { keymap_index: 0 });
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
+    keymap.tick_until_no_scheduled_events();
 
-        keymap.handle_input(input::Event::Press { keymap_index: 1 });
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
-        keymap.handle_input(input::Event::Release { keymap_index: 0 });
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
-        while keymap.has_scheduled_events() {
-            keymap.tick();
-            actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-        }
-
-        // Assert
-        let expected_reports: &[[u8; 8]] = &[
-            [0, 0, 0, 0, 0, 0, 0, 0],
-            [0, 0, K_O, 0, 0, 0, 0, 0],
-            [0, 0, K_O, K_G, 0, 0, 0, 0],
-            [0, 0, K_G, 0, 0, 0, 0, 0],
-        ];
-        assert_eq!(expected_reports, actual_reports.reports());
-    }
+    // Assert
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, K_O, 0, 0, 0, 0, 0],
+        [0, 0, K_O, K_G, 0, 0, 0, 0],
+        [0, 0, K_G, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, K_O, 0, 0, 0, 0, 0],
+        [0, 0, K_O, K_G, 0, 0, 0, 0],
+        [0, 0, K_G, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
 }

--- a/tests/rust/tap_hold/layered.rs
+++ b/tests/rust/tap_hold/layered.rs
@@ -1,9 +1,7 @@
 use smart_keymap::input;
-use smart_keymap::keymap;
+use smart_keymap::keymap::ObservedKeymap;
 
 use smart_keymap_macros::keymap;
-
-use keymap::DistinctReports;
 
 #[test]
 fn press_active_layer_when_hold_layer_mod_held() {
@@ -13,7 +11,7 @@ fn press_active_layer_when_hold_layer_mod_held() {
     // - In order to have { tap: Keyboard, hold: LayerMod },
     //    we need to use the aggregate composite::Key
     //    as the nested key type.
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -29,24 +27,18 @@ fn press_active_layer_when_hold_layer_mod_held() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // Act
     // - Press the tap-hold key.
     // - Resolve the tap-hold as hold (Time the tap-hold key out)
     // - Press the layered key.
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Tick until the tap-hold's timeout event occurs.
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Assert
     // - Check the keycode from the layer is used.
@@ -55,13 +47,14 @@ fn press_active_layer_when_hold_layer_mod_held() {
         [0, 0, 0, 0, 0, 0, 0, 0],
         [0, 0, 0x05, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
 
 #[test]
 fn uses_base_when_pressed_after_hold_layer_mod_released() {
     // Assemble
-    let mut keymap = keymap!(
+    let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
@@ -77,32 +70,21 @@ fn uses_base_when_pressed_after_hold_layer_mod_released() {
                 ],
             }
         "#
-    );
-    let mut actual_reports = DistinctReports::new();
+    ));
 
     // 1. Press the tap-hold key
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // 2. Resolve the tap-hold as hold (Time the tap-hold key out)
     // Tick until the tap-hold's timeout event occurs.
-    while keymap.has_scheduled_events() {
-        keymap.tick();
-        actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-    }
+    keymap.tick_until_no_scheduled_events();
 
     // 3. Release the tap-hold key (release layered::LayerModifier::Hold)
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-
-    for _ in 0..smart_keymap::keymap::INPUT_QUEUE_TICK_DELAY {
-        keymap.tick();
-    }
 
     // Act
     // Press the layered key; it should be the base key.
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    actual_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
     // Assert
     #[rustfmt::skip]
@@ -110,5 +92,6 @@ fn uses_base_when_pressed_after_hold_layer_mod_released() {
         [0, 0, 0, 0, 0, 0, 0, 0],
         [0, 0, 0x04, 0, 0, 0, 0, 0],
     ];
+    let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }


### PR DESCRIPTION
This PR addresses one of the sore points of the Rust integration tests: the tests have poor DX.

`ObservedKeymap`, added in #464, improves the UX a lot, and encompasses how the automated tests drive the `Keymap`.

This PR rewrites the integration tests (where suitable) to use `ObservedKeymap`.