### PR TITLE
tests: ceedling: add assemble/act/assert comments to tests

### DIFF
--- a/tests/ceedling/test/test_keydef_taphold.c
+++ b/tests/ceedling/test/test_keydef_taphold.c
@@ -15,71 +15,68 @@ void setUp(void) {}
 void tearDown(void) {}
 
 void test_taphold_dth_uth_is_tap(void) {
-  // Pressing T.H., then releasing T.H., is same as tapping the tap key.
-  // (Check the tap key gets pressed).
-
   uint8_t expected_report[8] = {0, 0, KC_C, 0, 0, 0, 0, 0};
   KeymapHidReport report = {};
   KeymapHidReport* actual_report = &report;
 
+  // assemble: init keymap
   keymap_init();
 
+  // act: press then release tap-hold key before hold timeout
   keymap_register_input_event((struct KeymapInputEvent){
       .event_type = KeymapEventPress,
       .value = 0}); // First key in keymap is TapHold(C, _)
   keymap_tick(actual_report);
   keymap_register_input_event(
       (struct KeymapInputEvent){.event_type = KeymapEventRelease, .value = 0});
-
   keymap_tick(actual_report);
+
+  // assert: tap key (C) appears in report
   TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
 }
 
 void test_taphold_dth_uth_eventually_clears(void) {
-  // Pressing T.H., then releasing T.H., is same as tapping the tap key.
-  // (Check the tap key releases).
-
   uint8_t expected_report[8] = {0, 0, 0, 0, 0, 0, 0, 0};
   KeymapHidReport report = {};
   KeymapHidReport* actual_report = &report;
 
+  // assemble: init keymap
   keymap_init();
 
+  // act: press then release tap-hold key, then poll until tap clears
   keymap_register_input_event((struct KeymapInputEvent){
       .event_type = KeymapEventPress,
       .value = 0}); // First key in keymap is TapHold(C, _)
   keymap_tick(actual_report);
   keymap_register_input_event(
       (struct KeymapInputEvent){.event_type = KeymapEventRelease, .value = 0});
-
   keymap_tick(actual_report);
 
-  // The 'tap' from the TapHold key should be released.
-  // after ... an implementation-specific number of ticks.
   for (int i = 0; i < 50; i++) {
     keymap_tick(actual_report);
   }
 
+  // assert: tap key released from report
   TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
 }
 
 void test_taphold_dth_eventually_holds(void) {
-  // Pressing T.H., is eventually the same as holding the hold key.
-
   uint8_t expected_report[8] = {MOD_LCTL, 0, 0, 0, 0, 0, 0, 0};
   KeymapHidReport report = {};
   KeymapHidReport* actual_report = &report;
 
+  // assemble: init keymap
   keymap_init();
 
+  // act: press tap-hold key and wait for hold timeout
   keymap_register_input_event((struct KeymapInputEvent){
       .event_type = KeymapEventPress,
       .value = 0}); // First key in keymap is TapHold(C, _)
 
-  // Wait 500ms
   for (int i = 0; i < 500; i++) {
     keymap_tick(actual_report);
   }
 
+  // assert: hold modifier (Left Ctrl) in report
   TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
 }

