### PR TITLE
ci: reusable setup-nickel composite action

### DIFF
--- a/.github/actions/setup-nickel/action.yml
+++ b/.github/actions/setup-nickel/action.yml
@@ -1,0 +1,18 @@
+name: Setup Nickel
+description: Install the pinned Nickel CLI binary
+
+inputs:
+  version:
+    description: Nickel release version
+    required: false
+    default: "1.16.0"
+
+runs:
+  using: composite
+  steps:
+    - name: Install nickel
+      shell: bash
+      run: |
+        wget -q "https://github.com/tweag/nickel/releases/download/${{ inputs.version }}/nickel-x86_64-linux"
+        chmod +x ./nickel-x86_64-linux
+        sudo cp ./nickel-x86_64-linux /usr/bin/nickel

--- a/.github/workflows/firmware-ch32x.yaml
+++ b/.github/workflows/firmware-ch32x.yaml
@@ -41,13 +41,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install nickel
-        run: |
-          wget https://github.com/tweag/nickel/releases/download/${{ env.NICKEL_VERSION }}/nickel-x86_64-linux
-          chmod +x ./nickel-x86_64-linux
-          sudo cp ./nickel-x86_64-linux /usr/bin/nickel
+      - name: Setup Nickel
+        uses: ./.github/actions/setup-nickel
+        with:
+          version: ${{ env.NICKEL_VERSION }}
 
       - name: Install cbindgen
         run: |

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -39,11 +39,10 @@ jobs:
             --package=smart-keymap \
             --package=keyberon-smart-keyboard
           cp -r target/doc _site/doc
-      - name: Install nickel
-        run: |
-          wget https://github.com/tweag/nickel/releases/download/${{ env.NICKEL_VERSION }}/nickel-x86_64-linux
-          chmod +x ./nickel-x86_64-linux
-          sudo cp ./nickel-x86_64-linux /usr/bin/nickel
+      - name: Setup Nickel
+        uses: ./.github/actions/setup-nickel
+        with:
+          version: ${{ env.NICKEL_VERSION }}
       - name: features.html
         run: |
           sudo apt update

--- a/.github/workflows/nickel-format.yaml
+++ b/.github/workflows/nickel-format.yaml
@@ -23,13 +23,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install nickel
-        run: |
-          wget https://github.com/tweag/nickel/releases/download/${{ env.NICKEL_VERSION }}/nickel-x86_64-linux
-          chmod +x ./nickel-x86_64-linux
-          sudo cp ./nickel-x86_64-linux /usr/bin/nickel
+      - name: Setup Nickel
+        uses: ./.github/actions/setup-nickel
+        with:
+          version: ${{ env.NICKEL_VERSION }}
 
       - name: Run make ncl-format
         run: make ncl-format

