### PR TITLE
tests: ceedling: E2E suites for layered, sticky, consumer, and mouse keys

### DIFF
--- a/tests/ceedling/ceedling.mk
+++ b/tests/ceedling/ceedling.mk
@@ -1,5 +1,5 @@
 CEEDLING = ceedling
-CEEDLING_KEYMAP_SUITES = callback keyboard layered tap_hold
+CEEDLING_KEYMAP_SUITES = consumer callback keyboard layered mouse sticky tap_hold
 CEEDLING_CARGO_TARGET = tests/ceedling/cargo-target
 
 # Rebuild copied libs when smart_keymap crate inputs change (not only keymap.ncl).
@@ -71,7 +71,10 @@ test-ceedling: format-ceedling
 test-ceedling: $(CEEDLING_LIBS)
 test-ceedling: $(CEEDLING_FIXTURES)
 	cd tests/ceedling && $(CEEDLING) --mixin=mixins/callback.yml test:path[callback]
+	cd tests/ceedling && $(CEEDLING) --mixin=mixins/consumer.yml test:path[consumer]
 	cd tests/ceedling && $(CEEDLING) --mixin=mixins/keyboard.yml test:path[keyboard]
 	cd tests/ceedling && $(CEEDLING) --mixin=mixins/layered.yml test:path[layered]
+	cd tests/ceedling && $(CEEDLING) --mixin=mixins/mouse.yml test:path[mouse]
+	cd tests/ceedling && $(CEEDLING) --mixin=mixins/sticky.yml test:path[sticky]
 	cd tests/ceedling && $(CEEDLING) --mixin=mixins/tap_hold.yml test:path[tap_hold]
 	cd tests/ceedling && $(CEEDLING) --mixin=mixins/protocol.yml test:path[protocol]

--- a/tests/ceedling/ceedling.mk
+++ b/tests/ceedling/ceedling.mk
@@ -1,5 +1,5 @@
 CEEDLING = ceedling
-CEEDLING_KEYMAP_SUITES = callback keyboard tap_hold
+CEEDLING_KEYMAP_SUITES = callback keyboard layered tap_hold
 CEEDLING_CARGO_TARGET = tests/ceedling/cargo-target
 
 # Rebuild copied libs when smart_keymap crate inputs change (not only keymap.ncl).
@@ -72,5 +72,6 @@ test-ceedling: $(CEEDLING_LIBS)
 test-ceedling: $(CEEDLING_FIXTURES)
 	cd tests/ceedling && $(CEEDLING) --mixin=mixins/callback.yml test:path[callback]
 	cd tests/ceedling && $(CEEDLING) --mixin=mixins/keyboard.yml test:path[keyboard]
+	cd tests/ceedling && $(CEEDLING) --mixin=mixins/layered.yml test:path[layered]
 	cd tests/ceedling && $(CEEDLING) --mixin=mixins/tap_hold.yml test:path[tap_hold]
 	cd tests/ceedling && $(CEEDLING) --mixin=mixins/protocol.yml test:path[protocol]

--- a/tests/ceedling/keymaps/consumer/keymap.ncl
+++ b/tests/ceedling/keymaps/consumer/keymap.ncl
@@ -1,0 +1,12 @@
+let K = import "keys.ncl" in
+
+{
+  keys = [
+    K.PlayPause,
+  ],
+
+  ceedling_fixture = {
+    suite = "CONSUMER",
+    PLAY_PAUSE_KEY = 0,
+  },
+}

--- a/tests/ceedling/keymaps/layered/keymap.ncl
+++ b/tests/ceedling/keymaps/layered/keymap.ncl
@@ -1,0 +1,20 @@
+let K = import "keys.ncl" in
+
+{
+  layers = [
+    [
+      { layer_modifier = { hold = 1 } },
+      K.A,
+    ],
+    [
+      null,
+      K.B,
+    ],
+  ],
+
+  ceedling_fixture = {
+    suite = "LAYERED",
+    LAYER_MOD_KEY = 0,
+    LAYERED_KEY = 1,
+  },
+}

