### PR TITLE
ncl: native Array KeymapKey for array layers (element blame)

### DIFF
--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -64,17 +64,17 @@
 
   KeymapLayerString = std.contract.from_validator keymap_layer_string,
 
-  keymap_layer = fun v =>
-    if std.is_string v then
-      keymap_layer_string v
-    else if std.is_array v then
-      validators.array.validator keymap_ncl.nullable_key.key_validator v
-    else
-      'Error {
-        message = "Expected keymap layer to be a whitespace-delimited string or an array of keys",
-      },
-
-  KeymapLayer = std.contract.from_validator keymap_layer,
+  KeymapLayer =
+    std.contract.custom (fun label value =>
+      if std.is_string value then
+        std.contract.check KeymapLayerString label value
+      else if std.is_array value then
+        std.contract.check (Array KeymapKey) label value
+      else
+        'Error {
+          message = "Expected keymap layer to be a whitespace-delimited string or an array of keys",
+        }
+    ),
 
   config | Config = {},
 


### PR DESCRIPTION
Hybrid `KeymapLayer` contract: keep the custom string-layer validator (#551, #553), use Nickel's native `Array KeymapKey` for array layers so bad keys get element-level blame.

## Problem

#551 unified string and array layer validation under `std.contract.from_validator keymap_layer`. The array branch used `validators.array.validator`, which only highlighted the **whole** layer array — not the offending key.

## Change

```nickel
KeymapLayer =
  std.contract.custom (fun label value =>
    if std.is_string value then
      std.contract.check KeymapLayerString label value
    else if std.is_array value then
      std.contract.check (Array KeymapKey) label value
    else
      'Error { message = "Expected keymap layer to be ..." }
  ),
```

String layers: unchanged (`keymap_layer_string_tokens`, unknown tokens, `extended_keys` value checks).

Array layers: native `Array KeymapKey` → Nickel `^^^` on the bad element.

## Before vs after (array layer)

```nickel
let K = import "keys.ncl" in
{ keys = [ K.A, { not_a_key = true } ], }
```

**Before:**
```
keys = [ K.A, { not_a_key = true } ],
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluated to this expression
```

**After:**
```
keys = [ K.A, { not_a_key = true } ],
                 ^^^^^^^^^^^^^^^^^^ applied to this expression
```

String-layer errors unchanged (`keys not defined: BadKeyName`, `key BadCustom: ...`).