### PR TITLE
fix firmware builds after keyberon matrix API change

### DIFF
--- a/.github/workflows/rust-stm32f4.yaml
+++ b/.github/workflows/rust-stm32f4.yaml
@@ -9,25 +9,31 @@ on:
       - master
     paths:
       - '.cargo/config.toml'
+      - '.github/workflows/rust-stm32f4.yaml'
       - 'Cargo.*'
       - 'ld/stm32f4xx-tinyuf2/*'
       - 'ncl/**/*.ncl'
-      - 'stm32f4-rtic-smart-keyboard/**'
+      - 'keyberon-smart-keyboard/**'
+      - 'rp2040-rtic-smart-keyboard/**'
       - 'src/**/*.rs'
       - 'smart-keymap-nickel-helper/**'
-      - 'keyberon-smart-keyboard/**'
+      - 'stm32-embassy-smart-keyboard/**'
+      - 'stm32f4-rtic-smart-keyboard/**'
   pull_request:
     branches:
       - '*'
     paths:
       - '.cargo/config.toml'
+      - '.github/workflows/rust-stm32f4.yaml'
       - 'Cargo.*'
       - 'ld/stm32f4xx-tinyuf2/*'
       - 'ncl/**/*.ncl'
-      - 'stm32f4-rtic-smart-keyboard/**'
+      - 'keyberon-smart-keyboard/**'
+      - 'rp2040-rtic-smart-keyboard/**'
       - 'src/**/*.rs'
       - 'smart-keymap-nickel-helper/**'
-      - 'keyberon-smart-keyboard/**'
+      - 'stm32-embassy-smart-keyboard/**'
+      - 'stm32f4-rtic-smart-keyboard/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -69,6 +75,15 @@ jobs:
 
       - name: Run Cargo Build (stm32f4-rtic-smart-keyboard, ex=minif4_36-rev2021_4-rhs)
         run: cargo build --release --target=thumbv7em-none-eabihf --package=stm32f4-rtic-smart-keyboard --example=minif4_36-rev2021_4-rhs
+
+      - name: Run Cargo Build (stm32-embassy-smart-keyboard)
+        run: cargo build --release --target=thumbv7em-none-eabihf --package=stm32-embassy-smart-keyboard
+
+      - name: Run Cargo Build (stm32-embassy-smart-keyboard, ex=minif4_36-rev2021_5-lhs)
+        run: cargo build --release --target=thumbv7em-none-eabihf --package=stm32-embassy-smart-keyboard --example=minif4_36-rev2021_5-lhs
+
+      - name: Run Cargo Build (stm32-embassy-smart-keyboard, ex=minif4_36-rev2021_5-rhs)
+        run: cargo build --release --target=thumbv7em-none-eabihf --package=stm32-embassy-smart-keyboard --example=minif4_36-rev2021_5-rhs
 
       - name: Run Cargo Doc
         run: |

--- a/.github/workflows/rust-thumbv6m-none-eabi.yaml
+++ b/.github/workflows/rust-thumbv6m-none-eabi.yaml
@@ -9,25 +9,31 @@ on:
       - master
     paths:
       - '.cargo/config.toml'
+      - '.github/workflows/rust-thumbv6m-none-eabi.yaml'
       - 'Cargo.*'
       - 'ld/rp2040/*'
       - 'ncl/**/*.ncl'
+      - 'keyberon-smart-keyboard/**'
       - 'rp2040-rtic-smart-keyboard/**'
       - 'src/**/*.rs'
       - 'smart-keymap-nickel-helper/**'
-      - 'keyberon-smart-keyboard/**'
+      - 'stm32-embassy-smart-keyboard/**'
+      - 'stm32f4-rtic-smart-keyboard/**'
   pull_request:
     branches:
       - '*'
     paths:
       - '.cargo/config.toml'
+      - '.github/workflows/rust-thumbv6m-none-eabi.yaml'
       - 'Cargo.*'
       - 'ld/rp2040/*'
       - 'ncl/**/*.ncl'
+      - 'keyberon-smart-keyboard/**'
       - 'rp2040-rtic-smart-keyboard/**'
       - 'src/**/*.rs'
       - 'smart-keymap-nickel-helper/**'
