### PR TITLE
ci: split Nickel checks and snapshot jobs

### DIFF
--- a/.github/workflows/nickel.yaml
+++ b/.github/workflows/nickel.yaml
@@ -20,14 +20,23 @@ on:
       - 'tests/ncl/**'
 
 jobs:
-  cargo-build:
-    runs-on: ${{ matrix.os }}
+  ncl-checks:
+    runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Nickel
+        uses: ./.github/actions/setup-nickel
+        with:
+          version: ${{ env.NICKEL_VERSION }}
+
+      - name: Run Nickel checks
+        run: make test-ncl-checks
+
+  ncl-snapshots:
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -50,9 +59,8 @@ jobs:
           shared-key: nickel-codegen
           cache-targets: riscv32imac-unknown-none-elf
 
-      - name: Run Nickel tests
-        run: |
-          ./ncl/scripts/run-tests.sh
+      - name: Run Nickel snapshot fixtures
+        run: make test-ncl-snapshots
 
       - name: Generate feature docs
         run: ./features/scripts/generate-doc.sh

--- a/ncl/ncl.mk
+++ b/ncl/ncl.mk
@@ -3,12 +3,15 @@ clean-generated-keymaps:
 	ncl/scripts/clean-generated-keymaps.sh
 
 .PHONY: test-ncl
-test-ncl: test-ncl-checks
-	ncl/scripts/run-tests.sh
+test-ncl: test-ncl-checks test-ncl-snapshots
 
 .PHONY: test-ncl-checks
 test-ncl-checks:
 	ncl/scripts/run-ncl-checks.sh
+
+.PHONY: test-ncl-snapshots
+test-ncl-snapshots:
+	ncl/scripts/run-snapshots.sh
 
 %/keymap.json:
 	ncl/scripts/keymap-ncl-to-json.sh $(shell dirname $@)

--- a/ncl/scripts/run-snapshots.sh
+++ b/ncl/scripts/run-snapshots.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Snapshot fixtures: export keymap.json/keymap.rs and diff against expected.rs,
+# then cargo-check each generated keymap.
+
+set -euo pipefail
+
+SCRIPTS_DIR="$(dirname "$0")"
+
+while IFS= read -r ncl_test; do
+  "${SCRIPTS_DIR}/test-ncl-diff.sh" "${ncl_test}"
+  "${SCRIPTS_DIR}/test-ncl-builds.sh" "${ncl_test}"
+done < <("${SCRIPTS_DIR}/list-ncl-snapshot-fixtures.sh")

--- a/ncl/scripts/run-tests.sh
+++ b/ncl/scripts/run-tests.sh
@@ -8,13 +8,5 @@ set -euo pipefail
 
 SCRIPTS_DIR="$(dirname "$0")"
 
-# Run the nickel checks first.
 "${SCRIPTS_DIR}/run-ncl-checks.sh"
-
-# For each snapshot fixture, check generated keymap.rs:
-#  - matches the expected snapshot,
-#  - type-checks (cargo check).
-while IFS= read -r ncl_test; do
-  "${SCRIPTS_DIR}/test-ncl-diff.sh" "${ncl_test}"
-  "${SCRIPTS_DIR}/test-ncl-builds.sh" "${ncl_test}"
-done < <("${SCRIPTS_DIR}/list-ncl-snapshot-fixtures.sh")
+"${SCRIPTS_DIR}/run-snapshots.sh"


### PR DESCRIPTION
## What

Splits the Nickel Codegen workflow into two parallel jobs:

- ncl-checks — make test-ncl-checks (seconds)
- ncl-snapshots — make test-ncl-snapshots (~3m)

Adds run-snapshots.sh and make test-ncl-snapshots. run-tests.sh / make test-ncl still run both locally.

## Why

Validator and pipeline contract regressions currently wait behind 16x export/diff/cargo-check. Splitting gives fast feedback on ncl-only changes.

## Behaviour

Same total coverage; jobs run in parallel on CI.