### PR TITLE
tests: add snapshot test for key abbreviation

### DIFF
--- a/ncl/scripts/run-tests.sh
+++ b/ncl/scripts/run-tests.sh
@@ -30,6 +30,7 @@ ncl_tests=(
     "keymap-60key-dvorak-simple"
     "keymap-60key-dvorak-simple-with-tap_hold"
     "keymap-34key-seniply"
+    "keymap-1key-abbrev-ent"
 )
 for ncl_test in "${ncl_tests[@]}"
 do

--- a/ncl/scripts/save-test-snapshots.sh
+++ b/ncl/scripts/save-test-snapshots.sh
@@ -24,6 +24,7 @@ ncl_tests=(
     "keymap-60key-dvorak-simple"
     "keymap-60key-dvorak-simple-with-tap_hold"
     "keymap-34key-seniply"
+    "keymap-1key-abbrev-ent"
 )
 for ncl_test in "${ncl_tests[@]}"
 do

--- a/tests/ncl/keymap-1key-abbrev-ent/.gitignore
+++ b/tests/ncl/keymap-1key-abbrev-ent/.gitignore
@@ -1,0 +1,1 @@
+keymap.json

--- a/tests/ncl/keymap-1key-abbrev-ent/expected.rs
+++ b/tests/ncl/keymap-1key-abbrev-ent/expected.rs
@@ -1,0 +1,117 @@
+/// Types and initial data used for constructing [KEYMAP].
+pub mod init {
+    use crate as smart_keymap;
+
+    /// Number of instructions used by the [crate::key::automation] implementation.
+    pub const AUTOMATION_INSTRUCTION_COUNT: usize = 0;
+
+    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
+    pub const LAYERED_LAYER_COUNT: usize = 0;
+
+    /// The maximum number of keys in a chord.
+    pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
+
+    /// The maximum number of chords.
+    pub const CHORDED_MAX_CHORDS: usize = 0;
+
+    /// The maximum number of overlapping chords for a chorded key.
+    pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+
+    /// The tap-dance definitions.
+    pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;
+
+    pub use smart_keymap::key::composite::Ref;
+
+    pub use smart_keymap::key::composite::Context;
+
+    pub use smart_keymap::key::composite::Event;
+
+    pub use smart_keymap::key::composite::PendingKeyState;
+
+    pub use smart_keymap::key::composite::KeyState;
+
+    const AUTOMATION: usize = 0;
+    const CALLBACK: usize = 0;
+    const CHORDED: usize = 0;
+    const CHORDED_AUXILIARY: usize = 0;
+    const KEYBOARD: usize = 0;
+    const LAYERED: usize = 0;
+    const LAYER_MODIFIERS: usize = 0;
+    const STICKY: usize = 0;
+    const TAP_DANCE: usize = 0;
+    const TAP_HOLD: usize = 0;
+
+    /// The System type
+    pub type System = smart_keymap::key::composite::System<
+        smart_keymap::key::composite::KeyArrays<
+            AUTOMATION,
+            CALLBACK,
+            CHORDED,
+            CHORDED_AUXILIARY,
+            KEYBOARD,
+            LAYERED,
+            LAYER_MODIFIERS,
+            STICKY,
+            TAP_DANCE,
+            TAP_HOLD,
+        >,
+    >;
+
+    /// The number of keys in the keymap.
+    pub const KEY_COUNT: usize = 1;
+
+    /// The key references.
+    pub const KEY_REFS: [Ref; KEY_COUNT] = [smart_keymap::key::composite::Ref::Keyboard(
+        smart_keymap::key::keyboard::Ref::KeyCode(40),
+    )];
+
+    /// The keymap config.
+    pub const CONFIG: smart_keymap::key::composite::Config = smart_keymap::key::composite::Config {
+        automation: smart_keymap::key::automation::Config::new(),
+        chorded: smart_keymap::key::chorded::Config {
+            chords: smart_keymap::slice::Slice::from_slice(&[]),
+            ..smart_keymap::key::chorded::Config::new()
+        },
+        sticky: smart_keymap::key::sticky::Config::new(),
+        tap_dance: smart_keymap::key::tap_dance::Config::new(),
+        tap_hold: smart_keymap::key::tap_hold::Config::new(),
+        ..smart_keymap::key::composite::Config::new()
+    };
+
+    /// Initial [Context] value.
+    pub const CONTEXT: Context =
+        smart_keymap::key::composite::Context::from_config(smart_keymap::key::composite::Config {
+            automation: smart_keymap::key::automation::Config::new(),
+            chorded: smart_keymap::key::chorded::Config {
+                chords: smart_keymap::slice::Slice::from_slice(&[]),
+                ..smart_keymap::key::chorded::Config::new()
+            },
+            sticky: smart_keymap::key::sticky::Config::new(),
+            tap_dance: smart_keymap::key::tap_dance::Config::new(),
+            tap_hold: smart_keymap::key::tap_hold::Config::new(),
+            ..smart_keymap::key::composite::Config::new()
+        });
+
+    /// The key system.
+    pub const SYSTEM: System = smart_keymap::key::composite::System::array_based(
+        smart_keymap::key::automation::System::new([]),
+        smart_keymap::key::callback::System::new([]),
+        smart_keymap::key::chorded::System::new([], []),
+        smart_keymap::key::keyboard::System::new([]),
+        smart_keymap::key::layered::System::new([], []),
+        smart_keymap::key::sticky::System::new([]),
+        smart_keymap::key::tap_dance::System::new([]),
+        smart_keymap::key::tap_hold::System::new([]),
+    );
+
+    /// Alias for the [keymap::Keymap] type.
+    pub type Keymap = smart_keymap::keymap::Keymap<
+        [Ref; KEY_COUNT],
+        Ref,
+        Context,
+        Event,
+        PendingKeyState,
+        KeyState,
+        System,
+    >;
+}

--- a/tests/ncl/keymap-1key-abbrev-ent/keymap.ncl
+++ b/tests/ncl/keymap-1key-abbrev-ent/keymap.ncl
@@ -1,0 +1,5 @@
+let K = import "keys.ncl" in
+
+{
+  keys = [ K.ENT ],
+}


### PR DESCRIPTION
The `ENT` key is an abbreviation of `Enter`, which is an alias for `Return`.

In an earlier revision of #527, I broke this alias. Let's cover it with a snapshot test.