### PR TITLE
ncl: OS semantic keys via named layers

### DIFF
--- a/features/keymap/key/semantic_os_desktop.feature
+++ b/features/keymap/key/semantic_os_desktop.feature
@@ -1,0 +1,175 @@
+Feature: Semantic OS Desktop Key
+
+  Semantic keys resolve to different outputs depending on which named
+  variant layer is active. `K.semantic` is Nickel sugar for a named-layer
+  `LayeredKey` (`{ named_layers = { windows = …, linux = …, macos = … } }`).
+
+  OS desktop switching is not a built-in key type: it is a named-layer
+  *group* plus exclusive `layer_mod.set_semantic_variant_to` switches.
+  The group list is the mask for `set_active_layers_amongst`; names
+  resolve to indices when the keymap is compiled.
+
+  Define a desk key once (e.g. `desk_left = K.semantic { .. }`), place it
+  on a single layer row in the layout, and pick the OS variant with the
+  switch keys. Named layers are assigned globally after any numbered
+  layers (alphabetical order among names).
+
+  Background:
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      let os = ["linux", "macos", "windows"] in
+      let os_windows = K.layer_mod.set_semantic_variant_to os "windows" in
+      let os_linux = K.layer_mod.set_semantic_variant_to os "linux" in
+      let os_macos = K.layer_mod.set_semantic_variant_to os "macos" in
+      let desk_left =
+        K.semantic {
+          windows = K.Left & K.LGUI & K.LeftCtrl,
+          linux = K.Left & K.LeftCtrl & K.LeftAlt,
+          macos = K.Left & K.LeftCtrl,
+        }
+      in
+      {
+        keys = [
+          os_windows,
+          os_linux,
+          os_macos,
+          desk_left,
+        ],
+      }
+      """
+
+  Example: desktop left sends Windows chord when Windows OS variant is active
+
+    When the keymap registers the following input
+      """
+      [
+        tap (K.layer_mod.set_semantic_variant_to ["linux", "macos", "windows"] "windows"),
+        press_keymap_index 3,
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { modifiers = { left_gui = true, left_ctrl = true }, key_codes = [K.Left] }
+      """
+
+  Example: desktop left sends Linux chord when Linux OS variant is active
+
+    When the keymap registers the following input
+      """
+      [
+        tap (K.layer_mod.set_semantic_variant_to ["linux", "macos", "windows"] "linux"),
+        press_keymap_index 3,
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { modifiers = { left_ctrl = true, left_alt = true }, key_codes = [K.Left] }
+      """
+
+  Example: desktop left sends macOS chord when macOS OS variant is active
+
+    When the keymap registers the following input
+      """
+      [
+        tap (K.layer_mod.set_semantic_variant_to ["linux", "macos", "windows"] "macos"),
+        press_keymap_index 3,
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { modifiers = { left_ctrl = true }, key_codes = [K.Left] }
+      """
+
+  Example: advanced — desk keys on Fn layer with OS switch on base layer
+
+    A small row layout: OS switches, `A` `B` `C` `D`, and `Fn`
+    (hold layer 1). `C` and `D` are normal keys on base; on Fn they are
+    semantic desk-left / desk-right. Numbered Fn layer and named OS
+    layers coexist (OS names sit after the numbered slot).
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      let os = ["linux", "macos", "windows"] in
+      let os_windows = K.layer_mod.set_semantic_variant_to os "windows" in
+      let os_linux = K.layer_mod.set_semantic_variant_to os "linux" in
+      let desk_left =
+        K.semantic {
+          windows = K.Left & K.LGUI & K.LeftCtrl,
+          linux = K.Left & K.LeftCtrl & K.LeftAlt,
+          macos = K.Left & K.LeftCtrl,
+        }
+      in
+      let desk_right =
+        K.semantic {
+          windows = K.Right & K.LGUI & K.LeftCtrl,
+          linux = K.Right & K.LeftCtrl & K.LeftAlt,
+          macos = K.Right & K.LeftCtrl,
+        }
+      in
+      {
+        layers = [
+          [
+            os_windows,
+            os_linux,
+            K.A,
+            K.B,
+            K.C,
+            K.D,
+            K.layer_mod.hold 1,
+          ],
+          [
+            K.TTTT,
+            K.TTTT,
+            K.TTTT,
+            K.TTTT,
+            desk_left,
+            desk_right,
+            K.TTTT,
+          ],
+        ],
+      }
+      """
+
+    When the keymap registers the following input
+      """
+      [
+        press_keymap_index 4,
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { key_codes = [K.C] }
+      """
+
+    When the keymap registers the following input
+      """
+      [
+        release_keymap_index 4,
+        release_keymap_index 6,
+        press (K.layer_mod.hold 1),
+        tap (K.layer_mod.set_semantic_variant_to ["linux", "macos", "windows"] "windows"),
+        press_keymap_index 4,
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { modifiers = { left_gui = true, left_ctrl = true }, key_codes = [K.Left] }
+      """
+
+    When the keymap registers the following input
+      """
+      [
+        release_keymap_index 4,
+        release_keymap_index 6,
+        press (K.layer_mod.hold 1),
+        tap (K.layer_mod.set_semantic_variant_to ["linux", "macos", "windows"] "linux"),
+        press_keymap_index 5,
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { modifiers = { left_ctrl = true, left_alt = true }, key_codes = [K.Right] }
+      """

--- a/features/scripts/generate-doc.sh
+++ b/features/scripts/generate-doc.sh
@@ -29,6 +29,7 @@ keymap_key_features=(
     "layer_modifier-set_active_layers_mask"
     "layer_modifier-sticky"
     "layer_modifier-sticky-config-timeout"
+    "semantic_os_desktop"
     "layer_modifier-toggle"
     "mouse"
     "sticky_modifiers"

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -1088,6 +1088,47 @@
             },
           ],
         },
+
+      # Same prepare path via authoring sugar (semantic + set_semantic_variant_to).
+      check_prepare_semantic_sugar =
+        let names = ["fn", "nav", "sym"] in
+        let keys = [
+          K.layer_mod.set_semantic_variant_to names "sym",
+          K.layer_mod.set_semantic_variant_to names "fn",
+          K.semantic { sym = K.A, fn = K.B, nav = K.C },
+        ]
+        in
+        {
+          actual = prepare_keys_named_layers keys |> std.array.map keymap_ncl.key.to_json_value,
+          expected = [
+            {
+              SetActiveLayers = {
+                layers = std.number.pow 2 3,
+                mask =
+                  (std.number.pow 2 1)
+                  + (std.number.pow 2 2)
+                  + (std.number.pow 2 3),
+              },
+            },
+            {
+              SetActiveLayers = {
+                layers = std.number.pow 2 1,
+                mask =
+                  (std.number.pow 2 1)
+                  + (std.number.pow 2 2)
+                  + (std.number.pow 2 3),
+              },
+            },
+            {
+              base = { key_code = 0 },
+              layered = [
+                { key_code = 5 },
+                { key_code = 6 },
+                { key_code = 4 },
+              ],
+            },
+          ],
+        },
     },
 
   chorded_keys

