### PR TITLE
Use named HID keycodes in Rust integration tests

### DIFF
--- a/tests/rust/automation.rs
+++ b/tests/rust/automation.rs
@@ -1,3 +1,4 @@
+use crate::hid_keycodes::*;
 use smart_keymap::keymap::ObservedKeymap;
 
 #[test]
@@ -28,7 +29,7 @@ fn test_simple_1char_string_macro() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -66,11 +67,11 @@ fn test_simple_string_macro() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x06, 0, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -105,15 +106,15 @@ fn test_shifted_string_macro() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [2, 0, 0x04, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x2C, 0, 0, 0, 0, 0],
+        [0, 0, KC_SPACE, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [2, 0, 0x06, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, KC_C, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x07, 0, 0, 0, 0, 0],
+        [0, 0, KC_D, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -132,8 +133,8 @@ fn test_macro_while_pressed() {
         let MY_MACRO = {
             automation_instructions = {
                 while_pressed = [
-                    { Press = { key_code = { Keyboard = 0x04 } } },
-                    { Release = { key_code = { Keyboard = 0x04 } } },
+                    { Press = { key_code = { Keyboard = 4 } } },
+                    { Release = { key_code = { Keyboard = 4 } } },
                 ],
             }
         }
@@ -159,11 +160,11 @@ fn test_macro_while_pressed() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -182,8 +183,8 @@ fn test_macro_on_release_not_fired_on_press() {
         let MY_MACRO = {
             automation_instructions = {
                 on_release = [
-                    { Press = { key_code = { Keyboard = 0x04 } } },
-                    { Release = { key_code = { Keyboard = 0x04 } } },
+                    { Press = { key_code = { Keyboard = 4 } } },
+                    { Release = { key_code = { Keyboard = 4 } } },
                 ],
             }
         }
@@ -222,17 +223,17 @@ fn test_macro_press_while_pressed_release() {
         let MY_MACRO = {
             automation_instructions = {
                 on_press = [
-                    { Press = { key_code = { Keyboard = 0x04 } } },
-                    { Release = { key_code = { Keyboard = 0x04 } } },
+                    { Press = { key_code = { Keyboard = 4 } } },
+                    { Release = { key_code = { Keyboard = 4 } } },
                 ],
                 while_pressed = [
-                    { Press = { key_code = { Keyboard = 0x05 } } },
-                    { Release = { key_code = { Keyboard = 0x05 } } },
+                    { Press = { key_code = { Keyboard = 5 } } },
+                    { Release = { key_code = { Keyboard = 5 } } },
                     { Wait = 1000 },
                 ],
                 on_release = [
-                    { Press = { key_code = { Keyboard = 0x06 } } },
-                    { Release = { key_code = { Keyboard = 0x06 } } },
+                    { Press = { key_code = { Keyboard = 6 } } },
+                    { Release = { key_code = { Keyboard = 6 } } },
                 ],
             }
         }
@@ -258,15 +259,15 @@ fn test_macro_press_while_pressed_release() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x06, 0, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -285,12 +286,12 @@ fn test_macro_press_and_release() {
         let MY_MACRO = {
             automation_instructions = {
                 on_press = [
-                    { Press = { key_code = { Keyboard = 0x04 } } },
-                    { Release = { key_code = { Keyboard = 0x04 } } },
+                    { Press = { key_code = { Keyboard = 4 } } },
+                    { Release = { key_code = { Keyboard = 4 } } },
                 ],
                 on_release = [
-                    { Press = { key_code = { Keyboard = 0x06 } } },
-                    { Release = { key_code = { Keyboard = 0x06 } } },
+                    { Press = { key_code = { Keyboard = 6 } } },
+                    { Release = { key_code = { Keyboard = 6 } } },
                 ],
             }
         }
@@ -313,9 +314,9 @@ fn test_macro_press_and_release() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x06, 0, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -334,10 +335,10 @@ fn test_macro_press_and_release_taps() {
         let MY_MACRO = {
             automation_instructions = {
                 on_press = [
-                    { Tap = { key_code = { Keyboard = 0x04 } } },
+                    { Tap = { key_code = { Keyboard = 4 } } },
                 ],
                 on_release = [
-                    { Tap = { key_code = { Keyboard = 0x06 } } },
+                    { Tap = { key_code = { Keyboard = 6 } } },
                 ],
             }
         }
@@ -360,9 +361,9 @@ fn test_macro_press_and_release_taps() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0x06, 0, 0, 0, 0],
-        [0, 0, 0x06, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, KC_C, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -404,9 +405,9 @@ fn test_macro_string_to_instructions() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0x06, 0, 0, 0, 0],
-        [0, 0, 0x06, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, KC_C, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();

--- a/tests/rust/caps_word.rs
+++ b/tests/rust/caps_word.rs
@@ -1,6 +1,7 @@
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 
+use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
@@ -33,8 +34,8 @@ fn tap_caps_word_shifts_keyboard_keys() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0x02, 0, 0, 0, 0, 0, 0, 0],
-        [0x02, 0, 0x04, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, KC_A, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
@@ -78,12 +79,12 @@ fn tap_caps_word_spc_deactivates_caps_word() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0x02, 0, 0, 0, 0, 0, 0, 0],
-        [0x02, 0, 0x04, 0, 0, 0, 0, 0],
-        [0x02, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x2C, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, KC_A, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, KC_SPACE, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());

--- a/tests/rust/chorded.rs
+++ b/tests/rust/chorded.rs
@@ -9,6 +9,7 @@ mod tap_hold_over_tap_hold;
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 
+use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
@@ -37,7 +38,7 @@ fn tap_auxiliary_key_acts_as_passthrough() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -70,7 +71,7 @@ fn tap_chorded_key_acts_as_passthrough() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -104,7 +105,7 @@ fn press_chord_acts_as_chord() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x06, 0, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
@@ -138,7 +139,7 @@ fn press_chord_alt_order_acts_as_chord() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x06, 0, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
@@ -173,7 +174,7 @@ fn nested_tap_chord_acts_as_chord() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x06, 0, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -209,7 +210,7 @@ fn rolling_tap_chord_acts_as_chord() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x06, 0, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -245,7 +246,7 @@ fn press_chord_4_acts_as_chord() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x08, 0, 0, 0, 0, 0],
+        [0, 0, KC_E, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
@@ -280,9 +281,9 @@ fn release_and_repress_chorded_after_hold_chord_acts_as_passthrough() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x06, 0, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
@@ -317,8 +318,8 @@ fn release_and_repress_aux_after_hold_chord_acts_as_passthrough() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x06, 0, 0, 0, 0, 0],
-        [0, 0, 0x06, 0x05, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
+        [0, 0, KC_C, KC_B, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());

--- a/tests/rust/chorded/over_layered_tap_hold.rs
+++ b/tests/rust/chorded/over_layered_tap_hold.rs
@@ -1,6 +1,7 @@
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 
+use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
@@ -39,9 +40,9 @@ fn tap_key_after_tapping_chord_on_default_layer() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x08, 0, 0, 0, 0, 0],
+        [0, 0, KC_E, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x06, 0, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -86,9 +87,9 @@ fn tap_key_after_tapping_chord_on_layer_1() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x08, 0, 0, 0, 0, 0],
+        [0, 0, KC_E, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x07, 0, 0, 0, 0, 0],
+        [0, 0, KC_D, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -127,7 +128,7 @@ fn tap_chorded_key_passes_through_as_tap() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -170,9 +171,9 @@ fn tap_key_after_tapping_chorded_key_on_layer_1() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x09, 0, 0, 0, 0, 0],
+        [0, 0, KC_F, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x07, 0, 0, 0, 0, 0],
+        [0, 0, KC_D, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();

--- a/tests/rust/chorded/overlapping.rs
+++ b/tests/rust/chorded/overlapping.rs
@@ -1,6 +1,7 @@
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 
+use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
@@ -37,7 +38,7 @@ fn overlap_tap_key_acts_as_passthrough() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -78,8 +79,8 @@ fn overlap_press_d_bc_results_in_passthrough_followed_by_chord() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x07, 0, 0, 0, 0, 0],
-        [0, 0, 0x07, 0x12, 0, 0, 0, 0],
+        [0, 0, KC_D, 0, 0, 0, 0, 0],
+        [0, 0, KC_D, KC_O, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
@@ -116,7 +117,7 @@ fn overlap_partial_press_cd_acts_as_chord() {
     keymap.tick_until_no_scheduled_events();
 
     // Assert
-    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0x13, 0, 0, 0, 0, 0]];
+    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, KC_P, 0, 0, 0, 0, 0]];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
@@ -152,7 +153,7 @@ fn overlap_partial_press_dc_acts_as_chord() {
     keymap.tick_until_no_scheduled_events();
 
     // Assert
-    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0x13, 0, 0, 0, 0, 0]];
+    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, KC_P, 0, 0, 0, 0, 0]];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
@@ -188,7 +189,7 @@ fn overlap_press_bc_acts_as_chord() {
     keymap.tick_until_no_scheduled_events();
 
     // Assert
-    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0x12, 0, 0, 0, 0, 0]];
+    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, KC_O, 0, 0, 0, 0, 0]];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
@@ -224,7 +225,7 @@ fn overlap_press_cb_acts_as_chord() {
     keymap.tick_until_no_scheduled_events();
 
     // Assert
-    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0x12, 0, 0, 0, 0, 0]];
+    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, KC_O, 0, 0, 0, 0, 0]];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
@@ -260,7 +261,7 @@ fn overlap_press_ab_acts_as_chord() {
     keymap.tick_until_no_scheduled_events();
 
     // Assert
-    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0x10, 0, 0, 0, 0, 0]];
+    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, KC_M, 0, 0, 0, 0, 0]];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
@@ -296,7 +297,7 @@ fn overlap_press_ba_acts_as_chord() {
     keymap.tick_until_no_scheduled_events();
 
     // Assert
-    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0x10, 0, 0, 0, 0, 0]];
+    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, KC_M, 0, 0, 0, 0, 0]];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
@@ -332,7 +333,7 @@ fn overlap_press_abc_acts_as_chord() {
     keymap.tick_until_no_scheduled_events();
 
     // Assert
-    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0x11, 0, 0, 0, 0, 0]];
+    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, KC_N, 0, 0, 0, 0, 0]];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
@@ -368,7 +369,7 @@ fn overlap_press_cba_acts_as_chord() {
     keymap.tick_until_no_scheduled_events();
 
     // Assert
-    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0x11, 0, 0, 0, 0, 0]];
+    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, KC_N, 0, 0, 0, 0, 0]];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
@@ -404,7 +405,7 @@ fn overlap_press_cab_acts_as_chord() {
     keymap.tick_until_no_scheduled_events();
 
     // Assert
-    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0x11, 0, 0, 0, 0, 0]];
+    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, KC_N, 0, 0, 0, 0, 0]];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
@@ -444,8 +445,8 @@ fn interrupting_satisfied_overlapped_chord_resolves_as_chord() {
     // Should chord BC then press D.
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x12, 0, 0, 0, 0, 0],
-        [0, 0, 0x12, 0x07, 0, 0, 0, 0],
+        [0, 0, KC_O, 0, 0, 0, 0, 0],
+        [0, 0, KC_O, KC_D, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());