--- a/tests/ceedling/keymaps/mouse/keymap.ncl
+++ b/tests/ceedling/keymaps/mouse/keymap.ncl
@@ -1,0 +1,16 @@
+let K = import "keys.ncl" in
+
+{
+  keys = [
+    K.MouseBtn1,
+    K.MouseLeft,
+    K.MouseWheelUp,
+  ],
+
+  ceedling_fixture = {
+    suite = "MOUSE",
+    MOUSE_BTN1_KEY = 0,
+    MOUSE_LEFT_KEY = 1,
+    MOUSE_WHEEL_UP_KEY = 2,
+  },
+}

--- a/tests/ceedling/keymaps/sticky/keymap.ncl
+++ b/tests/ceedling/keymaps/sticky/keymap.ncl
@@ -1,0 +1,14 @@
+let K = import "keys.ncl" in
+
+{
+  keys = [
+    K.sticky K.LeftShift,
+    K.A,
+  ],
+
+  ceedling_fixture = {
+    suite = "STICKY",
+    STICKY_SHIFT_KEY = 0,
+    KEY_A = 1,
+  },
+}

--- a/tests/ceedling/mixins/consumer.yml
+++ b/tests/ceedling/mixins/consumer.yml
@@ -1,0 +1,7 @@
+:paths:
+  :libraries:
+    - libs
+
+:libraries:
+  :system:
+    - smart_keymap_consumer

--- a/tests/ceedling/mixins/layered.yml
+++ b/tests/ceedling/mixins/layered.yml
@@ -1,0 +1,7 @@
+:paths:
+  :libraries:
+    - libs
+
+:libraries:
+  :system:
+    - smart_keymap_layered

--- a/tests/ceedling/mixins/mouse.yml
+++ b/tests/ceedling/mixins/mouse.yml
@@ -1,0 +1,7 @@
+:paths:
+  :libraries:
+    - libs
+
+:libraries:
+  :system:
+    - smart_keymap_mouse

--- a/tests/ceedling/mixins/sticky.yml
+++ b/tests/ceedling/mixins/sticky.yml
@@ -1,0 +1,7 @@
+:paths:
+  :libraries:
+    - libs
+
+:libraries:
+  :system:
+    - smart_keymap_sticky

--- a/tests/ceedling/test/consumer/test_keydef_consumer.c
+++ b/tests/ceedling/test/consumer/test_keydef_consumer.c
@@ -1,0 +1,64 @@
+#include "consumer_test_ceedling_fixture.h"
+
+#ifdef SUITE_CONSUMER
+
+#include "unity.h"
+
+#include "hid_consumer_codes.h"
+#include "smart_keymap.h"
+
+void setUp(void) {}
+
+void tearDown(void) {}
+
+void test_consumer_key_press_reports_usage(void) {
+  uint8_t expected_keyboard[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+  uint8_t expected_consumer[KEYMAP_HID_REPORT_CONSUMER_LEN] = {
+      CONSUMER_PLAY_PAUSE,
+      0,
+      0,
+      0,
+  };
+  KeymapHidReport report = {};
+  KeymapHidReport *actual_report = &report;
+
+  // assemble: init keymap
+  keymap_init();
+
+  // act: press Play/Pause consumer key
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_PLAY_PAUSE_KEY});
+  keymap_tick(actual_report);
+
+  // assert: usage appears in consumer[], not keyboard[]
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_keyboard, actual_report->keyboard, 8);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_consumer, actual_report->consumer,
+                                KEYMAP_HID_REPORT_CONSUMER_LEN);
+}
+
+void test_consumer_key_release_clears_usage(void) {
+  uint8_t expected_keyboard[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+  uint8_t expected_consumer[KEYMAP_HID_REPORT_CONSUMER_LEN] = {0, 0, 0, 0};
+  KeymapHidReport report = {};
+  KeymapHidReport *actual_report = &report;
+
+  // assemble: init keymap
+  keymap_init();
+
+  // act: press then release Play/Pause
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_PLAY_PAUSE_KEY});
+  keymap_tick(actual_report);
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventRelease, .value = KM_PLAY_PAUSE_KEY});
+  keymap_tick(actual_report);
+
+  // assert: consumer report cleared; keyboard still empty
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_keyboard, actual_report->keyboard, 8);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_consumer, actual_report->consumer,
+                                KEYMAP_HID_REPORT_CONSUMER_LEN);
+}
+
+#else
+#error "requires SUITE_CONSUMER"
+#endif

