### PR TITLE
ci: add cargo fmt and clippy checks

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -32,6 +32,37 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  cargo-fmt-clippy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          shared-key: rust-checks
+
+      - name: Install Rust lint components
+        run: rustup component add clippy rustfmt
+
+      - name: Setup Nickel
+        uses: ./.github/actions/setup-nickel
+        with:
+          version: ${{ env.NICKEL_VERSION }}
+
+      - name: Run Cargo Fmt
+        run: cargo fmt --all -- --check
+
+      - name: Run Cargo Clippy
+        run: |
+          cargo clippy --workspace \
+            --exclude rp2040-rtic-smart-keyboard \
+            --exclude stm32f4-rtic-smart-keyboard \
+            --exclude stm32-embassy-smart-keyboard \
+            -- -D warnings
+
   cargo-build:
     runs-on: ubuntu-latest
 

--- a/keyberon-smart-keyboard/src/input/smart_keymap.rs
+++ b/keyberon-smart-keyboard/src/input/smart_keymap.rs
@@ -15,6 +15,12 @@ pub struct KeyboardBackend {
     keymap_output: smart_keymap::keymap::KeymapOutput,
 }
 
+impl Default for KeyboardBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl KeyboardBackend {
     /// Constructs a new keyboard backend.
     pub fn new() -> Self {

--- a/smart_keymap/src/lib.rs
+++ b/smart_keymap/src/lib.rs
@@ -346,7 +346,7 @@ pub unsafe extern "C" fn keymap_register_input_after_ms(
             debug_assert!(next_ms > 0);
         }
 
-        next_ev.map_or(0, |t| t as u32)
+        next_ev.map_or(0, |t| t)
     }
 }
 
@@ -371,7 +371,7 @@ pub unsafe extern "C" fn keymap_next_event_timeout(report: &mut KeymapHidReport)
             debug_assert!(next_ms > 0);
         }
 
-        next_ev.map_or(0, |t| t as u32)
+        next_ev.map_or(0, |t| t)
     }
 }
 