--- a/tests/ceedling/test/test_keymap.c
+++ b/tests/ceedling/test/test_keymap.c
@@ -43,28 +43,30 @@ void test_keyboard_keyrelease(void) {
   KeymapHidReport report = {};
   KeymapHidReport* actual_report = &report;
 
+  // assemble: init keymap
   keymap_init();
 
+  // act: press then release key A
   keymap_register_input_event(
       (struct KeymapInputEvent){.event_type = KeymapEventPress, .value = 2});
   keymap_tick(actual_report);
   keymap_register_input_event(
       (struct KeymapInputEvent){.event_type = KeymapEventRelease, .value = 2});
-
   keymap_tick(actual_report);
 
+  // assert: empty report
   TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
 }
 
 void test_keyboard_keypress_sequence_da_db(void) {
-  // Pressing A, then B, should report "A B"
-
   uint8_t expected_report[8] = {0, 0, KC_A, KC_B, 0, 0, 0, 0};
   KeymapHidReport report = {};
   KeymapHidReport* actual_report = &report;
 
+  // assemble: init keymap
   keymap_init();
 
+  // act: press A then B
   keymap_register_input_event(
       (struct KeymapInputEvent){.event_type = KeymapEventPress,
                                 .value = 2}); // Third key in the keymap is A
@@ -72,20 +74,21 @@ void test_keyboard_keypress_sequence_da_db(void) {
   keymap_register_input_event(
       (struct KeymapInputEvent){.event_type = KeymapEventPress,
                                 .value = 3}); // Fourth key in the keymap is B
-
   keymap_tick(actual_report);
+
+  // assert: report shows A then B
   TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
 }
 
 void test_keyboard_keypress_sequence_db_da(void) {
-  // Pressing B, then A, should report "B A"
-
   uint8_t expected_report[8] = {0, 0, KC_B, KC_A, 0, 0, 0, 0};
   KeymapHidReport report = {};
   KeymapHidReport* actual_report = &report;
 
+  // assemble: init keymap
   keymap_init();
 
+  // act: press B then A
   keymap_register_input_event(
       (struct KeymapInputEvent){.event_type = KeymapEventPress,
                                 .value = 3}); // Fourth key in the keymap is B
@@ -93,20 +96,21 @@ void test_keyboard_keypress_sequence_db_da(void) {
   keymap_register_input_event(
       (struct KeymapInputEvent){.event_type = KeymapEventPress,
                                 .value = 2}); // Third key in the keymap is A
-
   keymap_tick(actual_report);
+
+  // assert: report shows B then A
   TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
 }
 
 void test_keyboard_keypress_sequence_da_db_ub(void) {
-  // Pressing A, then B; then releasing B, should report "A"
-
   uint8_t expected_report[8] = {0, 0, KC_A, 0, 0, 0, 0, 0};
   KeymapHidReport report = {};
   KeymapHidReport* actual_report = &report;
 
+  // assemble: init keymap
   keymap_init();
 
+  // act: press A, press B, release B
   keymap_register_input_event(
       (struct KeymapInputEvent){.event_type = KeymapEventPress,
                                 .value = 2}); // Third key in the keymap is A
@@ -117,20 +121,21 @@ void test_keyboard_keypress_sequence_da_db_ub(void) {
   keymap_tick(actual_report);
   keymap_register_input_event(
       (struct KeymapInputEvent){.event_type = KeymapEventRelease, .value = 3});
-
   keymap_tick(actual_report);
+
+  // assert: only A remains in report
   TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
 }
 
 void test_keyboard_keypress_sequence_da_db_ua(void) {
-  // Pressing A, then B; then releasing A, should report "B"
-
   uint8_t expected_report[8] = {0, 0, KC_B, 0, 0, 0, 0, 0};
   KeymapHidReport report = {};
   KeymapHidReport* actual_report = &report;
 
+  // assemble: init keymap
   keymap_init();
 
+  // act: press A, press B, release A
   keymap_register_input_event(
       (struct KeymapInputEvent){.event_type = KeymapEventPress,
                                 .value = 2}); // Third key in the keymap is A
@@ -141,8 +146,9 @@ void test_keyboard_keypress_sequence_da_db_ua(void) {
   keymap_tick(actual_report);
   keymap_register_input_event(
       (struct KeymapInputEvent){.event_type = KeymapEventRelease, .value = 2});
-
   keymap_tick(actual_report);
+
+  // assert: only B remains in report
   TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
 }
 
@@ -151,18 +157,19 @@ void test_keyboard_double_keypress(void) {
   KeymapHidReport report = {};
   KeymapHidReport* actual_report = &report;
 
+  // assemble: init keymap
   keymap_init();
 
+  // act: press A twice
+  keymap_register_input_event(
+      (struct KeymapInputEvent){.event_type = KeymapEventPress,
+                                .value = 2}); // Third key in the keymap is A
+  keymap_tick(actual_report);
   keymap_register_input_event(
       (struct KeymapInputEvent){.event_type = KeymapEventPress,
                                 .value = 2}); // Third key in the keymap is A
   keymap_tick(actual_report);
 
-  keymap_register_input_event(
-      (struct KeymapInputEvent){.event_type = KeymapEventPress,
-                                .value = 2}); // Third key in the keymap is A
-
-  keymap_tick(actual_report);
-
+  // assert: report still shows a single A
   TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
 }

--- a/tests/ceedling/test/test_keymap_event_driven.c
+++ b/tests/ceedling/test/test_keymap_event_driven.c
@@ -32,8 +32,10 @@ void test_event_driven_key_tap(void) {
   KeymapHidReport report = {};
   KeymapHidReport* actual_report = &report;
 
+  // assemble: init keymap
   keymap_init();
 
+  // act: press then release A via event-driven API
   keymap_register_input_after_ms(
       0,
       (struct KeymapInputEvent){.event_type = KeymapEventPress, .value = 2},
@@ -43,99 +45,102 @@ void test_event_driven_key_tap(void) {
       (struct KeymapInputEvent){.event_type = KeymapEventRelease, .value = 2},
       actual_report); // Third key in the keymap is A
 
+  // assert: empty report
   TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
 }
 
 void test_event_driven_tap_hold_key_tap(void) {
-  uint8_t expected_report[8] = {0, 0, KC_C, 0, 0, 0, 0, 0};
   KeymapHidReport report = {};
   KeymapHidReport* actual_report = &report;
 
+  // assemble: init keymap
   keymap_init();
 
   // Tap the C & TH.LCtrl
   uint16_t keymap_index = 0;
 
-  // Press (at time 0)
-  // - schedules event at time 200,
-  // - no key output.
+  // act: press tap-hold key at t=0
   {
     uint32_t actual_next_ev_ms = keymap_register_input_after_ms(
-       0,
-       (struct KeymapInputEvent){.event_type = KeymapEventPress, .value = keymap_index},
-       actual_report);
+        0,
+        (struct KeymapInputEvent){.event_type = KeymapEventPress, .value = keymap_index},
+        actual_report);
 
+    // assert: hold timeout scheduled, no key output yet
     TEST_ASSERT_EQUAL_UINT32(200, actual_next_ev_ms);
-    TEST_ASSERT_EQUAL_UINT8_ARRAY(((uint8_t[8]){0, 0, 0, 0, 0, 0, 0, 0}), actual_report->keyboard, 8);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(((uint8_t[8]){0, 0, 0, 0, 0, 0, 0, 0}),
+                                  actual_report->keyboard, 8);
   }
 
-  // Release (at time 150)
-  // - next ev is 50 ms later (at time 200),
-  // - should have 'C' output.
+  // act: release tap-hold key at t=150
   {
     uint32_t actual_next_ev_ms = keymap_register_input_after_ms(
-       150,
-       (struct KeymapInputEvent){.event_type = KeymapEventRelease, .value = keymap_index},
-       actual_report);
+        150,
+        (struct KeymapInputEvent){.event_type = KeymapEventRelease, .value = keymap_index},
+        actual_report);
 
+    // assert: tap fires immediately, next event in 50ms
     TEST_ASSERT_EQUAL_UINT32(50, actual_next_ev_ms);
-    TEST_ASSERT_EQUAL_UINT8_ARRAY(((uint8_t[8]){0, 0, KC_C, 0, 0, 0, 0, 0}), actual_report->keyboard, 8);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(((uint8_t[8]){0, 0, KC_C, 0, 0, 0, 0, 0}),
+                                  actual_report->keyboard, 8);
   }
 }
 
 void test_event_driven_tap_hold_key_tap_release_reported(void) {
-  uint8_t expected_report[8] = {0, 0, KC_C, 0, 0, 0, 0, 0};
   KeymapHidReport report = {};
   KeymapHidReport* actual_report = &report;
 
+  // assemble: init keymap
   keymap_init();
 
   // Tap the C & TH.LCtrl
   uint16_t keymap_index = 0;
 
-  // Press (at time 0)
-  // - schedules event at time 200,
-  // - no key output.
+  // act: press tap-hold key at t=0
   {
     uint32_t actual_next_ev_ms = keymap_register_input_after_ms(
-       0,
-       (struct KeymapInputEvent){.event_type = KeymapEventPress, .value = keymap_index},
-       actual_report);
+        0,
+        (struct KeymapInputEvent){.event_type = KeymapEventPress, .value = keymap_index},
+        actual_report);
 
+    // assert: hold timeout scheduled, polling not required yet
     TEST_ASSERT_EQUAL_UINT32(200, actual_next_ev_ms);
-    TEST_ASSERT_EQUAL_UINT8_ARRAY(((uint8_t[8]){0, 0, 0, 0, 0, 0, 0, 0}), actual_report->keyboard, 8);
-
-    // Keymap doesn't require polling yet.
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(((uint8_t[8]){0, 0, 0, 0, 0, 0, 0, 0}),
+                                  actual_report->keyboard, 8);
     TEST_ASSERT_FALSE(keymap_requires_polling());
   }
 
-  // Release (at time 150)
-  // - next ev is 50 ms later (at time 200),
-  // - should have 'C' output.
+  // act: release tap-hold key at t=150
   {
     uint32_t actual_next_ev_ms = keymap_register_input_after_ms(
-       150,
-       (struct KeymapInputEvent){.event_type = KeymapEventRelease, .value = keymap_index},
-       actual_report);
+        150,
+        (struct KeymapInputEvent){.event_type = KeymapEventRelease, .value = keymap_index},
+        actual_report);
 
+    // assert: tap reported, polling required until tap clears
     TEST_ASSERT_EQUAL_UINT32(50, actual_next_ev_ms);
-    TEST_ASSERT_EQUAL_UINT8_ARRAY(((uint8_t[8]){0, 0, KC_C, 0, 0, 0, 0, 0}), actual_report->keyboard, 8);
-
-    // Keymap requires polling until the 'tap' is finished.
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(((uint8_t[8]){0, 0, KC_C, 0, 0, 0, 0, 0}),
+                                  actual_report->keyboard, 8);
     TEST_ASSERT_TRUE(keymap_requires_polling());
   }
 
-  // Next tick: still has 'C' output (the tap is reported)
+  // act: first tick after tap
   {
     keymap_tick(actual_report);
-    TEST_ASSERT_EQUAL_UINT8_ARRAY(((uint8_t[8]){0, 0, KC_C, 0, 0, 0, 0, 0}), actual_report->keyboard, 8);
+
+    // assert: tap still held, polling still required
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(((uint8_t[8]){0, 0, KC_C, 0, 0, 0, 0, 0}),
+                                  actual_report->keyboard, 8);
     TEST_ASSERT_TRUE(keymap_requires_polling());
   }
 
-  // Next tick: no output (the tap is cleared)
+  // act: second tick clears tap
   {
     keymap_tick(actual_report);
-    TEST_ASSERT_EQUAL_UINT8_ARRAY(((uint8_t[8]){0, 0, 0, 0, 0, 0, 0, 0}), actual_report->keyboard, 8);
+
+    // assert: report empty, polling no longer required
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(((uint8_t[8]){0, 0, 0, 0, 0, 0, 0, 0}),
+                                  actual_report->keyboard, 8);
     TEST_ASSERT_FALSE(keymap_requires_polling());
   }
 }

--- a/tests/ceedling/test/test_message.c
+++ b/tests/ceedling/test/test_message.c
@@ -22,19 +22,21 @@ void test_keymap_serialise_event_press(void) {
 }
 
 void test_keymap_deserialise_event_press(void) {
+  // assemble: expected event and serialized input bytes
   KeymapInputEvent expected_event = {
       .event_type = KeymapEventPress,
       .value = 4,
   };
-
   uint8_t input[4] = {0x01, 0x02, 0x04, 0x00};
   uint8_t buf[4] = {0};
   KeymapInputEvent actual_event = {0};
 
+  // act: feed serialized bytes one at a time
   for (uint8_t i = 0; i < 4; i++) {
     keymap_message_buffer_receive_byte(&buf, input[i], &actual_event);
   }
 
+  // assert: reconstructed event matches original
   TEST_ASSERT_EQUAL_MEMORY(&expected_event, &actual_event,
                            sizeof(KeymapInputEvent));
 }


### PR DESCRIPTION
## Summary

Add `// assemble:`, `// act:`, and `// assert:` comments to non-trivial Ceedling tests so each case reads clearly as setup → behaviour → expectation.

Trivial single-step tests are left uncommented. Any test that has an `// act:` label includes all three sections, even when assemble is just `init keymap`.

## Test plan

- [x] `make test-ceedling` — 17/17 pass