-      - 'keyberon-smart-keyboard/**'
+      - 'stm32-embassy-smart-keyboard/**'
+      - 'stm32f4-rtic-smart-keyboard/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/stm32-embassy-smart-keyboard/examples/minif4_36-rev2021_5-lhs.rs
+++ b/stm32-embassy-smart-keyboard/examples/minif4_36-rev2021_5-lhs.rs
@@ -26,7 +26,7 @@ use usbd_hid::descriptor::{
 use keyberon_smart_keyboard::input::smart_keymap::keymap_index_of;
 use keyberon_smart_keyboard::input::smart_keymap::KeyboardBackend;
 use keyberon_smart_keyboard::input::MatrixScanner;
-use keyberon_smart_keyboard::smart_keymap::key;
+use smart_keymap::key;
 use keyberon_smart_keyboard::split::BackendMessage;
 
 use smart_keymap::input::Event;

--- a/stm32-embassy-smart-keyboard/src/main.rs
+++ b/stm32-embassy-smart-keyboard/src/main.rs
@@ -35,6 +35,8 @@ static CONTROL_BUF: StaticCell<[u8; 64]> = StaticCell::new();
 
 static KEYBOARD_BACKEND: StaticCell<KeyboardBackend> = StaticCell::new();
 
+static DEVICE_HANDLER: StaticCell<MyDeviceHandler> = StaticCell::new();
+static HID_STATE: StaticCell<State> = StaticCell::new();
 static HID_STATE_MOUSE: StaticCell<State> = StaticCell::new();
 static HID_STATE_CONSUMER: StaticCell<State> = StaticCell::new();
 
@@ -133,9 +135,9 @@ async fn main(_spawner: Spawner) {
     let ms_os_descriptor = MS_OS_DESCRIPTOR.init([0; 256]);
     let control_buf = CONTROL_BUF.init([0; 64]);
 
-    let mut device_handler = MyDeviceHandler::new();
+    let device_handler = DEVICE_HANDLER.init(MyDeviceHandler::new());
 
-    let mut state_kbd = State::new();
+    let state_kbd = HID_STATE.init(State::new());
     let state_mouse = HID_STATE_MOUSE.init(State::new());
     let state_consumer = HID_STATE_CONSUMER.init(State::new());
 
@@ -148,7 +150,7 @@ async fn main(_spawner: Spawner) {
         control_buf,
     );
 
-    builder.handler(&mut device_handler);
+    builder.handler(device_handler);
 
     let config = embassy_usb::class::hid::Config {
         report_descriptor: KeyboardReport::desc(),
@@ -156,7 +158,7 @@ async fn main(_spawner: Spawner) {
         poll_ms: 1,
         max_packet_size: 8,
     };
-    let hid_kbd = HidReaderWriter::<_, 1, 8>::new(&mut builder, &mut state_kbd, config);
+    let hid_kbd = HidReaderWriter::<_, 1, 8>::new(&mut builder, state_kbd, config);
 
     let config_mouse = embassy_usb::class::hid::Config {
         report_descriptor: MouseReport::desc(),

--- a/stm32-embassy-smart-keyboard/src/main.rs
+++ b/stm32-embassy-smart-keyboard/src/main.rs
@@ -22,7 +22,7 @@ use {defmt_rtt as _, panic_probe as _};
 
 use keyberon_smart_keyboard::input::smart_keymap::keymap_index_of;
 use keyberon_smart_keyboard::input::smart_keymap::KeyboardBackend;
-use keyberon_smart_keyboard::smart_keymap::key;
+use smart_keymap::key;
 
 use board::KEYMAP_INDICES;
 

--- a/stm32f4-rtic-smart-keyboard/examples/minif4_36-rev2021_4-lhs.rs
+++ b/stm32f4-rtic-smart-keyboard/examples/minif4_36-rev2021_4-lhs.rs
@@ -30,7 +30,7 @@ mod board {
     macro_rules! keyboard {
         ($gpioa:ident, $gpiob:ident) => {
             crate::board::Keyboard {
-                matrix: crate::board::Matrix::new([
+                matrix: match crate::board::Matrix::new([
                     [
                         Some($gpiob.pb15.into_pull_up_input().erase()),
                         Some($gpioa.pa8.into_pull_up_input().erase()),
@@ -59,7 +59,10 @@ mod board {
                         None,
                         None,
                     ],
-                ]),
+                ]) {
+                    Ok(matrix) => matrix,
+                    Err(e) => match e {},
+                },
                 debouncer: keyberon::debounce::Debouncer::new(
                     crate::board::PressedKeys::default(),
                     crate::board::PressedKeys::default(),

--- a/stm32f4-rtic-smart-keyboard/examples/minif4_36-rev2021_4-rhs.rs
+++ b/stm32f4-rtic-smart-keyboard/examples/minif4_36-rev2021_4-rhs.rs
@@ -30,7 +30,7 @@ mod board {
     macro_rules! keyboard {
         ($gpioa:ident, $gpiob:ident) => {
             crate::board::Keyboard {
-                matrix: crate::board::Matrix::new([
+                matrix: match crate::board::Matrix::new([
                     [
                         Some($gpioa.pa2.into_pull_up_input().erase()),
                         Some($gpioa.pa10.into_pull_up_input().erase()),
@@ -59,7 +59,10 @@ mod board {
                         None,
                         None,
                     ],
-                ]),
+                ]) {
+                    Ok(matrix) => matrix,
+                    Err(e) => match e {},
+                },
                 debouncer: keyberon::debounce::Debouncer::new(
                     crate::board::PressedKeys::default(),
                     crate::board::PressedKeys::default(),


### PR DESCRIPTION
Fixes STM32F4 CI failures introduced by the keyberon `DirectPinMatrix::new` API change in #580, and closes gaps that let that PR merge without firmware CI on the PR itself.

## Commits

1. **stm32f4-rtic-smart-keyboard** — split-board examples match on `DirectPinMatrix::new` `Result` instead of assuming infallible init
2. **stm32-embassy-smart-keyboard** — use `smart_keymap::key` (keyberon does not re-export `smart_keymap`)
3. **ci** — broaden STM32F4 / RP2040 workflow path filters so changes to any `*-smart-keyboard` crate trigger cross-target firmware CI; build stm32-embassy on the STM32F4 workflow (same `thumbv7em-none-eabihf` target)

## Context

`cargo build --release --target=thumbv7em-none-eabihf --package=stm32f4-rtic-smart-keyboard --example=minif4_36-rev2021_4-lhs` failed after #580 because examples still expected `DirectPinMatrix::new` to return the matrix directly.

PR #580 did not run Rust firmware workflows (only Copilot); `stm32-embassy-smart-keyboard/**` was not in any workflow path filter.