--- a/.github/workflows/nickel.yaml
+++ b/.github/workflows/nickel.yaml
@@ -31,13 +31,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install nickel
-        run: |
-          wget https://github.com/tweag/nickel/releases/download/${{ env.NICKEL_VERSION }}/nickel-x86_64-linux
-          chmod +x ./nickel-x86_64-linux
-          sudo cp ./nickel-x86_64-linux /usr/bin/nickel
+      - name: Setup Nickel
+        uses: ./.github/actions/setup-nickel
+        with:
+          version: ${{ env.NICKEL_VERSION }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/rust-stm32f4.yaml
+++ b/.github/workflows/rust-stm32f4.yaml
@@ -41,13 +41,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install nickel
-        run: |
-          wget https://github.com/tweag/nickel/releases/download/${{ env.NICKEL_VERSION }}/nickel-x86_64-linux
-          chmod +x ./nickel-x86_64-linux
-          sudo cp ./nickel-x86_64-linux /usr/bin/nickel
+      - name: Setup Nickel
+        uses: ./.github/actions/setup-nickel
+        with:
+          version: ${{ env.NICKEL_VERSION }}
 
       - name: Rust Add Target
         run: rustup target add thumbv7em-none-eabihf

--- a/.github/workflows/rust-thumbv6m-none-eabi.yaml
+++ b/.github/workflows/rust-thumbv6m-none-eabi.yaml
@@ -41,13 +41,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install nickel
-        run: |
-          wget https://github.com/tweag/nickel/releases/download/${{ env.NICKEL_VERSION }}/nickel-x86_64-linux
-          chmod +x ./nickel-x86_64-linux
-          sudo cp ./nickel-x86_64-linux /usr/bin/nickel
+      - name: Setup Nickel
+        uses: ./.github/actions/setup-nickel
+        with:
+          version: ${{ env.NICKEL_VERSION }}
 
       - name: Rust Add Target
         run: rustup target add thumbv6m-none-eabi

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -39,13 +39,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install nickel
-        run: |
-          wget https://github.com/tweag/nickel/releases/download/${{ env.NICKEL_VERSION }}/nickel-x86_64-linux
-          chmod +x ./nickel-x86_64-linux
-          sudo cp ./nickel-x86_64-linux /usr/bin/nickel
+      - name: Setup Nickel
+        uses: ./.github/actions/setup-nickel
+        with:
+          version: ${{ env.NICKEL_VERSION }}
 
       - name: Run Cargo Build
         run: cargo build
@@ -71,13 +70,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install nickel
-        run: |
-          wget https://github.com/tweag/nickel/releases/download/${{ env.NICKEL_VERSION }}/nickel-x86_64-linux
-          chmod +x ./nickel-x86_64-linux
-          sudo cp ./nickel-x86_64-linux /usr/bin/nickel
+      - name: Setup Nickel
+        uses: ./.github/actions/setup-nickel
+        with:
+          version: ${{ env.NICKEL_VERSION }}
 
       - name: Run Cargo Test (lib)
         run: cargo test --lib
@@ -87,13 +85,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install nickel
-        run: |
-          wget https://github.com/tweag/nickel/releases/download/${{ env.NICKEL_VERSION }}/nickel-x86_64-linux
-          chmod +x ./nickel-x86_64-linux
-          sudo cp ./nickel-x86_64-linux /usr/bin/nickel
+      - name: Setup Nickel
+        uses: ./.github/actions/setup-nickel
+        with:
+          version: ${{ env.NICKEL_VERSION }}
 
       - name: Run Cargo Test (rust-integration)
         run: cargo test --test rust-integration
@@ -103,13 +100,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install nickel
-        run: |
-          wget https://github.com/tweag/nickel/releases/download/${{ env.NICKEL_VERSION }}/nickel-x86_64-linux
-          chmod +x ./nickel-x86_64-linux
-          sudo cp ./nickel-x86_64-linux /usr/bin/nickel
+      - name: Setup Nickel
+        uses: ./.github/actions/setup-nickel
+        with:
+          version: ${{ env.NICKEL_VERSION }}
 
       - name: Run Cargo Test (cucumber-keymap)
         timeout-minutes: 15

--- a/.github/workflows/test-ceedling.yaml
+++ b/.github/workflows/test-ceedling.yaml
@@ -35,13 +35,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install nickel
-        run: |
-          wget https://github.com/tweag/nickel/releases/download/${{ env.NICKEL_VERSION }}/nickel-x86_64-linux
-          chmod +x ./nickel-x86_64-linux
-          sudo cp ./nickel-x86_64-linux /usr/bin/nickel
+      - name: Setup Nickel
+        uses: ./.github/actions/setup-nickel
+        with:
+          version: ${{ env.NICKEL_VERSION }}
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## What

Adds `.github/actions/setup-nickel` and switches every workflow that installs Nickel to use it. Bumps `actions/checkout` to v4 in the workflows touched.

## Why

Nickel install (`wget` + `chmod` + `sudo cp`) was duplicated in ~10 jobs across 8 workflow files, all pinned to the same `NICKEL_VERSION` env var. A composite action:

- keeps the install recipe in one place when we bump Nickel
- makes later CI tweaks (caching the binary, etc.) a single edit
- pairs naturally with bumping checkout while we're in those files

## Behaviour

No intended change to what CI runs — same Nickel version, same steps after setup.

## Follow-ups

Later PRs can build on this (rust-cache, split ncl-checks, concurrency) without re-copying install boilerplate.