### PR TITLE
tests: ceedling: callback key coverage

### DIFF
--- a/smart_keymap/src/lib.rs
+++ b/smart_keymap/src/lib.rs
@@ -386,6 +386,19 @@ pub unsafe extern "C" fn keymap_requires_polling() -> bool {
     unsafe { KEYMAP.requires_polling() }
 }
 
+/// Clears all registered callbacks.
+///
+/// # Safety
+///
+/// Not to be called concurrently with other `keymap_*` functions.
+#[allow(static_mut_refs)]
+#[no_mangle]
+pub unsafe extern "C" fn keymap_clear_callbacks() {
+    unsafe {
+        KEYMAP.clear_callbacks();
+    }
+}
+
 /// Registers a callback with the keymap.
 ///
 /// callback_id should be one of:

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -314,6 +314,11 @@ impl<
         self.idle_time = 0;
     }
 
+    /// Clears all registered callbacks.
+    pub fn clear_callbacks(&mut self) {
+        self.callbacks.clear();
+    }
+
     /// Registers the given callback to the keymap.
     ///
     /// Only one callback is set for each callback id.

--- a/tests/ceedling/ceedling.mk
+++ b/tests/ceedling/ceedling.mk
@@ -1,5 +1,5 @@
 CEEDLING = ceedling
-CEEDLING_KEYMAP_SUITES = keyboard tap_hold
+CEEDLING_KEYMAP_SUITES = callback keyboard tap_hold
 CEEDLING_CARGO_TARGET = tests/ceedling/cargo-target
 
 # Rebuild copied libs when smart_keymap crate inputs change (not only keymap.ncl).
@@ -65,7 +65,12 @@ tests/ceedling/libs/libsmart_keymap_default.a: $(CEEDLING_CARGO_TARGET)/default/
 	cp $< $@
 
 .PHONY: test-ceedling
-test-ceedling: include/smart_keymap.h fix-ceedling-vendor format-ceedling $(CEEDLING_LIBS) $(CEEDLING_FIXTURES)
+test-ceedling: include/smart_keymap.h
+test-ceedling: fix-ceedling-vendor
+test-ceedling: format-ceedling
+test-ceedling: $(CEEDLING_LIBS)
+test-ceedling: $(CEEDLING_FIXTURES)
+	cd tests/ceedling && $(CEEDLING) --mixin=mixins/callback.yml test:path[callback]
 	cd tests/ceedling && $(CEEDLING) --mixin=mixins/keyboard.yml test:path[keyboard]
 	cd tests/ceedling && $(CEEDLING) --mixin=mixins/tap_hold.yml test:path[tap_hold]
 	cd tests/ceedling && $(CEEDLING) --mixin=mixins/protocol.yml test:path[protocol]

--- a/tests/ceedling/keymaps/callback/keymap.ncl
+++ b/tests/ceedling/keymaps/callback/keymap.ncl
@@ -1,0 +1,16 @@
+let K = import "keys.ncl" in
+
+{
+  keys = [
+    K.reset,
+    K.reset_to_bootloader,
+    K.callback 3 4,
+  ],
+
+  ceedling_fixture = {
+    suite = "CALLBACK",
+    RESET_KEY = 0,
+    BOOTLOADER_KEY = 1,
+    CUSTOM_KEY = 2,
+  },
+}

--- a/tests/ceedling/mixins/callback.yml
+++ b/tests/ceedling/mixins/callback.yml
@@ -1,0 +1,7 @@
+:paths:
+  :libraries:
+    - libs
+
+:libraries:
+  :system:
+    - smart_keymap_callback

