### PR TITLE
ci: align pre-commit clippy excludes with CI

### DIFF
--- a/nix/git-hooks.nix
+++ b/nix/git-hooks.nix
@@ -18,7 +18,7 @@ in
     clippy = {
       enable = true;
       # Match .github/workflows/rust.yaml cargo-fmt-clippy job.
-      entry = "cargo clippy --workspace --all-targets -- -D warnings";
+      entry = "cargo clippy --workspace --exclude rp2040-rtic-smart-keyboard --exclude stm32f4-rtic-smart-keyboard --exclude stm32-embassy-smart-keyboard -- -D warnings";
       files = "\\.rs$";
       pass_filenames = false;
     };


### PR DESCRIPTION
## Summary

Aligns the pre-commit clippy hook with the `cargo-fmt-clippy` CI job by excluding firmware workspace crates that enable conflicting critical-section features.

## Motivation

PR #571 bundled this with the `InputEventQueue` refactor, but it is an independent CI/pre-commit concern and is easier to review and merge on its own.

Master already runs firmware `cargo check` and `-D warnings` in pre-commit (`1bb486c3`); this change completes parity by matching CI's crate exclusions.

## Changes

- Update `nix/git-hooks.nix` clippy `entry` to exclude `rp2040-rtic-smart-keyboard`, `stm32f4-rtic-smart-keyboard`, and `stm32-embassy-smart-keyboard`.

## Testing

- [x] Hook config matches `.github/workflows/rust.yaml` `cargo-fmt-clippy` job