### PR TITLE
tests: ceedling: per-suite reorganisation

### DIFF
--- a/tests/ceedling/.gitignore
+++ b/tests/ceedling/.gitignore
@@ -1,0 +1,3 @@
+libs/
+generated/
+cargo-target/

--- a/tests/ceedling/ceedling.mk
+++ b/tests/ceedling/ceedling.mk
@@ -1,6 +1,21 @@
 CEEDLING = ceedling
+CEEDLING_KEYMAP_SUITES = keyboard tap_hold
+CEEDLING_CARGO_TARGET = tests/ceedling/cargo-target
 
-TEST_KEYMAP = keymap-4key-simple
+# Rebuild copied libs when smart_keymap crate inputs change (not only keymap.ncl).
+CEEDLING_SMART_KEYMAP_RUST_DEPS = \
+	Cargo.toml \
+	build.rs \
+	smart_keymap/Cargo.toml \
+	smart_keymap/src/lib.rs \
+	$(wildcard src/*.rs) \
+	$(wildcard src/**/*.rs) \
+	$(wildcard smart-keymap-macros/src/*.rs) \
+	smart-keymap-macros/build.rs \
+	smart-keymap-macros/Cargo.toml \
+	$(wildcard smart-keymap-nickel-helper/src/*.rs) \
+	smart-keymap-nickel-helper/Cargo.toml \
+	$(wildcard ncl/*.ncl)
 
 # Ceedling vendors Unity from the Nix store with read-only perms;
 # a second run fails when it tries to overwrite build/vendor/*.c without this.
@@ -12,8 +27,45 @@ fix-ceedling-vendor:
 format-ceedling:
 	find tests/ceedling/test \( -name '*.c' -o -name '*.h' \) | xargs clang-format -i
 
-.PHONY: test-ceedling
-test-ceedling: include/smart_keymap.h fix-ceedling-vendor format-ceedling
-	env SMART_KEYMAP_CUSTOM_KEYMAP="$(shell pwd)/tests/ncl/$(TEST_KEYMAP)/keymap.ncl" \
+CEEDLING_LIBS = \
+	$(addprefix tests/ceedling/libs/libsmart_keymap_,$(addsuffix .a,$(CEEDLING_KEYMAP_SUITES))) \
+	tests/ceedling/libs/libsmart_keymap_default.a
+CEEDLING_FIXTURES = $(addprefix tests/ceedling/generated/,$(addsuffix _test_ceedling_fixture.h,$(CEEDLING_KEYMAP_SUITES)))
+
+define CEEDLING_KEYMAP_SUITE_RULES
+tests/ceedling/generated/$(1)_test_ceedling_fixture.h: tests/ceedling/keymaps/$(1)/keymap.ncl tests/ceedling/ncl/ceedling-fixture.ncl tests/ceedling/scripts/ceedling-fixture.sh
+	mkdir -p tests/ceedling/generated
+	tests/ceedling/scripts/ceedling-fixture.sh tests/ceedling/keymaps/$(1) > $$@
+
+$(CEEDLING_CARGO_TARGET)/$(1)/debug/libsmart_keymap.a: \
+		tests/ceedling/keymaps/$(1)/keymap.ncl \
+		include/smart_keymap.h \
+		tests/ceedling/generated/$(1)_test_ceedling_fixture.h \
+		$(CEEDLING_SMART_KEYMAP_RUST_DEPS)
+	mkdir -p $(CEEDLING_CARGO_TARGET)/$(1)
+	env CARGO_TARGET_DIR="$(CURDIR)/$(CEEDLING_CARGO_TARGET)/$(1)" \
+	  SMART_KEYMAP_CUSTOM_KEYMAP="$(CURDIR)/tests/ceedling/keymaps/$(1)/keymap.ncl" \
 	  $(CARGO) build --package "smart_keymap"
-	cd tests/ceedling && $(CEEDLING)
+
+tests/ceedling/libs/libsmart_keymap_$(1).a: $(CEEDLING_CARGO_TARGET)/$(1)/debug/libsmart_keymap.a
+	mkdir -p tests/ceedling/libs
+	cp $$< $$@
+endef
+
+$(foreach suite,$(CEEDLING_KEYMAP_SUITES),$(eval $(call CEEDLING_KEYMAP_SUITE_RULES,$(suite))))
+
+$(CEEDLING_CARGO_TARGET)/default/debug/libsmart_keymap.a: include/smart_keymap.h $(CEEDLING_SMART_KEYMAP_RUST_DEPS)
+	mkdir -p $(CEEDLING_CARGO_TARGET)/default
+	env CARGO_TARGET_DIR="$(CURDIR)/$(CEEDLING_CARGO_TARGET)/default" \
+	  env -u SMART_KEYMAP_CUSTOM_KEYMAP \
+	  $(CARGO) build --package "smart_keymap"
+
+tests/ceedling/libs/libsmart_keymap_default.a: $(CEEDLING_CARGO_TARGET)/default/debug/libsmart_keymap.a
+	mkdir -p tests/ceedling/libs
+	cp $< $@
+
+.PHONY: test-ceedling
+test-ceedling: include/smart_keymap.h fix-ceedling-vendor format-ceedling $(CEEDLING_LIBS) $(CEEDLING_FIXTURES)
+	cd tests/ceedling && $(CEEDLING) --mixin=mixins/keyboard.yml test:path[keyboard]
+	cd tests/ceedling && $(CEEDLING) --mixin=mixins/tap_hold.yml test:path[tap_hold]
+	cd tests/ceedling && $(CEEDLING) --mixin=mixins/protocol.yml test:path[protocol]

--- a/tests/ceedling/keymaps/keyboard/keymap.ncl
+++ b/tests/ceedling/keymaps/keyboard/keymap.ncl
@@ -1,0 +1,14 @@
+let K = import "keys.ncl" in
+
+{
+  keys = [
+    K.A,
+    K.B,
+  ],
+
+  ceedling_fixture = {
+    suite = "KEYBOARD",
+    KEY_A = 0,
+    KEY_B = 1,
+  },
+}

--- a/tests/ceedling/keymaps/tap_hold/keymap.ncl
+++ b/tests/ceedling/keymaps/tap_hold/keymap.ncl
@@ -1,0 +1,12 @@
+let K = import "keys.ncl" in
+
+{
+  keys = [
+    K.C & K.hold K.LeftCtrl,
+  ],
+
+  ceedling_fixture = {
+    suite = "TAP_HOLD",
+    TAP_HOLD_KEY = 0,
+  },
+}

--- a/tests/ceedling/mixins/keyboard.yml
+++ b/tests/ceedling/mixins/keyboard.yml
@@ -1,0 +1,7 @@
+:paths:
+  :libraries:
+    - libs
+
+:libraries:
+  :system:
+    - smart_keymap_keyboard

--- a/tests/ceedling/mixins/protocol.yml
+++ b/tests/ceedling/mixins/protocol.yml
@@ -1,0 +1,7 @@
+:paths:
+  :libraries:
+    - libs
+
+:libraries:
+  :system:
+    - smart_keymap_default

--- a/tests/ceedling/mixins/tap_hold.yml
+++ b/tests/ceedling/mixins/tap_hold.yml
@@ -1,0 +1,7 @@
+:paths:
+  :libraries:
+    - libs
+
+:libraries:
+  :system:
+    - smart_keymap_tap_hold

--- a/tests/ceedling/ncl/ceedling-fixture.ncl
+++ b/tests/ceedling/ncl/ceedling-fixture.ncl
@@ -1,0 +1,29 @@
+{
+  prefix = "KM_",
+
+  keymap = import "keymap.ncl",
+
+  fixture = keymap.ceedling_fixture,
+
+  suite = fixture.suite,
+
+  fixture_entries =
+    fixture
+    |> std.record.to_array
+    |> std.array.filter (fun { field, .. } => field != "suite"),
+
+  ceedling_fixture_h =
+    let header =
+      "#pragma once\n\n"
+      ++ "#define SUITE_%{suite} 1\n"
+    in
+    let defines =
+      fixture_entries
+      |> std.array.map (fun { field, value } => "#define %{prefix}%{field} %{std.to_string value}")
+      |> std.string.join "\n"
+    in
+    if defines == "" then
+      header
+    else
+      header ++ "\n" ++ defines,
+}

--- a/tests/ceedling/project.yml
+++ b/tests/ceedling/project.yml
@@ -16,14 +16,9 @@
   :source: []
   :include:
     - ../../include
+    - generated
   :support:
     - test/support
-  :libraries:
-    - ../../target/debug/
-
-:libraries:
-  :system:
-    - smart_keymap
 
 :unity:
   :defines:

--- a/tests/ceedling/scripts/ceedling-fixture.sh
+++ b/tests/ceedling/scripts/ceedling-fixture.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# $ ceedling-fixture.sh path/to/keymap-directory
+#
+# Emits a C header of #defines from the keymap's ceedling_fixture field.
+
+set -e
+
+SCRIPTS_DIR="$(dirname "$0")"
+REPOSITORY_DIR="${SCRIPTS_DIR}/../../.."
+NCL_DIR="${REPOSITORY_DIR}/ncl"
+CEEDLING_NCL_DIR="${SCRIPTS_DIR}/../ncl"
+
+KEYMAP_DIR="${1}"
+
+nickel export \
+  --format=raw \
+  --import-path="${KEYMAP_DIR}" \
+  --import-path="${NCL_DIR}" \
+  "${CEEDLING_NCL_DIR}/ceedling-fixture.ncl" \
+  --field="ceedling_fixture_h"

--- a/tests/ceedling/test/keyboard/test_keymap.c
+++ b/tests/ceedling/test/keyboard/test_keymap.c
@@ -1,3 +1,7 @@
+#include "keyboard_test_ceedling_fixture.h"
+
+#ifdef SUITE_KEYBOARD
+
 #include "unity.h"
 
 #include "hid_keycodes.h"
@@ -18,8 +22,6 @@ void test_copy_hid_boot_keyboard_report(void) {
   TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
 }
 
-// KEYMAP: [C & TH.LCtrl, D & TH.LSft, A, B]
-
 void test_keyboard_keypress(void) {
   uint8_t expected_report[8] = {0, 0, KC_A, 0, 0, 0, 0, 0};
   KeymapHidReport report = {};
@@ -27,10 +29,8 @@ void test_keyboard_keypress(void) {
 
   keymap_init();
 
-  keymap_register_input_event(
-      (struct KeymapInputEvent){.event_type = KeymapEventPress,
-                                .value = 2}); // Third key in the keymap is A
-
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_KEY_A});
   keymap_tick(actual_report);
 
   TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
@@ -45,11 +45,11 @@ void test_keyboard_keyrelease(void) {
   keymap_init();
 
   // act: press then release key A
-  keymap_register_input_event(
-      (struct KeymapInputEvent){.event_type = KeymapEventPress, .value = 2});
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_KEY_A});
   keymap_tick(actual_report);
-  keymap_register_input_event(
-      (struct KeymapInputEvent){.event_type = KeymapEventRelease, .value = 2});
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventRelease, .value = KM_KEY_A});
   keymap_tick(actual_report);
 
   // assert: empty report
@@ -65,13 +65,11 @@ void test_keyboard_keypress_sequence_da_db(void) {
   keymap_init();
 
   // act: press A then B
-  keymap_register_input_event(
-      (struct KeymapInputEvent){.event_type = KeymapEventPress,
-                                .value = 2}); // Third key in the keymap is A
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_KEY_A});
   keymap_tick(actual_report);
-  keymap_register_input_event(
-      (struct KeymapInputEvent){.event_type = KeymapEventPress,
-                                .value = 3}); // Fourth key in the keymap is B
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_KEY_B});
   keymap_tick(actual_report);
 
   // assert: report shows A then B
@@ -87,13 +85,11 @@ void test_keyboard_keypress_sequence_db_da(void) {
   keymap_init();
 
   // act: press B then A
-  keymap_register_input_event(
-      (struct KeymapInputEvent){.event_type = KeymapEventPress,
-                                .value = 3}); // Fourth key in the keymap is B
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_KEY_B});
   keymap_tick(actual_report);
-  keymap_register_input_event(
-      (struct KeymapInputEvent){.event_type = KeymapEventPress,
-                                .value = 2}); // Third key in the keymap is A
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_KEY_A});
   keymap_tick(actual_report);
 
   // assert: report shows B then A
@@ -109,16 +105,14 @@ void test_keyboard_keypress_sequence_da_db_ub(void) {
   keymap_init();
 
   // act: press A, press B, release B
-  keymap_register_input_event(
-      (struct KeymapInputEvent){.event_type = KeymapEventPress,
-                                .value = 2}); // Third key in the keymap is A
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_KEY_A});
   keymap_tick(actual_report);
-  keymap_register_input_event(
-      (struct KeymapInputEvent){.event_type = KeymapEventPress,
-                                .value = 3}); // Fourth key in the keymap is B
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_KEY_B});
   keymap_tick(actual_report);
-  keymap_register_input_event(
-      (struct KeymapInputEvent){.event_type = KeymapEventRelease, .value = 3});
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventRelease, .value = KM_KEY_B});
   keymap_tick(actual_report);
 
   // assert: only A remains in report
@@ -134,16 +128,14 @@ void test_keyboard_keypress_sequence_da_db_ua(void) {
   keymap_init();
 
   // act: press A, press B, release A
-  keymap_register_input_event(
-      (struct KeymapInputEvent){.event_type = KeymapEventPress,
-                                .value = 2}); // Third key in the keymap is A
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_KEY_A});
   keymap_tick(actual_report);
-  keymap_register_input_event(
-      (struct KeymapInputEvent){.event_type = KeymapEventPress,
-                                .value = 3}); // Fourth key in the keymap is B
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_KEY_B});
   keymap_tick(actual_report);
-  keymap_register_input_event(
-      (struct KeymapInputEvent){.event_type = KeymapEventRelease, .value = 2});
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventRelease, .value = KM_KEY_A});
   keymap_tick(actual_report);
 
   // assert: only B remains in report
@@ -159,15 +151,17 @@ void test_keyboard_double_keypress(void) {
   keymap_init();
 
   // act: press A twice
-  keymap_register_input_event(
-      (struct KeymapInputEvent){.event_type = KeymapEventPress,
-                                .value = 2}); // Third key in the keymap is A
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_KEY_A});
   keymap_tick(actual_report);
-  keymap_register_input_event(
-      (struct KeymapInputEvent){.event_type = KeymapEventPress,
-                                .value = 2}); // Third key in the keymap is A
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_KEY_A});
   keymap_tick(actual_report);
 
   // assert: report still shows a single A
   TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
 }
+
+#else
+#error "requires SUITE_KEYBOARD"
+#endif

--- a/tests/ceedling/test/keyboard/test_keymap_event_driven.c
+++ b/tests/ceedling/test/keyboard/test_keymap_event_driven.c
@@ -1,0 +1,56 @@
+#include "keyboard_test_ceedling_fixture.h"
+
+#ifdef SUITE_KEYBOARD
+
+#include "unity.h"
+
+#include "hid_keycodes.h"
+#include "smart_keymap.h"
+
+void setUp(void) {}
+
+void tearDown(void) {}
+
+void test_event_driven_key_press(void) {
+  uint8_t expected_report[8] = {0, 0, KC_A, 0, 0, 0, 0, 0};
+  KeymapHidReport report = {};
+  KeymapHidReport *actual_report = &report;
+
+  keymap_init();
+
+  keymap_register_input_after_ms(
+      0,
+      (struct KeymapInputEvent){.event_type = KeymapEventPress,
+                                .value = KM_KEY_A},
+      actual_report);
+
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
+}
+
+void test_event_driven_key_tap(void) {
+  uint8_t expected_report[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+  KeymapHidReport report = {};
+  KeymapHidReport *actual_report = &report;
+
+  // assemble: init keymap
+  keymap_init();
+
+  // act: press then release A via event-driven API
+  keymap_register_input_after_ms(
+      0,
+      (struct KeymapInputEvent){.event_type = KeymapEventPress,
+                                .value = KM_KEY_A},
+      actual_report);
+  keymap_register_input_after_ms(
+      0,
+      (struct KeymapInputEvent){.event_type = KeymapEventRelease,
+                                .value = KM_KEY_A},
+      actual_report);
+
+  // assert: empty report
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
+}
+
+#else
+#error "requires SUITE_KEYBOARD"
+#endif

--- a/tests/ceedling/test/protocol/test_message.c
+++ b/tests/ceedling/test/protocol/test_message.c
@@ -16,6 +16,7 @@ void test_keymap_serialise_event_press(void) {
       .value = 4,
   };
   uint8_t actual_message[4] = {0};
+
   keymap_serialize_event(actual_message, event);
 
   TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_message, actual_message, 4);

--- a/tests/ceedling/test/tap_hold/test_keydef_taphold.c
+++ b/tests/ceedling/test/tap_hold/test_keydef_taphold.c
@@ -1,3 +1,7 @@
+#include "tap_hold_test_ceedling_fixture.h"
+
+#ifdef SUITE_TAP_HOLD
+
 #include "unity.h"
 
 #include "hid_keycodes.h"
@@ -17,11 +21,10 @@ void test_taphold_dth_uth_is_tap(void) {
 
   // act: press then release tap-hold key before hold timeout
   keymap_register_input_event((struct KeymapInputEvent){
-      .event_type = KeymapEventPress,
-      .value = 0}); // First key in keymap is TapHold(C, _)
+      .event_type = KeymapEventPress, .value = KM_TAP_HOLD_KEY});
   keymap_tick(actual_report);
-  keymap_register_input_event(
-      (struct KeymapInputEvent){.event_type = KeymapEventRelease, .value = 0});
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventRelease, .value = KM_TAP_HOLD_KEY});
   keymap_tick(actual_report);
 
   // assert: tap key (C) appears in report
@@ -38,11 +41,10 @@ void test_taphold_dth_uth_eventually_clears(void) {
 
   // act: press then release tap-hold key, then poll until tap clears
   keymap_register_input_event((struct KeymapInputEvent){
-      .event_type = KeymapEventPress,
-      .value = 0}); // First key in keymap is TapHold(C, _)
+      .event_type = KeymapEventPress, .value = KM_TAP_HOLD_KEY});
   keymap_tick(actual_report);
-  keymap_register_input_event(
-      (struct KeymapInputEvent){.event_type = KeymapEventRelease, .value = 0});
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventRelease, .value = KM_TAP_HOLD_KEY});
   keymap_tick(actual_report);
 
   for (int i = 0; i < 50; i++) {
@@ -63,8 +65,7 @@ void test_taphold_dth_eventually_holds(void) {
 
   // act: press tap-hold key and wait for hold timeout
   keymap_register_input_event((struct KeymapInputEvent){
-      .event_type = KeymapEventPress,
-      .value = 0}); // First key in keymap is TapHold(C, _)
+      .event_type = KeymapEventPress, .value = KM_TAP_HOLD_KEY});
 
   for (int i = 0; i < 500; i++) {
     keymap_tick(actual_report);
@@ -73,3 +74,7 @@ void test_taphold_dth_eventually_holds(void) {
   // assert: hold modifier (Left Ctrl) in report
   TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
 }
+
+#else
+#error "requires SUITE_TAP_HOLD"
+#endif

--- a/tests/ceedling/test/tap_hold/test_keydef_taphold_event_driven.c
+++ b/tests/ceedling/test/tap_hold/test_keydef_taphold_event_driven.c
@@ -1,3 +1,7 @@
+#include "tap_hold_test_ceedling_fixture.h"
+
+#ifdef SUITE_TAP_HOLD
+
 #include "unity.h"
 
 #include "hid_keycodes.h"
@@ -7,43 +11,6 @@ void setUp(void) {}
 
 void tearDown(void) {}
 
-// KEYMAP: [C & TH.LCtrl, D & TH.LSft, A, B]
-
-void test_event_driven_key_press(void) {
-  uint8_t expected_report[8] = {0, 0, KC_A, 0, 0, 0, 0, 0};
-  KeymapHidReport report = {};
-  KeymapHidReport *actual_report = &report;
-
-  keymap_init();
-
-  keymap_register_input_after_ms(
-      0, (struct KeymapInputEvent){.event_type = KeymapEventPress, .value = 2},
-      actual_report); // Third key in the keymap is A
-
-  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
-}
-
-void test_event_driven_key_tap(void) {
-  uint8_t expected_report[8] = {0, 0, 0, 0, 0, 0, 0, 0};
-  KeymapHidReport report = {};
-  KeymapHidReport *actual_report = &report;
-
-  // assemble: init keymap
-  keymap_init();
-
-  // act: press then release A via event-driven API
-  keymap_register_input_after_ms(
-      0, (struct KeymapInputEvent){.event_type = KeymapEventPress, .value = 2},
-      actual_report); // Third key in the keymap is A
-  keymap_register_input_after_ms(
-      0,
-      (struct KeymapInputEvent){.event_type = KeymapEventRelease, .value = 2},
-      actual_report); // Third key in the keymap is A
-
-  // assert: empty report
-  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
-}
-
 void test_event_driven_tap_hold_key_tap(void) {
   KeymapHidReport report = {};
   KeymapHidReport *actual_report = &report;
@@ -51,15 +18,12 @@ void test_event_driven_tap_hold_key_tap(void) {
   // assemble: init keymap
   keymap_init();
 
-  // Tap the C & TH.LCtrl
-  uint16_t keymap_index = 0;
-
   // act: press tap-hold key at t=0
   {
     uint32_t actual_next_ev_ms = keymap_register_input_after_ms(
         0,
         (struct KeymapInputEvent){.event_type = KeymapEventPress,
-                                  .value = keymap_index},
+                                  .value = KM_TAP_HOLD_KEY},
         actual_report);
 
     // assert: hold timeout scheduled, no key output yet
@@ -73,7 +37,7 @@ void test_event_driven_tap_hold_key_tap(void) {
     uint32_t actual_next_ev_ms = keymap_register_input_after_ms(
         150,
         (struct KeymapInputEvent){.event_type = KeymapEventRelease,
-                                  .value = keymap_index},
+                                  .value = KM_TAP_HOLD_KEY},
         actual_report);
 
     // assert: tap fires immediately, next event in 50ms
@@ -90,15 +54,12 @@ void test_event_driven_tap_hold_key_tap_release_reported(void) {
   // assemble: init keymap
   keymap_init();
 
-  // Tap the C & TH.LCtrl
-  uint16_t keymap_index = 0;
-
   // act: press tap-hold key at t=0
   {
     uint32_t actual_next_ev_ms = keymap_register_input_after_ms(
         0,
         (struct KeymapInputEvent){.event_type = KeymapEventPress,
-                                  .value = keymap_index},
+                                  .value = KM_TAP_HOLD_KEY},
         actual_report);
 
     // assert: hold timeout scheduled, polling not required yet
@@ -113,7 +74,7 @@ void test_event_driven_tap_hold_key_tap_release_reported(void) {
     uint32_t actual_next_ev_ms = keymap_register_input_after_ms(
         150,
         (struct KeymapInputEvent){.event_type = KeymapEventRelease,
-                                  .value = keymap_index},
+                                  .value = KM_TAP_HOLD_KEY},
         actual_report);
 
     // assert: tap reported, polling required until tap clears
@@ -143,3 +104,7 @@ void test_event_driven_tap_hold_key_tap_release_reported(void) {
     TEST_ASSERT_FALSE(keymap_requires_polling());
   }
 }
+
+#else
+#error "requires SUITE_TAP_HOLD"
+#endif


### PR DESCRIPTION
## Summary

Reorganise Ceedling tests so each suite has its own keymap, static library, and test directory. This replaces the previous single `tests/ncl/keymap-4key-simple` build shared by all tests.

The goal is to scale Ceedling coverage, allowing Ceedling test suites for more targetted keymaps (rather than "one keymap for all ceedling suites").

## Motivation

- Previously, Ceedling linked a **pre-built** `libsmart_keymap.a`; key layout is fixed at cargo build time from `keymap.ncl`.
- One global library + hardcoded indices (`value = 2` for key A) does not scale to multiple smart-key families.
- Ceedling has no per-test library config — but `:flags` → `:test` → `:link` matchers can link different libs per test directory.

## New layout

```text
tests/ceedling/
  keymaps/
    keyboard/keymap.ncl      # suite keymap (A, B)
    tap_hold/keymap.ncl      # suite keymap (C & hold LCtrl)
  ncl/
    ceedling-fixture.ncl     # generates fixture headers from keymap metadata
  scripts/
    ceedling-fixture.sh      # nickel export wrapper
  libs/                      # gitignored — copied per-suite .a files
  generated/                 # gitignored — generated fixture headers
  test/
    keyboard/
      test_keymap.c
      test_keymap_event_driven.c
    tap_hold/
      test_keydef_taphold.c
      test_keydef_taphold_event_driven.c
    protocol/
      test_message.c         # default keymap (no custom keymap)
    support/
      hid_keycodes.h         # shared USB HID usages (KC_*, MOD_*)
  project.yml
  ceedling.mk
```

## How it works

### Per-suite builds (`ceedling.mk`)

For each entry in `CEEDLING_KEYMAP_SUITES` (`keyboard`, `tap_hold`):

1. **Fixture header** — `nickel export` reads `ceedling_fixture` from the suite keymap and writes `generated/<suite>_test_ceedling_fixture.h`.
2. **Static lib** — `cargo build` with `SMART_KEYMAP_CUSTOM_KEYMAP` pointing at the suite keymap; artefact copied to `libs/libsmart_keymap_<suite>.a`.
3. **Protocol suite** — `libs/libsmart_keymap_default.a` built without a custom keymap.

`make test-ceedling` depends on all libs + fixtures before running Ceedling.

### Per-suite linking (`project.yml`)

`:flags` → `:test` → `:link` matchers tie each test directory to its library:

| Test directory | Library |
|----------------|---------|
| `test/keyboard/` | `libsmart_keymap_keyboard.a` |
| `test/tap_hold/` | `libsmart_keymap_tap_hold.a` |
| `test/protocol/` | `libsmart_keymap_default.a` |

### Keymap metadata → C headers

Each suite keymap declares a `ceedling_fixture` record:

```nickel
ceedling_fixture = {
  suite = "KEYBOARD",
  KEY_A = 0,
  KEY_B = 1,
}
```

Generated header (example):

```c
#define SUITE_KEYBOARD 1

#define KM_KEY_A 0
#define KM_KEY_B 1
```

- **`SUITE_*`** — compile-time suite guard (`#ifdef SUITE_KEYBOARD` in test files).
- **`KM_*`** — keymap-specific indices (layout varies per suite).
- **`KC_*` / `MOD_*`** — shared HID constants in `test/support/hid_keycodes.h` (not per-keymap).

### Suite separation

- **Keyboard** keymap is plain keys only (`A`, `B`). No tap-hold indices.
- **Tap-hold** tests (polling + event-driven) live under `test/tap_hold/` with `KM_TAP_HOLD_KEY`.

## Ceedling caveat: unique test basenames

Ceedling identifies tests by **filename stem**, not path. Two files named `test_keymap_event_driven.c` in different directories collide (one runner, one `.out` — see [ThrowTheSwitch/Ceedling#592](https://github.com/ThrowTheSwitch/Ceedling/issues/592)).

Tap-hold event-driven tests are therefore named `test_keydef_taphold_event_driven.c`.