--- a/tests/ceedling/test/layered/test_keydef_layered.c
+++ b/tests/ceedling/test/layered/test_keydef_layered.c
@@ -1,0 +1,76 @@
+#include "layered_test_ceedling_fixture.h"
+
+#ifdef SUITE_LAYERED
+
+#include "unity.h"
+
+#include "hid_keycodes.h"
+#include "smart_keymap.h"
+
+void setUp(void) {}
+
+void tearDown(void) {}
+
+void test_layered_key_acts_as_base_when_no_layer_active(void) {
+  uint8_t expected_report[8] = {0, 0, KC_A, 0, 0, 0, 0, 0};
+  KeymapHidReport report = {};
+  KeymapHidReport *actual_report = &report;
+
+  // assemble: init keymap
+  keymap_init();
+
+  // act: press layered key with no layer modifier held
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_LAYERED_KEY});
+  keymap_tick(actual_report);
+
+  // assert: base-layer key (A) in report
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
+}
+
+void test_layered_key_acts_as_active_layer_when_layer_mod_held(void) {
+  uint8_t expected_report[8] = {0, 0, KC_B, 0, 0, 0, 0, 0};
+  KeymapHidReport report = {};
+  KeymapHidReport *actual_report = &report;
+
+  // assemble: init keymap
+  keymap_init();
+
+  // act: hold layer modifier, then press layered key
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_LAYER_MOD_KEY});
+  keymap_tick(actual_report);
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_LAYERED_KEY});
+  keymap_tick(actual_report);
+
+  // assert: active-layer key (B) in report
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
+}
+
+void test_layered_keypress_retained_when_layer_mod_released(void) {
+  uint8_t expected_report[8] = {0, 0, KC_B, 0, 0, 0, 0, 0};
+  KeymapHidReport report = {};
+  KeymapHidReport *actual_report = &report;
+
+  // assemble: init keymap
+  keymap_init();
+
+  // act: activate layer, press layered key, then release layer modifier
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_LAYER_MOD_KEY});
+  keymap_tick(actual_report);
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_LAYERED_KEY});
+  keymap_tick(actual_report);
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventRelease, .value = KM_LAYER_MOD_KEY});
+  keymap_tick(actual_report);
+
+  // assert: keypress resolved on layer 1 is retained after mod release
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
+}
+
+#else
+#error "requires SUITE_LAYERED"
+#endif

--- a/tests/ceedling/test/layered/test_keydef_layered_event_driven.c
+++ b/tests/ceedling/test/layered/test_keydef_layered_event_driven.c
@@ -1,0 +1,40 @@
+#include "layered_test_ceedling_fixture.h"
+
+#ifdef SUITE_LAYERED
+
+#include "unity.h"
+
+#include "hid_keycodes.h"
+#include "smart_keymap.h"
+
+void setUp(void) {}
+
+void tearDown(void) {}
+
+void test_event_driven_layered_key_with_layer_mod_held(void) {
+  uint8_t expected_report[8] = {0, 0, KC_B, 0, 0, 0, 0, 0};
+  KeymapHidReport report = {};
+  KeymapHidReport *actual_report = &report;
+
+  // assemble: init keymap
+  keymap_init();
+
+  // act: hold layer modifier and press layered key via event-driven API
+  keymap_register_input_after_ms(
+      0,
+      (struct KeymapInputEvent){.event_type = KeymapEventPress,
+                                .value = KM_LAYER_MOD_KEY},
+      actual_report);
+  keymap_register_input_after_ms(
+      0,
+      (struct KeymapInputEvent){.event_type = KeymapEventPress,
+                                .value = KM_LAYERED_KEY},
+      actual_report);
+
+  // assert: active-layer key (B) in report
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
+}
+
+#else
+#error "requires SUITE_LAYERED"
+#endif