--- a/tests/rust/chorded/overlapping_aux.rs
+++ b/tests/rust/chorded/overlapping_aux.rs
@@ -1,6 +1,7 @@
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 
+use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
@@ -34,7 +35,7 @@ fn overlap_aux_press_ad_results_chord() {
     keymap.tick_until_no_scheduled_events();
 
     // Assert
-    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0x10, 0, 0, 0, 0, 0]];
+    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, KC_M, 0, 0, 0, 0, 0]];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
@@ -70,7 +71,7 @@ fn overlap_aux_press_cd_results_chord() {
     keymap.tick_until_no_scheduled_events();
 
     // Assert
-    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0x12, 0, 0, 0, 0, 0]];
+    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, KC_O, 0, 0, 0, 0, 0]];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
@@ -106,7 +107,7 @@ fn overlap_aux_press_abd_results_chord() {
     keymap.tick_until_no_scheduled_events();
 
     // Assert
-    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0x11, 0, 0, 0, 0, 0]];
+    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, KC_N, 0, 0, 0, 0, 0]];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }

--- a/tests/rust/chorded/overlapping_simultaneous.rs
+++ b/tests/rust/chorded/overlapping_simultaneous.rs
@@ -1,6 +1,7 @@
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 
+use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
@@ -34,7 +35,7 @@ fn overlap_press_abcd_results_in_chord() {
     keymap.tick_until_no_scheduled_events();
 
     // Assert
-    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0x10, 0, 0, 0, 0, 0]];
+    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, KC_M, 0, 0, 0, 0, 0]];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
@@ -70,7 +71,7 @@ fn overlap_press_ab_results_in_chord() {
     keymap.tick_until_no_scheduled_events();
 
     // Assert
-    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0x11, 0, 0, 0, 0, 0]];
+    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, KC_N, 0, 0, 0, 0, 0]];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
@@ -106,7 +107,7 @@ fn overlap_press_cd_results_in_chord() {
     keymap.tick_until_no_scheduled_events();
 
     // Assert
-    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0x12, 0, 0, 0, 0, 0]];
+    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, KC_O, 0, 0, 0, 0, 0]];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
@@ -157,8 +158,8 @@ fn overlap_press_ab_then_cd_results_in_chords() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x11, 0, 0, 0, 0, 0],
-        [0, 0, 0x11, 0x12, 0, 0, 0, 0],
+        [0, 0, KC_N, 0, 0, 0, 0, 0],
+        [0, 0, KC_N, KC_O, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());

