### PR TITLE
ncl: propagate module validator messages for undispatched keys

### DIFF
--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -189,15 +189,58 @@
 
     Key = std.contract.from_validator key_validator,
 
+    # When no module's is_key matches, try validators for modules whose
+    # shape hints at author intent (e.g. K.caps_word record → caps_word).
+    key_validator_hint_modules = fun k =>
+      k
+      |> match {
+        { chords, .. } => [keymap_ncl.chorded],
+        { passthrough, .. } => [keymap_ncl.chorded_aux],
+        { layered, .. } => [keymap_ncl.layered],
+        { automation_instructions, .. } => [keymap_ncl.automation],
+        { tap_dances, .. } => [keymap_ncl.tap_dance],
+        { hold, .. } => [keymap_ncl.tap_hold],
+        { layer_modifier, .. } => [keymap_ncl.layer_modifier],
+        { keymap_callback, .. } => [keymap_ncl.callback],
+        { custom, .. } => [keymap_ncl.custom],
+        { toggle, .. } => [keymap_ncl.caps_word],
+        { consumer_code, .. } => [keymap_ncl.consumer],
+        { mouse, .. } => [keymap_ncl.mouse],
+        { sticky_modifiers, .. } => [keymap_ncl.sticky],
+        { key_code, .. } => [keymap_ncl.keyboard],
+        { modifiers, .. } => [keymap_ncl.keyboard],
+        _ => [],
+      },
+
+    key_validator_undispatched = fun k =>
+      key_validator_hint_modules k
+      |> match {
+        [] =>
+          'Error {
+            message = "Value is not a valid keymap key",
+          },
+        hint_modules =>
+          let hint_result =
+            hint_modules
+            |> std.array.map (fun km => km.key_validator k)
+            |> validators.first_error_result
+          in
+          hint_result
+          |> match {
+            'Error { .. } => hint_result,
+            _ =>
+              'Error {
+                message = "Value is not a valid keymap key",
+              },
+          },
+      },
+
     key_validator = fun k =>
       key_modules
       |> std.array.filter (fun km => km.is_key k)
       |> match {
         [km, ..] => km.key_validator k,
-        [] =>
-          'Error {
-            message = "Value is not a valid keymap key",
-          },
+        [] => key_validator_undispatched k,
       },
 
     is_key = fun k => 'Ok == key_validator k,
@@ -276,12 +319,33 @@
     check_unknown_record_is_error =
       keymap_ncl.key.key_validator { not_a_key = true } |> validators.check_is_error,
 
+    check_unknown_record_message =
+      keymap_ncl.key.key_validator { not_a_key = true }
+      |> match {
+        'Error { message } => message == "Value is not a valid keymap key",
+        _ => false,
+      },
+
     check_keyboard_is_ok =
       keymap_ncl.key.key_validator { key_code = 4 } == 'Ok,
 
     check_nullable_null_is_ok =
       keymap_ncl.nullable_key.key_validator null == 'Ok,
   },
+
+  checks.check_key_validator_hints =
+    let K = import "keys.ncl" in
+    {
+      check_caps_word_record_propagates_module_message =
+        keymap_ncl.key.key_validator K.caps_word
+        |> match {
+          'Error { message } => message == "Expected \"ToggleCapsWord\"",
+          _ => false,
+        },
+
+      check_caps_word_toggle_is_ok =
+        keymap_ncl.key.key_validator K.caps_word.toggle == 'Ok,
+    },
 
   checks.check_key_modules_dispatch =
     let K = import "keys.ncl" in

--- a/ncl/validators.ncl
+++ b/ncl/validators.ncl
@@ -115,6 +115,31 @@
         },
     },
 
+  checks.first_error_result = {
+    check_first_error =
+      first_error_result ['Error { message = "a" }, 'Ok, 'Error { message = "b" }] == 'Error { message = "a" },
+
+    check_all_ok =
+      first_error_result ['Ok, 'Ok] == 'Ok,
+  },
+
+  first_error_result = fun results =>
+    results
+    |> std.array.fold_left
+      (fun acc result =>
+        acc
+        |> match {
+          'Ok =>
+            result
+            |> match {
+              'Error { .. } => result,
+              _ => 'Ok,
+            },
+          err => err,
+        }
+      )
+      'Ok,
+
   checks.check_array_validators = {
     check_validator = 'Ok == array.validator is_number [1, 2, 3],
   },


### PR DESCRIPTION
Continues the #352 / #551–#556 error-message work. After layer and pipeline contracts, wrong **key shapes** often still surfaced a generic fallback even when a smart-key module had a specific validator message.

## Problem

`key_validator` dispatches via `key_modules` + `is_key`. When nothing matches (e.g. `K.caps_word` record instead of `K.caps_word.toggle` string), export reported:

```
Value is not a valid keymap key
```

…while `caps_word.key_validator` already knows the fix: `Expected "ToggleCapsWord"`.

`is_key` is defined as `'Ok == key_validator`, so non-matching shapes never reach the module validator through normal dispatch.

## Before / after

`keymap.ncl`:

```nickel
let K = import "keys.ncl" in {
  keys = [ K.caps_word ],  # meant K.caps_word.toggle
}
```

`nickel export … keymap.ncl --field=json_keymap`

**Before (master):**

```
error: contract broken by the value of `layers`
       Value is not a valid keymap key
   ┌─ ncl/keymap-ncl-to-json.ncl:86:13
   │
86 │     | Array KeymapLayer
   │             ----------- expected array element type
   │
   ┌─ keymap.ncl:1:41
   │
 1 │ let K = import "keys.ncl" in { keys = [ K.caps_word ] }
   │                                         ^^^^^^^^^^^ applied to this expression
```

**After (#558):**

```
error: contract broken by the value of `layers`
       Expected "ToggleCapsWord"
   ┌─ ncl/keymap-ncl-to-json.ncl:86:13
   │
86 │     | Array KeymapLayer
   │             ----------- expected array element type
   │
   ┌─ keymap.ncl:1:41
   │
 1 │ let K = import "keys.ncl" in { keys = [ K.caps_word ] }
   │                                         ^^^^^^^^^^^ applied to this expression
```

Same blame location; message now comes from the caps_word module validator via shape hints.

## Approach

When dispatch finds no matching module:

1. **`key_validator_hint_modules`** — record-shape `match` hints at author intent (`{ toggle, .. }` → caps_word, `{ hold, .. }` → tap_hold, `{ key_code, .. }` → keyboard, chorded/layered/automation fields, etc.)
2. Run hinted module validators; return first error via **`validators.first_error_result`**
3. If no shape hints (e.g. `{ not_a_key = true }`), keep the generic message — avoids misleading caps_word text on arbitrary records

Dispatch order (#555) and pipeline stage contracts (#556) unchanged.

String-layer errors (`key HoldTab: …`) and per-element array blame (#553–#554) are unchanged.

## Testing

- `make test-ncl-checks` — `checks.check_key_validator_hints`, `validators.first_error_result`