### PR TITLE
ncl: factor automation transform and contract automation_keys

### DIFF
--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -347,6 +347,26 @@
         |> validators.check_is_error,
     },
 
+  checks.check_automation_key_element =
+    let K = import "keys.ncl" in
+    {
+      check_plain_keyboard_ok =
+        automation_key_element_validator K.A == 'Ok,
+
+      check_string_macro_pre_transform_is_keymap_key =
+        keymap_ncl.key.key_validator (K.string_macro "a") == 'Ok,
+
+      check_string_macro_post_transform_ok =
+        let exec = { start = 0, length = 1 } in
+        automation_key_element_validator {
+          automation_instructions = {
+            on_press = exec,
+            while_pressed = exec,
+            on_release = exec,
+          },
+        } == 'Ok,
+    },
+
   checks.check_keymap_layer_string = {
     check_unknown_key_is_error =
       keymap_layer_string " A BadKeyName " |> validators.check_is_error,
@@ -483,27 +503,53 @@
         )
         layered_keys,
 
+  # One slot in `automation_transform.keys` after the instruction fold.
+  #
+  # Usually an ordinary keymap key (keyboard, null, layered, chorded, …). Automation
+  # keys — e.g. `K.string_macro "a"` (`{ automation_instructions.on_press = […] }`
+  # before this stage) — are rewritten to `automation::Key`: `automation_instructions`
+  # holds `{ start, length }` execution refs into the accumulated instruction list.
+  automation_key_element_validator = fun k =>
+    k
+    |> match {
+      { automation_instructions, .. } =>
+        keymap_ncl.automation.key_validator k,
+      _ =>
+        keymap_ncl.nullable_key.key_validator k,
+    },
+
+  AutomationKeyElement = std.contract.from_validator automation_key_element_validator,
+
+  AutomationTransform = {
+    automation_instructions | Array keymap_ncl.automation.Instruction,
+    keys | Array AutomationKeyElement,
+  },
+
+  automation_transform
+    | AutomationTransform
+    | doc "Fold chorded keys: flat `{ automation_instructions, keys }` — config instruction list plus post-transform key slots."
+    =
+      chorded_keys
+      |> std.array.fold_left
+        (fun { automation_instructions = prior_instructions, keys = prior_keys } k =>
+          let { acc, k } =
+            keymap_ncl.key.map_accum
+              keymap_ncl.automation.transform_keys_to_instructions
+              { automation_instructions = prior_instructions }
+              k
+          in
+          {
+            automation_instructions = acc.automation_instructions,
+            keys = prior_keys @ [k],
+          }
+        )
+        { automation_instructions = [], keys = [] },
+
   json_keymap
     | default
     | doc "The keymap.json output value."
     =
-      let keys = chorded_keys in
-      # Automation Instructions
-      let { acc = { automation_instructions }, keys } =
-        keys
-        |> std.array.fold_left
-          (fun { acc, keys } k =>
-            let { acc, k } =
-              keymap_ncl.key.map_accum
-                keymap_ncl.automation.transform_keys_to_instructions
-                acc
-                k
-            in
-            let keys = keys @ [k] in
-            { include acc, include keys }
-          )
-          { acc = { automation_instructions = [], }, keys = [] }
-      in
+      let { automation_instructions, keys } = automation_transform in
       let automation_config =
         if std.array.length automation_instructions > 0 then
           { automation.instructions = automation_instructions }

--- a/ncl/smart_keys/automation/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/automation/keymap-ncl-to-json.ncl
@@ -47,6 +47,8 @@
 
       Key = std.contract.from_validator key_validator,
 
+      Instruction = smart_keymap.automation.instruction.Json,
+
       key_instructions = {
         ncl_validator =
           validators.record.validator {


### PR DESCRIPTION
Continues the #352 / #556 pipeline-contract work. `layered_keys` and `chorded_keys` were contracted; the automation `fold_left` still lived inline inside `json_keymap` with no stage validation.

## Pipeline

```
layers → … → layered_keys → chorded_keys → automation_transform → json_keymap
```

`automation_transform` is `{ acc, keys }` — fold accumulates `config.automation.instructions` and rewrites automation keys to `{ start, length }` execution refs. A custom contract checks `keys | Array AutomationKeyElement` on the fold result.

## Before / after: bad `automation_instructions`

Author-time mistakes in `automation_instructions` still fail at **`layers`** (`Array KeymapKey`). **Unchanged** on this PR — same message, same blame location.

Example keymap:

```nickel
{
  keys = [
    {
      automation_instructions = {
        on_press = [{ NotAnInstruction = true }],
      },
    },
  ],
}
```

**Before (master)** — `nickel export … --field=json_keymap`:

```
error: contract broken by the value of `layers`
       Value is not a valid keymap key
   ┌─ ncl/keymap-ncl-to-json.ncl:86:13
   │     | Array KeymapLayer
   …
   ┌─ keymap.ncl:3:5
   │     { automation_instructions = { on_press = […] } },
```

**After (#559)** — same error for `--field=json_keymap`, `--field=automation_transform`, or any field that forces `layers` first.

Why: `automation.is_key` is `'Ok == key_validator k`. Invalid instructions fail `automation.key_validator`, so dispatch falls through to the generic `key_modules` message. The pipeline never reaches `automation_transform` for these keys.

(The automation validator itself would say e.g. `any_of: value didn't match any of the contracts` / `No validators satisfied` for a bad instruction variant — but that detail is not surfaced to authors today.)

## What this PR does change

- Names the automation fold (`automation_transform`) instead of hiding it inside `json_keymap`
- Contracts **post-transform** keys (`Execution` refs), same class of pipeline win as #556
- `json_keymap` destructures `{ acc, keys }` from `automation_transform` in one binding (no redundant `automation_keys` / `automation_instructions` fields; no double eval)
- Inspect post-transform state: `nickel export … --field=automation_transform`

Valid `keymap-1key-automation` export:

```json
{
  "acc": { "automation_instructions": [{ "Tap": { "key_code": { "Keyboard": 4 } } }] },
  "keys": [{
    "automation_instructions": {
      "on_press": { "start": 0, "length": 1 },
      "while_pressed": { "start": 1, "length": 0 },
      "on_release": { "start": 1, "length": 0 }
    }
  }]
}
```

## Changes

- Extract automation fold into **`automation_transform`** with `Array AutomationKeyElement` contract on `.keys`
- **`automation_key_element_validator`** — `{ automation_instructions, .. }` → `automation.Key`; else → `nullable_key`
- **`json_keymap`** — `let { acc = { automation_instructions }, keys } = automation_transform in …`
- `checks.check_automation_key_element`

## Testing

- `make test-ncl-checks`
- `keymap-1key-automation` export