--- a/tests/rust/chorded/required_idle_time.rs
+++ b/tests/rust/chorded/required_idle_time.rs
@@ -1,6 +1,7 @@
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 
+use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
@@ -37,9 +38,9 @@ fn press_chord_resolves_as_passthrough_quickly_following_key_press() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x07, 0, 0, 0, 0, 0],
-        [0, 0, 0x07, 0x04, 0, 0, 0, 0],
-        [0, 0, 0x07, 0x04, 0x05, 0, 0, 0],
+        [0, 0, KC_D, 0, 0, 0, 0, 0],
+        [0, 0, KC_D, KC_A, 0, 0, 0, 0],
+        [0, 0, KC_D, KC_A, KC_B, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
@@ -79,9 +80,9 @@ fn press_chord_resolves_as_passthrough_quickly_alt_following_key_press() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x07, 0, 0, 0, 0, 0],
-        [0, 0, 0x07, 0x05, 0, 0, 0, 0],
-        [0, 0, 0x07, 0x05, 0x04, 0, 0, 0],
+        [0, 0, KC_D, 0, 0, 0, 0, 0],
+        [0, 0, KC_D, KC_B, 0, 0, 0, 0],
+        [0, 0, KC_D, KC_B, KC_A, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
@@ -122,10 +123,10 @@ fn press_chord_resolves_as_passthrough_when_pressed_quickly() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x07, 0, 0, 0, 0, 0],
+        [0, 0, KC_D, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0x05, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, KC_B, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
@@ -166,9 +167,9 @@ fn press_chord_resolves_as_chord_when_pressed_after_required_idle_time() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x07, 0, 0, 0, 0, 0],
+        [0, 0, KC_D, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x06, 0, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
@@ -208,8 +209,8 @@ fn press_chord_resolves_as_chord_following_key_press_after_required_idle_time() 
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x07, 0, 0, 0, 0, 0],
-        [0, 0, 0x07, 0x06, 0, 0, 0, 0],
+        [0, 0, KC_D, 0, 0, 0, 0, 0],
+        [0, 0, KC_D, KC_C, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
@@ -249,8 +250,8 @@ fn press_chord_resolves_as_chord_following_key_press_after_required_idle_time_al
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x07, 0, 0, 0, 0, 0],
-        [0, 0, 0x07, 0x06, 0, 0, 0, 0],
+        [0, 0, KC_D, 0, 0, 0, 0, 0],
+        [0, 0, KC_D, KC_C, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
@@ -302,11 +303,11 @@ fn quick_press_chord_resolves_as_chord_following_tap_chord() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x07, 0, 0, 0, 0, 0],
+        [0, 0, KC_D, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x06, 0, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x06, 0, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());

