### PR TITLE
ci: trim redundant workflow setup

### DIFF
--- a/.github/workflows/firmware-ch32x.yaml
+++ b/.github/workflows/firmware-ch32x.yaml
@@ -35,13 +35,7 @@ concurrency:
 
 jobs:
   build-firmware-ch32x:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code

--- a/.github/workflows/nickel.yaml
+++ b/.github/workflows/nickel.yaml
@@ -67,4 +67,5 @@ jobs:
         run: make test-ncl-snapshots
 
       - name: Generate feature docs
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: ./features/scripts/generate-doc.sh

--- a/.github/workflows/rust-stm32f4.yaml
+++ b/.github/workflows/rust-stm32f4.yaml
@@ -35,13 +35,7 @@ concurrency:
 
 jobs:
   cargo-build-target-thumbv7em-none-eabihf:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code

--- a/.github/workflows/rust-thumbv6m-none-eabi.yaml
+++ b/.github/workflows/rust-thumbv6m-none-eabi.yaml
@@ -35,13 +35,7 @@ concurrency:
 
 jobs:
   cargo-build-target-thumbv6m-none-eabi:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -33,13 +33,7 @@ concurrency:
 
 jobs:
   cargo-build:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -85,11 +79,6 @@ jobs:
         uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           shared-key: rust-checks
-
-      - name: Setup Nickel
-        uses: ./.github/actions/setup-nickel
-        with:
-          version: ${{ env.NICKEL_VERSION }}
 
       - name: Run Cargo Test (lib)
         run: cargo test --lib

--- a/.github/workflows/test-ceedling.yaml
+++ b/.github/workflows/test-ceedling.yaml
@@ -29,13 +29,7 @@ concurrency:
 
 jobs:
   unity-test:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## What

- **cargo-test-lib**: drop Setup Nickel (lib unit tests do not use Nickel)
- **Single-OS matrices**: replace `matrix.os: [ubuntu-latest]` with `runs-on: ubuntu-latest` in Nickel Codegen, Rust Checks cargo-build, Ceedling, CH32X, STM32F4, thumbv6m jobs
- **generate-doc**: only on `push` to `master` (gh-pages already regenerates docs on merge)

## Why

Small clarity and cost wins: fewer no-op steps, less YAML noise. Feature doc generation on every PR duplicated work already done on master deploy.

## Note

If #562 (split ncl jobs) merges first, rebase this branch and keep the `if:` on generate-doc under `ncl-snapshots`.