### PR TITLE
firmware: unwrap discipline

### DIFF
--- a/keyberon-smart-keyboard/src/input.rs
+++ b/keyberon-smart-keyboard/src/input.rs
@@ -34,7 +34,9 @@ impl<const COLS: usize, const ROWS: usize, M: MatrixScanner<COLS, ROWS>> Keyboar
 
     /// Scans the matrix and returns the debounced events.
     pub fn events(&mut self) -> heapless::Vec<Event, 8> {
-        let key_presses = self.matrix.get().unwrap();
-        self.debouncer.events(key_presses).collect()
+        match self.matrix.get() {
+            Ok(key_presses) => self.debouncer.events(key_presses).collect(),
+            Err(_) => heapless::Vec::new(),
+        }
     }
 }

--- a/keyberon-smart-keyboard/src/lib.rs
+++ b/keyberon-smart-keyboard/src/lib.rs
@@ -94,6 +94,7 @@
 
 #![no_main]
 #![no_std]
+#![warn(clippy::unwrap_used)]
 
 /// Useful traits and structs related to input.
 pub mod input;

--- a/keyberon-smart-keyboard/src/matrix.rs
+++ b/keyberon-smart-keyboard/src/matrix.rs
@@ -15,11 +15,11 @@ impl<P, const CS: usize, const RS: usize, E: Debug> DirectPinMatrix<P, CS, RS>
 where
     P: InputPin<Error = E>,
 {
-    pub fn new(pins: [[Option<P>; CS]; RS]) -> Self
+    pub fn new(pins: [[Option<P>; CS]; RS]) -> Result<Self, E>
     where
         P: InputPin<Error = E>,
     {
-        Self(keyberon::matrix::DirectPinMatrix::new(pins).unwrap())
+        keyberon::matrix::DirectPinMatrix::new(pins).map(Self)
     }
 }
 
