### PR TITLE
tests: ceedling: simplify project.yml to non-default settings

### DIFF
--- a/tests/ceedling/project.yml
+++ b/tests/ceedling/project.yml
@@ -1,228 +1,30 @@
-# =========================================================================
-#   Ceedling - Test-Centered Build System for C
-#   ThrowTheSwitch.org
-#   Copyright (c) 2010-24 Mike Karlesky, Mark VanderVoord, & Greg Williams
-#   SPDX-License-Identifier: MIT
-# =========================================================================
-
 ---
 :project:
-  # how to use ceedling. If you're not sure, leave this as `gem` and `?`
   :which_ceedling: gem
   :ceedling_version: 1.0.0
-
-  # optional features. If you don't need them, keep them turned off for performance
-  :use_mocks: TRUE
-  :use_test_preprocessor: :none
-  :use_backtrace: :simple
-  :use_decorators: :auto #Decorate Ceedling's output text. Your options are :auto, :all, or :none
-
-  # tweak the way ceedling handles automatic tasks
   :build_root: build
-  :test_file_prefix: test_
-  :default_tasks:
-    - test:all
+  :use_mocks: FALSE
 
-  # performance options. If your tools start giving mysterious errors, consider
-  # dropping this to 1 to force single-tasking
-  :test_threads: 1
-  :compile_threads: 8
-
-  # enable release build (more details in release_build section below)
-  :release_build: FALSE
-
-# Specify where to find mixins and any that should be enabled automatically
-:mixins:
-  :enabled: []
-  :load_paths: []
-
-# further details to configure the way Ceedling handles test code
-:test_build:
-  :use_assembly: FALSE
-
-# further details to configure the way Ceedling handles release code
-:release_build:
-  :output: MyApp.out
-  :use_assembly: FALSE
-  :artifacts: []
-
-# Plugins are optional Ceedling features which can be enabled. Ceedling supports
-# a variety of plugins which may effect the way things are compiled, reported,
-# or may provide new command options. Refer to the readme in each plugin for
-# details on how to use it.
 :plugins:
-  :load_paths: []
   :enabled:
-    #- beep                           # beeps when finished, so you don't waste time waiting for ceedling
-    - module_generator                # handy for quickly creating source, header, and test templates
-    #- gcov                           # test coverage using gcov. Requires gcc, gcov, and a coverage analyzer like gcovr
-    #- bullseye                       # test coverage using bullseye. Requires bullseye for your platform
-    #- command_hooks                  # write custom actions to be called at different points during the build process
-    #- compile_commands_json_db       # generate a compile_commands.json file
-    #- dependencies                   # automatically fetch 3rd party libraries, etc.
-    #- subprojects                    # managing builds and test for static libraries
-    #- fake_function_framework        # use FFF instead of CMock
-
-    # Report options (You'll want to choose one stdout option, but may choose multiple stored options if desired)
-    #- report_build_warnings_log
-    #- report_tests_gtestlike_stdout
-    #- report_tests_ide_stdout
-    #- report_tests_log_factory
     - report_tests_pretty_stdout
-    #- report_tests_raw_output_log
-    #- report_tests_teamcity_stdout
 
