### PR TITLE
ncl: contract layered_keys and chorded_keys pipeline outputs

### DIFF
--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -307,6 +307,12 @@
       check_plain_key_ok =
         layered_key_element_validator K.A == 'Ok,
 
+      check_null_ok =
+        layered_key_element_validator null == 'Ok,
+
+      check_string_token_ok =
+        layered_key_element_validator K.caps_word.toggle == 'Ok,
+
       check_layered_composite_ok =
         layered_key_element_validator (K.A & { layered = [ null, K.B] }) == 'Ok,
 
@@ -319,6 +325,12 @@
     {
       check_plain_key_ok =
         chorded_key_element_validator K.A == 'Ok,
+
+      check_null_ok =
+        chorded_key_element_validator null == 'Ok,
+
+      check_string_token_ok =
+        chorded_key_element_validator K.caps_word.toggle == 'Ok,
 
       check_passthrough_ok =
         chorded_key_element_validator { passthrough = K.A } == 'Ok,
@@ -408,20 +420,23 @@
   layers_of_keys = layers |> std.array.map layer_as_array_of_keys,
 
   layered_key_element_validator = fun k =>
-    if std.record.has_field "layered" k then
+    if std.is_record k && std.record.has_field "layered" k then
       keymap_ncl.layered.key_validator k
     else
-      keymap_ncl.key.key_validator k,
+      keymap_ncl.nullable_key.key_validator k,
 
   LayeredKeyElement = std.contract.from_validator layered_key_element_validator,
 
   chorded_key_element_validator = fun k =>
-    if std.record.has_field "chords" k then
-      keymap_ncl.chorded.key_validator k
-    else if std.record.has_field "passthrough" k then
-      keymap_ncl.chorded_aux.key_validator k
+    if std.is_record k then
+      if std.record.has_field "chords" k then
+        keymap_ncl.chorded.key_validator k
+      else if std.record.has_field "passthrough" k then
+        keymap_ncl.chorded_aux.key_validator k
+      else
+        keymap_ncl.nullable_key.key_validator k
     else
-      keymap_ncl.key.key_validator k,
+      keymap_ncl.nullable_key.key_validator k,
 
   ChordedKeyElement = std.contract.from_validator chorded_key_element_validator,
 

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -422,8 +422,7 @@
   layered_key_element_validator = fun k =>
     k
     |> match {
-      k if std.is_record k && std.record.has_field "layered" k =>
-        keymap_ncl.layered.key_validator k,
+      { layered, .. } => keymap_ncl.layered.key_validator k,
       _ => keymap_ncl.nullable_key.key_validator k,
     },
 
@@ -432,10 +431,8 @@
   chorded_key_element_validator = fun k =>
     k
     |> match {
-      k if std.is_record k && std.record.has_field "chords" k =>
-        keymap_ncl.chorded.key_validator k,
-      k if std.is_record k && std.record.has_field "passthrough" k =>
-        keymap_ncl.chorded_aux.key_validator k,
+      { chords, .. } => keymap_ncl.chorded.key_validator k,
+      { passthrough, .. } => keymap_ncl.chorded_aux.key_validator k,
       _ => keymap_ncl.nullable_key.key_validator k,
     },
 

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -420,23 +420,24 @@
   layers_of_keys = layers |> std.array.map layer_as_array_of_keys,
 
   layered_key_element_validator = fun k =>
-    if std.is_record k && std.record.has_field "layered" k then
-      keymap_ncl.layered.key_validator k
-    else
-      keymap_ncl.nullable_key.key_validator k,
+    k
+    |> match {
+      k if std.is_record k && std.record.has_field "layered" k =>
+        keymap_ncl.layered.key_validator k,
+      _ => keymap_ncl.nullable_key.key_validator k,
+    },
 
   LayeredKeyElement = std.contract.from_validator layered_key_element_validator,
 
   chorded_key_element_validator = fun k =>
-    if std.is_record k then
-      if std.record.has_field "chords" k then
-        keymap_ncl.chorded.key_validator k
-      else if std.record.has_field "passthrough" k then
-        keymap_ncl.chorded_aux.key_validator k
-      else
-        keymap_ncl.nullable_key.key_validator k
-    else
-      keymap_ncl.nullable_key.key_validator k,
+    k
+    |> match {
+      k if std.is_record k && std.record.has_field "chords" k =>
+        keymap_ncl.chorded.key_validator k,
+      k if std.is_record k && std.record.has_field "passthrough" k =>
+        keymap_ncl.chorded_aux.key_validator k,
+      _ => keymap_ncl.nullable_key.key_validator k,
+    },
 
   ChordedKeyElement = std.contract.from_validator chorded_key_element_validator,
 

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -301,6 +301,39 @@
         && !(std.record.has_field "chords" json),
     },
 
