### PR TITLE
tests: ceedling: fix Nix vendor read-only permissions on rerun

### DIFF
--- a/tests/ceedling/ceedling.mk
+++ b/tests/ceedling/ceedling.mk
@@ -2,8 +2,14 @@ CEEDLING = ceedling
 
 TEST_KEYMAP = keymap-4key-simple
 
+# Ceedling vendors Unity from the Nix store with read-only perms;
+# a second run fails when it tries to overwrite build/vendor/*.c without this.
+.PHONY: fix-ceedling-vendor
+fix-ceedling-vendor:
+	if test -d tests/ceedling/build/vendor; then chmod -R u+w tests/ceedling/build/vendor; fi
+
 .PHONY: test-ceedling
-test-ceedling: include/smart_keymap.h
+test-ceedling: include/smart_keymap.h fix-ceedling-vendor
 	env SMART_KEYMAP_CUSTOM_KEYMAP="$(shell pwd)/tests/ncl/$(TEST_KEYMAP)/keymap.ncl" \
 	  $(CARGO) build --package "smart_keymap"
 	cd tests/ceedling && $(CEEDLING)


### PR DESCRIPTION
## Summary

- Add `fix-ceedling-vendor` phony Make target that chmods `tests/ceedling/build/vendor/` writable

## Problem

Ceedling vendors Unity from the Nix store into `build/vendor/` on every startup. Nix store files are read-only, and `cp_r` preserves those permissions. The first run succeeds; the second fails with:

```
Permission denied @ rb_sysopen - build/vendor/unity/src/./unity.c
```
