### PR TITLE
ci: limit gh-pages deploy to doc-relevant paths

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -6,6 +6,16 @@ env:
 on:
   push:
     branches: ["master"]
+    paths:
+      - '.cargo/**'
+      - '.github/workflows/gh-pages.yaml'
+      - 'Cargo.*'
+      - 'features/**'
+      - 'keyberon-smart-keyboard/**'
+      - 'ncl/**'
+      - 'rp2040-rtic-smart-keyboard/**'
+      - 'smart-keymap-nickel-helper/**'
+      - 'src/**'
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
## Summary

- Add `paths:` filters to the GitHub Pages workflow
- Skip deploys on master pushes that do not touch crates, features, ncl, or the workflow itself

The doc build only needs changes under those areas; unrelated master commits no longer trigger a full deploy.