@@ -29,7 +29,7 @@ where
     P: InputPin<Error = core::convert::Infallible>,
 {
     fn is_boot_key_pressed(&mut self) -> bool {
-        self.0.get().unwrap()[0][0]
+        self.0.get().ok().is_some_and(|keys| keys[0][0])
     }
 
     fn get(&mut self) -> Result<[[bool; CS]; RS], core::convert::Infallible> {
@@ -112,12 +112,14 @@ where
     D: DelayNs,
 {
     fn is_boot_key_pressed(&mut self) -> bool {
-        self.rows[0].set_low().unwrap();
+        let Ok(()) = self.rows[0].set_low() else {
+            return false;
+        };
         self.delay.delay_us(self.select_delay_us);
 
-        let is_pressed = self.cols[0].is_low().unwrap();
+        let is_pressed = self.cols[0].is_low().unwrap_or(false);
 
-        self.rows[0].set_high().unwrap();
+        let _ = self.rows[0].set_high();
         self.delay.delay_us(self.unselect_delay_us);
 
         is_pressed

--- a/rp2040-rtic-smart-keyboard/examples/pico42.rs
+++ b/rp2040-rtic-smart-keyboard/examples/pico42.rs
@@ -164,14 +164,16 @@ mod app {
             app_init::init_timer(ctx.device.TIMER, &mut ctx.device.RESETS, &clocks);
 
         // Set up the USB driver
-        *ctx.local.usb_bus = Some(UsbBusAllocator::new(hal::usb::UsbBus::new(
-            ctx.device.USBCTRL_REGS,
-            ctx.device.USBCTRL_DPRAM,
-            clocks.usb_clock,
-            true,
-            &mut ctx.device.RESETS,
-        )));
-        let usb_bus = ctx.local.usb_bus.as_ref().unwrap();
+        let usb_bus = ctx
+            .local
+            .usb_bus
+            .insert(UsbBusAllocator::new(hal::usb::UsbBus::new(
+                ctx.device.USBCTRL_REGS,
+                ctx.device.USBCTRL_DPRAM,
+                clocks.usb_clock,
+                true,
+                &mut ctx.device.RESETS,
+            )));
 
         let (usb_dev, usb_serial, usb_class) = app_init::init_usb_device(
             usb_bus,
@@ -194,7 +196,9 @@ mod app {
             &mut ctx.device.RESETS,
         );
         board::rows_and_cols!(gpio_pins, cols, rows);
-        let mut matrix = DelayedMatrix::new(cols, rows, timer, 5, 5).unwrap();
+        let Ok(mut matrix) = DelayedMatrix::new(cols, rows, timer, 5, 5) else {
+            panic!("matrix init failed");
+        };
 
         // Check if bootloader pressed
         if matrix.is_boot_key_pressed() {
@@ -247,7 +251,7 @@ mod app {
         } = c.local;
 
         alarm.clear_interrupt();
-        alarm.schedule(1.millis()).unwrap();
+        let _ = alarm.schedule(1.millis());
 
         for event in keyboard.events() {
             if let Some(event) = keymap_index_of(&KEYMAP_INDICES, event) {

--- a/rp2040-rtic-smart-keyboard/src/app_init.rs
+++ b/rp2040-rtic-smart-keyboard/src/app_init.rs
@@ -31,7 +31,7 @@ pub fn init_clocks(
     resets: &mut pac::RESETS,
 ) -> (hal::Watchdog, ClocksManager) {
     let mut watchdog = hal::Watchdog::new(watchdog);
-    let clocks = hal::clocks::init_clocks_and_plls(
+    let Some(clocks) = hal::clocks::init_clocks_and_plls(
         XOSC_CRYSTAL_FREQ,
         xosc,
         clocks,
@@ -40,8 +40,9 @@ pub fn init_clocks(
         resets,
         &mut watchdog,
     )
-    .ok()
-    .unwrap();
+    .ok() else {
+        panic!("clock init failed");
+    };
     (watchdog, clocks)
 }
 
@@ -52,9 +53,11 @@ pub fn init_timer(
     clocks: &ClocksManager,
 ) -> (timer::Timer, timer::Alarm0) {
     let mut timer = timer::Timer::new(pac_timer, resets, clocks);
-    let mut alarm = timer.alarm_0().unwrap();
+    let Some(mut alarm) = timer.alarm_0() else {
+        panic!("timer alarm init failed");
+    };
     alarm.enable_interrupt();
-    alarm.schedule(1.millis()).unwrap();
+    let _ = alarm.schedule(1.millis());
     (timer, alarm)
 }
 
@@ -76,13 +79,16 @@ pub fn init_usb_device(
 
     let serial = SerialPort::new(usb_bus);
 
-    let usb_dev = UsbDeviceBuilder::new(usb_bus, UsbVidPid(vid, pid))
+    let Some(usb_dev_builder) = UsbDeviceBuilder::new(usb_bus, UsbVidPid(vid, pid))
         .strings(&[StringDescriptors::new(LangID::EN_US)
             .manufacturer(mfr)
             .product(product)
             .serial_number(env!("CARGO_PKG_VERSION"))])
-        .unwrap()
-        .build();
+        .ok()
+    else {
+        panic!("usb descriptor init failed");
+    };
+    let usb_dev = usb_dev_builder.build();
 
     (usb_dev, serial, usb_class)
 }

--- a/rp2040-rtic-smart-keyboard/src/lib.rs
+++ b/rp2040-rtic-smart-keyboard/src/lib.rs
@@ -8,6 +8,7 @@
 
 #![no_main]
 #![no_std]
+#![warn(clippy::unwrap_used)]
 
 /// Items related to app initialization.
 pub mod app_init;

--- a/rp2040-rtic-smart-keyboard/src/main.rs
+++ b/rp2040-rtic-smart-keyboard/src/main.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+#![warn(clippy::unwrap_used)]
 
 #[cfg(not(custom_board))]
 mod board {
@@ -115,14 +116,16 @@ mod app {
             app_init::init_timer(ctx.device.TIMER, &mut ctx.device.RESETS, &clocks);
 
         // Set up the USB driver
-        *ctx.local.usb_bus = Some(UsbBusAllocator::new(hal::usb::UsbBus::new(
-            ctx.device.USBCTRL_REGS,
-            ctx.device.USBCTRL_DPRAM,
-            clocks.usb_clock,
-            true,
-            &mut ctx.device.RESETS,
-        )));
-        let usb_bus = ctx.local.usb_bus.as_ref().unwrap();
+        let usb_bus = ctx
+            .local
+            .usb_bus
+            .insert(UsbBusAllocator::new(hal::usb::UsbBus::new(
+                ctx.device.USBCTRL_REGS,
+                ctx.device.USBCTRL_DPRAM,
+                clocks.usb_clock,
+                true,
+                &mut ctx.device.RESETS,
+            )));
 
         let (usb_dev, usb_serial, usb_class) = app_init::init_usb_device(
             usb_bus,
@@ -145,7 +148,9 @@ mod app {
             &mut ctx.device.RESETS,
         );
         board::rows_and_cols!(gpio_pins, cols, rows);
-        let mut matrix = DelayedMatrix::new(cols, rows, timer, 5, 5).unwrap();
+        let Ok(mut matrix) = DelayedMatrix::new(cols, rows, timer, 5, 5) else {
+            panic!("matrix init failed");
+        };
 
         // Check if bootloader pressed
         if matrix.is_boot_key_pressed() {
@@ -210,7 +215,7 @@ mod app {
         } = c.local;
 
         alarm.clear_interrupt();
-        alarm.schedule(1.millis()).unwrap();
+        let _ = alarm.schedule(1.millis());
 
         for event in keyboard.events() {
             if let Some(event) = keymap_index_of(&KEYMAP_INDICES, event) {
@@ -248,7 +253,7 @@ mod app {
                         .take(4)
                         .collect::<heapless::Vec<_, 4>>()
                         .into_array()
-                        .unwrap(),
+                        .unwrap_or([Consumer::Unassigned; 4]),
                 }
             };
             if consumer_report != *previous_consumer {

--- a/stm32-embassy-smart-keyboard/examples/minif4_36-rev2021_5-lhs.rs
+++ b/stm32-embassy-smart-keyboard/examples/minif4_36-rev2021_5-lhs.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+#![warn(clippy::unwrap_used)]
 
 use embassy_executor::Spawner;
 use embassy_futures::join::join;
@@ -304,7 +305,7 @@ async fn main(spawner: Spawner) {
         BACKEND_CHANNEL.sender();
 
     let config = usart::Config::default();
-    let uart = Uart::new_half_duplex(
+    let Ok(uart) = Uart::new_half_duplex(
         p.USART1,
         p.PB6,
         Irqs,
@@ -313,8 +314,9 @@ async fn main(spawner: Spawner) {
         config,
         HalfDuplexReadback::NoReadback,
         HalfDuplexConfig::OpenDrainExternal,
-    )
-    .unwrap();
+    ) else {
+        panic!("uart init failed");
+    };
 
     let out_fut = async {
         let mut rh_kbd = MyRequestHandler {};
@@ -330,15 +332,9 @@ async fn main(spawner: Spawner) {
         .await;
     };
 
-    spawner
-        .spawn(keyboard_backend(writer_kbd, writer_mouse, writer_consumer))
-        .unwrap();
-    spawner
-        .spawn(keyboard_matrix_scan(matrix_scan_sender, keyboard))
-        .unwrap();
-    spawner
-        .spawn(keyboard_split_rx(matrix_scan_sender, uart))
-        .unwrap();
+    let _ = spawner.spawn(keyboard_backend(writer_kbd, writer_mouse, writer_consumer));
+    let _ = spawner.spawn(keyboard_matrix_scan(matrix_scan_sender, keyboard));
+    let _ = spawner.spawn(keyboard_split_rx(matrix_scan_sender, uart));
 
     join(usb_fut, out_fut).await;
 }

--- a/stm32-embassy-smart-keyboard/examples/minif4_36-rev2021_5-rhs.rs
+++ b/stm32-embassy-smart-keyboard/examples/minif4_36-rev2021_5-rhs.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+#![warn(clippy::unwrap_used)]
 
 use embassy_executor::Spawner;
 use embassy_stm32::time::Hertz;
@@ -202,7 +203,7 @@ async fn main(_spawner: Spawner) {
     }
 
     let config = usart::Config::default();
-    let usart = Uart::new_half_duplex(
+    let Ok(usart) = Uart::new_half_duplex(
         p.USART1,
         p.PB6,
         Irqs,
@@ -211,8 +212,9 @@ async fn main(_spawner: Spawner) {
         config,
         HalfDuplexReadback::NoReadback,
         HalfDuplexConfig::OpenDrainExternal,
-    )
-    .unwrap();
+    ) else {
+        panic!("uart init failed");
+    };
     let (mut tx, _) = usart.split();
 
     loop {
@@ -222,8 +224,8 @@ async fn main(_spawner: Spawner) {
             if let Some(input_event) = keymap_index_of(&KEYMAP_INDICES, event) {
                 let message = Message { input_event };
                 let buf = message.serialize();
-                tx.write(&buf).await.unwrap();
-                tx.flush().await.unwrap();
+                let _ = tx.write(&buf).await;
+                let _ = tx.flush().await;
             }
         }
     }

--- a/stm32-embassy-smart-keyboard/src/main.rs
+++ b/stm32-embassy-smart-keyboard/src/main.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+#![warn(clippy::unwrap_used)]
 
 use core::sync::atomic::{AtomicBool, Ordering};
 

--- a/stm32f4-rtic-smart-keyboard/examples/minif4_36-rev2021_4-lhs.rs
+++ b/stm32f4-rtic-smart-keyboard/examples/minif4_36-rev2021_4-lhs.rs
@@ -139,8 +139,10 @@ mod app {
             (gpioa.pa11, gpioa.pa12),
             &clocks,
         );
-        *c.local.usb_bus = Some(UsbBusType::new(usb, c.local.ep_memory));
-        let usb_bus = c.local.usb_bus.as_ref().unwrap();
+        let usb_bus = c
+            .local
+            .usb_bus
+            .insert(UsbBusType::new(usb, c.local.ep_memory));
 
         let (usb_dev, usb_class) = app_init::init_usb_device(
             usb_bus,
@@ -188,7 +190,7 @@ mod app {
     fn rx(c: rx::Context) {
         let rx::LocalResources { split_conn_rx } = c.local;
         if let Some(event) = split_conn_rx.read() {
-            layout::spawn(BackendMessage::Event(event)).unwrap();
+            let _ = layout::spawn(BackendMessage::Event(event));
         }
     }
 
@@ -252,7 +254,7 @@ mod app {
                                 .take(4)
                                 .collect::<heapless::Vec<_, 4>>()
                                 .into_array()
-                                .unwrap(),
+                                .unwrap_or([Consumer::Unassigned; 4]),
                         }
                     };
                     if consumer_report != *previous_consumer {
@@ -299,10 +301,10 @@ mod app {
         for event in keyboard.events() {
             if let Some(event) = keymap_index_of(&KEYMAP_INDICES, event) {
                 split_conn_tx.write(event);
-                layout::spawn(BackendMessage::Event(event)).unwrap();
+                let _ = layout::spawn(BackendMessage::Event(event));
             }
         }
 
-        layout::spawn(BackendMessage::Tick).unwrap();
+        let _ = layout::spawn(BackendMessage::Tick);
     }
 }

--- a/stm32f4-rtic-smart-keyboard/examples/minif4_36-rev2021_4-rhs.rs
+++ b/stm32f4-rtic-smart-keyboard/examples/minif4_36-rev2021_4-rhs.rs
@@ -139,8 +139,10 @@ mod app {
             (gpioa.pa11, gpioa.pa12),
             &clocks,
         );
-        *c.local.usb_bus = Some(UsbBusType::new(usb, c.local.ep_memory));
-        let usb_bus = c.local.usb_bus.as_ref().unwrap();
+        let usb_bus = c
+            .local
+            .usb_bus
+            .insert(UsbBusType::new(usb, c.local.ep_memory));
 
         let (usb_dev, usb_class) = app_init::init_usb_device(
             usb_bus,
@@ -188,7 +190,7 @@ mod app {
     fn rx(c: rx::Context) {
         let rx::LocalResources { split_conn_rx } = c.local;
         if let Some(event) = split_conn_rx.read() {
-            layout::spawn(BackendMessage::Event(event)).unwrap();
+            let _ = layout::spawn(BackendMessage::Event(event));
         }
     }
 
@@ -252,7 +254,7 @@ mod app {
                                 .take(4)
                                 .collect::<heapless::Vec<_, 4>>()
                                 .into_array()
-                                .unwrap(),
+                                .unwrap_or([Consumer::Unassigned; 4]),
                         }
                     };
                     if consumer_report != *previous_consumer {
@@ -299,10 +301,10 @@ mod app {
         for event in keyboard.events() {
             if let Some(event) = keymap_index_of(&KEYMAP_INDICES, event) {
                 split_conn_tx.write(event);
-                layout::spawn(BackendMessage::Event(event)).unwrap();
+                let _ = layout::spawn(BackendMessage::Event(event));
             }
         }
 
-        layout::spawn(BackendMessage::Tick).unwrap();
+        let _ = layout::spawn(BackendMessage::Tick);
     }
 }

--- a/stm32f4-rtic-smart-keyboard/src/app_init.rs
+++ b/stm32f4-rtic-smart-keyboard/src/app_init.rs
@@ -37,20 +37,23 @@ pub fn init_usb_device(
         .add_device(usbd_human_interface_device::device::mouse::WheelMouseConfig::default())
         .build(usb_bus);
 
-    let usb_dev = UsbDeviceBuilder::new(usb_bus, UsbVidPid(vid, pid))
+    let Some(usb_dev_builder) = UsbDeviceBuilder::new(usb_bus, UsbVidPid(vid, pid))
         .strings(&[StringDescriptors::new(LangID::EN_US)
             .manufacturer(mfr)
             .product(product)
             .serial_number(env!("CARGO_PKG_VERSION"))])
-        .unwrap()
-        .build();
+        .ok()
+    else {
+        panic!("usb descriptor init failed");
+    };
+    let usb_dev = usb_dev_builder.build();
 
     (usb_dev, usb_class)
 }
 
 pub fn init_timer(clocks: &Clocks, tim3: TIM3) -> CounterUs<TIM3> {
     let mut timer = tim3.counter_us(clocks);
-    timer.start(1.millis()).unwrap();
+    let _ = timer.start(1.millis());
     timer.listen(Event::Update);
     timer
 }

--- a/stm32f4-rtic-smart-keyboard/src/lib.rs
+++ b/stm32f4-rtic-smart-keyboard/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_main]
 #![no_std]
+#![warn(clippy::unwrap_used)]
 
 pub mod app_init;
 

--- a/stm32f4-rtic-smart-keyboard/src/main.rs
+++ b/stm32f4-rtic-smart-keyboard/src/main.rs
@@ -1,5 +1,6 @@
 #![no_main]
 #![no_std]
+#![warn(clippy::unwrap_used)]
 
 #[cfg(not(custom_board))]
 mod board {
@@ -116,8 +117,10 @@ mod app {
             (gpioa.pa11, gpioa.pa12),
             &clocks,
         );
-        *c.local.usb_bus = Some(UsbBusType::new(usb, c.local.ep_memory));
-        let usb_bus = c.local.usb_bus.as_ref().unwrap();
+        let usb_bus = c
+            .local
+            .usb_bus
+            .insert(UsbBusType::new(usb, c.local.ep_memory));
 
         let (usb_dev, usb_class) = app_init::init_usb_device(
             usb_bus,
@@ -212,7 +215,7 @@ mod app {
                         .take(4)
                         .collect::<heapless::Vec<_, 4>>()
                         .into_array()
-                        .unwrap(),
+                        .unwrap_or([Consumer::Unassigned; 4]),
                 }
             };
             if consumer_report != *previous_consumer {

--- a/stm32f4-rtic-smart-keyboard/src/split/app_init.rs
+++ b/stm32f4-rtic-smart-keyboard/src/split/app_init.rs
@@ -21,13 +21,14 @@ pub fn init_serial(
     buf: &'static mut [u8; BUFFER_SIZE],
 ) -> (TransportWriter, TransportReader) {
     let pins = (pb6.into_alternate(), pb7.into_alternate());
-    let mut serial = Serial::new(
+    let Ok(mut serial) = Serial::new(
         usart1,
         pins,
         Config::default().baudrate(9_600.bps()),
         clocks,
-    )
-    .unwrap();
+    ) else {
+        panic!("serial init failed");
+    };
     serial.listen(Event::RxNotEmpty);
 
     let (tx, rx) = serial.split();

--- a/stm32f4-rtic-smart-keyboard/src/split/transport.rs
+++ b/stm32f4-rtic-smart-keyboard/src/split/transport.rs
@@ -35,8 +35,8 @@ impl TransportWriter {
     pub fn write(&mut self, input_event: Event) {
         let message = Message { input_event };
         for b in message.serialize() {
-            block!(self.tx.write(b)).unwrap();
+            let _ = block!(self.tx.write(b));
         }
-        block!(self.tx.flush()).unwrap();
+        let _ = block!(self.tx.flush());
     }
 }


### PR DESCRIPTION
Follow-up to #579 — applies the same unwrap discipline to Rust firmware crates.

## Commits (one per crate)

1. `keyberon-smart-keyboard` — matrix scan errors return empty events; boot-key and `DirectPinMatrix` init avoid panicking on IO failure
2. `rp2040-rtic-smart-keyboard` — init failures panic explicitly; runtime alarm reschedule and consumer report assembly ignore errors
3. `stm32f4-rtic-smart-keyboard` — init failures panic explicitly; runtime USB/timer/serial paths and RTIC spawn drop on error
4. `stm32-embassy-smart-keyboard` — UART init failures panic explicitly; runtime split TX and task spawn ignore errors

## Policy

- `#![warn(clippy::unwrap_used)]` on each firmware crate
- Runtime collection/IO full or transient failure → drop/ignore
- Unrecoverable init failure → explicit `panic!` (not bare `unwrap`)

C firmware (`ch32x035-*`, `ch58x-*`) is out of scope.