### PR TITLE
ncl: use cargo check in snapshot compile tests

### DIFF
--- a/ncl/scripts/run-tests.sh
+++ b/ncl/scripts/run-tests.sh
@@ -2,7 +2,7 @@
 
 # Tests the Nickel keymaps under tests/ncl,
 #  checking the generated output matches expected snapshots,
-#  and that the generated keymap builds.
+#  and that the generated keymap type-checks.
 
 set -euo pipefail
 
@@ -13,7 +13,7 @@ SCRIPTS_DIR="$(dirname "$0")"
 
 # For each snapshot fixture, check generated keymap.rs:
 #  - matches the expected snapshot,
-#  - can be compiled.
+#  - type-checks (cargo check).
 while IFS= read -r ncl_test; do
   "${SCRIPTS_DIR}/test-ncl-diff.sh" "${ncl_test}"
   "${SCRIPTS_DIR}/test-ncl-builds.sh" "${ncl_test}"

--- a/ncl/scripts/test-ncl-builds.sh
+++ b/ncl/scripts/test-ncl-builds.sh
@@ -2,7 +2,7 @@
 
 # $ test-ncl-builds.sh ncl-test-name
 #
-# Runs cargo build with the keymap.rs generated from the keymap.json
+# Runs cargo check with the keymap.rs generated from the keymap.json
 #  for the given ncl snapshot test.
 
 set -e
@@ -29,7 +29,7 @@ SMART_KEYMAP_CUSTOM_KEYMAP=$(realpath "${KEYMAP_DIR}/keymap.rs")
 
 export SMART_KEYMAP_CUSTOM_KEYMAP
 
-cargo rustc \
+cargo check \
     --target riscv32imac-unknown-none-elf \
     --release \
     --package smart_keymap \


### PR DESCRIPTION
Switches NCL snapshot compile verification from `cargo rustc` to `cargo check`.

## Changes

- `test-ncl-builds.sh`: `cargo rustc` → `cargo check` (same target, package, and flags otherwise).
- `run-tests.sh`: comment updates to match.

Stacked on #550 (fixture discovery).

Split from #548 (closed).