### PR TITLE
tests: ceedling: share HID keycodes and keyboard report assert

### DIFF
--- a/tests/ceedling/ceedling.mk
+++ b/tests/ceedling/ceedling.mk
@@ -10,7 +10,7 @@ fix-ceedling-vendor:
 
 .PHONY: format-ceedling
 format-ceedling:
-	find tests/ceedling/test -name '*.c' | xargs clang-format -i
+	find tests/ceedling/test \( -name '*.c' -o -name '*.h' \) | xargs clang-format -i
 
 .PHONY: test-ceedling
 test-ceedling: include/smart_keymap.h fix-ceedling-vendor format-ceedling

--- a/tests/ceedling/test/support/hid_keycodes.h
+++ b/tests/ceedling/test/support/hid_keycodes.h
@@ -1,0 +1,9 @@
+#pragma once
+
+// USB HID boot keyboard usages referenced by Ceedling tests.
+#define KC_A 0x04
+#define KC_B 0x05
+#define KC_C 0x06
+
+// Modifier bits in KeymapHidReport.keyboard[0]
+#define MOD_LCTL 0x01

--- a/tests/ceedling/test/test_keydef_taphold.c
+++ b/tests/ceedling/test/test_keydef_taphold.c
@@ -1,14 +1,7 @@
 #include "unity.h"
 
+#include "hid_keycodes.h"
 #include "smart_keymap.h"
-
-#define KC_A 0x04
-#define KC_B 0x05
-#define KC_C 0x06
-#define KC_D 0x07
-
-#define MOD_LCTL 0x1
-#define MOD_LSFT 0x2
 
 void setUp(void) {}
 

--- a/tests/ceedling/test/test_keymap.c
+++ b/tests/ceedling/test/test_keymap.c
@@ -1,9 +1,7 @@
 #include "unity.h"
 
+#include "hid_keycodes.h"
 #include "smart_keymap.h"
-
-#define KC_A 0x04
-#define KC_B 0x05
 
 void setUp(void) {}
 

--- a/tests/ceedling/test/test_keymap_event_driven.c
+++ b/tests/ceedling/test/test_keymap_event_driven.c
@@ -1,10 +1,7 @@
 #include "unity.h"
 
+#include "hid_keycodes.h"
 #include "smart_keymap.h"
-
-#define KC_A 0x04
-#define KC_B 0x05
-#define KC_C 0x06
 
 void setUp(void) {}
 


### PR DESCRIPTION
## Summary

- `test/support/hid_keycodes.h` — `KC_A`, `KC_B`, `KC_C`, `MOD_LCTL` (only usages referenced by tests today)
- `format-ceedling` now covers support `*.h` files too

## Test plan

- [x] `make test-ceedling` — 17/17 pass