--- a/tests/ceedling/test/mouse/test_keydef_mouse.c
+++ b/tests/ceedling/test/mouse/test_keydef_mouse.c
@@ -1,0 +1,91 @@
+#include "mouse_test_ceedling_fixture.h"
+
+#ifdef SUITE_MOUSE
+
+#include "unity.h"
+
+#include "hid_keycodes.h"
+#include "smart_keymap.h"
+
+void setUp(void) {}
+
+void tearDown(void) {}
+
+void test_mouse_button_press_reports_in_mouse_field(void) {
+  uint8_t expected_keyboard[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+  KeymapHidReport report = {};
+  KeymapHidReport *actual_report = &report;
+
+  // assemble: init keymap
+  keymap_init();
+
+  // act: press mouse button 1
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_MOUSE_BTN1_KEY});
+  keymap_tick(actual_report);
+
+  // assert: button state in mouse report; keyboard[] unused
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_keyboard, actual_report->keyboard, 8);
+  TEST_ASSERT_EQUAL_UINT8(1, actual_report->mouse.pressed_buttons);
+  TEST_ASSERT_EQUAL_INT8(0, actual_report->mouse.x);
+  TEST_ASSERT_EQUAL_INT8(0, actual_report->mouse.y);
+  TEST_ASSERT_EQUAL_INT8(0, actual_report->mouse.vertical_scroll);
+  TEST_ASSERT_EQUAL_INT8(0, actual_report->mouse.horizontal_scroll);
+}
+
+void test_mouse_button_release_clears_mouse_field(void) {
+  uint8_t expected_keyboard[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+  KeymapHidReport report = {};
+  KeymapHidReport *actual_report = &report;
+
+  // assemble: init keymap
+  keymap_init();
+
+  // act: press then release mouse button 1
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_MOUSE_BTN1_KEY});
+  keymap_tick(actual_report);
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventRelease, .value = KM_MOUSE_BTN1_KEY});
+  keymap_tick(actual_report);
+
+  // assert: mouse report cleared
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_keyboard, actual_report->keyboard, 8);
+  TEST_ASSERT_EQUAL_UINT8(0, actual_report->mouse.pressed_buttons);
+  TEST_ASSERT_EQUAL_INT8(0, actual_report->mouse.x);
+  TEST_ASSERT_EQUAL_INT8(0, actual_report->mouse.y);
+  TEST_ASSERT_EQUAL_INT8(0, actual_report->mouse.vertical_scroll);
+  TEST_ASSERT_EQUAL_INT8(0, actual_report->mouse.horizontal_scroll);
+}
+
+void test_mouse_keys_combine_in_mouse_field(void) {
+  uint8_t expected_keyboard[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+  KeymapHidReport report = {};
+  KeymapHidReport *actual_report = &report;
+
+  // assemble: init keymap
+  keymap_init();
+
+  // act: press button, cursor-left, and wheel-up keys together
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_MOUSE_BTN1_KEY});
+  keymap_tick(actual_report);
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_MOUSE_LEFT_KEY});
+  keymap_tick(actual_report);
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_MOUSE_WHEEL_UP_KEY});
+  keymap_tick(actual_report);
+
+  // assert: button, movement, and scroll accumulate in one mouse report
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_keyboard, actual_report->keyboard, 8);
+  TEST_ASSERT_EQUAL_UINT8(1, actual_report->mouse.pressed_buttons);
+  TEST_ASSERT_EQUAL_INT8(-5, actual_report->mouse.x);
+  TEST_ASSERT_EQUAL_INT8(0, actual_report->mouse.y);
+  TEST_ASSERT_EQUAL_INT8(1, actual_report->mouse.vertical_scroll);
+  TEST_ASSERT_EQUAL_INT8(0, actual_report->mouse.horizontal_scroll);
+}
+
+#else
+#error "requires SUITE_MOUSE"
+#endif

