### PR TITLE
ncl: branch key validators instead of any_of

### DIFF
--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -168,8 +168,15 @@
     Key = std.contract.from_validator key_validator,
 
     key_validator = fun k =>
-      k
-      |> validators.any_of (key_modules |> std.array.map (fun km => km.key_validator)),
+      key_modules
+      |> std.array.filter (fun km => km.is_key k)
+      |> match {
+        [km, ..] => km.key_validator k,
+        [] =>
+          'Error {
+            message = "Value is not a valid keymap key",
+          },
+      },
 
     is_key = fun k => 'Ok == key_validator k,
 
@@ -194,11 +201,10 @@
     Key = std.contract.from_validator key_validator,
 
     key_validator = fun k =>
-      k
-      |> validators.any_of [
-        keymap_ncl.key.key_validator,
-        keymap_ncl.null_.key_validator,
-      ],
+      if k == null then
+        keymap_ncl.null_.key_validator k
+      else
+        keymap_ncl.key.key_validator k,
 
     is_key = fun k => 'Ok == key_validator k,
 
@@ -242,6 +248,17 @@
     | doc "Maps each field in an array to the value of the given record."
     = fun record fields =>
       fields |> std.array.map (std.function.flip std.record.get record),
+
+  checks.check_key_validator = {
+    check_unknown_record_is_error =
+      keymap_ncl.key.key_validator { not_a_key = true } |> validators.check_is_error,
+
+    check_keyboard_is_ok =
+      keymap_ncl.key.key_validator { key_code = 4 } == 'Ok,
+
+    check_nullable_null_is_ok =
+      keymap_ncl.nullable_key.key_validator null == 'Ok,
+  },
 
   checks.check_keymap_layer_string = {
     check_unknown_key_is_error =


### PR DESCRIPTION
Atomic follow-up to layer-string validation (#551). Replaces `validators.any_of` in keymap key contracts with explicit branching.

## Problem

Array-layer mistakes (`{ not_a_key = true }`, `K.caps_word` instead of `K.caps_word.toggle`) failed with `No validators satisfied` at the `layers` contract. Same class of issue as layer strings: `any_of` does not surface useful validator messages.

## Changes

**`keymap_ncl.key.key_validator`**
- Find matching modules via each module's `is_key` (not `any_of` over all validators)
- First match → delegate to that module's validator (same rule as `key_module_for_value` and legacy `any_of` ordering via `key_modules` list)
- No match → `Value is not a valid keymap key`

Multiple modules may match the same record shape (e.g. tap-hold thumb keys with a `layered` field in `keymap-36key-rgoulter`). That overlap is intentional; we keep first-match dispatch rather than treating it as an error.

**`keymap_ncl.nullable_key.key_validator`**
- Branch on `null` vs non-null before delegating (no `any_of`)

**Checks:** `checks.check_key_validator` regression tests

## Before vs after

### Nonsense record

```nickel
let K = import "keys.ncl" in
{
  keys = [ K.A, { not_a_key = true } ],
}
```

**Before (`master`, #551, no #552):**
```
error: contract broken by the value of `layers`
       No validators satisfied
   ┌─ keymap.ncl:3:10
 3 │   keys = [ K.A, { not_a_key = true } ],
```

**After (#552):**
```
error: contract broken by the value of `layers`
       Value is not a valid keymap key
   ┌─ keymap.ncl:3:10
 3 │   keys = [ K.A, { not_a_key = true } ],
```

## Verdict

**Infrastructure PR** — right failure mode, stable short output, foundation for follow-ups. Worth merging before richer messages.

## Follow-up (out of scope)

- Which array element failed (e.g. index 1)
- Shape hints (`K.caps_word` record → suggest `K.caps_word.toggle`)
- Passthrough best per-module validator message when no module matches
- Validate `custom_keys` / `extended_keys` values (string layers only check names today)
