### PR TITLE
features: add automation.feature spec file

### DIFF
--- a/features/keymap/key/automation.feature
+++ b/features/keymap/key/automation.feature
@@ -1,0 +1,52 @@
+Feature: Automation Key
+
+  Automation keys implement macro key behaviour.
+
+  For common use cases, it's simpler to use higher-level wrappers
+   around the key, such as `K.string_macro` (documented below),
+   or otherwise use Nickel's expressive language to build abstractions
+   above it.
+
+  For examples of this key in other smart keyboard firmware, see e.g.:
+
+  - [fak's macros](https://github.com/semickolon/fak?tab=readme-ov-file#macros)
+
+  - [QMK's macro keys](https://docs.qmk.fm/feature_macros),
+
+  - [ZMK's macro behaviors](https://zmk.dev/docs/keymaps/behaviors/macros)
+
+  Example: string macro key
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+
+      let MY_MACRO = {
+          automation_instructions = [
+              { Press = { key_code = { Keyboard = 0x04 } } },
+              { Release = { key_code = { Keyboard = 0x04 } } },
+              { Press = { key_code = { Keyboard = 0x05 } } },
+              { Release = { key_code = { Keyboard = 0x05 } } },
+              { Press = { key_code = { Keyboard = 0x06 } } },
+              { Release = { key_code = { Keyboard = 0x06 } } },
+          ],
+      } in
+      {
+        keys = [
+            MY_MACRO,
+        ],
+      }
+      """
+    When the keymap registers the following input
+      """
+      [
+        tap_keymap_index 0,
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        tap K.A,
+        tap K.B,
+        tap K.C,
+      ]
+      """

--- a/features/scripts/generate-doc.sh
+++ b/features/scripts/generate-doc.sh
@@ -13,6 +13,7 @@ NCL_DIR="${REPOSITORY_DIR}/ncl"
 KEYMAP_FEATURE_MD=""
 
 keymap_key_features=(
+    "automation"
     "automation-string"
     "callback"
     "caps_word"


### PR DESCRIPTION
This PR adds a feature file demonstrating the automation key at a lower-level than the `string_macro` key field demonstrated by the `automation-string` feature.