--- a/tests/rust/chorded/tap_hold.rs
+++ b/tests/rust/chorded/tap_hold.rs
@@ -1,6 +1,7 @@
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 
+use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
@@ -32,7 +33,7 @@ fn tap_chord_acts_as_chorded_tap() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x06, 0, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();

--- a/tests/rust/chorded/tap_hold_over_tap_hold.rs
+++ b/tests/rust/chorded/tap_hold_over_tap_hold.rs
@@ -1,6 +1,7 @@
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 
+use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
@@ -33,7 +34,7 @@ fn tap_chord_acts_as_chorded_tap() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x06, 0, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -102,7 +103,7 @@ fn tap_chorded_key_acts_as_passthrough_tap() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -170,7 +171,7 @@ fn tap_auxiliary_key_acts_as_passthrough_tap() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -204,7 +205,7 @@ fn hold_auxiliary_key_acts_as_passthrough_hold() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [2, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());

--- a/tests/rust/event_based.rs
+++ b/tests/rust/event_based.rs
@@ -1,6 +1,7 @@
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedEventBasedKeymap;
 
+use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
@@ -78,7 +79,7 @@ fn uninterrupted_th_tap_is_tap() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -112,7 +113,7 @@ fn held_press_resolves_as_hold() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0x01, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());

--- a/tests/rust/hid_keycodes.rs
+++ b/tests/rust/hid_keycodes.rs
@@ -1,0 +1,26 @@
+//! USB HID boot keyboard usage codes referenced by Rust integration tests.
+//!
+//! Values match `tests/ceedling/test/support/hid_keycodes.h` and `ncl/hid-usage-keyboard.ncl`.
+
+#![allow(dead_code)]
+
+pub const KC_A: u8 = 0x04;
+pub const KC_B: u8 = 0x05;
+pub const KC_C: u8 = 0x06;
+pub const KC_D: u8 = 0x07;
+pub const KC_E: u8 = 0x08;
+pub const KC_F: u8 = 0x09;
+pub const KC_G: u8 = 0x0A;
+pub const KC_K: u8 = 0x0E;
+pub const KC_L: u8 = 0x0F;
+pub const KC_M: u8 = 0x10;
+pub const KC_N: u8 = 0x11;
+pub const KC_O: u8 = 0x12;
+pub const KC_P: u8 = 0x13;
+pub const KC_SPACE: u8 = 0x2C;
+pub const KC_SLASH: u8 = 0x38;
+
+/// Modifier bits in HID boot keyboard report byte 0.
+pub const MOD_LCTL: u8 = 0x01;
+pub const MOD_LSHFT: u8 = 0x02;
+pub const MOD_LCTL_LSHFT: u8 = MOD_LCTL | MOD_LSHFT;

