### PR TITLE
Support Keyboard Modifiers for Hold layer modifier

### DIFF
--- a/features/keymap/key/layer_modifier-modified_hold.feature
+++ b/features/keymap/key/layer_modifier-modified_hold.feature
@@ -1,0 +1,50 @@
+Feature: Layer Modifier: Hold (Modified)
+
+  `K.layer_mod.hold` keys support being modified with keyboard modifiers,
+   just as keyboard keys can be modified.
+
+  e.g. `K.layer_mod.hold 1 & K.LeftShift` key acts as both `Hold(1)` and
+   `LeftShift` while held.
+
+  Background:
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        layers = [
+          [
+            K.layer_mod.hold 1 & K.LeftShift,
+            K.A,
+          ],
+          [
+            K.TTTT,
+            K.B,
+          ],
+        ],
+      }
+      """
+
+  Example: modified hold layer modifier key reports as modifier
+    When the keymap registers the following input
+      """
+      [
+        press (K.layer_mod.hold 1 & K.LeftShift),
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { modifiers = { left_shift = true } }
+      """
+
+  Example: layers acts as active layer when a hold modifier key is held
+    When the keymap registers the following input
+      """
+      [
+        press (K.layer_mod.hold 1 & K.LeftShift),
+        press (K.B),
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { modifiers = { left_shift = true }, key_codes = [K.B] }
+      """

--- a/features/scripts/generate-doc.sh
+++ b/features/scripts/generate-doc.sh
@@ -24,6 +24,7 @@ keymap_key_features=(
     "layered"
     "layer_modifier-default"
     "layer_modifier-hold"
+    "layer_modifier-modified_hold"
     "layer_modifier-set_active_layers"
     "layer_modifier-sticky"
     "layer_modifier-toggle"

--- a/ncl/smart_keys/layered/keymap-codegen.ncl
+++ b/ncl/smart_keys/layered/keymap-codegen.ncl
@@ -67,7 +67,7 @@
   checks.layer_modifier_is = {
     # Use a json value to check the "is" predicate.
     check_json_is_hold =
-      let json = { Hold = 0 } in
+      let json = { Hold = [0, 0] } in
       smart_keymap.layered.modifier_key.is_json json,
     check_json_is_toggle =
       let json = { Toggle = 1 } in
@@ -85,7 +85,7 @@
         key_type = "%{module}::ModifierKey",
 
         # c.f. doc_de_layered.md.
-        # JSON serialization of key::layered::ModifierKey has variants: Default(layer), Hold(layer), SetActiveLayers([layer, ...]).
+        # JSON serialization of key::layered::ModifierKey has variants: Default(layer), Hold(layer, kb_mods), SetActiveLayers([layer, ...]).
         json_validator =
           validators.record.validator {
             fields_validator =
@@ -94,7 +94,20 @@
                 validators.record.has_only_fields ["Default", "Hold", "Sticky", "SetActiveLayers", "Toggle"],
               ],
             field_validators = {
-              Hold = validators.is_number,
+              Hold = fun hold =>
+                hold
+                |> match {
+                  [layer_index, kb_mods] =>
+                    let valid_layer_index = validators.is_number layer_index in
+                    let valid_kb_mods = validators.is_number kb_mods in
+                    [valid_layer_index, valid_kb_mods]
+                    |> match {
+                      ['Ok, 'Ok] => 'Ok,
+                      [err, 'Ok] => err,
+                      ['Ok, err] => err,
+                    },
+                  _ => 'Error { message = "expected Hold to be [layer_index, kb_mods]" },
+                },
               Toggle = validators.is_number,
               Sticky = validators.is_number,
               SetActiveLayers = validators.is_number,
@@ -114,13 +127,20 @@
                 variant = "Default",
                 rust_expr = "%{module}::ModifierKey::default(%{std.to_string layer_index})",
               },
-            { Hold = layer_index } =>
+            { Hold = [layer_index, kb_mods] } =>
               {
                 include json,
                 include module,
                 include key_type,
                 variant = "Hold",
-                rust_expr = "%{module}::ModifierKey::hold(%{std.to_string layer_index})",
+                rust_expr =
+                  let layer_index_expr = layer_index |> std.to_string in
+                  let key_expr = "%{module}::ModifierKey::hold(%{layer_index_expr})" in
+                  if kb_mods == 0 then
+                    key_expr
+                  else
+                    let kmod_expr = "smart_keymap::key::KeyboardModifiers::from_byte(%{kb_mods |> std.to_string})" in
+                    "(%{key_expr}).with_keyboard_modifiers(%{kmod_expr})",
               },
             { Toggle = layer_index } =>
               {

--- a/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
@@ -1,6 +1,8 @@
 {
   validators,
 
+  keyboard_modifiers,
+
   checks.layer_modifier =
     let K = import "keys.ncl" in
     {
@@ -34,6 +36,15 @@
         k
         |> match {
           { layer_modifier = { default_ } } => validators.is_number default_,
+          { layer_modifier = { hold }, modifiers } =>
+            let layer_validation = validators.is_number hold in
+            let mods_validation = keyboard_modifiers.validator modifiers in
+            [layer_validation, mods_validation]
+            |> match {
+              ['Ok, 'Ok] => 'Ok,
+              [err, 'Ok] => err,
+              ['Ok, err] => err,
+            },
           { layer_modifier = { hold } } => validators.is_number hold,
           { layer_modifier = { sticky } } => validators.is_number sticky,
           { layer_modifier = { toggle } } => validators.all_of [validators.is_number, validators.is_greater_than 0] toggle,
@@ -48,6 +59,9 @@
         |> match {
           { layer_modifier = { default_ = default_layer } } =>
             { Default = default_layer },
+          { layer_modifier = { hold = hold_layer }, modifiers = km } =>
+            let km = keyboard_modifiers.to_json_value km in
+            { Hold = [hold_layer, km] },
           { layer_modifier = { hold = hold_layer } } =>
             { Hold = [hold_layer, 0] },
           { layer_modifier = { toggle = toggle_layer } } =>

--- a/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
@@ -10,8 +10,8 @@
       },
 
       check_json_value_hold = {
-        actual = K.layer_mod.hold 0 |> keymap_ncl.key.to_json_value,
-        expected = { Hold = 0 },
+        actual = K.layer_mod.hold 3 |> keymap_ncl.key.to_json_value,
+        expected = { Hold = [3, 0] },
       },
 
       keymap_example_toggle = {
@@ -49,7 +49,7 @@
           { layer_modifier = { default_ = default_layer } } =>
             { Default = default_layer },
           { layer_modifier = { hold = hold_layer } } =>
-            { Hold = hold_layer },
+            { Hold = [hold_layer, 0] },
           { layer_modifier = { toggle = toggle_layer } } =>
             { Toggle = toggle_layer },
           { layer_modifier = { sticky = sticky_layer } } =>

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -1278,6 +1278,7 @@ impl<K: Debug + Keys> key::System<Ref> for System<K> {
             (Ref::Keyboard(r), KeyState::Keyboard(ks)) => self.keyboard.key_output(r, ks),
             (Ref::Mouse(r), KeyState::Mouse(ks)) => self.mouse.key_output(r, ks),
             (Ref::Sticky(r), KeyState::Sticky(ks)) => self.sticky.key_output(r, ks),
+            (Ref::Layered(r), KeyState::LayerModifier(ks)) => self.layered.key_output(r, ks),
             (_, _) => None,
         }
     }

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 
 use crate::input;
 use crate::key;
+use crate::key::KeyboardModifiers;
 
 /// The type used for layer index.
 pub type LayerIndex = u32;
@@ -29,8 +30,8 @@ pub enum Ref {
 /// Modifier layer key affects what layers are active.
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq)]
 pub enum ModifierKey {
-    /// Activates the given layer when the held.
-    Hold(LayerIndex),
+    /// Activates the given layer when held.
+    Hold(LayerIndex, KeyboardModifiers),
     /// Toggles whether the given layer is active when pressed.
     Toggle(LayerIndex),
     /// Sticky layer modifier, similar to sticky modifier key.
@@ -47,7 +48,15 @@ pub enum ModifierKey {
 impl ModifierKey {
     /// Create a new [ModifierKey] that activates the given layer when held.
     pub const fn hold(layer: LayerIndex) -> Self {
-        ModifierKey::Hold(layer)
+        ModifierKey::Hold(layer, key::KeyboardModifiers::NONE)
+    }
+
+    /// Adds keyboard modifiers to a Hold modifier key.
+    pub const fn with_keyboard_modifiers(self, mods: key::KeyboardModifiers) -> Self {
+        match self {
+            ModifierKey::Hold(layer, _) => ModifierKey::Hold(layer, mods),
+            other => other,
+        }
     }
 
     /// Create a new [ModifierKey] that activates the layer when held, or makes it sticky when tapped.
@@ -95,7 +104,7 @@ impl ModifierKey {
     /// Pressing a [ModifierKey::Hold] emits a [LayerEvent::Activated] event.
     pub fn new_pressed_key(&self) -> (ModifierKeyState, Option<LayerEvent>) {
         match self {
-            ModifierKey::Hold(layer) => {
+            ModifierKey::Hold(layer, _) => {
                 (ModifierKeyState::new(), Some(LayerEvent::Activated(*layer)))
             }
             ModifierKey::Toggle(layer) => {
@@ -524,7 +533,7 @@ impl ModifierKeyState {
         key: &ModifierKey,
     ) -> Option<LayerEvent> {
         match key {
-            ModifierKey::Hold(layer) => match event {
+            ModifierKey::Hold(layer, _) => match event {
                 key::Event::Input(input::Event::Release { keymap_index: ki }) => {
                     if keymap_index == ki {
                         Some(LayerEvent::Deactivated(*layer))
@@ -675,10 +684,20 @@ impl<
 
     fn key_output(
         &self,
-        _key_ref: &Self::Ref,
+        key_ref: &Self::Ref,
         _key_state: &Self::KeyState,
     ) -> Option<key::KeyOutput> {
-        None
+        if let Ref::Modifier(mod_key_index) = key_ref {
+            let key = self.modifier_keys[*mod_key_index as usize];
+            match key {
+                ModifierKey::Hold(_, mods) if mods != key::KeyboardModifiers::NONE => {
+                    Some(key::KeyOutput::from_key_modifiers(mods))
+                }
+                _ => None,
+            }
+        } else {
+            None
+        }
     }
 }
 
@@ -707,7 +726,7 @@ mod tests {
     #[test]
     fn test_pressing_hold_modifier_key_emits_event_activate_layer() {
         let layer = 1;
-        let key = ModifierKey::Hold(layer);
+        let key = ModifierKey::hold(layer);
 
         let (_pressed_key, layer_event) = key.new_pressed_key();
 
@@ -718,7 +737,7 @@ mod tests {
     fn test_releasing_hold_modifier_key_emits_event_deactivate_layer() {
         // Assemble: press a Hold layer modifier key
         let layer = 1;
-        let key = ModifierKey::Hold(layer);
+        let key = ModifierKey::hold(layer);
         let keymap_index = 9; // arbitrary
         let (mut pressed_key_state, _) = key.new_pressed_key();
 
@@ -746,7 +765,7 @@ mod tests {
     fn test_releasing_different_hold_modifier_key_does_not_emit_event() {
         // Assemble: press a Hold layer modifier key
         let layer = 1;
-        let key = ModifierKey::Hold(layer);
+        let key = ModifierKey::hold(layer);
         let keymap_index = 9; // arbitrary
         let (mut pressed_key_state, _) = key.new_pressed_key();
 

--- a/tests/rust/layered.rs
+++ b/tests/rust/layered.rs
@@ -1,3 +1,4 @@
+mod modified_hold;
 mod set_active_layers;
 mod sticky;
 mod tap_hold;

--- a/tests/rust/layered/modified_hold.rs
+++ b/tests/rust/layered/modified_hold.rs
@@ -1,0 +1,60 @@
+use smart_keymap::input;
+use smart_keymap::keymap::ObservedKeymap;
+use smart_keymap_macros::keymap;
+
+#[test]
+fn press_modified_hold_reports_as_modifier() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                layers = [
+                    [K.layer_mod.hold 1 & { modifiers = { left_shift = true } }, K.A],
+                    [K.TTTT, K.B],
+                ],
+            }
+        "#
+    ));
+
+    // Act
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert
+    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0x02, 0, 0, 0, 0, 0, 0, 0]];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn press_modified_hold_modifies_layer() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                layers = [
+                    [K.layer_mod.hold 1 & { modifiers = { left_shift = true } }, K.A],
+                    [K.TTTT, K.B],
+                ],
+            }
+        "#
+    ));
+
+    // Act
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0x02, 0, 0, 0, 0, 0, 0, 0],
+        [0x02, 0, 0x05, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}


### PR DESCRIPTION
This PR updates smart keymap so the `Hold` layer modifier can output a keyboard modifier while it's held.

- the `key::layered::ModifierKey` to support `KeyboardModifiers`.
- the `keymap.ncl` supporting code has been updated.
- some specifications/integration tests have been added.

I had been considering having some kind of `ModifiedKey(ref)`. But a downside of that is it only makes sense *while* the key is pressed. Whereas Nickel expressions like `k & K.LeftShift` should modify `k` with some kind of "Left Shift" behaviour. -- e.g. It's plausible we'll want to support other layer modifiers than just Hold (or may be not support them). e.g. 'K.layer_mod.toggle ... & K.LeftShift` intuitively should activate the layer with shift. -- So instead, it's better to support `KeyboardModifiers` (which are already not specific to `key::keyboard` anyway, since they're in the `key::KeyOutput`).

Implementing feature request suggested in #524.