+  checks.check_layered_key_element =
+    let K = import "keys.ncl" in
+    {
+      check_plain_key_ok =
+        layered_key_element_validator K.A == 'Ok,
+
+      check_layered_composite_ok =
+        layered_key_element_validator (K.A & { layered = [ null, K.B] }) == 'Ok,
+
+      check_invalid_is_error =
+        layered_key_element_validator { not_a_key = true } |> validators.check_is_error,
+    },
+
+  checks.check_chorded_key_element =
+    let K = import "keys.ncl" in
+    {
+      check_plain_key_ok =
+        chorded_key_element_validator K.A == 'Ok,
+
+      check_passthrough_ok =
+        chorded_key_element_validator { passthrough = K.A } == 'Ok,
+
+      check_full_chord_ok =
+        chorded_key_element_validator {
+          chords = [[0, K.C]],
+          passthrough = K.A,
+        } == 'Ok,
+
+      check_passthrough_invalid_inner_is_error =
+        chorded_key_element_validator { passthrough = { not_a_key = true } }
+        |> validators.check_is_error,
+    },
+
   checks.check_keymap_layer_string = {
     check_unknown_key_is_error =
       keymap_layer_string " A BadKeyName " |> validators.check_is_error,
@@ -374,7 +407,26 @@
 
   layers_of_keys = layers |> std.array.map layer_as_array_of_keys,
 
+  layered_key_element_validator = fun k =>
+    if std.record.has_field "layered" k then
+      keymap_ncl.layered.key_validator k
+    else
+      keymap_ncl.key.key_validator k,
+
+  LayeredKeyElement = std.contract.from_validator layered_key_element_validator,
+
+  chorded_key_element_validator = fun k =>
+    if std.record.has_field "chords" k then
+      keymap_ncl.chorded.key_validator k
+    else if std.record.has_field "passthrough" k then
+      keymap_ncl.chorded_aux.key_validator k
+    else
+      keymap_ncl.key.key_validator k,
+
+  ChordedKeyElement = std.contract.from_validator chorded_key_element_validator,
+
   layered_keys
+    | Array LayeredKeyElement
     | doc "Constructs array of key::layered::LayeredKey values from layers."
     =
       if std.array.length layers == 0 then
@@ -396,24 +448,26 @@
           )
           (std.array.length base_keys),
 
-  chorded_keys =
-    std.array.map_with_index
-      (fun key_index k =>
-        chords
-        |> std.array.map_with_index (fun idx ch => ch & { chord_index = idx })
-        |> std.array.filter (fun { indices = [chord_primary_key_index, ..], .. } => chord_primary_key_index == key_index)
-        |> match {
-          [] =>
-            if std.array.any (fun { indices, .. } => std.array.elem key_index indices) chords then
-              { passthrough = k }
-            else
-              k,
-          chords_ =>
-            let chords_ = chords_ |> std.array.map (fun { chord_index, key, .. } => [chord_index, key]) in
-            { chords = chords_, passthrough = k },
-        }
-      )
-      layered_keys,
+  chorded_keys
+    | Array ChordedKeyElement
+    =
+      std.array.map_with_index
+        (fun key_index k =>
+          chords
+          |> std.array.map_with_index (fun idx ch => ch & { chord_index = idx })
+          |> std.array.filter (fun { indices = [chord_primary_key_index, ..], .. } => chord_primary_key_index == key_index)
+          |> match {
+            [] =>
+              if std.array.any (fun { indices, .. } => std.array.elem key_index indices) chords then
+                { passthrough = k }
+              else
+                k,
+            chords_ =>
+              let chords_ = chords_ |> std.array.map (fun { chord_index, key, .. } => [chord_index, key]) in
+              { chords = chords_, passthrough = k },
+          }
+        )
+        layered_keys,
 
   json_keymap
     | default


