### PR TITLE
rust: unwrap discipline phase 2 (key + split)

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -57,17 +57,19 @@ impl<E: Copy + Debug> KeyEvents<E> {
 
     /// Adds an event with the schedule to the [KeyEvents].
     pub fn schedule_event(&mut self, delay: u16, event: Event<E>) {
-        self.0.push(ScheduledEvent::after(delay, event)).unwrap();
+        let _ = self.0.push(ScheduledEvent::after(delay, event));
     }
 
     /// Adds events from the other [KeyEvents] to the [KeyEvents].
     pub fn extend(&mut self, other: KeyEvents<E>) {
-        other.0.into_iter().for_each(|ev| self.0.push(ev).unwrap());
+        other.0.into_iter().for_each(|ev| {
+            let _ = self.0.push(ev);
+        });
     }
 
     /// Adds an event from to the [KeyEvents].
     pub fn add_event(&mut self, ev: ScheduledEvent<E>) {
-        self.0.push(ev).unwrap();
+        let _ = self.0.push(ev);
     }
 
     /// Maps over the KeyEvents.
@@ -387,28 +389,28 @@ impl KeyboardModifiers {
         let mut key_codes = heapless::Vec::new();
 
         if self.0 & Self::LEFT_CTRL_U8 != 0 {
-            key_codes.push(0xE0).unwrap();
+            let _ = key_codes.push(0xE0);
         }
         if self.0 & Self::LEFT_SHIFT_U8 != 0 {
-            key_codes.push(0xE1).unwrap();
+            let _ = key_codes.push(0xE1);
         }
         if self.0 & Self::LEFT_ALT_U8 != 0 {
-            key_codes.push(0xE2).unwrap();
+            let _ = key_codes.push(0xE2);
         }
         if self.0 & Self::LEFT_GUI_U8 != 0 {
-            key_codes.push(0xE3).unwrap();
+            let _ = key_codes.push(0xE3);
         }
         if self.0 & Self::RIGHT_CTRL_U8 != 0 {
-            key_codes.push(0xE4).unwrap();
+            let _ = key_codes.push(0xE4);
         }
         if self.0 & Self::RIGHT_SHIFT_U8 != 0 {
-            key_codes.push(0xE5).unwrap();
+            let _ = key_codes.push(0xE5);
         }
         if self.0 & Self::RIGHT_ALT_U8 != 0 {
-            key_codes.push(0xE6).unwrap();
+            let _ = key_codes.push(0xE6);
         }
         if self.0 & Self::RIGHT_GUI_U8 != 0 {
-            key_codes.push(0xE7).unwrap();
+            let _ = key_codes.push(0xE7);
         }
 
         key_codes

--- a/src/key/chorded.rs
+++ b/src/key/chorded.rs
@@ -284,7 +284,7 @@ impl<const MAX_CHORDS: usize, const MAX_CHORD_SIZE: usize, const MAX_PRESSED_IND
         pressed_chords.for_each(|&chord| {
             for &i in chord.as_slice() {
                 if let Err(pos) = res.binary_search(&i) {
-                    res.insert(pos, i).unwrap();
+                    let _ = res.insert(pos, i);
                 }
             }
         });
@@ -302,7 +302,11 @@ impl<const MAX_CHORDS: usize, const MAX_CHORD_SIZE: usize, const MAX_PRESSED_IND
         keymap_index: u16,
     ) -> heapless::Vec<ChordState<MAX_CHORD_SIZE>, { MAX_CHORDS }> {
         match self.pressed_chord_with_index(keymap_index) {
-            Some(chord_state) => heapless::Vec::from_slice(&[chord_state]).unwrap(),
+            Some(chord_state) => {
+                let mut chords = heapless::Vec::new();
+                let _ = chords.push(chord_state);
+                chords
+            }
             None => {
                 let chords_indices_span = self.pressed_chords_indices_span();
                 self.config
@@ -779,7 +783,8 @@ impl<const MAX_CHORDS: usize, const MAX_CHORD_SIZE: usize, const MAX_PRESSED_IND
         context: &Context<MAX_CHORDS, MAX_CHORD_SIZE, MAX_PRESSED_INDICES>,
         keymap_index: u16,
     ) -> Self {
-        let pressed_indices = heapless::Vec::from_slice(&[keymap_index]).unwrap();
+        let mut pressed_indices = heapless::Vec::new();
+        let _ = pressed_indices.push(keymap_index);
         let possible_chords = context.chords_for_keymap_index(keymap_index);
 
         Self {
@@ -1079,6 +1084,7 @@ impl<
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -749,6 +749,7 @@ impl<
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/key/tap_dance.rs
+++ b/src/key/tap_dance.rs
@@ -244,23 +244,27 @@ impl<
         let (maybe_resolution, pke) = pending_state.handle_event(context, keymap_index, event);
 
         if let Some(TapDanceResolution(idx)) = maybe_resolution {
-            let new_key_ref = key.definitions[idx as usize].unwrap();
-
-            (
-                Some(key::NewPressedKey::key(new_key_ref)),
-                pke.into_events(),
-            )
+            if let Some(new_key_ref) = key.definitions[idx as usize] {
+                (
+                    Some(key::NewPressedKey::key(new_key_ref)),
+                    pke.into_events(),
+                )
+            } else {
+                (None, pke.into_events())
+            }
         } else {
             // check pending_state press_count against key definitions
             let definition_count = key.definitions.iter().filter(|o| o.is_some()).count();
             if pending_state.press_count as usize >= definition_count - 1 {
                 let idx = definition_count - 1;
-                let new_key_ref = key.definitions[idx].unwrap();
-
-                (
-                    Some(key::NewPressedKey::key(new_key_ref)),
-                    pke.into_events(),
-                )
+                if let Some(new_key_ref) = key.definitions[idx] {
+                    (
+                        Some(key::NewPressedKey::key(new_key_ref)),
+                        pke.into_events(),
+                    )
+                } else {
+                    (None, pke.into_events())
+                }
             } else {
                 (None, pke.into_events())
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,13 +52,11 @@ pub mod input;
 /// The core interface for the smart keymap library is [key::System],
 ///  and its associated [key::Context], `PendingKeyState`, and [key::KeyState] types.
 /// Together, these are used to define smart key behaviour.
-#[allow(clippy::unwrap_used)]
 pub mod key;
 /// Keymap implementation.
 pub mod keymap;
 
 /// Split keyboard support.
-#[allow(clippy::unwrap_used)]
 pub mod split;
 
 /// A helper value type for Copy-able slices.

--- a/src/split.rs
+++ b/src/split.rs
@@ -22,7 +22,7 @@ impl Message {
     /// Serialize the message into a bytes.
     pub fn serialize(&self) -> [u8; BUFFER_SIZE] {
         let mut buf = [0u8; BUFFER_SIZE];
-        postcard::to_slice_cobs(self, &mut buf).unwrap();
+        let _ = postcard::to_slice_cobs(self, &mut buf);
         buf
     }
 
@@ -43,6 +43,7 @@ pub fn receive_byte(buf: &mut [u8; BUFFER_SIZE], byte: u8) -> postcard::Result<M
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
## Summary

Extends unwrap discipline from earlier efforts (#576, keymap/input-queue/scheduler) to the remaining core library modules: `key` and `split`.

## Policy (unchanged)

| Failure kind | Policy |
|--------------|--------|
| Runtime collection full | Drop/ignore — never panic on firmware path |
| Tests | `unwrap` allowed in `#[cfg(test)]` modules |

## Changes

- Remove `#[allow(clippy::unwrap_used)]` from `key` and `split` in `src/lib.rs`
- **`key.rs`**: `KeyEvents` bounded pushes and `KeyboardModifiers::as_key_codes` use drop-on-full
- **`chorded.rs`**: `insert` / initial `pressed_indices` / single-chord vec use push-or-ignore
- **`tap_dance.rs`**: missing tap-dance definition resolves to no-op instead of `unwrap`
- **`split.rs`**: `Message::serialize` ignores postcard encode failure
- Test-module allows on `chorded`, `layered`, `split` tests

## Testing

- [x] `cargo clippy -p smart-keymap -- -D warnings`
- [x] `cargo test -p smart-keymap --lib`