### PR TITLE
ci: add Rust dependency caching

### DIFF
--- a/.github/workflows/firmware-ch32x.yaml
+++ b/.github/workflows/firmware-ch32x.yaml
@@ -63,7 +63,7 @@ jobs:
         run: rustup target add "${CH32X_TARGET}"
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           shared-key: firmware-ch32x
           cache-targets: ${{ env.CH32X_TARGET }}

--- a/.github/workflows/firmware-ch32x.yaml
+++ b/.github/workflows/firmware-ch32x.yaml
@@ -62,6 +62,12 @@ jobs:
       - name: Rust Add Target
         run: rustup target add "${CH32X_TARGET}"
 
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          shared-key: firmware-ch32x
+          cache-targets: ${{ env.CH32X_TARGET }}
+
       - name: Build Keymap
         run: |
           cargo build \

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -30,6 +30,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          shared-key: gh-pages
       - name: Run Cargo Doc
         run: |
           mkdir -p _site

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           shared-key: gh-pages
       - name: Run Cargo Doc

--- a/.github/workflows/nickel.yaml
+++ b/.github/workflows/nickel.yaml
@@ -45,7 +45,7 @@ jobs:
           rustup target add riscv32imac-unknown-none-elf
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           shared-key: nickel-codegen
           cache-targets: riscv32imac-unknown-none-elf

--- a/.github/workflows/nickel.yaml
+++ b/.github/workflows/nickel.yaml
@@ -44,6 +44,12 @@ jobs:
           sudo apt-get install -y gawk pandoc
           rustup target add riscv32imac-unknown-none-elf
 
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          shared-key: nickel-codegen
+          cache-targets: riscv32imac-unknown-none-elf
+
       - name: Run Nickel tests
         run: |
           ./ncl/scripts/run-tests.sh

--- a/.github/workflows/rust-stm32f4.yaml
+++ b/.github/workflows/rust-stm32f4.yaml
@@ -52,7 +52,7 @@ jobs:
         run: rustup target add thumbv7em-none-eabihf
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           shared-key: rust-stm32f4
           cache-targets: thumbv7em-none-eabihf

--- a/.github/workflows/rust-stm32f4.yaml
+++ b/.github/workflows/rust-stm32f4.yaml
@@ -51,6 +51,12 @@ jobs:
       - name: Rust Add Target
         run: rustup target add thumbv7em-none-eabihf
 
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          shared-key: rust-stm32f4
+          cache-targets: thumbv7em-none-eabihf
+
       - name: Run Cargo Build
         run: cargo build --release --target=thumbv7em-none-eabihf --no-default-features
 

--- a/.github/workflows/rust-thumbv6m-none-eabi.yaml
+++ b/.github/workflows/rust-thumbv6m-none-eabi.yaml
@@ -51,6 +51,12 @@ jobs:
       - name: Rust Add Target
         run: rustup target add thumbv6m-none-eabi
 
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          shared-key: rust-thumbv6m
+          cache-targets: thumbv6m-none-eabi
+
       - name: Run Cargo Build
         run: cargo build --target=thumbv6m-none-eabi --no-default-features
 

--- a/.github/workflows/rust-thumbv6m-none-eabi.yaml
+++ b/.github/workflows/rust-thumbv6m-none-eabi.yaml
@@ -52,7 +52,7 @@ jobs:
         run: rustup target add thumbv6m-none-eabi
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           shared-key: rust-thumbv6m
           cache-targets: thumbv6m-none-eabi

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -41,6 +41,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          shared-key: rust-checks
+
       - name: Setup Nickel
         uses: ./.github/actions/setup-nickel
         with:
@@ -72,6 +77,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          shared-key: rust-checks
+
       - name: Setup Nickel
         uses: ./.github/actions/setup-nickel
         with:
@@ -87,6 +97,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          shared-key: rust-checks
+
       - name: Setup Nickel
         uses: ./.github/actions/setup-nickel
         with:
@@ -101,6 +116,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          shared-key: rust-checks
 
       - name: Setup Nickel
         uses: ./.github/actions/setup-nickel

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           shared-key: rust-checks
 
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           shared-key: rust-checks
 
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           shared-key: rust-checks
 
@@ -118,7 +118,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           shared-key: rust-checks
 

--- a/.github/workflows/test-ceedling.yaml
+++ b/.github/workflows/test-ceedling.yaml
@@ -52,6 +52,11 @@ jobs:
           chmod +x ./cbindgen
           sudo cp ./cbindgen /usr/bin/cbindgen
 
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          shared-key: ceedling
+
       - name: Run Ceedling Tests
         run: |
           export PATH=$(gem environment user_gemhome)/bin:$PATH

--- a/.github/workflows/test-ceedling.yaml
+++ b/.github/workflows/test-ceedling.yaml
@@ -53,7 +53,7 @@ jobs:
           sudo cp ./cbindgen /usr/bin/cbindgen
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           shared-key: ceedling
 


### PR DESCRIPTION
## What

Adds `swatinem/rust-cache@v2` to every workflow job that runs `cargo` (Rust Checks jobs, Nickel Codegen fixture builds, cross-target firmware workflows, Ceedling, gh-pages doc build).

Each workflow uses a distinct `shared-key` so parallel jobs in the same workflow can reuse downloaded crates. Cross-compile jobs set `cache-targets` for their `rustup target`.

## Why

Recent PR runs show Rust Checks dominated by `cucumber-keymap` (~11m) and `rust-integration` (~7m), with repeated cold builds across pushes. Caching helps most on the second and later pushes to a PR branch, where registry and target restore avoids recompiling the workspace from scratch.

First push on a branch still pays full compile cost; this is not a substitute for slimming cucumber, but it is cheap to add.

## Behaviour

No change to which tests run. Cache misses fall back to a normal cargo build.

## Note

Stacks cleanly with #560 (setup-nickel action); no dependency either way.