--- a/tests/rust/keymap.rs
+++ b/tests/rust/keymap.rs
@@ -3,6 +3,7 @@ mod caps_word;
 mod chorded;
 mod consumer;
 mod custom;
+mod hid_keycodes;
 mod layered;
 mod mouse;
 mod sticky;
@@ -13,6 +14,7 @@ mod ms_per_tick;
 
 mod event_based;
 
+use hid_keycodes::*;
 use smart_keymap::keymap::ObservedKeymap;
 
 #[test]
@@ -28,7 +30,7 @@ fn basic_keymap_expression() {
         use smart_keymap::key::composite as key_system;
         const KEY_COUNT: usize = 1;
         const KEY_REFS: [Ref; KEY_COUNT] = [smart_keymap::key::composite::Ref::Keyboard(
-            smart_keymap::key::keyboard::Ref::KeyCode(0x04),
+            smart_keymap::key::keyboard::Ref::KeyCode(KC_A),
         )];
         const CONTEXT: Context = Context::from_config(key_system::Config::new());
 
@@ -58,7 +60,7 @@ fn basic_keymap_expression() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -93,7 +95,7 @@ fn basic_keymap_expression_macro() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();

--- a/tests/rust/layered.rs
+++ b/tests/rust/layered.rs
@@ -7,6 +7,7 @@ mod toggle;
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 
+use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
@@ -28,7 +29,7 @@ fn press_base_key_when_no_layers_active() {
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
 
     // Assert
-    let expected_report: [u8; 8] = [0, 0, 0x04, 0, 0, 0, 0, 0];
+    let expected_report: [u8; 8] = [0, 0, KC_A, 0, 0, 0, 0, 0];
     let actual_report = keymap.boot_keyboard_report();
     assert_eq!(expected_report, actual_report,);
 }
@@ -53,7 +54,7 @@ fn press_active_layer_when_layer_mod_held() {
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
 
     // Assert
-    let expected_report: [u8; 8] = [0, 0, 0x05, 0, 0, 0, 0, 0];
+    let expected_report: [u8; 8] = [0, 0, KC_B, 0, 0, 0, 0, 0];
     let actual_report = keymap.boot_keyboard_report();
     assert_eq!(expected_report, actual_report);
 }
@@ -79,7 +80,7 @@ fn press_retained_when_layer_mod_released() {
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
 
     // Assert
-    let expected_report: [u8; 8] = [0, 0, 0x05, 0, 0, 0, 0, 0];
+    let expected_report: [u8; 8] = [0, 0, KC_B, 0, 0, 0, 0, 0];
     let actual_report = keymap.boot_keyboard_report();
     assert_eq!(expected_report, actual_report);
 }
@@ -105,7 +106,7 @@ fn uses_base_when_pressed_after_layer_mod_released() {
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
 
     // Assert
-    let expected_report: [u8; 8] = [0, 0, 0x04, 0, 0, 0, 0, 0];
+    let expected_report: [u8; 8] = [0, 0, KC_A, 0, 0, 0, 0, 0];
     let actual_report = keymap.boot_keyboard_report();
     assert_eq!(expected_report, actual_report);
 }

--- a/tests/rust/layered/modified_hold.rs
+++ b/tests/rust/layered/modified_hold.rs
@@ -1,3 +1,4 @@
+use crate::hid_keycodes::*;
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 use smart_keymap_macros::keymap;
@@ -23,7 +24,8 @@ fn press_modified_hold_reports_as_modifier() {
     keymap.tick_until_no_scheduled_events();
 
     // Assert
-    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0x02, 0, 0, 0, 0, 0, 0, 0]];
+    let expected_reports: &[[u8; 8]] =
+        &[[0, 0, 0, 0, 0, 0, 0, 0], [MOD_LSHFT, 0, 0, 0, 0, 0, 0, 0]];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
@@ -52,8 +54,8 @@ fn press_modified_hold_modifies_layer() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0x02, 0, 0, 0, 0, 0, 0, 0],
-        [0x02, 0, 0x05, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, KC_B, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());

--- a/tests/rust/layered/set_active_layers.rs
+++ b/tests/rust/layered/set_active_layers.rs
@@ -1,6 +1,7 @@
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 
+use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
@@ -38,13 +39,13 @@ fn tap_set_active_layers_activates_layers() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x06, 0, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x07, 0, 0, 0, 0, 0],
+        [0, 0, KC_D, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -74,7 +75,7 @@ fn press_set_active_layers_activates_layers() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());

