### PR TITLE
ci: add reusable setup-cbindgen composite action

### DIFF
--- a/.github/actions/setup-cbindgen/action.yml
+++ b/.github/actions/setup-cbindgen/action.yml
@@ -1,0 +1,18 @@
+name: Setup cbindgen
+description: Install the pinned cbindgen CLI binary
+
+inputs:
+  version:
+    description: cbindgen release version
+    required: false
+    default: "0.28.0"
+
+runs:
+  using: composite
+  steps:
+    - name: Install cbindgen
+      shell: bash
+      run: |
+        wget -q "https://github.com/mozilla/cbindgen/releases/download/${{ inputs.version }}/cbindgen"
+        chmod +x ./cbindgen
+        sudo cp ./cbindgen /usr/bin/cbindgen

--- a/.github/workflows/firmware-ch32x.yaml
+++ b/.github/workflows/firmware-ch32x.yaml
@@ -46,11 +46,8 @@ jobs:
         with:
           version: ${{ env.NICKEL_VERSION }}
 
-      - name: Install cbindgen
-        run: |
-          wget https://github.com/mozilla/cbindgen/releases/download/0.28.0/cbindgen
-          chmod +x ./cbindgen
-          sudo cp ./cbindgen /usr/bin/cbindgen
+      - name: Setup cbindgen
+        uses: ./.github/actions/setup-cbindgen
 
       - name: Install xpack toolchain
         run: |

--- a/.github/workflows/test-ceedling.yaml
+++ b/.github/workflows/test-ceedling.yaml
@@ -46,9 +46,11 @@ jobs:
           export GEM_HOME=$(gem environment user_gemhome)
           gem install bundler --user-install
           bundle install
-          wget https://github.com/mozilla/cbindgen/releases/download/0.28.0/cbindgen
-          chmod +x ./cbindgen
-          sudo cp ./cbindgen /usr/bin/cbindgen
+      - name: Setup cbindgen
+        uses: ./.github/actions/setup-cbindgen
+
+      - name: Install Ruby dependencies
+        run: |
 
       - name: Rust cache
         uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1


### PR DESCRIPTION
## Summary

- Add `.github/actions/setup-cbindgen` (pinned v0.28.0)
- Use it in the CH32X firmware and Ceedling workflows

Same pattern as `setup-nickel`; removes duplicated wget/install blocks.