### PR TITLE
ncl: discover snapshot fixtures; use cargo check in compile tests

### DIFF
--- a/ncl/scripts/list-ncl-snapshot-fixtures.sh
+++ b/ncl/scripts/list-ncl-snapshot-fixtures.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Lists tests/ncl fixture directories that have expected.rs snapshots.
+# One fixture name per line, sorted for stable ordering.
+
+set -euo pipefail
+
+SCRIPTS_DIR="$(dirname "$0")"
+NCL_TESTS_DIR="${SCRIPTS_DIR}/../../tests/ncl"
+
+for fixture_dir in "${NCL_TESTS_DIR}"/keymap-*; do
+  [[ -d "${fixture_dir}" ]] || continue
+  [[ -f "${fixture_dir}/expected.rs" ]] || continue
+  basename "${fixture_dir}"
+done | sort

--- a/ncl/scripts/run-tests.sh
+++ b/ncl/scripts/run-tests.sh
@@ -2,38 +2,21 @@
 
 # Tests the Nickel keymaps under tests/ncl,
 #  checking the generated output matches expected snapshots,
-#  and that the generated keymap builds.
+#  and that the generated keymap type-checks.
 
-set -e
+set -euo pipefail
 
 SCRIPTS_DIR="$(dirname "$0")"
 
 # Run the nickel checks first.
 "${SCRIPTS_DIR}/run-ncl-checks.sh"
 
-# Then with each of the listed `tests/ncl`, check its generated keymap.rs:
+mapfile -t ncl_tests < <("${SCRIPTS_DIR}/list-ncl-snapshot-fixtures.sh")
+
+# For each snapshot fixture, check generated keymap.rs:
 #  - matches the expected snapshot,
-#  - can be compiled.
-ncl_tests=(
-    "keymap-1key-simple"
-    "keymap-1key-tap_dance"
-    "keymap-1key-tap_hold"
-    "keymap-1key-custom"
-    "keymap-1key-2layer-th-lmod"
-    "keymap-1key-callback-custom"
-    "keymap-1key-automation"
-    "keymap-2key-2layer-simple"
-    "keymap-2key-2layer-composite"
-    "keymap-2key-chorded"
-    "keymap-48key-basic"
-    "keymap-48key-rgoulter"
-    "keymap-60key-dvorak-simple"
-    "keymap-60key-dvorak-simple-with-tap_hold"
-    "keymap-34key-seniply"
-    "keymap-1key-abbrev-ent"
-)
-for ncl_test in "${ncl_tests[@]}"
-do
-    "${SCRIPTS_DIR}/test-ncl-diff.sh" "${ncl_test}"
-    "${SCRIPTS_DIR}/test-ncl-builds.sh" "${ncl_test}"
+#  - type-checks (cargo check).
+for ncl_test in "${ncl_tests[@]}"; do
+  "${SCRIPTS_DIR}/test-ncl-diff.sh" "${ncl_test}"
+  "${SCRIPTS_DIR}/test-ncl-builds.sh" "${ncl_test}"
 done

--- a/ncl/scripts/save-test-snapshots.sh
+++ b/ncl/scripts/save-test-snapshots.sh
@@ -1,32 +1,13 @@
 #!/usr/bin/env bash
 
-# Tests the Nickel keymaps under tests/ncl,
-#  checking the generated output matches expected snapshots,
-#  and that the generated keymap builds.
+# Refreshes expected.rs snapshots for tests/ncl fixtures.
 
-set -e
+set -euo pipefail
 
 SCRIPTS_DIR="$(dirname "$0")"
 
-ncl_tests=(
-    "keymap-1key-simple"
-    "keymap-1key-tap_dance"
-    "keymap-1key-tap_hold"
-    "keymap-1key-custom"
-    "keymap-1key-2layer-th-lmod"
-    "keymap-1key-callback-custom"
-    "keymap-1key-automation"
-    "keymap-2key-2layer-simple"
-    "keymap-2key-2layer-composite"
-    "keymap-2key-chorded"
-    "keymap-48key-basic"
-    "keymap-48key-rgoulter"
-    "keymap-60key-dvorak-simple"
-    "keymap-60key-dvorak-simple-with-tap_hold"
-    "keymap-34key-seniply"
-    "keymap-1key-abbrev-ent"
-)
-for ncl_test in "${ncl_tests[@]}"
-do
-    "${SCRIPTS_DIR}/save-keymap-rs-snapshot.sh" "${ncl_test}"
+mapfile -t ncl_tests < <("${SCRIPTS_DIR}/list-ncl-snapshot-fixtures.sh")
+
+for ncl_test in "${ncl_tests[@]}"; do
+  "${SCRIPTS_DIR}/save-keymap-rs-snapshot.sh" "${ncl_test}"
 done

--- a/ncl/scripts/test-ncl-builds.sh
+++ b/ncl/scripts/test-ncl-builds.sh
@@ -2,7 +2,7 @@
 
 # $ test-ncl-builds.sh ncl-test-name
 #
-# Runs cargo build with the keymap.rs generated from the keymap.json
+# Runs cargo check with the keymap.rs generated from the keymap.json
 #  for the given ncl snapshot test.
 
 set -e
@@ -29,7 +29,7 @@ SMART_KEYMAP_CUSTOM_KEYMAP=$(realpath "${KEYMAP_DIR}/keymap.rs")
 
 export SMART_KEYMAP_CUSTOM_KEYMAP
 
-cargo rustc \
+cargo check \
     --target riscv32imac-unknown-none-elf \
     --release \
     --package smart_keymap \


### PR DESCRIPTION
## Summary

Simplifies the NCL snapshot test harness: compile verification only needs `cargo check`, and fixture directories are discovered from the filesystem instead of a hand-maintained list.

## Changes

### `cargo check` instead of `cargo rustc`

`test-ncl-builds.sh` verifies that codegen'd `keymap.rs` type-checks for the firmware target (`riscv32imac-unknown-none-elf`). Linking release artifacts for each of 16 fixtures is unnecessary; `cargo check` is sufficient and faster.

### Auto-discover snapshot fixtures

New `list-ncl-snapshot-fixtures.sh` lists `tests/ncl/keymap-*` directories that contain `expected.rs` (sorted, one per line).

`run-tests.sh` and `save-test-snapshots.sh` use it via `mapfile` — no duplicated hard-coded arrays. Adding a snapshot fixture only requires committing `expected.rs`; removing the snapshot drops the fixture from the suite automatically.

Fixtures without `expected.rs` (e.g. `keymap-36key-miryoku`) are intentionally excluded.

## Test plan

- [x] `make test-ncl`