--- a/tests/rust/layered/sticky.rs
+++ b/tests/rust/layered/sticky.rs
@@ -1,6 +1,7 @@
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 
+use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
@@ -29,7 +30,7 @@ fn next_press_after_tapping_sticky_layer_press_is_modified() {
     keymap.tick_until_no_scheduled_events();
 
     // Assert
-    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0x0E, 0, 0, 0, 0, 0]];
+    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, KC_K, 0, 0, 0, 0, 0]];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
@@ -66,9 +67,9 @@ fn only_next_press_after_tapping_sticky_layer_press_is_modified() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x0E, 0, 0, 0, 0, 0],
+        [0, 0, KC_K, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
@@ -99,7 +100,7 @@ fn interrupting_sticky_layer_press_acts_as_hold_modifier() {
     keymap.tick_until_no_scheduled_events();
 
     // Assert
-    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0x0E, 0, 0, 0, 0, 0]];
+    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, KC_K, 0, 0, 0, 0, 0]];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
 }
@@ -135,9 +136,9 @@ fn interrupting_sticky_layer_press_acts_as_hold_modifier_while_held() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x0E, 0, 0, 0, 0, 0],
+        [0, 0, KC_K, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x0F, 0, 0, 0, 0, 0],
+        [0, 0, KC_L, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
@@ -177,9 +178,9 @@ fn interrupting_sticky_layer_press_acts_as_hold_modifier_until_released() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x0E, 0, 0, 0, 0, 0],
+        [0, 0, KC_K, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());

--- a/tests/rust/layered/tap_hold.rs
+++ b/tests/rust/layered/tap_hold.rs
@@ -1,6 +1,7 @@
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 
+use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
@@ -29,7 +30,7 @@ fn key_taps() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();

--- a/tests/rust/layered/toggle.rs
+++ b/tests/rust/layered/toggle.rs
@@ -1,6 +1,7 @@
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 
+use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
@@ -23,7 +24,7 @@ fn press_active_layer_when_layer_mod_toggle_pressed() {
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
 
     // Assert
-    let expected_report: [u8; 8] = [0, 0, 0x05, 0, 0, 0, 0, 0];
+    let expected_report: [u8; 8] = [0, 0, KC_B, 0, 0, 0, 0, 0];
     let actual_report = keymap.boot_keyboard_report();
     assert_eq!(expected_report, actual_report);
 }
@@ -49,7 +50,7 @@ fn press_active_layer_when_layer_mod_toggle_tapped() {
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
 
     // Assert
-    let expected_report: [u8; 8] = [0, 0, 0x05, 0, 0, 0, 0, 0];
+    let expected_report: [u8; 8] = [0, 0, KC_B, 0, 0, 0, 0, 0];
     let actual_report = keymap.boot_keyboard_report();
     assert_eq!(expected_report, actual_report);
 }
@@ -77,7 +78,7 @@ fn toggle_tapped_twice_deactivates_layer() {
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
 
     // Assert
-    let expected_report: [u8; 8] = [0, 0, 0x04, 0, 0, 0, 0, 0];
+    let expected_report: [u8; 8] = [0, 0, KC_A, 0, 0, 0, 0, 0];
     let actual_report = keymap.boot_keyboard_report();
     assert_eq!(expected_report, actual_report);
 }