--- a/tests/ceedling/test/callback/test_keydef_callback.c
+++ b/tests/ceedling/test/callback/test_keydef_callback.c
@@ -1,0 +1,91 @@
+#include "callback_test_ceedling_fixture.h"
+
+#ifdef SUITE_CALLBACK
+
+#include "unity.h"
+
+#include "hid_keycodes.h"
+#include "smart_keymap.h"
+
+static int reset_callback_count;
+
+static void reset_callback(void) { reset_callback_count++; }
+
+void setUp(void) {
+  reset_callback_count = 0;
+  keymap_init();
+  keymap_clear_callbacks();
+}
+
+void tearDown(void) {}
+
+void test_callback_not_invoked_without_registration(void) {
+  uint8_t expected_report[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+  KeymapHidReport report = {};
+  KeymapHidReport *actual_report = &report;
+
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_RESET_KEY});
+  keymap_tick(actual_report);
+
+  TEST_ASSERT_EQUAL_INT(0, reset_callback_count);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
+}
+
+void test_reset_callback_invoked_on_press(void) {
+  uint8_t expected_report[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+  KeymapHidReport report = {};
+  KeymapHidReport *actual_report = &report;
+
+  keymap_register_callback(KEYMAP_CALLBACK_RESET, reset_callback);
+
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_RESET_KEY});
+  keymap_tick(actual_report);
+
+  TEST_ASSERT_EQUAL_INT(1, reset_callback_count);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
+}
+
+void test_callback_not_invoked_on_release(void) {
+  uint8_t expected_report[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+  KeymapHidReport report = {};
+  KeymapHidReport *actual_report = &report;
+
+  keymap_register_callback(KEYMAP_CALLBACK_RESET, reset_callback);
+
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_RESET_KEY});
+  keymap_tick(actual_report);
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventRelease, .value = KM_RESET_KEY});
+  keymap_tick(actual_report);
+
+  TEST_ASSERT_EQUAL_INT(1, reset_callback_count);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
+}
+
+void test_callback_invoked_on_each_press(void) {
+  uint8_t expected_report[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+  KeymapHidReport report = {};
+  KeymapHidReport *actual_report = &report;
+
+  keymap_register_callback(KEYMAP_CALLBACK_RESET, reset_callback);
+
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_RESET_KEY});
+  keymap_tick(actual_report);
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventRelease, .value = KM_RESET_KEY});
+  keymap_tick(actual_report);
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_RESET_KEY});
+  keymap_tick(actual_report);
+
+  TEST_ASSERT_EQUAL_INT(2, reset_callback_count);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
+}
+
+#else
+#error "requires SUITE_CALLBACK"
+#endif

--- a/tests/ceedling/test/callback/test_keydef_callback_types.c
+++ b/tests/ceedling/test/callback/test_keydef_callback_types.c
@@ -1,0 +1,58 @@
+#include "callback_test_ceedling_fixture.h"
+
+#ifdef SUITE_CALLBACK
+
+#include "unity.h"
+
+#include "hid_keycodes.h"
+#include "smart_keymap.h"
+
+static int bootloader_callback_count;
+static int custom_callback_count;
+
+static void bootloader_callback(void) { bootloader_callback_count++; }
+
+static void custom_callback(void) { custom_callback_count++; }
+
+void setUp(void) {
+  bootloader_callback_count = 0;
+  custom_callback_count = 0;
+  keymap_init();
+  keymap_clear_callbacks();
+}
+
+void tearDown(void) {}
+
+void test_bootloader_callback_invoked_on_press(void) {
+  uint8_t expected_report[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+  KeymapHidReport report = {};
+  KeymapHidReport *actual_report = &report;
+
+  keymap_register_callback(KEYMAP_CALLBACK_BOOTLOADER, bootloader_callback);
+
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_BOOTLOADER_KEY});
+  keymap_tick(actual_report);
+
+  TEST_ASSERT_EQUAL_INT(1, bootloader_callback_count);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
+}
+
+void test_custom_callback_invoked_on_press(void) {
+  uint8_t expected_report[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+  KeymapHidReport report = {};
+  KeymapHidReport *actual_report = &report;
+
+  keymap_register_custom_callback(3, 4, custom_callback);
+
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_CUSTOM_KEY});
+  keymap_tick(actual_report);
+
+  TEST_ASSERT_EQUAL_INT(1, custom_callback_count);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
+}
+
+#else
+#error "requires SUITE_CALLBACK"
+#endif


### PR DESCRIPTION
## Summary

Adds Ceedling test coverage for callback keys in `libsmart_keymap`, and exposes `keymap_clear_callbacks()` so tests can reset the callback table.

Callback keys invoke firmware-defined handlers (`keymap_register_callback`, `keymap_register_custom_callback`) on press and produce no HID keyboard output. Behaviour is described in `features/keymap/key/callback.feature`; this PR adds the corresponding C integration tests.

## Changes

### `keymap_clear_callbacks()` (commit 1)

- `Keymap::clear_callbacks()` on the Rust keymap
- `keymap_clear_callbacks()` exported in the C API (via cbindgen into `include/smart_keymap.h` at build time)
- `keymap_init()` is unchanged: registered callbacks persist across init, matching existing firmware (e.g. CH32X registers in `keyboard_init()` before `keymap_init()`)

### Ceedling callback suite (commit 2)

- New keymap fixture: `tests/ceedling/keymaps/callback/keymap.ncl` with reset, bootloader, and custom `(3, 4)` keys
- `test_keydef_callback.c` — reset callback behaviour (unregistered press, press, release, re-press)
- `test_keydef_callback_types.c` — bootloader and custom callbacks
- Tests call `keymap_init()` + `keymap_clear_callbacks()` in `setUp` so each case registers callbacks independently
- Two test executables: the callback table holds two entries (`LinearMap<_, 2>`), so bootloader and custom tests are split from the reset-focused file
- `ceedling.mk`: `callback` added to `CEEDLING_KEYMAP_SUITES` (alphabetical order); `test-ceedling` prerequisites split one per line