### PR TITLE
tests: ceedling: clang-format test sources

### DIFF
--- a/tests/ceedling/ceedling.mk
+++ b/tests/ceedling/ceedling.mk
@@ -8,8 +8,12 @@ TEST_KEYMAP = keymap-4key-simple
 fix-ceedling-vendor:
 	if test -d tests/ceedling/build/vendor; then chmod -R u+w tests/ceedling/build/vendor; fi
 
+.PHONY: format-ceedling
+format-ceedling:
+	find tests/ceedling/test -name '*.c' | xargs clang-format -i
+
 .PHONY: test-ceedling
-test-ceedling: include/smart_keymap.h fix-ceedling-vendor
+test-ceedling: include/smart_keymap.h fix-ceedling-vendor format-ceedling
 	env SMART_KEYMAP_CUSTOM_KEYMAP="$(shell pwd)/tests/ncl/$(TEST_KEYMAP)/keymap.ncl" \
 	  $(CARGO) build --package "smart_keymap"
 	cd tests/ceedling && $(CEEDLING)

--- a/tests/ceedling/test/test_keydef_taphold.c
+++ b/tests/ceedling/test/test_keydef_taphold.c
@@ -17,7 +17,7 @@ void tearDown(void) {}
 void test_taphold_dth_uth_is_tap(void) {
   uint8_t expected_report[8] = {0, 0, KC_C, 0, 0, 0, 0, 0};
   KeymapHidReport report = {};
-  KeymapHidReport* actual_report = &report;
+  KeymapHidReport *actual_report = &report;
 
   // assemble: init keymap
   keymap_init();
@@ -38,7 +38,7 @@ void test_taphold_dth_uth_is_tap(void) {
 void test_taphold_dth_uth_eventually_clears(void) {
   uint8_t expected_report[8] = {0, 0, 0, 0, 0, 0, 0, 0};
   KeymapHidReport report = {};
-  KeymapHidReport* actual_report = &report;
+  KeymapHidReport *actual_report = &report;
 
   // assemble: init keymap
   keymap_init();
@@ -63,7 +63,7 @@ void test_taphold_dth_uth_eventually_clears(void) {
 void test_taphold_dth_eventually_holds(void) {
   uint8_t expected_report[8] = {MOD_LCTL, 0, 0, 0, 0, 0, 0, 0};
   KeymapHidReport report = {};
-  KeymapHidReport* actual_report = &report;
+  KeymapHidReport *actual_report = &report;
 
   // assemble: init keymap
   keymap_init();

--- a/tests/ceedling/test/test_keymap.c
+++ b/tests/ceedling/test/test_keymap.c
@@ -12,7 +12,7 @@ void tearDown(void) {}
 void test_copy_hid_boot_keyboard_report(void) {
   uint8_t expected_report[8] = {0, 0, 0, 0, 0, 0, 0, 0};
   KeymapHidReport report = {};
-  KeymapHidReport* actual_report = &report;
+  KeymapHidReport *actual_report = &report;
 
   keymap_init();
   keymap_tick(actual_report);
@@ -25,7 +25,7 @@ void test_copy_hid_boot_keyboard_report(void) {
 void test_keyboard_keypress(void) {
   uint8_t expected_report[8] = {0, 0, KC_A, 0, 0, 0, 0, 0};
   KeymapHidReport report = {};
-  KeymapHidReport* actual_report = &report;
+  KeymapHidReport *actual_report = &report;
 
   keymap_init();
 
@@ -41,7 +41,7 @@ void test_keyboard_keypress(void) {
 void test_keyboard_keyrelease(void) {
   uint8_t expected_report[8] = {0, 0, 0, 0, 0, 0, 0, 0};
   KeymapHidReport report = {};
-  KeymapHidReport* actual_report = &report;
+  KeymapHidReport *actual_report = &report;
 
   // assemble: init keymap
   keymap_init();
@@ -61,7 +61,7 @@ void test_keyboard_keyrelease(void) {
 void test_keyboard_keypress_sequence_da_db(void) {
   uint8_t expected_report[8] = {0, 0, KC_A, KC_B, 0, 0, 0, 0};
   KeymapHidReport report = {};
-  KeymapHidReport* actual_report = &report;
+  KeymapHidReport *actual_report = &report;
 
   // assemble: init keymap
   keymap_init();
@@ -83,7 +83,7 @@ void test_keyboard_keypress_sequence_da_db(void) {
 void test_keyboard_keypress_sequence_db_da(void) {
   uint8_t expected_report[8] = {0, 0, KC_B, KC_A, 0, 0, 0, 0};
   KeymapHidReport report = {};
-  KeymapHidReport* actual_report = &report;
+  KeymapHidReport *actual_report = &report;
 
   // assemble: init keymap
   keymap_init();
@@ -105,7 +105,7 @@ void test_keyboard_keypress_sequence_db_da(void) {
 void test_keyboard_keypress_sequence_da_db_ub(void) {
   uint8_t expected_report[8] = {0, 0, KC_A, 0, 0, 0, 0, 0};
   KeymapHidReport report = {};
-  KeymapHidReport* actual_report = &report;
+  KeymapHidReport *actual_report = &report;
 
   // assemble: init keymap
   keymap_init();
@@ -130,7 +130,7 @@ void test_keyboard_keypress_sequence_da_db_ub(void) {
 void test_keyboard_keypress_sequence_da_db_ua(void) {
   uint8_t expected_report[8] = {0, 0, KC_B, 0, 0, 0, 0, 0};
   KeymapHidReport report = {};
-  KeymapHidReport* actual_report = &report;
+  KeymapHidReport *actual_report = &report;
 
   // assemble: init keymap
   keymap_init();
@@ -155,7 +155,7 @@ void test_keyboard_keypress_sequence_da_db_ua(void) {
 void test_keyboard_double_keypress(void) {
   uint8_t expected_report[8] = {0, 0, KC_A, 0, 0, 0, 0, 0};
   KeymapHidReport report = {};
-  KeymapHidReport* actual_report = &report;
+  KeymapHidReport *actual_report = &report;
 
   // assemble: init keymap
   keymap_init();

--- a/tests/ceedling/test/test_keymap_event_driven.c
+++ b/tests/ceedling/test/test_keymap_event_driven.c
@@ -15,13 +15,12 @@ void tearDown(void) {}
 void test_event_driven_key_press(void) {
   uint8_t expected_report[8] = {0, 0, KC_A, 0, 0, 0, 0, 0};
   KeymapHidReport report = {};
-  KeymapHidReport* actual_report = &report;
+  KeymapHidReport *actual_report = &report;
 
   keymap_init();
 
   keymap_register_input_after_ms(
-      0,
-      (struct KeymapInputEvent){.event_type = KeymapEventPress, .value = 2},
+      0, (struct KeymapInputEvent){.event_type = KeymapEventPress, .value = 2},
       actual_report); // Third key in the keymap is A
 
   TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
@@ -30,15 +29,14 @@ void test_event_driven_key_press(void) {
 void test_event_driven_key_tap(void) {
   uint8_t expected_report[8] = {0, 0, 0, 0, 0, 0, 0, 0};
   KeymapHidReport report = {};
-  KeymapHidReport* actual_report = &report;
+  KeymapHidReport *actual_report = &report;
 
   // assemble: init keymap
   keymap_init();
 
   // act: press then release A via event-driven API
   keymap_register_input_after_ms(
-      0,
-      (struct KeymapInputEvent){.event_type = KeymapEventPress, .value = 2},
+      0, (struct KeymapInputEvent){.event_type = KeymapEventPress, .value = 2},
       actual_report); // Third key in the keymap is A
   keymap_register_input_after_ms(
       0,
@@ -51,7 +49,7 @@ void test_event_driven_key_tap(void) {
 
 void test_event_driven_tap_hold_key_tap(void) {
   KeymapHidReport report = {};
-  KeymapHidReport* actual_report = &report;
+  KeymapHidReport *actual_report = &report;
 
   // assemble: init keymap
   keymap_init();
@@ -63,7 +61,8 @@ void test_event_driven_tap_hold_key_tap(void) {
   {
     uint32_t actual_next_ev_ms = keymap_register_input_after_ms(
         0,
-        (struct KeymapInputEvent){.event_type = KeymapEventPress, .value = keymap_index},
+        (struct KeymapInputEvent){.event_type = KeymapEventPress,
+                                  .value = keymap_index},
         actual_report);
 
     // assert: hold timeout scheduled, no key output yet
@@ -76,7 +75,8 @@ void test_event_driven_tap_hold_key_tap(void) {
   {
     uint32_t actual_next_ev_ms = keymap_register_input_after_ms(
         150,
-        (struct KeymapInputEvent){.event_type = KeymapEventRelease, .value = keymap_index},
+        (struct KeymapInputEvent){.event_type = KeymapEventRelease,
+                                  .value = keymap_index},
         actual_report);
 
     // assert: tap fires immediately, next event in 50ms
@@ -88,7 +88,7 @@ void test_event_driven_tap_hold_key_tap(void) {
 
 void test_event_driven_tap_hold_key_tap_release_reported(void) {
   KeymapHidReport report = {};
-  KeymapHidReport* actual_report = &report;
+  KeymapHidReport *actual_report = &report;
 
   // assemble: init keymap
   keymap_init();
@@ -100,7 +100,8 @@ void test_event_driven_tap_hold_key_tap_release_reported(void) {
   {
     uint32_t actual_next_ev_ms = keymap_register_input_after_ms(
         0,
-        (struct KeymapInputEvent){.event_type = KeymapEventPress, .value = keymap_index},
+        (struct KeymapInputEvent){.event_type = KeymapEventPress,
+                                  .value = keymap_index},
         actual_report);
 
     // assert: hold timeout scheduled, polling not required yet
@@ -114,7 +115,8 @@ void test_event_driven_tap_hold_key_tap_release_reported(void) {
   {
     uint32_t actual_next_ev_ms = keymap_register_input_after_ms(
         150,
-        (struct KeymapInputEvent){.event_type = KeymapEventRelease, .value = keymap_index},
+        (struct KeymapInputEvent){.event_type = KeymapEventRelease,
+                                  .value = keymap_index},
         actual_report);
 
     // assert: tap reported, polling required until tap clears


### PR DESCRIPTION
## Summary

Run `clang-format` (default LLVM style, same as firmware trees) on `tests/ceedling/test/*.c`.

Also adds `make format-ceedling` so test sources can be re-formatted the same way as firmware (`find … | xargs clang-format -i`).

No `.clang-format` file — matches existing firmware practice (devenv `clang-tools`, no pinned style).

## Test plan

- [x] `make test-ceedling` — 17/17 pass