### PR TITLE
Automation: queue executions

### DIFF
--- a/src/key/automation.rs
+++ b/src/key/automation.rs
@@ -30,6 +30,14 @@ impl Execution {
     pub const fn is_empty(&self) -> bool {
         self.length == 0
     }
+
+    /// Increments the execution to the next instruction.
+    pub fn incr(&mut self) {
+        if self.length > 0 {
+            self.start += 1;
+            self.length -= 1;
+        }
+    }
 }
 
 /// Definition for a automation key.

--- a/src/key/automation.rs
+++ b/src/key/automation.rs
@@ -19,6 +19,19 @@ pub struct Execution {
     pub length: u16,
 }
 
+impl Execution {
+    /// An empty execution.
+    pub const EMPTY: Self = Self {
+        start: 0,
+        length: 0,
+    };
+
+    /// Returns true if the execution is empty (length == 0).
+    pub const fn is_empty(&self) -> bool {
+        self.length == 0
+    }
+}
+
 /// Definition for a automation key.
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct Key {

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -1279,6 +1279,6 @@ mod tests {
 
     #[test]
     fn test_sizeof_event() {
-        assert_eq!(8, core::mem::size_of::<Event>());
+        assert_eq!(12, core::mem::size_of::<Event>());
     }
 }


### PR DESCRIPTION
This refactors how `key::automation` executes its instructions. Rather than directly executing each `Execution` into `key::KeyEvents` as it receives them, the `Context` now enqueues the `Executions`, and executes the macro upon a periodic event.

This will allow for some more sophisticated `key::automation` behaviour.

- - -

`key::automation::Event` increased by `4` bytes to `6`, and `key::composite::Event` from `8` to `12`.