-# Specify which reports you'd like from the log factory
-:report_tests_log_factory:
-  :reports:
-    - json
-    - junit
-    - cppunit
-    - html
-
-# override the default extensions for your system and toolchain
-:extension:
-  #:header: .h
-  #:source: .c
-  #:assembly: .s
-  #:dependencies: .d
-  #:object: .o
-  :executable: .out
-  #:testpass: .pass
-  #:testfail: .fail
-  #:subprojects: .a
-
-# This is where Ceedling should look for your source and test files.
-# see documentation for the many options for specifying this.
 :paths:
   :test:
     - +:test/**
     - -:test/support
   :source: []
   :include:
-    - ../../include # In simple projects, this entry often duplicates :source
+    - ../../include
   :support:
     - test/support
   :libraries:
     - ../../target/debug/
 
-# You can even specify specific files to add or remove from your test
-# and release collections. Usually it's better to use paths and let
-# Ceedling do the work for you!
-:files:
-  :test: []
-  :source: []
+:libraries:
+  :system:
+    - smart_keymap
 
-# Compilation symbols to be injected into builds
-# See documentation for advanced options:
-#  - Test name matchers for different symbols per test executable build
-#  - Referencing symbols in multiple lists using advanced YAML
-#  - Specifiying symbols used during test preprocessing
-:defines:
-  :test:
-    - TEST # Simple list option to add symbol 'TEST' to compilation of all files in all test executables
-  :release: []
-
-  # Enable to inject name of a test as a unique compilation symbol into its respective executable build.
-  :use_test_definition: FALSE
-
-# Configure additional command line flags provided to tools used in each build step
-# :flags:
-#   :release:
-#     :compile:         # Add '-Wall' and '--02' to compilation of all files in release target
-#       - -Wall
-#       - --O2
-#   :test:
-#     :compile:
-#       '(_|-)special': # Add '-pedantic' to compilation of all files in all test executables with '_special' or '-special' in their names
-#         - -pedantic
-#       '*':            # Add '-foo' to compilation of all files in all test executables
-#         - -foo
-
-# Configuration Options specific to CMock. See CMock docs for details
-:cmock:
-  # Core conffiguration
-  :plugins:                        # What plugins should be used by CMock?
-    - :ignore
-    - :callback
-  :verbosity:  2                   # the options being 0 errors only, 1 warnings and errors, 2 normal info, 3 verbose
-  :when_no_prototypes:  :warn      # the options being :ignore, :warn, or :erro
-
-  # File configuration
-  :skeleton_path:  ''              # Subdirectory to store stubs when generated (default: '')
-  :mock_prefix:  'mock_'           # Prefix to append to filenames for mocks
-  :mock_suffix:  ''                # Suffix to append to filenames for mocks
-
-  # Parser configuration
-  :strippables:  ['(?:__attribute__\s*\([ (]*.*?[ )]*\)+)']
-  :attributes:
-     - __ramfunc
-     - __irq
-     - __fiq
-     - register
-     - extern
-  :c_calling_conventions:
-     - __stdcall
-     - __cdecl
-     - __fastcall
-  :treat_externs:  :exclude        # the options being :include or :exclud
-  :treat_inlines:  :exclude        # the options being :include or :exclud
-
-  # Type handling configuration
-  #:unity_helper_path: ''          # specify a string of where to find a unity_helper.h file to discover custom type assertions
-  :treat_as:                       # optionally add additional types to map custom types
-    uint8:    HEX8
-    uint16:   HEX16
-    uint32:   UINT32
-    int8:     INT8
-    bool:     UINT8
-  #:treat_as_array:  {}            # hint to cmock that these types are pointers to something
-  #:treat_as_void:  []             # hint to cmock that these types are actually aliases of void
-  :memcmp_if_unknown:  true        # allow cmock to use the memory comparison assertions for unknown types
-  :when_ptr:  :compare_data        # hint to cmock how to handle pointers in general, the options being :compare_ptr, :compare_data, or :smart
-
-  # Mock generation configuration
-  :weak:  ''                       # Symbol to use to declare weak functions
-  :enforce_strict_ordering: true   # Do we want cmock to enforce ordering of all function calls?
-  :fail_on_unexpected_calls: true  # Do we want cmock to fail when it encounters a function call that wasn't expected?
-  :callback_include_count: true    # Do we want cmock to include the number of calls to this callback, when using callbacks?
-  :callback_after_arg_check: false # Do we want cmock to enforce an argument check first when using a callback?
-  #:includes: []                   # You can add additional includes here, or specify the location with the options below
-  #:includes_h_pre_orig_header: []
-  #:includes_h_post_orig_header: []
-  #:includes_c_pre_header:  []
-  #:includes_c_post_header:  []
-  #:array_size_type:  []            # Specify a type or types that should be used for array lengths
-  #:array_size_name:  'size|len'    # Specify a name or names that CMock might automatically recognize as the length of an array
-  :exclude_setjmp_h:  false        # Don't use setjmp when running CMock. Note that this might result in late reporting or out-of-order failures.
-
-# Configuration options specific to Unity.
 :unity:
   :defines:
     - UNITY_EXCLUDE_FLOAT
-
-# You can optionally have ceedling create environment variables for you before
-# performing the rest of its tasks.
-:environment: []
-# :environment:
-#   # List enforces order allowing later to reference earlier with inline Ruby substitution
-#   - :var1: value
-#   - :var2: another value
-#   - :path:            # Special PATH handling with platform-specific path separators
-#     - #{ENV['PATH']}  # Environment variables can use inline Ruby substitution
-#     - /another/path/to/include
-
-# LIBRARIES
-# These libraries are automatically injected into the build process. Those specified as
-# common will be used in all types of builds. Otherwise, libraries can be injected in just
-# tests or releases. These options are MERGED with the options in supplemental yaml files.
-:libraries:
-  :placement: :end
-  :flag: "-l${1}"
-  :path_flag: "-L ${1}"
-  :system:
-    - smart_keymap
-  :test: []
-  :release: []
-
-...


### PR DESCRIPTION
## Summary

Trim `tests/ceedling/project.yml` from ~228 lines to ~30 by removing Ceedling boilerplate, commented defaults, and unused sections (CMock config, mixins, release build, module_generator, etc.).

Kept only project-specific settings:

- Paths to tests, includes, `smart_keymap` static lib
- `:use_mocks: FALSE`
- `UNITY_EXCLUDE_FLOAT`
- `report_tests_pretty_stdout` plugin

## Test plan

- [x] `make test-ceedling` — 17/17 pass