--- a/tests/rust/sticky.rs
+++ b/tests/rust/sticky.rs
@@ -3,6 +3,7 @@ mod release_on_next_press;
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 
+use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
@@ -35,8 +36,8 @@ fn tap_sticky_mod_modifies_next_keyboard_key() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0x02, 0, 0, 0, 0, 0, 0, 0],
-        [0x02, 0, 0x04, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, KC_A, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
@@ -72,8 +73,8 @@ fn tap_sticky_mod_acts_as_regular_mod_when_interrupted_by_key_slash() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0x02, 0, 0, 0, 0, 0, 0, 0],
-        [0x02, 0, 0x38, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, KC_SLASH, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
@@ -113,10 +114,10 @@ fn tap_sticky_mod_modifies_only_next_keyboard_key() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0x02, 0, 0, 0, 0, 0, 0, 0],
-        [0x02, 0, 0x04, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x38, 0, 0, 0, 0, 0],
+        [0, 0, KC_SLASH, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
@@ -157,8 +158,8 @@ fn tap_sticky_mod_acts_as_regular_mod_when_interrupted_by_key() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0x02, 0, 0x04, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, KC_A, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -198,9 +199,9 @@ fn tap_multiple_sticky_mod_modifies_next_keyboard_key() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0x02, 0, 0, 0, 0, 0, 0, 0],
-        [0x03, 0, 0, 0, 0, 0, 0, 0],
-        [0x03, 0, 0x04, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL_LSHFT, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL_LSHFT, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -244,10 +245,10 @@ fn tap_sticky_mod_modifies_next_keyboard_key_until_released() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0x02, 0, 0, 0, 0, 0, 0, 0],
-        [0x02, 0, 0x04, 0, 0, 0, 0, 0],
-        [0x02, 0, 0x04, 0x38, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, KC_A, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, KC_A, KC_SLASH, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();

--- a/tests/rust/sticky/release_on_next_press.rs
+++ b/tests/rust/sticky/release_on_next_press.rs
@@ -1,6 +1,7 @@
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 
+use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
@@ -34,8 +35,8 @@ fn tap_sticky_mod_modifies_next_keyboard_key() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0x02, 0, 0, 0, 0, 0, 0, 0],
-        [0x02, 0, 0x04, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, KC_A, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
@@ -76,10 +77,10 @@ fn tap_sticky_mod_modifies_only_next_keyboard_key() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0x02, 0, 0, 0, 0, 0, 0, 0],
-        [0x02, 0, 0x04, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x38, 0, 0, 0, 0, 0],
+        [0, 0, KC_SLASH, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
@@ -121,8 +122,8 @@ fn tap_sticky_mod_acts_as_regular_mod_when_interrupted_by_key() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0x02, 0, 0x04, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, KC_A, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -163,9 +164,9 @@ fn tap_multiple_sticky_mod_modifies_next_keyboard_key() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0x02, 0, 0, 0, 0, 0, 0, 0],
-        [0x03, 0, 0, 0, 0, 0, 0, 0],
-        [0x03, 0, 0x04, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL_LSHFT, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL_LSHFT, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -206,9 +207,9 @@ fn tap_sticky_mod_releases_on_next_key_press() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0x02, 0, 0, 0, 0, 0, 0, 0],
-        [0x02, 0, 0x04, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0x38, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, KC_A, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, KC_SLASH, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());

--- a/tests/rust/tap_dance.rs
+++ b/tests/rust/tap_dance.rs
@@ -1,6 +1,7 @@
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 
+use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
@@ -27,7 +28,7 @@ fn key_press_once_and_hold_resolves_as_first_definition() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
@@ -59,7 +60,7 @@ fn key_tap_once_resolves_as_first_definition() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -93,7 +94,7 @@ fn key_tap_once_then_press_and_hold_resolves_as_second_definition() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());

--- a/tests/rust/tap_hold.rs
+++ b/tests/rust/tap_hold.rs
@@ -7,6 +7,7 @@ mod required_idle_time;
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 
+use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
@@ -33,7 +34,7 @@ fn key_tapped() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -62,7 +63,7 @@ fn key_uninterrupted_tap_is_reported() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
@@ -112,7 +113,7 @@ fn key_unaffected_by_prev_key_release() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();

--- a/tests/rust/tap_hold/hold_on_interrupt_press.rs
+++ b/tests/rust/tap_hold/hold_on_interrupt_press.rs
@@ -1,6 +1,7 @@
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 
+use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
@@ -31,9 +32,9 @@ fn rolled_presses_resolves_hold() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0x01, 0, 0, 0, 0, 0, 0, 0],
-        [0x01, 0, 0x05, 0, 0, 0, 0, 0],
-        [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, KC_B, 0, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -66,8 +67,8 @@ fn interrupting_press_resolves_hold() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0x01, 0, 0, 0, 0, 0, 0, 0],
-        [0x01, 0, 0x05, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, KC_B, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());

