### PR TITLE
ci: cancel superseded PR workflow runs

### DIFF
--- a/.github/workflows/firmware-ch32x.yaml
+++ b/.github/workflows/firmware-ch32x.yaml
@@ -29,6 +29,10 @@ on:
       - 'smart_keymap/**'
       - 'firmware/ch32x035-usb-device-compositekm-c/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-firmware-ch32x:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/nickel-format.yaml
+++ b/.github/workflows/nickel-format.yaml
@@ -17,6 +17,10 @@ on:
       - 'ncl/**'
       - 'tests/ncl/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check-format:
     runs-on: ubuntu-latest

--- a/.github/workflows/nickel.yaml
+++ b/.github/workflows/nickel.yaml
@@ -19,6 +19,10 @@ on:
       - 'src/**'
       - 'tests/ncl/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   cargo-build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/rust-stm32f4.yaml
+++ b/.github/workflows/rust-stm32f4.yaml
@@ -29,6 +29,10 @@ on:
       - 'smart-keymap-nickel-helper/**'
       - 'keyberon-smart-keyboard/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   cargo-build-target-thumbv7em-none-eabihf:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/rust-thumbv6m-none-eabi.yaml
+++ b/.github/workflows/rust-thumbv6m-none-eabi.yaml
@@ -29,6 +29,10 @@ on:
       - 'smart-keymap-nickel-helper/**'
       - 'keyberon-smart-keyboard/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   cargo-build-target-thumbv6m-none-eabi:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -27,6 +27,10 @@ on:
       - 'smart-keymap-nickel-helper/**'
       - 'tests/**/*.rs'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   cargo-build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-ceedling.yaml
+++ b/.github/workflows/test-ceedling.yaml
@@ -23,6 +23,10 @@ on:
       - 'smart_keymap/**'
       - 'tests/ceedling/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   unity-test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## What

Adds a `concurrency` group to each CI workflow (except gh-pages, which already has its own).

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

## Why

Rapid pushes to a PR branch currently leave older runs going (e.g. the ~11m cucumber job). Cancelling superseded runs saves runner time and reduces noise.

`cancel-in-progress` is false for `push` to master so production/master CI is not interrupted.

## Note

Stacks independently of #562 (split ncl jobs).