### PR TITLE
ncl: strict key extensions evaluation

### DIFF
--- a/ncl/keys.ncl
+++ b/ncl/keys.ncl
@@ -1,23 +1,23 @@
 let { key_extensions, extend_keys, .. } = import "key-extensions.ncl" in
 
-let rec keys =
-  std.array.fold_left
-    extend_keys
-    { include keys }
-    [
-      key_extensions.abbreviations,
-      key_extensions.aliases,
-      key_extensions.automation,
-      key_extensions.callback,
-      key_extensions.caps_word,
-      key_extensions.consumer,
-      key_extensions.custom,
-      key_extensions.keyboard,
-      key_extensions.layered,
-      key_extensions.mouse,
-      key_extensions.literals,
-      key_extensions.shifted,
-      key_extensions.sticky,
-      key_extensions.tap_hold,
-    ]
-in keys |> std.record.remove "keys"
+std.array.fold_left
+  extend_keys
+  {}
+  [
+    key_extensions.automation,
+    key_extensions.callback,
+    key_extensions.caps_word,
+    key_extensions.consumer,
+    key_extensions.consumer_aliases,
+    key_extensions.custom,
+    key_extensions.keyboard,
+    key_extensions.keyboard_shifted,
+    key_extensions.keyboard_aliases,
+    key_extensions.keyboard_abbreviations,
+    key_extensions.layered,
+    key_extensions.mouse,
+    key_extensions.mouse_aliases,
+    key_extensions.literals,
+    key_extensions.sticky,
+    key_extensions.tap_hold,
+  ]

--- a/ncl/smart_keys/consumer/key-extensions.ncl
+++ b/ncl/smart_keys/consumer/key-extensions.ncl
@@ -4,10 +4,10 @@
       (import "hid-usage-consumer.ncl")
       |> std.record.map_values (fun uc => { consumer_code = uc }),
 
-    aliases = {
-      keys,
-      VolUp = keys.VolumeUp,
-      VolDown = keys.VolumeDown,
-    },
+    consumer_aliases = fun keys =>
+      {
+        VolUp = keys.VolumeUp,
+        VolDown = keys.VolumeDown,
+      },
   },
 }

--- a/ncl/smart_keys/keyboard/key-extensions.ncl
+++ b/ncl/smart_keys/keyboard/key-extensions.ncl
@@ -25,206 +25,202 @@
         }
       ),
 