--- a/ncl/smart_keys/layered/key-extensions.ncl
+++ b/ncl/smart_keys/layered/key-extensions.ncl
@@ -28,9 +28,24 @@
             affected_layers = affected_layers_,
           },
         },
+      # Exclusive switch within a named-layer group.
+      # `variant_names` is the mask (all members); `variant_name` is the one to activate.
+      # Names resolve to indices when the keymap is compiled to JSON.
+      set_semantic_variant_to = fun variant_names variant_name =>
+        {
+          layer_modifier = {
+            set_active_layers_to = [variant_name],
+            affected_layers = variant_names,
+          },
+        },
     },
 
     # Layer Transparency
     TTTT = null,
+
+    # Semantic / variant key sugar: `named_layers` form of LayeredKey.
+    # Unit `{}` base (keyboard noop) so callers can use `K.semantic {..}` without
+    # `K.NO &`. Indices for names are assigned globally when compiling the keymap.
+    semantic = fun variants => { named_layers = variants },
   },
 }

--- a/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
@@ -72,6 +72,22 @@
             affected_layers = ["fn", "nav"],
           }
         ),
+
+      # set_semantic_variant_to: sugar over set_active_layers_amongst for exclusive groups.
+      check_set_semantic_variant_to = {
+        actual = K.layer_mod.set_semantic_variant_to ["fn", "nav", "sym"] "nav",
+        expected = {
+          layer_modifier = {
+            set_active_layers_to = ["nav"],
+            affected_layers = ["fn", "nav", "sym"],
+          },
+        },
+      },
+
+      check_set_semantic_variant_to_is_key =
+        keymap_ncl.layer_modifier.is_key (
+          K.layer_mod.set_semantic_variant_to ["fn", "nav", "sym"] "nav"
+        ),
     },
 
   # Layer index: numeric (1-based) or named-layer string (resolved before to_json_value).
