### PR TITLE
ncl: improve keymap layer string validation errors

### DIFF
--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -25,9 +25,37 @@
 
   KeymapKey = keymap_ncl.nullable_key.Key,
 
-  KeymapLayerString = String,
+  keymap_layer_string = fun v =>
+    v
+    |> validators.is_string
+    |> match {
+      'Ok =>
+        v
+        |> words_from_whitespace_delimited_string
+        |> std.array.filter (fun w => !(std.record.has_field w extended_keys))
+        |> match {
+          [] => 'Ok,
+          words =>
+            'Error {
+              message = "Invalid keymap layer string: keys not defined: %{words |> std.string.join ", "}",
+            },
+        },
+      e => e,
+    },
 
-  KeymapLayer = std.contract.any_of [KeymapLayerString, Array KeymapKey],
+  KeymapLayerString = std.contract.from_validator keymap_layer_string,
+
+  keymap_layer = fun v =>
+    if std.is_string v then
+      keymap_layer_string v
+    else if std.is_array v then
+      validators.array.validator keymap_ncl.nullable_key.key_validator v
+    else
+      'Error {
+        message = "Expected keymap layer to be a whitespace-delimited string or an array of keys",
+      },
+
+  KeymapLayer = std.contract.from_validator keymap_layer,
 
   config | Config = {},
 
@@ -215,6 +243,14 @@
     = fun record fields =>
       fields |> std.array.map (std.function.flip std.record.get record),
 
+  checks.check_keymap_layer_string = {
+    check_unknown_key_is_error =
+      keymap_layer_string " A BadKeyName " |> validators.check_is_error,
+
+    check_valid_string_is_ok =
+      keymap_layer_string " A " == 'Ok,
+  },
+
   checks.check_layer_as_array_of_keys = {
     check_layer_as_array_of_keys = {
       actual = layer_as_array_of_keys " A ",
@@ -227,6 +263,10 @@
     },
   },
 
+  extended_keys =
+    let { extend_keys, .. } = import "key-extensions.ncl" in
+    extend_keys (import "keys.ncl") custom_keys,
+
   # Return array-of-keys representation of layer.
   #
   # A KeymapLayer may be either:
@@ -234,11 +274,9 @@
   #   - String
   layer_as_array_of_keys = fun l =>
     if std.is_string l then
-      let { extend_keys, .. } = import "key-extensions.ncl" in
-      let K = extend_keys (import "keys.ncl") custom_keys in
       l
       |> words_from_whitespace_delimited_string
-      |> map_fields_with_record K
+      |> map_fields_with_record extended_keys
     else
       l,
 

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -247,6 +247,14 @@
     check_unknown_key_is_error =
       keymap_layer_string " A BadKeyName " |> validators.check_is_error,
 
+    check_unknown_key_message =
+      keymap_layer_string " A BadKeyName "
+      |> match {
+        'Error { message } =>
+          std.string.contains "keys not defined: BadKeyName" message,
+        _ => false,
+      },
+
     check_valid_string_is_ok =
       keymap_layer_string " A " == 'Ok,
   },


### PR DESCRIPTION
Supersedes #352. Improves Nickel error messages when a whitespace-delimited layer string references undefined keys.

## Problem

Malformed `keymap.ncl` with unknown string-layer key names fails during export with a long, indirect stack trace — not a clear explanation of what went wrong.

Example `keymap.ncl`:

```nickel
let K = import "keys.ncl" in

{
  keys = " A BadKeyName ",
}
```

### Before (`master`)

```
error: contract broken by the caller of `get`
       missing field
     ┌─ <stdlib/std.ncl>:3701:9
     ...
     = The record given as an argument lacks the required field `BadKeyName`.

note: ... keymap-ncl-to-json.ncl:162:7 ... While calling to km
note: ... keymap-ncl-to-json.ncl:272:9 ... calling <func>
note: ... validators.ncl:44:8 ... calling is_record
...many more notes through automation/keymap-ncl-to-json, key_module_for_value, fold_left...
```

No mention of `keymap.ncl`, no mention of the bad token — you have to infer `BadKeyName` from deep inside `get` / `map_fields_with_record`.

### After (this PR)

```
error: contract broken by the value of `layers`
       Invalid keymap layer string: keys not defined: BadKeyName
   ┌─ ncl/keymap-ncl-to-json.ncl:69:8
   ...
   ┌─ keymap.ncl:4:10
 4 │   keys = " A BadKeyName ",
```

## Changes

- Add `keymap_layer_string` validator — checks each token exists in `extended_keys` (including `custom_keys`)
- Replace `KeymapLayer` `any_of` with a branching `keymap_layer` validator so the custom message surfaces during `nickel export`
- Factor `extended_keys` for shared use by validation and `layer_as_array_of_keys`
- Add `checks.check_keymap_layer_string` (error + message substring + valid string)

## Follow-up (out of scope)

Array-layer malformed keys (`{ not_a_key = true }`, `K.caps_word` vs `K.caps_word.toggle`) still report `No validators satisfied` — needs better `keymap_ncl.key.key_validator` error aggregation in a later PR.