### PR TITLE
ci: cargo test: use longer timeout for cucumber suite

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -112,5 +112,5 @@ jobs:
           sudo cp ./nickel-x86_64-linux /usr/bin/nickel
 
       - name: Run Cargo Test (cucumber-keymap)
-        timeout-minutes: 8
+        timeout-minutes: 15
         run: cargo test --test cucumber-keymap


### PR DESCRIPTION
From #527, we noticed that the cucumber suite takes much longer (10 minutes) with newer Nickel version.