-    abbreviations = {
-      keys,
+    keyboard_abbreviations = fun keys =>
+      {
+        XXXX = keys.NO,
 
-      XXXX = keys.NO,
+        RET = keys.Return,
+        ESC = keys.Escape,
+        BSPC = keys.Backspace,
+        TAB = keys.Tab,
+        SPC = keys.Space,
 
-      RET = keys.Return,
-      ESC = keys.Escape,
-      BSPC = keys.Backspace,
-      TAB = keys.Tab,
-      SPC = keys.Space,
+        ENT = keys.Enter,
 
-      ENT = keys.Enter,
+        EXCL = keys.Exclaim,
+        AT = keys.At,
+        HASH = keys.Hash,
+        DLR = keys.Dollar,
+        PCT = keys.Percent,
+        CARE = keys.Caret, # ^
+        AMP = keys.Ampersand,
+        ASTR = keys.Asterisk,
+        LPRN = keys.LeftParen,
+        RPRN = keys.RightParen,
 
-      EXCL = keys.Exclaim,
-      AT = keys.At,
-      HASH = keys.Hash,
-      DLR = keys.Dollar,
-      PCT = keys.Percent,
-      CARE = keys.Caret, # ^
-      AMP = keys.Ampersand,
-      ASTR = keys.Asterisk,
-      LPRN = keys.LeftParen,
-      RPRN = keys.RightParen,
+        PERC = keys.Percent,
+        CIRC = keys.Circumflex, # ^
 
-      PERC = keys.Percent,
-      CIRC = keys.Circumflex, # ^
+        LBRK = keys.LeftBracket, # [
+        LCBR = keys.LeftCurlyBracket, # {
+        LBRC = keys.LeftBrace, # {
+        RBRK = keys.RightBracket,
+        RCBR = keys.RightCurlyBracket,
+        RBRC = keys.RightBrace,
 
-      LBRK = keys.LeftBracket, # [
-      LCBR = keys.LeftCurlyBracket, # {
-      LBRC = keys.LeftBrace, # {
-      RBRK = keys.RightBracket,
-      RCBR = keys.RightCurlyBracket,
-      RBRC = keys.RightBrace,
+        GRV = keys.Grave, # `
+        TILD = keys.Tilde, # ~
 
-      GRV = keys.Grave, # `
-      TILD = keys.Tilde, # ~
+        MINS = keys.Minus,
+        UNDS = keys.Underscore,
+        EQLS = keys.Equals,
+        PLUS = keys.Plus,
 
-      MINS = keys.Minus,
-      UNDS = keys.Underscore,
-      EQLS = keys.Equals,
-      PLUS = keys.Plus,
+        SLSH = keys.Slash,
+        QUES = keys.Question,
+        BSLS = keys.Backslash,
+        PIPE = keys.Pipe,
 
-      SLSH = keys.Slash,
-      QUES = keys.Question,
-      BSLS = keys.Backslash,
-      PIPE = keys.Pipe,
+        SCLN = keys.Semicolon,
+        COLN = keys.Colon,
+        QUOT = keys.Quote,
+        DQUO = keys.DoubleQuote,
 
-      SCLN = keys.Semicolon,
-      COLN = keys.Colon,
-      QUOT = keys.Quote,
-      DQUO = keys.DoubleQuote,
+        COMM = keys.Comma,
+        LABR = keys.LeftAngleBracket,
+        DOT = keys.Dot,
+        RABR = keys.RightAngleBracket,
 
-      COMM = keys.Comma,
-      LABR = keys.LeftAngleBracket,
-      DOT = keys.Dot,
-      RABR = keys.RightAngleBracket,
+        CAPS = keys.CapsLock,
 
-      CAPS = keys.CapsLock,
+        PSCR = keys.PrintScreen,
+        SCRL = keys.ScrollLock,
+        PAUS = keys.Pause,
 
-      PSCR = keys.PrintScreen,
-      SCRL = keys.ScrollLock,
-      PAUS = keys.Pause,
+        SLCK = keys.ScrollLock,
 
-      SLCK = keys.ScrollLock,
+        INS = keys.Insert,
+        HOME = keys.Home,
+        PGUP = keys.PageUp,
+        DEL = keys.Delete,
+        END = keys.End,
+        PGDN = keys.PageDown,
 
-      INS = keys.Insert,
-      HOME = keys.Home,
-      PGUP = keys.PageUp,
-      DEL = keys.Delete,
-      END = keys.End,
-      PGDN = keys.PageDown,
+        RGHT = keys.Right,
+        LEFT = keys.Left,
+        DOWN = keys.Down,
+        UP = keys.Up,
 
-      RGHT = keys.Right,
-      LEFT = keys.Left,
-      DOWN = keys.Down,
-      UP = keys.Up,
+        NPNL = keys.NumLock,
+        NPSL = keys.NPSlash,
+        NPST = keys.NPStar,
+        NPMN = keys.NPMinus,
+        NPPL = keys.NPPlus,
+        NPEN = keys.NPEnter,
+        NPDT = keys.NPDot,
 
-      NPNL = keys.NumLock,
-      NPSL = keys.NPSlash,
-      NPST = keys.NPStar,
-      NPMN = keys.NPMinus,
-      NPPL = keys.NPPlus,
-      NPEN = keys.NPEnter,
-      NPDT = keys.NPDot,
+        LCTL = keys.LeftCtrl,
+        LSFT = keys.LeftShift,
+        LALT = keys.LeftAlt,
+        LGUI = keys.LeftGUI,
+        RCTL = keys.RightCtrl,
+        RSFT = keys.RightShift,
+        RALT = keys.RightAlt,
+        RGUI = keys.RightGUI,
 
-      LCTL = keys.LeftCtrl,
-      LSFT = keys.LeftShift,
-      LALT = keys.LeftAlt,
-      LGUI = keys.LeftGUI,
-      RCTL = keys.RightCtrl,
-      RSFT = keys.RightShift,
-      RALT = keys.RightAlt,
-      RGUI = keys.RightGUI,
+        APPN = keys.Application,
 
-      APPN = keys.Application,
+        NUSH = keys.NonUSHash,
+        NUSB = keys.NonUSBackslash,
 
-      NUSH = keys.NonUSHash,
-      NUSB = keys.NonUSBackslash,
+        RST = keys.reset,
+        BOOT = keys.reset_to_bootloader,
 
-      RST = keys.reset,
-      BOOT = keys.reset_to_bootloader,
+        CWTG = keys.caps_word.toggle,
+      },
 
-      CWTG = keys.caps_word.toggle,
-    },
+    keyboard_aliases = fun keys =>
+      {
+        Enter = keys.Return,
+        Circumflex = keys.Caret, # ^
+        LeftBrace = keys.LeftCurlyBracket, # {
+        RightBrace = keys.RightCurlyBracket,
+      },
 
