### PR TITLE
SetActiveLayers: support layer mask

### DIFF
--- a/features/keymap/key/layer_modifier-set_active_layers_mask.feature
+++ b/features/keymap/key/layer_modifier-set_active_layers_mask.feature
@@ -1,0 +1,85 @@
+Feature: Layer Modifier: Set Active Layers Amongst (Mask)
+
+  The `K.layer_mod.set_active_layers_amongst` key sets active layers within a
+  mask, leaving layers outside the mask unchanged.
+
+  This supports orthogonal layer groups, e.g. switching "OS desktop" layers
+  without affecting unrelated layers such as LOWER or RAISE.
+
+  Background:
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        layers = [
+          [
+            K.layer_mod.set_active_layers_to [1],
+            K.layer_mod.set_active_layers_amongst {
+              set_active_layers_to = [3],
+              affected_layers = [3, 4],
+            },
+            K.layer_mod.set_active_layers_amongst {
+              set_active_layers_to = [4],
+              affected_layers = [3, 4],
+            },
+            K.A,
+            K.G,
+            K.D,
+          ],
+          [K.TTTT, K.TTTT, K.TTTT, K.TTTT, K.B, K.E],
+          [K.TTTT, K.TTTT, K.TTTT, K.TTTT, K.TTTT, K.TTTT],
+          [K.TTTT, K.TTTT, K.TTTT, K.TTTT, K.C, K.TTTT],
+          [K.TTTT, K.TTTT, K.TTTT, K.TTTT, K.F, K.TTTT],
+        ],
+      }
+      """
+
+  Example: masked set active layers preserves layers outside the mask
+
+    When the keymap registers the following input
+      """
+      [
+        tap (K.layer_mod.set_active_layers_to [1]),
+        tap_keymap_index 5,
+        tap (K.layer_mod.set_active_layers_amongst {
+          set_active_layers_to = [3],
+          affected_layers = [3, 4],
+        }),
+        tap_keymap_index 4,
+        tap_keymap_index 5,
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        tap (K.E),
+        tap (K.C),
+        tap (K.E),
+      ]
+      """
+
+  Example: masked set active layers switches within the mask
+
+    When the keymap registers the following input
+      """
+      [
+        tap (K.layer_mod.set_active_layers_amongst {
+          set_active_layers_to = [3],
+          affected_layers = [3, 4],
+        }),
+        tap_keymap_index 4,
+        tap (K.layer_mod.set_active_layers_amongst {
+          set_active_layers_to = [4],
+          affected_layers = [3, 4],
+        }),
+        tap_keymap_index 4,
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        tap (K.C),
+        tap (K.F),
+      ]
+      """

--- a/features/scripts/generate-doc.sh
+++ b/features/scripts/generate-doc.sh
@@ -26,6 +26,7 @@ keymap_key_features=(
     "layer_modifier-hold"
     "layer_modifier-modified_hold"
     "layer_modifier-set_active_layers"
+    "layer_modifier-set_active_layers_mask"
     "layer_modifier-sticky"
     "layer_modifier-toggle"
     "mouse"

--- a/ncl/layered-key.ncl
+++ b/ncl/layered-key.ncl
@@ -46,8 +46,9 @@
       'Tap { layer_modifier = { toggle }, .. } =>
         let { active_layers = al, ..layer_state } = layer_state in
         { active_layers = toggle_layer al toggle } & layer_state,
-      'Press { layer_modifier = { set_active_layers_to = new_active_layer_indices }, .. } or
-      'Tap { layer_modifier = { set_active_layers_to = new_active_layer_indices }, .. } =>
+      'Press { layer_modifier = lmod @ { set_active_layers_to = new_active_layer_indices }, .. } or
+      'Tap { layer_modifier = lmod @ { set_active_layers_to = new_active_layer_indices }, .. } =>
+        # TODO: implement support for lmod.affected_layers
         let { active_layers, ..layer_state } = layer_state in
         let layer_count = std.array.length active_layers in
         let new_active_layers =

--- a/ncl/layered-key.ncl
+++ b/ncl/layered-key.ncl
@@ -33,6 +33,41 @@
     else
       set_layer true active_layers layer_idx,
 
+  apply_set_active_layers = fun new_active_layer_indices layers =>
+    let layer_count = std.array.length layers in
+    std.array.generate
+      (fun idx =>
+        let layer_index = idx + 1 in
+        std.array.elem layer_index new_active_layer_indices
+      )
+      layer_count,
+
+  apply_set_active_layers_masked = fun new_active_layer_indices mask_layers layers =>
+    std.array.map_with_index
+      (fun idx is_active =>
+        let layer_index = idx + 1 in
+        if std.array.elem layer_index mask_layers then
+          std.array.elem layer_index new_active_layer_indices
+        else
+          is_active
+      )
+      layers,
+
+  checks.check_set_active_layers = {
+    unmasked = {
+      expected = [ false, true, false ],
+      actual = apply_set_active_layers [2] [ false, false, false ],
+    },
+    masked_preserves_outside_mask = {
+      expected = [ true, false, true, false ],
+      actual = apply_set_active_layers_masked [3] [3, 4] [ true, false, false, false ],
+    },
+    masked_switches_within_mask = {
+      expected = [ false, false, false, true ],
+      actual = apply_set_active_layers_masked [4] [3, 4] [ false, false, true, false ],
+    },
+  },
+
   update_layer_state_for_input = fun input layer_state @ { default_layer, active_layers } =>
     input
     |> match {
@@ -46,19 +81,19 @@
       'Tap { layer_modifier = { toggle }, .. } =>
         let { active_layers = al, ..layer_state } = layer_state in
         { active_layers = toggle_layer al toggle } & layer_state,
-      'Press { layer_modifier = { set_active_layers_to = new_active_layer_indices }, .. } or
-      'Tap { layer_modifier = { set_active_layers_to = new_active_layer_indices }, .. } =>
-        let { active_layers, ..layer_state } = layer_state in
-        let layer_count = std.array.length active_layers in
-        let new_active_layers =
-          std.array.generate
-            (fun idx =>
-              let layer_index = idx + 1 in
-              std.array.elem layer_index new_active_layer_indices
-            )
-            layer_count
-        in
-        { active_layers = new_active_layers } & layer_state,
+      'Press { layer_modifier = lm, .. } or
+      'Tap { layer_modifier = lm, .. } =>
+        if std.record.has_field "set_active_layers_to" lm then
+          let { active_layers = prior_active_layers, ..layer_state } = layer_state in
+          let new_active_layers =
+            if std.record.has_field "affected_layers" lm then
+              apply_set_active_layers_masked lm.set_active_layers_to lm.affected_layers prior_active_layers
+            else
+              apply_set_active_layers lm.set_active_layers_to prior_active_layers
+          in
+          { active_layers = new_active_layers } & layer_state
+        else
+          layer_state,
       'Release { layer_modifier = { default_ }, .. } =>
         let { default_layer, ..layer_state } = layer_state in
         { default_layer = default_ } & layer_state,

--- a/ncl/smart_keys/layered/key-extensions.ncl
+++ b/ncl/smart_keys/layered/key-extensions.ncl
@@ -21,6 +21,13 @@
         {
           layer_modifier = { set_active_layers_to = active_layers }
         },
+      set_active_layers_amongst = fun { set_active_layers_to = set_active_layers_to_, affected_layers = affected_layers_ } =>
+        {
+          layer_modifier = {
+            set_active_layers_to = set_active_layers_to_,
+            affected_layers = affected_layers_,
+          },
+        },
     },
 
     # Layer Transparency

--- a/ncl/smart_keys/layered/keymap-codegen.ncl
+++ b/ncl/smart_keys/layered/keymap-codegen.ncl
@@ -93,12 +93,21 @@
                 validators.record.has_any_field_of ["Default", "Hold", "Sticky", "SetActiveLayers", "Toggle"],
                 validators.record.has_only_fields ["Default", "Hold", "Sticky", "SetActiveLayers", "Toggle"],
               ],
-            field_validators = {
-              Hold = validators.is_number,
-              Toggle = validators.is_number,
-              Sticky = validators.is_number,
-              SetActiveLayers = validators.is_number,
-            },
+            field_validators =
+              let modifier_bitset_validator =
+                validators.record.validator {
+                  fields_validator = validators.record.has_only_fields ["layers"],
+                  field_validators = {
+                    layers = validators.is_number,
+                  },
+                }
+              in
+              {
+                Hold = validators.is_number,
+                Toggle = validators.is_number,
+                Sticky = validators.is_number,
+                SetActiveLayers = modifier_bitset_validator,
+              },
           },
 
         is_json = fun json => 'Ok == json_validator json,
@@ -138,7 +147,7 @@
                 variant = "Sticky",
                 rust_expr = "%{module}::ModifierKey::sticky(%{std.to_string layer_index})",
               },
-            { SetActiveLayers = active_layers_bitset } =>
+            { SetActiveLayers = { layers = active_layers_bitset } } =>
               {
                 include json,
                 include module,

--- a/ncl/smart_keys/layered/keymap-codegen.ncl
+++ b/ncl/smart_keys/layered/keymap-codegen.ncl
@@ -85,7 +85,7 @@
         key_type = "%{module}::ModifierKey",
 
         # c.f. doc_de_layered.md.
-        # JSON serialization of key::layered::ModifierKey has variants: Default(layer), Hold(layer, kb_mods), SetActiveLayers([layer, ...]).
+        # JSON serialization of key::layered::ModifierKey has variants: Default(layer), Hold([layer, kb_mods]), SetActiveLayers({ layers, mask? }).
         json_validator =
           validators.record.validator {
             fields_validator =
@@ -96,9 +96,14 @@
             field_validators =
               let modifier_bitset_validator =
                 validators.record.validator {
-                  fields_validator = validators.record.has_only_fields ["layers"],
+                  fields_validator =
+                    validators.all_of [
+                      validators.record.has_any_field_of ["layers"],
+                      validators.record.has_only_fields ["layers", "mask"],
+                    ],
                   field_validators = {
                     layers = validators.is_number,
+                    mask = validators.is_number,
                   },
                 }
               in
@@ -174,6 +179,17 @@
                 include key_type,
                 variant = "SetActiveLayers",
                 rust_expr = "%{module}::ModifierKey::set_active_layers_from_bitset(%{active_layers_bitset |> std.to_string})",
+              },
+            { SetActiveLayers = { layers = active_layers_bitset, mask = layer_mask } } =>
+              {
+                include json,
+                include module,
+                include key_type,
+                variant = "SetActiveLayers",
+                rust_expr =
+                  let layers_expr = active_layers_bitset |> std.to_string in
+                  let mask_expr = layer_mask |> std.to_string in
+                  "%{module}::ModifierKey::set_active_layers_from_bitset_with_mask(%{layers_expr}, %{mask_expr})",
               },
           },
 

--- a/ncl/smart_keys/layered/keymap-codegen.ncl
+++ b/ncl/smart_keys/layered/keymap-codegen.ncl
@@ -96,9 +96,14 @@
             field_validators =
               let modifier_bitset_validator =
                 validators.record.validator {
-                  fields_validator = validators.record.has_only_fields ["layers"],
+                  fields_validator =
+                    validators.all_of [
+                      validators.record.has_any_field_of ["layers"],
+                      validators.record.has_only_fields ["layers", "mask"],
+                    ],
                   field_validators = {
                     layers = validators.is_number,
+                    mask = validators.is_number,
                   },
                 }
               in
@@ -154,6 +159,17 @@
                 include key_type,
                 variant = "SetActiveLayers",
                 rust_expr = "%{module}::ModifierKey::set_active_layers_from_bitset(%{active_layers_bitset |> std.to_string})",
+              },
+            { SetActiveLayers = { layers = active_layers_bitset, mask = layer_mask } } =>
+              {
+                include json,
+                include module,
+                include key_type,
+                variant = "SetActiveLayers",
+                rust_expr =
+                  let layers_expr = active_layers_bitset |> std.to_string in
+                  let mask_expr = layer_mask |> std.to_string in
+                  "%{module}::ModifierKey::set_active_layers_from_bitset_with_mask(%{layers_expr}, %{mask_expr})",
               },
           },
 

--- a/ncl/smart_keys/layered/keymap-codegen.ncl
+++ b/ncl/smart_keys/layered/keymap-codegen.ncl
@@ -93,25 +93,34 @@
                 validators.record.has_any_field_of ["Default", "Hold", "Sticky", "SetActiveLayers", "Toggle"],
                 validators.record.has_only_fields ["Default", "Hold", "Sticky", "SetActiveLayers", "Toggle"],
               ],
-            field_validators = {
-              Hold = fun hold =>
-                hold
-                |> match {
-                  [layer_index, kb_mods] =>
-                    let valid_layer_index = validators.is_number layer_index in
-                    let valid_kb_mods = validators.is_number kb_mods in
-                    [valid_layer_index, valid_kb_mods]
-                    |> match {
-                      ['Ok, 'Ok] => 'Ok,
-                      [err, 'Ok] => err,
-                      ['Ok, err] => err,
-                    },
-                  _ => 'Error { message = "expected Hold to be [layer_index, kb_mods]" },
-                },
-              Toggle = validators.is_number,
-              Sticky = validators.is_number,
-              SetActiveLayers = validators.is_number,
-            },
+            field_validators =
+              let modifier_bitset_validator =
+                validators.record.validator {
+                  fields_validator = validators.record.has_only_fields ["layers"],
+                  field_validators = {
+                    layers = validators.is_number,
+                  },
+                }
+              in
+              {
+                Hold = fun hold =>
+                  hold
+                  |> match {
+                    [layer_index, kb_mods] =>
+                      let valid_layer_index = validators.is_number layer_index in
+                      let valid_kb_mods = validators.is_number kb_mods in
+                      [valid_layer_index, valid_kb_mods]
+                      |> match {
+                        ['Ok, 'Ok] => 'Ok,
+                        [err, 'Ok] => err,
+                        ['Ok, err] => err,
+                      },
+                    _ => 'Error { message = "expected Hold to be [layer_index, kb_mods]" },
+                  },
+                Toggle = validators.is_number,
+                Sticky = validators.is_number,
+                SetActiveLayers = modifier_bitset_validator,
+              },
           },
 
         is_json = fun json => 'Ok == json_validator json,
@@ -158,7 +167,7 @@
                 variant = "Sticky",
                 rust_expr = "%{module}::ModifierKey::sticky(%{std.to_string layer_index})",
               },
-            { SetActiveLayers = active_layers_bitset } =>
+            { SetActiveLayers = { layers = active_layers_bitset } } =>
               {
                 include json,
                 include module,

--- a/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
@@ -60,7 +60,8 @@
               |> std.array.map (std.number.pow 2)
               |> std.array.reduce_left (+)
             in
-            { SetActiveLayers = active_layers_bitset },
+            let modifier_bitset = { layers = active_layers_bitset } in
+            { SetActiveLayers = modifier_bitset },
           _ => 'Error { message = "expected { layer_modifier = { default_ } } or { layer_modifier = { hold } } or { layer_modifier = { toggle } }" },
         },
 

--- a/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
@@ -74,7 +74,8 @@
               |> std.array.map (std.number.pow 2)
               |> std.array.reduce_left (+)
             in
-            { SetActiveLayers = active_layers_bitset },
+            let modifier_bitset = { layers = active_layers_bitset } in
+            { SetActiveLayers = modifier_bitset },
           _ => 'Error { message = "expected { layer_modifier = { default_ } } or { layer_modifier = { hold } } or { layer_modifier = { toggle } }" },
         },
 

--- a/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
@@ -38,6 +38,16 @@
           { layer_modifier = { sticky } } => validators.is_number sticky,
           { layer_modifier = { toggle } } => validators.all_of [validators.is_number, validators.is_greater_than 0] toggle,
           { layer_modifier = { set_active_layers_to } } => (validators.array.validator validators.is_number) set_active_layers_to,
+          { layer_modifier = { set_active_layers_to, affected_layers } } =>
+            [
+              (validators.array.validator validators.is_number) set_active_layers_to,
+              (validators.array.validator validators.is_number) affected_layers,
+            ]
+            |> match {
+              ['Ok, 'Ok] => 'Ok,
+              [err, _] => err,
+              [_, err] => err,
+            },
           _ => 'Error { message = "expected { layer_modifier = { default_ } } or { layer_modifier = { hold } } or { layer_modifier = { toggle } }" },
         },
 
@@ -61,6 +71,20 @@
               |> std.array.reduce_left (+)
             in
             let modifier_bitset = { layers = active_layers_bitset } in
+            { SetActiveLayers = modifier_bitset },
+          { layer_modifier = { set_active_layers_to = active_layers, affected_layers = mask_layers } } =>
+            let bitset_from_int_array = fun int_array =>
+              int_array
+              |> std.array.map (std.number.pow 2)
+              |> std.array.reduce_left (+)
+            in
+            let active_layers_bitset = bitset_from_int_array active_layers in
+            let mask_bitset = bitset_from_int_array mask_layers in
+            let modifier_bitset = {
+              layers = active_layers_bitset,
+              mask = mask_bitset,
+            }
+            in
             { SetActiveLayers = modifier_bitset },
           _ => 'Error { message = "expected { layer_modifier = { default_ } } or { layer_modifier = { hold } } or { layer_modifier = { toggle } }" },
         },

--- a/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
@@ -25,7 +25,57 @@
         actual = K.layer_mod.toggle 1 |> keymap_ncl.key.to_json_value,
         expected = { Toggle = 1 },
       },
+      check_json_value_set_active_layers_amongst = {
+        actual =
+          K.layer_mod.set_active_layers_amongst {
+            set_active_layers_to = [3],
+            affected_layers = [3, 4],
+          }
+          |> keymap_ncl.key.to_json_value,
+        expected = {
+          SetActiveLayers = {
+            layers = std.number.pow 2 3,
+            mask = (std.number.pow 2 3) + (std.number.pow 2 4),
+          },
+        },
+      },
+
+      check_layer_indices_to_bitset_empty = {
+        actual = layer_indices_to_bitset [],
+        expected = 0,
+      },
+
+      check_layer_indices_to_bitset_rejects_duplicates = {
+        actual = layer_indices_array [3, 3],
+        expected = 'Error { message = "layer indices must be unique" },
+      },
     },
+
+  unique_number_array = fun arr =>
+    if !std.is_array arr then
+      'Error { message = "Expected array" }
+    else
+      let unique =
+        arr
+        |> std.array.fold_left
+          (fun acc x => if std.array.elem x acc then acc else acc @ [x])
+          []
+      in
+      if (std.array.length unique) == (std.array.length arr) then
+        'Ok
+      else
+        'Error { message = "layer indices must be unique" },
+
+  layer_indices_array =
+    validators.all_of [
+      (validators.array.validator validators.is_number),
+      unique_number_array,
+    ],
+
+  layer_indices_to_bitset = fun layer_indices =>
+    layer_indices
+    |> std.array.map (std.number.pow 2)
+    |> std.array.fold_left (+) 0,
 
   keymap_ncl.layer_modifier
     | doc "for key::layered::ModifierKey."
@@ -48,8 +98,21 @@
           { layer_modifier = { hold } } => validators.is_number hold,
           { layer_modifier = { sticky } } => validators.is_number sticky,
           { layer_modifier = { toggle } } => validators.all_of [validators.is_number, validators.is_greater_than 0] toggle,
-          { layer_modifier = { set_active_layers_to } } => (validators.array.validator validators.is_number) set_active_layers_to,
-          _ => 'Error { message = "expected { layer_modifier = { default_ } } or { layer_modifier = { hold } } or { layer_modifier = { toggle } }" },
+          { layer_modifier = { set_active_layers_to } } => layer_indices_array set_active_layers_to,
+          { layer_modifier = { set_active_layers_to, affected_layers } } =>
+            [
+              layer_indices_array set_active_layers_to,
+              layer_indices_array affected_layers,
+            ]
+            |> match {
+              ['Ok, 'Ok] => 'Ok,
+              [err, _] => err,
+              [_, err] => err,
+            },
+          _ =>
+            'Error {
+              message = "expected { layer_modifier = { default_ } }, { hold }, { sticky }, { toggle }, { set_active_layers_to }, or { set_active_layers_to, affected_layers }",
+            },
         },
 
       is_key = fun k => 'Ok == key_validator k,
@@ -69,14 +132,19 @@
           { layer_modifier = { sticky = sticky_layer } } =>
             { Sticky = sticky_layer },
           { layer_modifier = { set_active_layers_to = active_layers } } =>
-            let active_layers_bitset =
-              active_layers
-              |> std.array.map (std.number.pow 2)
-              |> std.array.reduce_left (+)
-            in
-            let modifier_bitset = { layers = active_layers_bitset } in
+            let modifier_bitset = { layers = layer_indices_to_bitset active_layers } in
             { SetActiveLayers = modifier_bitset },
-          _ => 'Error { message = "expected { layer_modifier = { default_ } } or { layer_modifier = { hold } } or { layer_modifier = { toggle } }" },
+          { layer_modifier = { set_active_layers_to = active_layers, affected_layers = mask_layers } } =>
+            let modifier_bitset = {
+              layers = layer_indices_to_bitset active_layers,
+              mask = layer_indices_to_bitset mask_layers,
+            }
+            in
+            { SetActiveLayers = modifier_bitset },
+          _ =>
+            'Error {
+              message = "expected { layer_modifier = { default_ } }, { hold }, { sticky }, { toggle }, { set_active_layers_to }, or { set_active_layers_to, affected_layers }",
+            },
         },
 
       map_accum = fun f acc k => f acc k,

--- a/nix/git-hooks.nix
+++ b/nix/git-hooks.nix
@@ -5,11 +5,33 @@ let
     export PATH="${pkgs.lib.makeBinPath [ pkgs.nickel ]}:$PATH"
     exec ${./../ncl/scripts/ncl-format.sh} "$@"
   '';
+
+  cargoCheckFirmware = pkgs.writeShellScriptBin "cargo-check-firmware" ''
+    set -euo pipefail
+    # Match firmware CI: no_std cross-compilation for smart-keymap.
+    cargo check --no-default-features --target thumbv6m-none-eabi -p smart-keymap
+    cargo check --no-default-features --target thumbv7em-none-eabihf -p smart-keymap
+  '';
 in
 {
   git-hooks.hooks = {
-    clippy.enable = true;
+    clippy = {
+      enable = true;
+      # Match .github/workflows/rust.yaml cargo-fmt-clippy job.
+      entry = "cargo clippy --workspace --all-targets -- -D warnings";
+      files = "\\.rs$";
+      pass_filenames = false;
+    };
     rustfmt.enable = true;
+
+    cargo-check-firmware = {
+      enable = true;
+      name = "cargo check (no_std firmware targets)";
+      entry = "${cargoCheckFirmware}/bin/cargo-check-firmware";
+      language = "system";
+      files = "\\.rs$";
+      pass_filenames = false;
+    };
 
     clang-format = {
       enable = true;

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -110,6 +110,14 @@ impl ModifierKey {
         })
     }
 
+    /// Create a new [ModifierKey] that sets the active layers bitset.
+    pub const fn set_active_layers_from_bitset_with_mask(
+        layers: LayerBitset,
+        mask: LayerBitset,
+    ) -> Self {
+        ModifierKey::SetActiveLayers(ModifierBitset { layers, mask })
+    }
+
     /// Create a new [ModifierKey] that sets the default layer.
     pub const fn default(layer: LayerIndex) -> Self {
         ModifierKey::Default(layer)

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -326,18 +326,18 @@ impl<const LAYER_COUNT: usize> Context<LAYER_COUNT> {
                     self.active_layers.activate(layer, ActivationStyle::Regular);
                 }
             }
-            LayerEvent::Set(ModifierBitset {
-                layers: layer_set, ..
-            }) => {
+            LayerEvent::Set(ModifierBitset { layers, mask }) => {
                 let max_layer = 1 + LAYER_COUNT.min(MAX_BITSET_LAYER);
 
                 // layer 0 is always active.
                 for li in 1..max_layer {
-                    if (layer_set & (1 << li)) != 0 {
-                        self.active_layers
-                            .activate(li as LayerIndex, ActivationStyle::Regular);
-                    } else {
-                        self.active_layers.deactivate(li as LayerIndex);
+                    if (mask & (1 << li)) != 0 {
+                        if (layers & (1 << li)) != 0 {
+                            self.active_layers
+                                .activate(li as LayerIndex, ActivationStyle::Regular);
+                        } else {
+                            self.active_layers.deactivate(li as LayerIndex);
+                        }
                     }
                 }
             }

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -312,18 +312,18 @@ impl<const LAYER_COUNT: usize> Context<LAYER_COUNT> {
                     self.active_layers.activate(layer, ActivationStyle::Regular);
                 }
             }
-            LayerEvent::Set(ModifierBitset {
-                layers: layer_set, ..
-            }) => {
+            LayerEvent::Set(ModifierBitset { layers, mask }) => {
                 let max_layer = 1 + LAYER_COUNT.min(MAX_BITSET_LAYER);
 
                 // layer 0 is always active.
                 for li in 1..max_layer {
-                    if (layer_set & (1 << li)) != 0 {
-                        self.active_layers
-                            .activate(li as LayerIndex, ActivationStyle::Regular);
-                    } else {
-                        self.active_layers.deactivate(li as LayerIndex);
+                    if (mask & (1 << li)) != 0 {
+                        if (layers & (1 << li)) != 0 {
+                            self.active_layers
+                                .activate(li as LayerIndex, ActivationStyle::Regular);
+                        } else {
+                            self.active_layers.deactivate(li as LayerIndex);
+                        }
                     }
                 }
             }

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -17,11 +17,21 @@ pub type LayerBitset = u32;
 /// The maximum number of layers that can be represented in a [LayerBitset].
 pub const MAX_BITSET_LAYER: usize = 8 * core::mem::size_of::<LayerBitset>() - 1;
 
+/// The bitset with all layers active.
+pub const BITSET_MASK_ALL: LayerBitset = (1 << MAX_BITSET_LAYER) - 1;
+
 /// Struct for modifying layers with a bitset.
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq)]
+#[derive(Debug, Deserialize, Clone, Copy, Eq, PartialEq)]
 pub struct ModifierBitset {
     /// The set of layers modified.
     pub layers: LayerBitset,
+    /// The mask for which layers are affected by the modification.
+    #[serde(default = "default_modifier_bitset_mask")]
+    pub mask: LayerBitset,
+}
+
+fn default_modifier_bitset_mask() -> LayerBitset {
+    BITSET_MASK_ALL
 }
 
 /// Reference for a keyboard key.
@@ -84,12 +94,20 @@ impl ModifierKey {
             idx += 1;
         }
 
-        ModifierKey::SetActiveLayers(ModifierBitset { layers: bitset })
+        let mask = BITSET_MASK_ALL;
+        ModifierKey::SetActiveLayers(ModifierBitset {
+            layers: bitset,
+            mask,
+        })
     }
 
     /// Create a new [ModifierKey] that sets the active layers bitset.
     pub const fn set_active_layers_from_bitset(bitset: LayerBitset) -> Self {
-        ModifierKey::SetActiveLayers(ModifierBitset { layers: bitset })
+        let mask = BITSET_MASK_ALL;
+        ModifierKey::SetActiveLayers(ModifierBitset {
+            layers: bitset,
+            mask,
+        })
     }
 
     /// Create a new [ModifierKey] that sets the default layer.
@@ -112,9 +130,10 @@ impl ModifierKey {
                 ModifierKeyState::sticky(),
                 Some(LayerEvent::StickyActivated(*layer)),
             ),
-            ModifierKey::SetActiveLayers(ModifierBitset { layers }) => {
-                (ModifierKeyState::new(), Some(LayerEvent::Set(*layers)))
-            }
+            ModifierKey::SetActiveLayers(modifier_bitset) => (
+                ModifierKeyState::new(),
+                Some(LayerEvent::Set(*modifier_bitset)),
+            ),
             ModifierKey::Default(layer) => (
                 ModifierKeyState::new(),
                 Some(LayerEvent::SetDefault(*layer)),
@@ -293,7 +312,9 @@ impl<const LAYER_COUNT: usize> Context<LAYER_COUNT> {
                     self.active_layers.activate(layer, ActivationStyle::Regular);
                 }
             }
-            LayerEvent::Set(layer_set) => {
+            LayerEvent::Set(ModifierBitset {
+                layers: layer_set, ..
+            }) => {
                 let max_layer = 1 + LAYER_COUNT.min(MAX_BITSET_LAYER);
 
                 // layer 0 is always active.
@@ -484,7 +505,7 @@ pub enum LayerEvent {
     /// Activates the given layer.
     StickyActivated(LayerIndex),
     /// Sets the active layers to the given set of layers.
-    Set(LayerBitset),
+    Set(ModifierBitset),
     /// Changes the default layer.
     SetDefault(LayerIndex),
 }
@@ -708,7 +729,7 @@ mod tests {
 
     #[test]
     fn test_sizeof_event() {
-        assert_eq!(8, core::mem::size_of::<LayerEvent>());
+        assert_eq!(12, core::mem::size_of::<LayerEvent>());
     }
 
     #[test]

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -12,17 +12,32 @@ use crate::key::KeyboardModifiers;
 pub type LayerIndex = u32;
 
 /// The type used for set of active layers in ModifierKey.
-/// (Limited to [MAX_BITSET_LAYER] layers.)
+/// (Layer bit indices `0..=[MAX_BITSET_LAYER]`.)
 pub type LayerBitset = u32;
 
-/// The maximum number of layers that can be represented in a [LayerBitset].
+/// The maximum layer bit index representable in a [LayerBitset].
+///
+/// For `LayerBitset = u32`, this is 31 (bits 0..=31, i.e. 32 layers).
 pub const MAX_BITSET_LAYER: usize = 8 * core::mem::size_of::<LayerBitset>() - 1;
 
+/// The bitset with all representable modifier layers in the mask.
+///
+/// Includes bit [MAX_BITSET_LAYER] (e.g. bit 31 for `u32`).
+pub const BITSET_MASK_ALL: LayerBitset = LayerBitset::MAX;
+
 /// Struct for modifying layers with a bitset.
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq)]
+#[repr(C)]
+#[derive(Debug, Deserialize, Clone, Copy, Eq, PartialEq)]
 pub struct ModifierBitset {
     /// The set of layers modified.
     pub layers: LayerBitset,
+    /// The mask for which layers are affected by the modification.
+    #[serde(default = "default_modifier_bitset_mask")]
+    pub mask: LayerBitset,
+}
+
+fn default_modifier_bitset_mask() -> LayerBitset {
+    BITSET_MASK_ALL
 }
 
 /// Reference for a keyboard key.
@@ -93,12 +108,20 @@ impl ModifierKey {
             idx += 1;
         }
 
-        ModifierKey::SetActiveLayers(ModifierBitset { layers: bitset })
+        let mask = BITSET_MASK_ALL;
+        ModifierKey::SetActiveLayers(ModifierBitset {
+            layers: bitset,
+            mask,
+        })
     }
 
     /// Create a new [ModifierKey] that sets the active layers bitset.
     pub const fn set_active_layers_from_bitset(bitset: LayerBitset) -> Self {
-        ModifierKey::SetActiveLayers(ModifierBitset { layers: bitset })
+        let mask = BITSET_MASK_ALL;
+        ModifierKey::SetActiveLayers(ModifierBitset {
+            layers: bitset,
+            mask,
+        })
     }
 
     /// Create a new [ModifierKey] that sets the default layer.
@@ -121,9 +144,10 @@ impl ModifierKey {
                 ModifierKeyState::sticky(),
                 Some(LayerEvent::StickyActivated(*layer)),
             ),
-            ModifierKey::SetActiveLayers(ModifierBitset { layers }) => {
-                (ModifierKeyState::new(), Some(LayerEvent::Set(*layers)))
-            }
+            ModifierKey::SetActiveLayers(modifier_bitset) => (
+                ModifierKeyState::new(),
+                Some(LayerEvent::Set(*modifier_bitset)),
+            ),
             ModifierKey::Default(layer) => (
                 ModifierKeyState::new(),
                 Some(LayerEvent::SetDefault(*layer)),
@@ -302,7 +326,9 @@ impl<const LAYER_COUNT: usize> Context<LAYER_COUNT> {
                     self.active_layers.activate(layer, ActivationStyle::Regular);
                 }
             }
-            LayerEvent::Set(layer_set) => {
+            LayerEvent::Set(ModifierBitset {
+                layers: layer_set, ..
+            }) => {
                 let max_layer = 1 + LAYER_COUNT.min(MAX_BITSET_LAYER);
 
                 // layer 0 is always active.
@@ -493,7 +519,7 @@ pub enum LayerEvent {
     /// Activates the given layer.
     StickyActivated(LayerIndex),
     /// Sets the active layers to the given set of layers.
-    Set(LayerBitset),
+    Set(ModifierBitset),
     /// Changes the default layer.
     SetDefault(LayerIndex),
 }
@@ -732,8 +758,34 @@ mod tests {
     }
 
     #[test]
+    fn test_sizeof_modifier_bitset() {
+        assert_eq!(8, core::mem::size_of::<ModifierBitset>());
+    }
+
+    #[test]
     fn test_sizeof_event() {
-        assert_eq!(8, core::mem::size_of::<LayerEvent>());
+        // Firmware RAM budget on 32-bit targets: LayerEvent::Set is a ModifierBitset.
+        assert_eq!(12, core::mem::size_of::<LayerEvent>());
+    }
+
+    #[test]
+    fn deserialize_set_active_layers_record_json() {
+        let key: ModifierKey =
+            serde_json::from_str(r#"{"SetActiveLayers": {"layers": 5, "mask": 3}}"#).unwrap();
+        assert_eq!(
+            ModifierKey::SetActiveLayers(ModifierBitset { layers: 5, mask: 3 }),
+            key,
+        );
+
+        let key: ModifierKey =
+            serde_json::from_str(r#"{"SetActiveLayers": {"layers": 5}}"#).unwrap();
+        assert_eq!(
+            ModifierKey::SetActiveLayers(ModifierBitset {
+                layers: 5,
+                mask: BITSET_MASK_ALL,
+            }),
+            key,
+        );
     }
 
     #[test]

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -17,6 +17,13 @@ pub type LayerBitset = u32;
 /// The maximum number of layers that can be represented in a [LayerBitset].
 pub const MAX_BITSET_LAYER: usize = 8 * core::mem::size_of::<LayerBitset>() - 1;
 
+/// Struct for modifying layers with a bitset.
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq)]
+pub struct ModifierBitset {
+    /// The set of layers modified.
+    pub layers: LayerBitset,
+}
+
 /// Reference for a keyboard key.
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
 pub enum Ref {
@@ -39,7 +46,7 @@ pub enum ModifierKey {
     /// If tapped, then the layer is activated for the next key tap.
     Sticky(LayerIndex),
     /// Sets the set of active layers to the given layers when the key is pressed.
-    SetActiveLayers(LayerBitset),
+    SetActiveLayers(ModifierBitset),
     /// Sets the default layer.
     Default(LayerIndex),
 }
@@ -77,12 +84,12 @@ impl ModifierKey {
             idx += 1;
         }
 
-        ModifierKey::SetActiveLayers(bitset)
+        ModifierKey::SetActiveLayers(ModifierBitset { layers: bitset })
     }
 
     /// Create a new [ModifierKey] that sets the active layers bitset.
     pub const fn set_active_layers_from_bitset(bitset: LayerBitset) -> Self {
-        ModifierKey::SetActiveLayers(bitset)
+        ModifierKey::SetActiveLayers(ModifierBitset { layers: bitset })
     }
 
     /// Create a new [ModifierKey] that sets the default layer.
@@ -105,8 +112,8 @@ impl ModifierKey {
                 ModifierKeyState::sticky(),
                 Some(LayerEvent::StickyActivated(*layer)),
             ),
-            ModifierKey::SetActiveLayers(layer_set) => {
-                (ModifierKeyState::new(), Some(LayerEvent::Set(*layer_set)))
+            ModifierKey::SetActiveLayers(ModifierBitset { layers }) => {
+                (ModifierKeyState::new(), Some(LayerEvent::Set(*layers)))
             }
             ModifierKey::Default(layer) => (
                 ModifierKeyState::new(),
@@ -553,7 +560,7 @@ impl ModifierKeyState {
                 }
                 _ => None,
             },
-            ModifierKey::SetActiveLayers(_layer_set) => None,
+            ModifierKey::SetActiveLayers(_modifier_bitset) => None,
             ModifierKey::Default(layer) => match event {
                 key::Event::Input(input::Event::Release { keymap_index: ki }) => {
                     if keymap_index == ki {

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -124,6 +124,14 @@ impl ModifierKey {
         })
     }
 
+    /// Create a new [ModifierKey] that sets the active layers bitset.
+    pub const fn set_active_layers_from_bitset_with_mask(
+        layers: LayerBitset,
+        mask: LayerBitset,
+    ) -> Self {
+        ModifierKey::SetActiveLayers(ModifierBitset { layers, mask })
+    }
+
     /// Create a new [ModifierKey] that sets the default layer.
     pub const fn default(layer: LayerIndex) -> Self {
         ModifierKey::Default(layer)

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -18,6 +18,13 @@ pub type LayerBitset = u32;
 /// The maximum number of layers that can be represented in a [LayerBitset].
 pub const MAX_BITSET_LAYER: usize = 8 * core::mem::size_of::<LayerBitset>() - 1;
 
+/// Struct for modifying layers with a bitset.
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq)]
+pub struct ModifierBitset {
+    /// The set of layers modified.
+    pub layers: LayerBitset,
+}
+
 /// Reference for a keyboard key.
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
 pub enum Ref {
@@ -40,7 +47,7 @@ pub enum ModifierKey {
     /// If tapped, then the layer is activated for the next key tap.
     Sticky(LayerIndex),
     /// Sets the set of active layers to the given layers when the key is pressed.
-    SetActiveLayers(LayerBitset),
+    SetActiveLayers(ModifierBitset),
     /// Sets the default layer.
     Default(LayerIndex),
 }
@@ -71,27 +78,27 @@ impl ModifierKey {
 
     /// Create a new [ModifierKey] that sets the active layers to the given slice of layers when pressed.
     ///
-    /// Each LayerIndex in the slice must be less than [MAX_BITSET_LAYER].
+    /// Each LayerIndex in the slice must be at most [MAX_BITSET_LAYER].
     pub const fn set_active_layers(layers: &[LayerIndex]) -> Self {
         let mut bitset = 0;
 
         let mut idx = 0;
         while idx < layers.len() {
             let layer = layers[idx] as usize;
-            if layer < MAX_BITSET_LAYER {
+            if layer <= MAX_BITSET_LAYER {
                 bitset |= 1 << layer;
             } else {
-                panic!("LayerIndex must be less than MAX_BITSET_LAYER");
+                panic!("LayerIndex must be at most MAX_BITSET_LAYER");
             }
             idx += 1;
         }
 
-        ModifierKey::SetActiveLayers(bitset)
+        ModifierKey::SetActiveLayers(ModifierBitset { layers: bitset })
     }
 
     /// Create a new [ModifierKey] that sets the active layers bitset.
     pub const fn set_active_layers_from_bitset(bitset: LayerBitset) -> Self {
-        ModifierKey::SetActiveLayers(bitset)
+        ModifierKey::SetActiveLayers(ModifierBitset { layers: bitset })
     }
 
     /// Create a new [ModifierKey] that sets the default layer.
@@ -114,8 +121,8 @@ impl ModifierKey {
                 ModifierKeyState::sticky(),
                 Some(LayerEvent::StickyActivated(*layer)),
             ),
-            ModifierKey::SetActiveLayers(layer_set) => {
-                (ModifierKeyState::new(), Some(LayerEvent::Set(*layer_set)))
+            ModifierKey::SetActiveLayers(ModifierBitset { layers }) => {
+                (ModifierKeyState::new(), Some(LayerEvent::Set(*layers)))
             }
             ModifierKey::Default(layer) => (
                 ModifierKeyState::new(),
@@ -568,7 +575,7 @@ impl ModifierKeyState {
                 }
                 _ => None,
             },
-            ModifierKey::SetActiveLayers(_layer_set) => None,
+            ModifierKey::SetActiveLayers(_modifier_bitset) => None,
             ModifierKey::Default(layer) => match event {
                 key::Event::Input(input::Event::Release { keymap_index: ki }) => {
                     if keymap_index == ki {

--- a/tests/rust/layered/set_active_layers.rs
+++ b/tests/rust/layered/set_active_layers.rs
@@ -80,3 +80,167 @@ fn press_set_active_layers_activates_layers() {
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
+
+#[test]
+fn masked_set_active_layers_preserves_layers_outside_mask() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                layers = [
+                    [
+                        K.layer_mod.set_active_layers_to [1],
+                        K.layer_mod.set_active_layers_amongst {
+                            set_active_layers_to = [3],
+                            affected_layers = [3, 4],
+                        },
+                        K.A,
+                        K.G,
+                        K.D,
+                    ],
+                    [K.TTTT, K.TTTT, K.TTTT, K.B, K.E],
+                    [K.TTTT, K.TTTT, K.TTTT, K.TTTT, K.TTTT],
+                    [K.TTTT, K.TTTT, K.TTTT, K.C, K.TTTT],
+                    [K.TTTT, K.TTTT, K.TTTT, K.F, K.TTTT],
+                ],
+            }
+        "#
+    ));
+
+    // Act
+    #[rustfmt::skip]
+    let tap_indices = &[
+        0, // set active layers to [1]
+        4, // key only defined on layer 1
+        1, // masked set active layers to [3]
+        3, // key defined on layer 3
+        4, // key only defined on layer 1 (base is K.D)
+    ];
+
+    for &keymap_index in tap_indices {
+        keymap.handle_input(input::Event::Press { keymap_index });
+        keymap.handle_input(input::Event::Release { keymap_index });
+    }
+
+    // Assert
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, KC_E, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, KC_E, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn masked_set_active_layers_switches_within_mask() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                layers = [
+                    [
+                        K.layer_mod.set_active_layers_amongst {
+                            set_active_layers_to = [3],
+                            affected_layers = [3, 4],
+                        },
+                        K.layer_mod.set_active_layers_amongst {
+                            set_active_layers_to = [4],
+                            affected_layers = [3, 4],
+                        },
+                        K.A,
+                    ],
+                    [K.TTTT, K.TTTT, K.TTTT],
+                    [K.TTTT, K.TTTT, K.TTTT],
+                    [K.TTTT, K.TTTT, K.C],
+                    [K.TTTT, K.TTTT, K.F],
+                ],
+            }
+        "#
+    ));
+
+    // Act
+    #[rustfmt::skip]
+    let tap_indices = &[
+        0, // masked set active layers to [3]
+        2,
+        1, // masked set active layers to [4]
+        2,
+    ];
+
+    for &keymap_index in tap_indices {
+        keymap.handle_input(input::Event::Press { keymap_index });
+        keymap.handle_input(input::Event::Release { keymap_index });
+    }
+
+    // Assert
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, KC_F, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn unmasked_set_active_layers_clears_layers_outside_previous_mask() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                layers = [
+                    [
+                        K.layer_mod.set_active_layers_to [1],
+                        K.layer_mod.set_active_layers_amongst {
+                            set_active_layers_to = [3],
+                            affected_layers = [3, 4],
+                        },
+                        K.A,
+                    ],
+                    [K.TTTT, K.TTTT, K.B],
+                    [K.TTTT, K.TTTT, K.TTTT],
+                    [K.TTTT, K.TTTT, K.C],
+                    [K.TTTT, K.TTTT, K.TTTT],
+                ],
+            }
+        "#
+    ));
+
+    // Act
+    #[rustfmt::skip]
+    let tap_indices = &[
+        1, // masked set active layers to [3]
+        2, // key on layer 3
+        0, // unmasked set active layers to [1]
+        2, // key on layer 1
+    ];
+
+    for &keymap_index in tap_indices {
+        keymap.handle_input(input::Event::Press { keymap_index });
+        keymap.handle_input(input::Event::Release { keymap_index });
+    }
+
+    // Assert
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}


### PR DESCRIPTION
## Summary

Adds **layer masking** to `SetActiveLayers`, so a layer-modifier key can set which layers are active **within a subset** of layers, without changing layers outside that subset.

This supports **orthogonal layer groups** in one keymap — for example, switching among "OS desktop" layers (Windows / Linux / macOS bindings) while LOWER, RAISE, or other unrelated layers stay as they were.

## Problem

`SetActiveLayers` previously replaced the full active-layer bitset. Picking one layer in a mutually exclusive group (e.g. "Windows desktop") would clear every other active layer, including layers used for unrelated purposes.

## Behaviour

`SetActiveLayers` now carries a `ModifierBitset { layers, mask }`:

- For each layer index in `mask`: activate if the bit is set in `layers`, otherwise deactivate.
- Layers **outside** `mask` are left unchanged.

Unmasked `set_active_layers_to` keeps the old semantics: `mask` defaults to all layers (`BITSET_MASK_ALL`), so existing keymaps are unchanged.

Hold, Toggle, and Sticky are unchanged — they already affect a single layer and do not replace the bitset.

## Authoring (`keymap.ncl`)

Existing API (full bitset replace):

```nickel
K.layer_mod.set_active_layers_to [1]
```

Masked set (new):

```nickel
K.layer_mod.set_active_layers_amongst {
  set_active_layers_to = [3],
  affected_layers = [3, 4, 5],
}
```

Only layers 3, 4, and 5 are updated; layer 1 (e.g. LOWER) remains active if it was already on.

## Implementation

| Area | Change |
|------|--------|
| Rust | `ModifierBitset`, masking in `LayerEvent::Set`, `set_active_layers_from_bitset_with_mask` |
| Nickel codegen / ncl-to-json | `{ layers, mask }` JSON for `SetActiveLayers` |
| `layered-key.ncl` | Layer-state sim for Cucumber input resolution |
| Tests | Rust integration tests, Cucumber feature, ncl contract check |

## Tests

- `tests/rust/layered/set_active_layers.rs` — preserve outside mask, switch within mask, unmasked replace
- `features/keymap/key/layer_modifier-set_active_layers_mask.feature`

## Related

Motivated by context-dependent / "semantic" keys built on `LayeredKey` (same slot, different output per active variant). Masked `SetActiveLayers` is the layer-switching primitive; Nickel authoring sugar can follow separately.
