### PR TITLE
ncl: discover snapshot fixtures from tests/ncl

### DIFF
--- a/ncl/scripts/list-ncl-snapshot-fixtures.sh
+++ b/ncl/scripts/list-ncl-snapshot-fixtures.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Lists tests/ncl fixture directories that have expected.rs snapshots.
+# One fixture name per line, sorted for stable ordering.
+
+set -euo pipefail
+
+SCRIPTS_DIR="$(dirname "$0")"
+NCL_TESTS_DIR="${SCRIPTS_DIR}/../../tests/ncl"
+
+for fixture_dir in "${NCL_TESTS_DIR}"/keymap-*; do
+  [[ -d "${fixture_dir}" ]] || continue
+  [[ -f "${fixture_dir}/expected.rs" ]] || continue
+  basename "${fixture_dir}"
+done | sort

--- a/ncl/scripts/run-tests.sh
+++ b/ncl/scripts/run-tests.sh
@@ -4,36 +4,17 @@
 #  checking the generated output matches expected snapshots,
 #  and that the generated keymap builds.
 
-set -e
+set -euo pipefail
 
 SCRIPTS_DIR="$(dirname "$0")"
 
 # Run the nickel checks first.
 "${SCRIPTS_DIR}/run-ncl-checks.sh"
 
-# Then with each of the listed `tests/ncl`, check its generated keymap.rs:
+# For each snapshot fixture, check generated keymap.rs:
 #  - matches the expected snapshot,
 #  - can be compiled.
-ncl_tests=(
-    "keymap-1key-simple"
-    "keymap-1key-tap_dance"
-    "keymap-1key-tap_hold"
-    "keymap-1key-custom"
-    "keymap-1key-2layer-th-lmod"
-    "keymap-1key-callback-custom"
-    "keymap-1key-automation"
-    "keymap-2key-2layer-simple"
-    "keymap-2key-2layer-composite"
-    "keymap-2key-chorded"
-    "keymap-48key-basic"
-    "keymap-48key-rgoulter"
-    "keymap-60key-dvorak-simple"
-    "keymap-60key-dvorak-simple-with-tap_hold"
-    "keymap-34key-seniply"
-    "keymap-1key-abbrev-ent"
-)
-for ncl_test in "${ncl_tests[@]}"
-do
-    "${SCRIPTS_DIR}/test-ncl-diff.sh" "${ncl_test}"
-    "${SCRIPTS_DIR}/test-ncl-builds.sh" "${ncl_test}"
-done
+while IFS= read -r ncl_test; do
+  "${SCRIPTS_DIR}/test-ncl-diff.sh" "${ncl_test}"
+  "${SCRIPTS_DIR}/test-ncl-builds.sh" "${ncl_test}"
+done < <("${SCRIPTS_DIR}/list-ncl-snapshot-fixtures.sh")

--- a/ncl/scripts/save-test-snapshots.sh
+++ b/ncl/scripts/save-test-snapshots.sh
@@ -1,32 +1,11 @@
 #!/usr/bin/env bash
 
-# Tests the Nickel keymaps under tests/ncl,
-#  checking the generated output matches expected snapshots,
-#  and that the generated keymap builds.
+# Refreshes expected.rs snapshots for tests/ncl fixtures.
 
-set -e
+set -euo pipefail
 
 SCRIPTS_DIR="$(dirname "$0")"
 
-ncl_tests=(
-    "keymap-1key-simple"
-    "keymap-1key-tap_dance"
-    "keymap-1key-tap_hold"
-    "keymap-1key-custom"
-    "keymap-1key-2layer-th-lmod"
-    "keymap-1key-callback-custom"
-    "keymap-1key-automation"
-    "keymap-2key-2layer-simple"
-    "keymap-2key-2layer-composite"
-    "keymap-2key-chorded"
-    "keymap-48key-basic"
-    "keymap-48key-rgoulter"
-    "keymap-60key-dvorak-simple"
-    "keymap-60key-dvorak-simple-with-tap_hold"
-    "keymap-34key-seniply"
-    "keymap-1key-abbrev-ent"
-)
-for ncl_test in "${ncl_tests[@]}"
-do
-    "${SCRIPTS_DIR}/save-keymap-rs-snapshot.sh" "${ncl_test}"
-done
+while IFS= read -r ncl_test; do
+  "${SCRIPTS_DIR}/save-keymap-rs-snapshot.sh" "${ncl_test}"
+done < <("${SCRIPTS_DIR}/list-ncl-snapshot-fixtures.sh")


### PR DESCRIPTION
Replaces the hard-coded snapshot fixture list in the NCL test scripts with discovery from `tests/ncl`.

## Changes

- Add `ncl/scripts/list-ncl-snapshot-fixtures.sh` — lists `keymap-*` directories that contain `expected.rs`, sorted for stable ordering (16 fixtures today).
- Update `run-tests.sh` and `save-test-snapshots.sh` to iterate that script's output instead of maintaining a duplicate array.

No change to compile verification (`cargo rustc` remains in `test-ncl-builds.sh`).

Split from #548 (closed). Follow-up: #549 (cargo check).