--- a/tests/rust/tap_hold/hold_on_interrupt_tap.rs
+++ b/tests/rust/tap_hold/hold_on_interrupt_tap.rs
@@ -1,6 +1,7 @@
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 
+use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
@@ -31,9 +32,9 @@ fn rolled_presses_resolves_tap() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0x05, 0, 0, 0, 0],
-        [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, KC_B, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -68,9 +69,9 @@ fn interrupting_tap_resolves_hold() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0x01, 0, 0, 0, 0, 0, 0, 0],
-        [0x01, 0, 0x05, 0, 0, 0, 0, 0],
-        [0x01, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, KC_B, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
@@ -119,11 +120,11 @@ fn rolling_nested_tap_th_tap_th_tap_kbd() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0x05, 0, 0, 0, 0],
-        [0, 0, 0x04, 0x05, 0x06, 0, 0, 0],
-        [0, 0, 0x05, 0x06, 0, 0, 0, 0],
-        [0, 0, 0x06, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, KC_B, 0, 0, 0, 0],
+        [0, 0, KC_A, KC_B, KC_C, 0, 0, 0],
+        [0, 0, KC_B, KC_C, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -173,11 +174,11 @@ fn rolling_nested_tap_th_tap_th_tap_th() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0x05, 0, 0, 0, 0],
-        [0, 0, 0x04, 0x05, 0x06, 0, 0, 0],
-        [0, 0, 0x05, 0x06, 0, 0, 0, 0],
-        [0, 0, 0x06, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, KC_B, 0, 0, 0, 0],
+        [0, 0, KC_A, KC_B, KC_C, 0, 0, 0],
+        [0, 0, KC_B, KC_C, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -225,11 +226,11 @@ fn tap_th_after_rolling_th_kbd() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0x05, 0, 0, 0, 0],
-        [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, KC_B, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x06, 0, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -272,9 +273,9 @@ fn tap_th_then_tap_th() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x06, 0, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();

--- a/tests/rust/tap_hold/interrupt_ignore.rs
+++ b/tests/rust/tap_hold/interrupt_ignore.rs
@@ -1,6 +1,7 @@
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 
+use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
@@ -30,9 +31,9 @@ fn rolled_presses() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0x05, 0, 0, 0, 0],
-        [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, KC_B, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -42,9 +43,6 @@ fn rolled_presses() {
 #[test]
 fn rolled_presses_desc_keycodes() {
     // Assemble
-    const K_G: u8 = 0x0A;
-    const K_O: u8 = 0x12;
-
     let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
@@ -66,9 +64,9 @@ fn rolled_presses_desc_keycodes() {
 
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, K_O, 0, 0, 0, 0, 0],
-        [0, 0, K_O, K_G, 0, 0, 0, 0],
-        [0, 0, K_G, 0, 0, 0, 0, 0],
+        [0, 0, KC_O, 0, 0, 0, 0, 0],
+        [0, 0, KC_O, KC_G, 0, 0, 0, 0],
+        [0, 0, KC_G, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
@@ -86,13 +84,13 @@ fn rolled_presses_desc_keycodes() {
     // Assert
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, K_O, 0, 0, 0, 0, 0],
-        [0, 0, K_O, K_G, 0, 0, 0, 0],
-        [0, 0, K_G, 0, 0, 0, 0, 0],
+        [0, 0, KC_O, 0, 0, 0, 0, 0],
+        [0, 0, KC_O, KC_G, 0, 0, 0, 0],
+        [0, 0, KC_G, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, K_O, 0, 0, 0, 0, 0],
-        [0, 0, K_O, K_G, 0, 0, 0, 0],
-        [0, 0, K_G, 0, 0, 0, 0, 0],
+        [0, 0, KC_O, 0, 0, 0, 0, 0],
+        [0, 0, KC_O, KC_G, 0, 0, 0, 0],
+        [0, 0, KC_G, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());

--- a/tests/rust/tap_hold/layered.rs
+++ b/tests/rust/tap_hold/layered.rs
@@ -1,6 +1,7 @@
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 
+use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
@@ -45,7 +46,7 @@ fn press_active_layer_when_hold_layer_mod_held() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());
@@ -90,7 +91,7 @@ fn uses_base_when_pressed_after_hold_layer_mod_released() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
     assert_eq!(expected_reports, actual_reports.reports());

--- a/tests/rust/tap_hold/required_idle_time.rs
+++ b/tests/rust/tap_hold/required_idle_time.rs
@@ -1,6 +1,7 @@
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 
+use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
@@ -37,9 +38,9 @@ fn tap_hold_resolves_as_tap_when_pressed_before_required_idle_time() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -80,9 +81,9 @@ fn tap_hold_resolves_as_tap_when_tapped_after_required_idle_time() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x05, 0, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
     ];
     let actual_reports = keymap.distinct_reports();
@@ -126,7 +127,7 @@ fn tap_hold_resolves_as_hold_when_held_after_required_idle_time() {
     #[rustfmt::skip]
     let expected_reports: &[[u8; 8]] = &[
         [0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0x04, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],
         [1, 0, 0, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 0],


### PR DESCRIPTION
## Summary

Rust integration tests previously used raw hex literals like `0x04` in expected HID reports, which are hard to read without mentally mapping to key names. This change introduces shared `KC_*` and `MOD_*` constants (matching the Ceedling test header and `ncl/hid-usage-keyboard.ncl`) and uses them across the `tests/rust/` suite.

## Changes

- Add `tests/rust/hid_keycodes.rs` with keyboard usage codes and modifier bit constants.
- Replace hex literals in expected HID report assertions with named constants (e.g. `KC_A`, `MOD_LSHFT`).
- Standardize imports via `crate::hid_keycodes::*` in nested test modules.

## Out of scope

- Automation macro JSON still uses bare numeric usage codes (`Keyboard = 4`) because Nickel key refs are key objects, not raw usage values.
- Keymap indices (e.g. `press_indices = &[2, 0, 1]`) remain plain integers.
- `src/` unit tests are unchanged; same pattern could be applied in a follow-up.

## Test plan

- [x] `cargo test --test rust-integration` (123 tests passed)