### PR DESCRIPTION
Continues the #352 / #551–#554 work on Nickel error messages.

Those PRs improved validation at **author input** (`layers`).

This PR closes the next gap: **pipeline outputs** that were still unchecked until deep inside `json_keymap` evaluation.

## The problem: two phases, one contracted

`keymap-ncl-to-json.sh` exports `--field=json_keymap`. Nickel evaluates a transform pipeline. Contracts only ran where fields were annotated — mostly `layers` (and config like `chords`). Everything below was plain evaluation: a bad derived key could sail through layer validation and fail dozens of frames later (i.e. a long/unclear error message), or only when `to_json_value` hit the wrong shape.

```
keymap.ncl  (author writes)
  │
  │  layers ──contract──► KeymapLayer          ✅ #551–#554
  │     │                    (string tokens or Array KeymapKey)
  │     ▼
  │  layer_as_array_of_keys                    (resolve strings → records)
  │     ▼
  │  layered_keys                              ❌ was uncontracted
  │     │                    merge layers → plain key, or
  │     │                    base_key & { layered = [ … ] }
  │     ▼
  │  chorded_keys                              ❌ was uncontracted
  │     │                    plain key, { passthrough = k }, or
  │     │                    { chords, passthrough }
  │     ▼
  └  json_keymap                               automation fold + to_json_value
```

So we had good errors for “unknown token in layer string” and “bad key in `layers = [ … ]`”, but not for “this **merged layered composite** is malformed” or “this **chord wrapper** has an invalid inner key” — failures that only appear after transforms run.

## Why not `Array KeymapKey` on pipeline outputs?

`KeymapKey` is for **author-facing** input:

- `layers = " A B "` / `layers = [ K.A, K.B ]`
- `keys = [ K.A, K.B ]` directly
- explicit composites in source: `K.Tab & K.hold … & { layered = [ … ] }`

Pipeline slots are **stage-specific shapes**:

| Field | After transform, each slot is… |
|-------|--------------------------------|
| `layered_keys` | A plain `KeymapKey`, **or** `{ layered, ..base }` from multi-layer merge |
| `chorded_keys` | A plain key, **`{ passthrough = k }`** (auxiliary), or **`{ chords, passthrough }`** (primary) |

Using `Array KeymapKey` on those outputs would re-use export dispatch semantics for validation — 'not incorrect', but the wrong abstraction.

Stage contracts document what each transform may emit.

## What this PR adds

Explicit validators (field-presence branching, not `key_modules` first-match):

- **`LayeredKeyElement`**: `layered` field → `layered.Key`; else → `KeymapKey`
- **`ChordedKeyElement`**: `chords` → `chorded.Key`; `passthrough` → `chorded_aux.Key`; else → `KeymapKey`

Attached as:

```nickel
layered_keys | Array LayeredKeyElement = …
chorded_keys | Array ChordedKeyElement = …
```

Nickel now checks these **results** before `json_keymap` consumes them — so a bad composite fails at the pipeline stage that produced it, with a contract error instead of a deep eval stack.

Checks: `checks.check_layered_key_element`, `checks.check_chorded_key_element` (plain keys, composites, invalid inner passthrough).

## Relationship to #555

#555 made `key_modules` order the spec for **export** when one record matches several modules (e.g. tap-hold thumb + `layered` stack). #556 is orthogonal: it names and validates **what the layering/chording transforms output**. Export still uses `key_modules`; pipeline contracts use explicit branches.

## Not in scope

- `json_keymap` automation transform output (next gap if we want the same treatment)
- Tightening author `KeymapKey` / `KeymapLayer` — intentionally still loose

## Testing

- `make test-ncl-checks` — includes new element validators and #555 dispatch checks
- `json_keymap` export on rgoulter / seniply / chorded fixtures