### PR TITLE
ncl: use match in nullable_key key_validator

### DIFF
--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -223,10 +223,11 @@
     Key = std.contract.from_validator key_validator,
 
     key_validator = fun k =>
-      if k == null then
-        keymap_ncl.null_.key_validator k
-      else
-        keymap_ncl.key.key_validator k,
+      k
+      |> match {
+        null => keymap_ncl.null_.key_validator k,
+        _ => keymap_ncl.key.key_validator k,
+      },
 
     is_key = fun k => 'Ok == key_validator k,
 


### PR DESCRIPTION
Small style tidy: `nullable_key.key_validator` used `if k == null` while sibling validators (`null_`, pipeline element validators, smart-key modules) use `match`.

## Change

```nickel
key_validator = fun k =>
  k
  |> match {
    null => keymap_ncl.null_.key_validator k,
    _ => keymap_ncl.key.key_validator k,
  },
```

Behaviour unchanged — `check_nullable_null_is_ok` still passes.

## Testing

- `make test-ncl-checks`