@@ -222,6 +238,23 @@
       check_layered_and_named_layers_is_key =
         let key = K.A & { layered = [ null, K.B], named_layers = { fn = K.C } } in
         keymap_ncl.layered.is_key key,
+
+      # K.semantic is thin sugar over named_layers (unit {} base).
+      check_semantic_is_named_layered =
+        let key = K.semantic { fn = K.A, nav = K.B, sym = K.C } in
+        keymap_ncl.layered.is_key key
+        && std.record.has_field "named_layers" key,
+
+      check_semantic_authoring_form = {
+        actual = K.semantic { fn = K.A, nav = K.B, sym = K.C },
+        expected = {
+          named_layers = {
+            fn = { key_code = 4 },
+            nav = { key_code = 5 },
+            sym = { key_code = 6 },
+          },
+        },
+      },
 
       # Pure layered form (unit {} base) serializes with key_code 0 base.
       check_pure_layered_unit_base = {


### PR DESCRIPTION
## Summary

Reimplements the OS desktop / semantic key sugar from the earlier draft **on top of named layers** (#594), instead of hard-coded layer indices 3/4/5.

No new Rust `key::*` types. Everything lowers to existing `LayeredKey` + masked `SetActiveLayers`.

## Nickel API

| Helper | Purpose |
|--------|---------|
| `K.semantic { windows = …, linux = …, macos = … }` | Named-layer `LayeredKey` (`{ layered = variants }`) |
| `K.os_windows` / `K.os_linux` / `K.os_macos` | Masked variant switch keys using **layer names** |
| `K.layer_mod.set_semantic_variant_to` | Generic named-variant switch for any name group |
| `K.os_desktop_layers` | `["linux", "macos", "windows"]` (alpha order) |

Layer names in `layer_mod` / OS switches are resolved to 1-based indices when compiling the keymap (after numbered layers, alphabetical named order).

Example:

```nickel
let desktop_left =
  K.semantic {
    windows = K.Left & K.LGUI & K.LeftCtrl,
    linux   = K.Left & K.LeftCtrl & K.LeftAlt,
    macos   = K.Left & K.LeftCtrl,
  }
in
{
  keys = [ K.os_windows, K.os_linux, K.os_macos, desktop_left ],
}
```

## Stack

Depends on #594 (named layers). Base branch: `ncl-named-layers`.

## Also in this PR

- `prepare_keys_named_layers`: lower named records + resolve string layer indices in `layer_mod`
- `inputs-to-json`: use prepared keys for lookup / layer state; fix `ReleaseKeymapIndex` emitting `Press`
- Cucumber: `features/keymap/key/semantic_os_desktop.feature`

## How to verify

```bash
ncl/scripts/run-ncl-checks.sh
cargo test -p smart-keymap --test cucumber-keymap -- -i '**/semantic_os_desktop.feature'
```