-    aliases = {
-      keys,
+    literals = fun keys =>
+      {
+        "1" = keys.N1,
+        "2" = keys.N2,
+        "3" = keys.N3,
+        "4" = keys.N4,
+        "5" = keys.N5,
+        "6" = keys.N6,
+        "7" = keys.N7,
+        "8" = keys.N8,
+        "9" = keys.N9,
+        "0" = keys.N0,
 
-      Enter = keys.Return,
-      Circumflex = keys.Caret, # ^
-      LeftBrace = keys.LeftCurlyBracket, # {
-      RightBrace = keys.RightCurlyBracket,
-    },
+        "!" = keys.Exclaim,
+        "@" = keys.At,
+        "#" = keys.Hash,
+        "$" = keys.Dollar,
+        "%" = keys.Percent,
+        "^" = keys.Caret,
+        "&" = keys.Ampersand,
+        "*" = keys.Asterisk,
+        "(" = keys.LeftParen,
+        ")" = keys.RightParen,
 
-    literals = {
-      keys,
+        "[" = keys.LeftBracket,
+        "{" = keys.LeftCurlyBracket,
+        "]" = keys.RightBracket,
+        "}" = keys.RightCurlyBracket,
 
-      "1" = keys.N1,
-      "2" = keys.N2,
-      "3" = keys.N3,
-      "4" = keys.N4,
-      "5" = keys.N5,
-      "6" = keys.N6,
-      "7" = keys.N7,
-      "8" = keys.N8,
-      "9" = keys.N9,
-      "0" = keys.N0,
+        "`" = keys.Grave,
+        "~" = keys.Tilde,
 
-      "!" = keys.Exclaim,
-      "@" = keys.At,
-      "#" = keys.Hash,
-      "$" = keys.Dollar,
-      "%" = keys.Percent,
-      "^" = keys.Caret,
-      "&" = keys.Ampersand,
-      "*" = keys.Asterisk,
-      "(" = keys.LeftParen,
-      ")" = keys.RightParen,
+        "-" = keys.Minus,
+        "_" = keys.Underscore,
+        "=" = keys.Equals,
+        "+" = keys.Plus,
 
-      "[" = keys.LeftBracket,
-      "{" = keys.LeftCurlyBracket,
-      "]" = keys.RightBracket,
-      "}" = keys.RightCurlyBracket,
+        "/" = keys.Slash,
+        "?" = keys.Question,
+        "\\" = keys.Backslash,
+        "|" = keys.Pipe,
 
-      "`" = keys.Grave,
-      "~" = keys.Tilde,
+        ";" = keys.Semicolon,
+        ":" = keys.Colon,
+        "'" = keys.Quote,
+        "\"" = keys.DoubleQuote,
 
-      "-" = keys.Minus,
-      "_" = keys.Underscore,
-      "=" = keys.Equals,
-      "+" = keys.Plus,
+        "," = keys.Comma,
+        "<" = keys.LeftAngleBracket,
+        "." = keys.Dot,
+        ">" = keys.RightAngleBracket,
 
-      "/" = keys.Slash,
-      "?" = keys.Question,
-      "\\" = keys.Backslash,
-      "|" = keys.Pipe,
+        " " = keys.Space,
+      },
 
-      ";" = keys.Semicolon,
-      ":" = keys.Colon,
-      "'" = keys.Quote,
-      "\"" = keys.DoubleQuote,
+    keyboard_shifted = fun keys =>
+      {
+        Exclaim = keys.N1 & keys.LeftShift,
+        At = keys.N2 & keys.LeftShift,
+        Hash = keys.N3 & keys.LeftShift,
+        Dollar = keys.N4 & keys.LeftShift,
+        Percent = keys.N5 & keys.LeftShift,
+        Caret = keys.N6 & keys.LeftShift, # ^
+        Ampersand = keys.N7 & keys.LeftShift,
+        Asterisk = keys.N8 & keys.LeftShift,
+        LeftParen = keys.N9 & keys.LeftShift,
+        RightParen = keys.N0 & keys.LeftShift,
 
-      "," = keys.Comma,
-      "<" = keys.LeftAngleBracket,
-      "." = keys.Dot,
-      ">" = keys.RightAngleBracket,
+        LeftCurlyBracket = keys.LeftBracket & keys.LeftShift,
+        RightCurlyBracket = keys.RightBracket & keys.LeftShift,
 
-      " " = keys.Space,
-    },
+        Tilde = keys.Grave & keys.LeftShift, # ~
 
-    shifted = {
-      keys,
+        Plus = keys.Equals & keys.LeftShift,
+        Underscore = keys.Minus & keys.LeftShift,
 
-      Exclaim = keys.N1 & keys.LeftShift,
-      At = keys.N2 & keys.LeftShift,
-      Hash = keys.N3 & keys.LeftShift,
-      Dollar = keys.N4 & keys.LeftShift,
-      Percent = keys.N5 & keys.LeftShift,
-      Caret = keys.N6 & keys.LeftShift, # ^
-      Ampersand = keys.N7 & keys.LeftShift,
-      Asterisk = keys.N8 & keys.LeftShift,
-      LeftParen = keys.N9 & keys.LeftShift,
-      RightParen = keys.N0 & keys.LeftShift,
+        Question = keys.Slash & keys.LeftShift,
+        Pipe = keys.Backslash & keys.LeftShift,
 
-      LeftCurlyBracket = keys.LeftBracket & keys.LeftShift,
-      RightCurlyBracket = keys.RightBracket & keys.LeftShift,
+        Colon = keys.Semicolon & keys.LeftShift,
+        DoubleQuote = keys.Quote & keys.LeftShift,
 
-      Tilde = keys.Grave & keys.LeftShift, # ~
-
-      Plus = keys.Equals & keys.LeftShift,
-      Underscore = keys.Minus & keys.LeftShift,
-
-      Question = keys.Slash & keys.LeftShift,
-      Pipe = keys.Backslash & keys.LeftShift,
-
-      Colon = keys.Semicolon & keys.LeftShift,
-      DoubleQuote = keys.Quote & keys.LeftShift,
-
-      LeftAngleBracket = keys.Comma & keys.LeftShift,
-      RightAngleBracket = keys.Dot & keys.LeftShift,
-    },
+        LeftAngleBracket = keys.Comma & keys.LeftShift,
+        RightAngleBracket = keys.Dot & keys.LeftShift,
+      },
   },
 }