@@ -404,6 +404,10 @@ pub unsafe extern "C" fn keymap_clear_callbacks() {
 /// callback_id should be one of:
 /// - KEYMAP_CALLBACK_RESET
 /// - KEYMAP_CALLBACK_BOOTLOADER
+///
+/// # Safety
+///
+/// Not to be called concurrently with other `keymap_*` functions.
 #[allow(static_mut_refs)]
 #[no_mangle]
 pub unsafe extern "C" fn keymap_register_callback(
@@ -424,6 +428,10 @@ pub unsafe extern "C" fn keymap_register_callback(
 }
 
 /// Registers a custom callback with the keymap.
+///
+/// # Safety
+///
+/// Not to be called concurrently with other `keymap_*` functions.
 #[allow(static_mut_refs)]
 #[no_mangle]
 pub unsafe extern "C" fn keymap_register_custom_callback(
@@ -438,6 +446,10 @@ pub unsafe extern "C" fn keymap_register_custom_callback(
 }
 
 /// Registers a bluetooth callback with the keymap.
+///
+/// # Safety
+///
+/// Not to be called concurrently with other `keymap_*` functions.
 #[allow(static_mut_refs)]
 #[no_mangle]
 pub unsafe extern "C" fn keymap_register_bluetooth_callback(
@@ -451,6 +463,10 @@ pub unsafe extern "C" fn keymap_register_bluetooth_callback(
 }
 
 /// Serializes the given event into the given buffer.
+///
+/// # Safety
+///
+/// `buf` must point to a buffer large enough for the serialized message.
 #[no_mangle]
 pub unsafe extern "C" fn keymap_serialize_event(buf: *mut u8, event: KeymapInputEvent) {
     unsafe {
@@ -462,6 +478,10 @@ pub unsafe extern "C" fn keymap_serialize_event(buf: *mut u8, event: KeymapInput
 
 /// Deserializes the given bytes into the given pointer;
 /// returns true if successful, false if fails.
+///
+/// # Safety
+///
+/// `event` must be a valid, aligned pointer to a writable [KeymapInputEvent].
 #[no_mangle]
 pub unsafe extern "C" fn keymap_message_buffer_receive_byte(
     buf: &mut [u8; MESSAGE_BUFFER_LEN],

--- a/src/key.rs
+++ b/src/key.rs
@@ -178,6 +178,9 @@ impl<R, PKS, KS> PressedKeyResult<R, PKS, KS> {
     }
 }
 
+/// Outcome of [System::new_pressed_key].
+pub type NewPressedKeyOutput<R, PKS, KS, E> = (PressedKeyResult<R, PKS, KS>, KeyEvents<E>);
+
 /// The interface for key `System` behaviour.
 ///
 /// A `System` has an associated `Ref`, [Context], `Event`, and [KeyState].
@@ -215,10 +218,7 @@ pub trait System<R>: Debug {
         keymap_index: u16,
         context: &Self::Context,
         key_ref: Self::Ref,
-    ) -> (
-        PressedKeyResult<R, Self::PendingKeyState, Self::KeyState>,
-        KeyEvents<Self::Event>,
-    );
+    ) -> NewPressedKeyOutput<R, Self::PendingKeyState, Self::KeyState, Self::Event>;
 
     /// Update the given pending key state with the given impl.
     fn update_pending_state(

--- a/src/key/caps_word.rs
+++ b/src/key/caps_word.rs
@@ -17,6 +17,12 @@ pub struct Context {
     is_active: bool,
 }
 
+impl Default for Context {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Context {
     /// Constructs a new [Context].
     pub const fn new() -> Self {

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -285,6 +285,12 @@ pub struct Config {
     pub tap_hold: TapHoldConfig,
 }
 
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Config {
     /// Constructs a new [Config] with default values.
     pub const fn new() -> Self {
@@ -978,6 +984,7 @@ impl<
     >
 {
     /// Constructs a new [System].
+    #[allow(clippy::too_many_arguments)]
     pub const fn array_based(
         automation: AutomationSystem<[AutomationKey; AUTOMATION]>,
         callback: CallbackSystem<[CallbackKey; CALLBACK]>,
@@ -1009,6 +1016,7 @@ impl<
 #[cfg(feature = "std")]
 impl System<KeyVecs> {
     /// Constructs a new [System].
+    #[allow(clippy::too_many_arguments)]
     pub const fn vec_based(
         automation: AutomationSystem<Vec<AutomationKey>>,
         callback: CallbackSystem<Vec<CallbackKey>>,

--- a/src/key/consumer.rs
+++ b/src/key/consumer.rs
@@ -42,6 +42,12 @@ impl<R: Debug> System<R> {
     }
 }
 
+impl<R: Debug> Default for System<R> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<R: Debug> key::System<R> for System<R> {
     type Ref = Ref;
     type Context = Context;

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -510,6 +510,12 @@ pub struct ModifierKeyState {
     behavior: Behavior,
 }
 
+impl Default for ModifierKeyState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ModifierKeyState {
     /// Constructs a regular ModifierKeyState
     pub fn new() -> Self {

--- a/src/key/mouse.rs
+++ b/src/key/mouse.rs
@@ -58,6 +58,12 @@ impl<R: Debug> System<R> {
     }
 }
 
+impl<R: Debug> Default for System<R> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<R: Debug> key::System<R> for System<R> {
     type Ref = Ref;
     type Context = Context;

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -38,17 +38,9 @@ const MAX_QUEUED_INPUT_EVENTS: usize = 32;
 pub const INPUT_QUEUE_TICK_DELAY: u8 = 1;
 
 /// Constructs an HID report or a sequence of key codes from the given sequence of [key::KeyOutput].
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Default, PartialEq)]
 pub struct KeymapOutput {
     pressed_key_codes: heapless::Vec<key::KeyOutput, { MAX_PRESSED_KEYS }>,
-}
-
-impl Default for KeymapOutput {
-    fn default() -> Self {
-        Self {
-            pressed_key_codes: heapless::Vec::new(),
-        }
-    }
 }
 
 impl KeymapOutput {
@@ -184,7 +176,7 @@ pub enum KeymapCallback {
 }
 
 /// Context provided from the keymap to the smart keys.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct KeymapContext {
     /// Number of milliseconds since keymap has been initialized.
     pub time_ms: u32,

--- a/src/keymap/distinct_reports.rs
+++ b/src/keymap/distinct_reports.rs
@@ -24,13 +24,7 @@ impl Debug for DistinctReports {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         // Debug fmt with each of the [u8; 8] on one line.
         f.debug_tuple("DistinctReports")
-            .field(
-                &self
-                    .0
-                    .iter()
-                    .map(|r| ReportDebugHelper(r))
-                    .collect::<Vec<_>>(),
-            )
+            .field(&self.0.iter().map(ReportDebugHelper).collect::<Vec<_>>())
             .finish()
     }
 }


### PR DESCRIPTION
## Summary

- Add a `cargo-fmt-clippy` job to the Rust Checks workflow
- Run `cargo fmt --all -- --check` and workspace `clippy` with `-D warnings`
- Exclude embedded board firmware packages (`rp2040-rtic-smart-keyboard`, `stm32f4-rtic-smart-keyboard`, `stm32-embassy-smart-keyboard`) — they only build under their cross-target workflows
- Fix existing clippy violations in host-buildable crates so CI passes on first run

Closes the gap between local devenv git hooks (`clippy`, `rustfmt`) and CI.