--- a/tests/ceedling/test/sticky/test_keydef_sticky.c
+++ b/tests/ceedling/test/sticky/test_keydef_sticky.c
@@ -1,0 +1,81 @@
+#include "sticky_test_ceedling_fixture.h"
+
+#ifdef SUITE_STICKY
+
+#include "unity.h"
+
+#include "hid_keycodes.h"
+#include "smart_keymap.h"
+
+void setUp(void) {}
+
+void tearDown(void) {}
+
+static void tap_key(uint16_t key, KeymapHidReport *report) {
+  keymap_register_input_event(
+      (struct KeymapInputEvent){.event_type = KeymapEventPress, .value = key});
+  keymap_tick(report);
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventRelease, .value = key});
+  keymap_tick(report);
+}
+
+void test_sticky_mod_modifies_next_keyboard_key(void) {
+  uint8_t expected_report[8] = {MOD_LSHFT, 0, KC_A, 0, 0, 0, 0, 0};
+  KeymapHidReport report = {};
+  KeymapHidReport *actual_report = &report;
+
+  // assemble: init keymap
+  keymap_init();
+
+  // act: tap sticky shift, then press A
+  tap_key(KM_STICKY_SHIFT_KEY, actual_report);
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_KEY_A});
+  keymap_tick(actual_report);
+
+  // assert: sticky shift applies to the next key only
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_report, actual_report->keyboard, 8);
+}
+
+void test_sticky_mod_only_affects_next_keyboard_key(void) {
+  uint8_t expected_shifted[8] = {MOD_LSHFT, 0, KC_A, 0, 0, 0, 0, 0};
+  uint8_t expected_unshifted[8] = {0, 0, KC_A, 0, 0, 0, 0, 0};
+  KeymapHidReport report = {};
+  KeymapHidReport *actual_report = &report;
+
+  // assemble: init keymap
+  keymap_init();
+
+  // act: consume sticky shift on a tap of A
+  tap_key(KM_STICKY_SHIFT_KEY, actual_report);
+  tap_key(KM_KEY_A, actual_report);
+  for (int i = 0; i < 10; i++) {
+    keymap_tick(actual_report);
+  }
+
+  // act: press A again without re-arming sticky shift
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_KEY_A});
+  keymap_tick(actual_report);
+
+  // assert: sticky modifier was consumed; A is unshifted
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_unshifted, actual_report->keyboard, 8);
+
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventRelease, .value = KM_KEY_A});
+  keymap_tick(actual_report);
+
+  // act: re-arm sticky shift and press A once more
+  tap_key(KM_STICKY_SHIFT_KEY, actual_report);
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventPress, .value = KM_KEY_A});
+  keymap_tick(actual_report);
+
+  // assert: newly armed sticky shift applies again
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_shifted, actual_report->keyboard, 8);
+}
+
+#else
+#error "requires SUITE_STICKY"
+#endif

--- a/tests/ceedling/test/support/hid_consumer_codes.h
+++ b/tests/ceedling/test/support/hid_consumer_codes.h
@@ -1,0 +1,6 @@
+#pragma once
+
+// Consumer control usages surfaced in KeymapHidReport.consumer[].
+// Firmware reads pressed codes from report->consumer (up to
+// KEYMAP_HID_REPORT_CONSUMER_LEN entries; unused slots are zero).
+#define CONSUMER_PLAY_PAUSE 0xCD

--- a/tests/ceedling/test/support/hid_keycodes.h
+++ b/tests/ceedling/test/support/hid_keycodes.h
@@ -7,3 +7,4 @@
 
 // Modifier bits in KeymapHidReport.keyboard[0]
 #define MOD_LCTL 0x01
+#define MOD_LSHFT 0x02


### PR DESCRIPTION
## Summary

Extends Ceedling coverage for `libsmart_keymap` with some E2E suites that exercise the C API path end-to-end: a per-suite `keymap.ncl` is codegen'd into a static lib, linked from C tests, and driven via `keymap_tick()` or the event-driven input API. 

This complements existing Rust integration and Cucumber tests by proving the same key behaviour through the firmware-facing C bindings and `KeymapHidReport` layout.

## New suites

| Suite | Tests | API | What it proves |
|---|---|---|---|
| **layered** | 4 | tick + event-driven | base vs active layer; key retained after layer-mod release |
| **sticky** | 2 | tick | one-shot sticky modifier arms then consumes on next key |
| **consumer** | 2 | tick | usages in `report.consumer[]`; `keyboard[]` stays empty |
| **mouse** | 3 | tick | button/movement/scroll in `report.mouse`; fields combine |

**Total:** 11 new tests (28 Ceedling tests overall).

## Notable details

- Each suite has its own keymap fixture under `tests/ceedling/keymaps/` and mixin under `mixins/`, following the existing keyboard/tap_hold pattern.
- Consumer and mouse tests demonstrate how firmware should observe non-keyboard output (`hid_consumer_codes.h`, explicit `report.mouse` field assertions).
- Layered event-driven test mirrors the keyboard event-driven pattern via `keymap_register_input_after_ms`.
- Tests use assemble/act/assert comments where behaviour is non-obvious (layer retention, sticky consumption, alternate report fields).