--- a/ncl/smart_keys/mouse/key-extensions.ncl
+++ b/ncl/smart_keys/mouse/key-extensions.ncl
@@ -18,22 +18,21 @@
       MouseWheelLeft = { mouse = "WheelLeft" },
       MouseWheelRight = { mouse = "WheelRight" },
     },
-    aliases = {
-      keys,
+    mouse_aliases = fun keys =>
+      {
+        MouseBtn1 = keys.MouseButton1,
+        MouseBtn2 = keys.MouseButton2,
+        MouseBtn3 = keys.MouseButton3,
+        MouseBtn4 = keys.MouseButton4,
+        MouseBtn5 = keys.MouseButton5,
+        MouseBtn6 = keys.MouseButton6,
+        MouseBtn7 = keys.MouseButton7,
+        MouseBtn8 = keys.MouseButton8,
 
-      MouseBtn1 = keys.MouseButton1,
-      MouseBtn2 = keys.MouseButton2,
-      MouseBtn3 = keys.MouseButton3,
-      MouseBtn4 = keys.MouseButton4,
-      MouseBtn5 = keys.MouseButton5,
-      MouseBtn6 = keys.MouseButton6,
-      MouseBtn7 = keys.MouseButton7,
-      MouseBtn8 = keys.MouseButton8,
-
-      MouseScrollUp = keys.MouseWheelUp,
-      MouseScrollDown = keys.MouseWheelDown,
-      MouseScrollLeft = keys.MouseWheelLeft,
-      MouseScrollRight = keys.MouseWheelRight,
-    },
+        MouseScrollUp = keys.MouseWheelUp,
+        MouseScrollDown = keys.MouseWheelDown,
+        MouseScrollLeft = keys.MouseWheelLeft,
+        MouseScrollRight = keys.MouseWheelRight,
+      },
   },
 }

--- a/ncl/smart_keys/tap_hold/key-extensions.ncl
+++ b/ncl/smart_keys/tap_hold/key-extensions.ncl
@@ -1,18 +1,17 @@
 {
-  key_extensions.tap_hold = {
-    keys,
+  key_extensions.tap_hold = fun keys =>
+    {
+      hold
+        | doc "creates a hold key modifier"
+        = fun key => { hold = key },
 
-    hold
-      | doc "creates a hold key modifier"
-      = fun key => { hold = key },
-
-    H_LCtrl = hold keys.LeftCtrl,
-    H_LShift = hold keys.LeftShift,
-    H_LAlt = hold keys.LeftAlt,
-    H_LGUI = hold keys.LeftGUI,
-    H_RCtrl = hold keys.RightCtrl,
-    H_RShift = hold keys.RightShift,
-    H_RAlt = hold keys.RightAlt,
-    H_RGUI = hold keys.RightGUI,
-  },
+      H_LCtrl = hold keys.LeftCtrl,
+      H_LShift = hold keys.LeftShift,
+      H_LAlt = hold keys.LeftAlt,
+      H_LGUI = hold keys.LeftGUI,
+      H_RCtrl = hold keys.RightCtrl,
+      H_RShift = hold keys.RightShift,
+      H_RAlt = hold keys.RightAlt,
+      H_RGUI = hold keys.RightGUI,
+    },
 }


### PR DESCRIPTION
Avoid errors related to infinite recursion, which somehow regressed from earlier `nickel` versions.