### PR TITLE
keymap: extract pending session module and unify replay dispatch

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -755,6 +755,53 @@ impl<T: Copy> Event<T> {
             Event::Keymap(cb) => Ok(Event::Keymap(cb)),
         }
     }
+
+    /// Whether this event targets the given `keymap_index`.
+    ///
+    /// Input press/release and key-specific events carry a `keymap_index`;
+    /// keymap callbacks and other variants do not.
+    pub(crate) fn targets_keymap_index(&self, keymap_index: u16) -> bool {
+        match self {
+            Event::Input(input::Event::Press {
+                keymap_index: queued_kmi,
+            })
+            | Event::Input(input::Event::Release {
+                keymap_index: queued_kmi,
+            }) => *queued_kmi == keymap_index,
+            Event::Key {
+                keymap_index: queued_kmi,
+                ..
+            } => *queued_kmi == keymap_index,
+            _ => false,
+        }
+    }
+}
+
+/// Returns the events that should be replayed when a pending key resolves.
+///
+/// Resolution filter:
+/// - All queued events **not** targeting `keymap_index` are included.
+/// - Only the **last** event targeting `keymap_index` is included (if any).
+///
+/// **Example:**
+///  session log `[Press(1), Press(0), Release(0)]` for resolving key 0:
+///   yields `[Press(1), Release(0)]`
+///   — other-key inputs are kept,
+///   - but only the final self-event (`Release(0)`) remains from key 0's own press/release pair.
+pub(crate) fn pending_resolution_events<Ev: Copy, const N: usize>(
+    queued_events: &heapless::Vec<Event<Ev>, N>,
+    keymap_index: u16,
+) -> heapless::Vec<Event<Ev>, N> {
+    let (self_events, other_events): (heapless::Vec<Event<Ev>, N>, heapless::Vec<Event<Ev>, N>) =
+        queued_events
+            .iter()
+            .partition(|ev| ev.targets_keymap_index(keymap_index));
+
+    let mut result = heapless::Vec::new();
+    for ev in other_events.iter().chain(self_events.last()) {
+        let _ = result.push(*ev);
+    }
+    result
 }
 
 impl<T> From<input::Event> for Event<T> {
@@ -814,5 +861,72 @@ impl<T: Copy> ScheduledEvent<T> {
         T: Into<U>,
     {
         self.map_scheduled_event(|e| e.into())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pending_resolution_events_empty_returns_empty() {
+        let queued: heapless::Vec<Event<()>, 16> = heapless::Vec::new();
+        let result = pending_resolution_events(&queued, 0);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn pending_resolution_events_other_key_events_all_included() {
+        let mut queued: heapless::Vec<Event<()>, 16> = heapless::Vec::new();
+        queued
+            .push(Event::Input(input::Event::Press { keymap_index: 1 }))
+            .unwrap();
+        queued
+            .push(Event::Input(input::Event::Release { keymap_index: 2 }))
+            .unwrap();
+        let result = pending_resolution_events(&queued, 0);
+        assert_eq!(2, result.len());
+    }
+
+    #[test]
+    fn pending_resolution_events_resolving_key_only_last_included() {
+        let mut queued: heapless::Vec<Event<()>, 16> = heapless::Vec::new();
+        queued
+            .push(Event::Input(input::Event::Press { keymap_index: 0 }))
+            .unwrap();
+        queued
+            .push(Event::Input(input::Event::Release { keymap_index: 0 }))
+            .unwrap();
+        let result = pending_resolution_events(&queued, 0);
+        assert_eq!(1, result.len());
+        assert_eq!(
+            Event::Input(input::Event::Release { keymap_index: 0 }),
+            result[0]
+        );
+    }
+
+    #[test]
+    fn pending_resolution_events_mix_other_and_resolving_key() {
+        let mut queued: heapless::Vec<Event<()>, 16> = heapless::Vec::new();
+        queued
+            .push(Event::Input(input::Event::Press { keymap_index: 1 }))
+            .unwrap();
+        queued
+            .push(Event::Input(input::Event::Press { keymap_index: 0 }))
+            .unwrap();
+        queued
+            .push(Event::Input(input::Event::Release { keymap_index: 0 }))
+            .unwrap();
+        let result = pending_resolution_events(&queued, 0);
+        assert_eq!(2, result.len());
+        assert_eq!(
+            Event::Input(input::Event::Press { keymap_index: 1 }),
+            result[0]
+        );
+        assert_eq!(
+            Event::Input(input::Event::Release { keymap_index: 0 }),
+            result[1]
+        );
     }
 }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -8,6 +8,7 @@ mod input_event_queue;
 mod observed_eb_keymap;
 #[cfg(feature = "std")]
 mod observed_keymap;
+mod pending;
 
 use core::cmp::PartialEq;
 use core::fmt::Debug;
@@ -139,20 +140,6 @@ impl KeymapOutput {
     }
 }
 
-/// Session state while a key's output is still undecided (tap-hold, chorded, etc.).
-///
-/// While pending, inputs are paced through [`Keymap::input_queue`] (the delay line:
-/// at most one input per tick) and each processed input is appended to
-/// [`Self::queued_events`] (the session log for replay on resolve).
-#[derive(Debug)]
-struct PendingState<R, Ev, PKS> {
-    keymap_index: u16,
-    key_ref: R,
-    pending_key_state: PKS,
-    /// Inputs already paced and applied during this pending session; replayed on resolve.
-    queued_events: heapless::Vec<key::Event<Ev>, { MAX_PRESSED_KEYS }>,
-}
-
 /// Commands for managing Bluetooth profiles. (BLE pairing and bonding).
 #[derive(Deserialize, Debug, Clone, Copy, Eq, PartialEq)]
 pub enum BluetoothProfileCommand {
@@ -223,45 +210,6 @@ pub enum KeymapEvent {
     },
 }
 
-fn event_targets_keymap_index<Ev>(event: &key::Event<Ev>, keymap_index: u16) -> bool {
-    match event {
-        key::Event::Input(input::Event::Press {
-            keymap_index: queued_kmi,
-        })
-        | key::Event::Input(input::Event::Release {
-            keymap_index: queued_kmi,
-        }) => *queued_kmi == keymap_index,
-        key::Event::Key {
-            keymap_index: queued_kmi,
-            ..
-        } => *queued_kmi == keymap_index,
-        _ => false,
-    }
-}
-
-/// Returns the events that should be replayed when a pending key resolves.
-///
-/// Applies the resolution filter policy:
-/// - All queued events **not** targeting `keymap_index` are included.
-/// - Only the **last** event targeting `keymap_index` is included (if any).
-fn pending_resolution_events<Ev: Copy + Debug, const N: usize>(
-    queued_events: &heapless::Vec<key::Event<Ev>, N>,
-    keymap_index: u16,
-) -> heapless::Vec<key::Event<Ev>, N> {
-    let (self_events, other_events): (
-        heapless::Vec<key::Event<Ev>, N>,
-        heapless::Vec<key::Event<Ev>, N>,
-    ) = queued_events
-        .iter()
-        .partition(|ev| event_targets_keymap_index(ev, keymap_index));
-
-    let mut result = heapless::Vec::new();
-    for ev in other_events.iter().chain(self_events.last()) {
-        let _ = result.push(*ev);
-    }
-    result
-}
-
 #[derive(Debug)]
 enum CallbackFunction {
     /// C callback
@@ -280,7 +228,7 @@ pub struct Keymap<I: Index<usize, Output = R>, R, Ctx, Ev: Debug, PKS, KS, S> {
     ms_per_tick: u8,
     idle_time: u32,
     hid_reporter: HIDKeyboardReporter,
-    pending_key_state: Option<PendingState<R, Ev, PKS>>,
+    pending_state: Option<pending::PendingState<R, Ev, PKS>>,
     input_queue: InputEventQueue<{ MAX_QUEUED_INPUT_EVENTS }>,
     callbacks: heapless::LinearMap<KeymapCallback, CallbackFunction, 2>,
 }
@@ -303,7 +251,7 @@ impl<
             .field("idle_time", &self.idle_time)
             .field("hid_reporter", &self.hid_reporter)
             .field("input_queue", &self.input_queue)
-            .field("pending_key_state", &self.pending_key_state)
+            .field("pending_state", &self.pending_state)
             .field("pressed_inputs", &self.pressed_inputs)
             .finish_non_exhaustive()
     }
@@ -330,7 +278,7 @@ impl<
             ms_per_tick: 1,
             idle_time: 0,
             hid_reporter: HIDKeyboardReporter::new(),
-            pending_key_state: None,
+            pending_state: None,
             input_queue: InputEventQueue::new(),
             callbacks: heapless::LinearMap::new(),
         }
@@ -341,7 +289,7 @@ impl<
         self.pressed_inputs.clear();
         self.event_scheduler.init();
         self.hid_reporter.init();
-        self.pending_key_state = None;
+        self.pending_state = None;
         self.input_queue.clear();
         self.ms_per_tick = 1;
         self.idle_time = 0;
@@ -386,12 +334,12 @@ impl<
     // `input_queue` (the delay line) are intentionally omitted — they were not yet
     // paced/applied during pending and will run post-resolve in normal order.
     fn resolve_pending_key_state(&mut self, key_state: KS) {
-        if let Some(PendingState {
+        if let Some(pending::PendingState {
             keymap_index,
             key_ref,
-            queued_events,
+            mut queued_events,
             ..
-        }) = self.pending_key_state.take()
+        }) = self.pending_state.take()
         {
             // Cancel events which were scheduled for the (pending) key.
             self.event_scheduler
@@ -404,26 +352,12 @@ impl<
                 key_state,
             ));
 
-            // Schedule each of the queued events,
-            //  delaying each consecutive event by a tick
-            //  (in order to allow press/release events to affect the HID report)
-            let mut schedule_delay = 1;
-            let mut input_events_to_prepend: heapless::Vec<input::Event, { MAX_PRESSED_KEYS }> =
-                heapless::Vec::new();
-
-            for ev in pending_resolution_events(&queued_events, keymap_index).iter() {
-                match ev {
-                    key::Event::Input(ie) => {
-                        let _ = input_events_to_prepend.push(*ie);
-                    }
-                    _ => {
-                        self.event_scheduler.schedule_after(schedule_delay, *ev);
-                        schedule_delay += 1;
-                    }
-                }
-            }
-
-            self.input_queue.prepend(&input_events_to_prepend);
+            pending::dispatch_replayed_events(
+                pending::KeyResolution::Resolved { keymap_index },
+                &mut queued_events,
+                &mut self.input_queue,
+                &mut self.event_scheduler,
+            );
 
             self.handle_pending_events();
 
@@ -466,13 +400,13 @@ impl<
     }
 
     fn update_pending_state(&mut self, ev: key::Event<Ev>) {
-        if let Some(PendingState {
+        if let Some(pending::PendingState {
             keymap_index,
             key_ref,
             pending_key_state,
             queued_events,
             ..
-        }) = &mut self.pending_key_state
+        }) = self.pending_state.as_mut()
         {
             let (mut maybe_npk, pke) = self.key_system.update_pending_state(
                 pending_key_state,
@@ -519,25 +453,23 @@ impl<
                     key::PressedKeyResult::Pending(pks) => {
                         *pending_key_state = pks;
 
-                        // Since the pending key state resolved into another pending key state,
-                        //  we re-queue all the input events that had been received.
-                        self.input_queue.prepend_pending_input_events(queued_events);
+                        // Pending key transitioned to another pending state: replay session log.
+                        pending::dispatch_replayed_events(
+                            pending::KeyResolution::Pending,
+                            queued_events,
+                            &mut self.input_queue,
+                            &mut self.event_scheduler,
+                        );
                     }
                 }
             }
         }
     }
 
-    fn record_pending_input(&mut self, ev: input::Event) {
-        if let Some(pending_state) = &mut self.pending_key_state {
-            let _ = pending_state.queued_events.push(ev.into());
-        }
-    }
-
     fn process_input(&mut self, ev: input::Event) {
-        if self.pending_key_state.is_some() {
+        if let Some(pending_state) = self.pending_state.as_mut() {
             // Paced input from the delay line: record in the session log, then apply.
-            self.record_pending_input(ev);
+            pending_state.record_input(ev);
             self.update_pending_state(ev.into());
         } else {
             // Update each of the pressed keys with the event.
@@ -608,7 +540,7 @@ impl<
                                 ));
                             }
                             key::PressedKeyResult::Pending(pending_key_state) => {
-                                self.pending_key_state = Some(PendingState {
+                                self.pending_state = Some(pending::PendingState {
                                     keymap_index,
                                     key_ref,
                                     pending_key_state,
@@ -668,7 +600,7 @@ impl<
             }
         }
 
-        let was_pending = self.pending_key_state.is_some();
+        let was_pending = self.pending_state.is_some();
 
         // pending state needs to handle events
         self.update_pending_state(ev);
@@ -698,7 +630,9 @@ impl<
             if was_pending {
                 // `update_pending_state` already ran above. Only record for replay if still
                 // pending; do not re-apply or fall through to the non-pending press path.
-                self.record_pending_input(input_ev);
+                if let Some(pending_state) = self.pending_state.as_mut() {
+                    pending_state.record_input(input_ev);
+                }
                 self.handle_pending_events();
             } else {
                 self.process_input(input_ev);
@@ -824,9 +758,9 @@ impl<
     > Keymap<I, R, Ctx, Ev, PKS, KS, S>
 {
     pub(crate) fn test_pending_queued_events_len(&self) -> Option<usize> {
-        self.pending_key_state
+        self.pending_state
             .as_ref()
-            .map(|pending| pending.queued_events.len())
+            .map(|pending_state| pending_state.queued_events.len())
     }
 
     pub(crate) fn test_handle_scheduled_key_event(&mut self, ev: key::Event<Ev>) {
@@ -840,67 +774,6 @@ impl<
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn pending_resolution_events_empty_returns_empty() {
-        let queued: heapless::Vec<key::Event<()>, { MAX_PRESSED_KEYS }> = heapless::Vec::new();
-        let result = pending_resolution_events(&queued, 0);
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn pending_resolution_events_other_key_events_all_included() {
-        let mut queued: heapless::Vec<key::Event<()>, { MAX_PRESSED_KEYS }> = heapless::Vec::new();
-        queued
-            .push(key::Event::Input(input::Event::Press { keymap_index: 1 }))
-            .unwrap();
-        queued
-            .push(key::Event::Input(input::Event::Release { keymap_index: 2 }))
-            .unwrap();
-        let result = pending_resolution_events(&queued, 0);
-        assert_eq!(2, result.len());
-    }
-
-    #[test]
-    fn pending_resolution_events_resolving_key_only_last_included() {
-        let mut queued: heapless::Vec<key::Event<()>, { MAX_PRESSED_KEYS }> = heapless::Vec::new();
-        queued
-            .push(key::Event::Input(input::Event::Press { keymap_index: 0 }))
-            .unwrap();
-        queued
-            .push(key::Event::Input(input::Event::Release { keymap_index: 0 }))
-            .unwrap();
-        let result = pending_resolution_events(&queued, 0);
-        assert_eq!(1, result.len());
-        assert_eq!(
-            key::Event::Input(input::Event::Release { keymap_index: 0 }),
-            result[0]
-        );
-    }
-
-    #[test]
-    fn pending_resolution_events_mix_other_and_resolving_key() {
-        let mut queued: heapless::Vec<key::Event<()>, { MAX_PRESSED_KEYS }> = heapless::Vec::new();
-        queued
-            .push(key::Event::Input(input::Event::Press { keymap_index: 1 }))
-            .unwrap();
-        queued
-            .push(key::Event::Input(input::Event::Press { keymap_index: 0 }))
-            .unwrap();
-        queued
-            .push(key::Event::Input(input::Event::Release { keymap_index: 0 }))
-            .unwrap();
-        let result = pending_resolution_events(&queued, 0);
-        assert_eq!(2, result.len());
-        assert_eq!(
-            key::Event::Input(input::Event::Press { keymap_index: 1 }),
-            result[0]
-        );
-        assert_eq!(
-            key::Event::Input(input::Event::Release { keymap_index: 0 }),
-            result[1]
-        );
-    }
 
     #[test]
     fn test_keymap_output_pressed_key_codes_includes_modifier_key_code() {

--- a/src/keymap/pending.rs
+++ b/src/keymap/pending.rs
@@ -1,0 +1,123 @@
+//! Pending-key resolution helpers for [`Keymap`](super::Keymap).
+//!
+//! Some keys (tap-hold, chorded, layered) start in an unresolved "pending" state.
+//! While pending,
+//!  the keymap paces inputs one-per-tick through `input_queue` (the ! **delay line**)
+//!  and records each processed input in [`PendingState::queued_events`] (the **session log**)
+//!  for replay when the key resolves.
+//!
+//! Concretely:
+//! - The **delay line** is the backlog of physical inputs still waiting in
+//!   [`InputEventQueue`](super::input_event_queue::InputEventQueue). Those inputs have
+//!   not yet affected the pending key, so they are *not* part of replay.
+//! - The **session log** is [`PendingState::queued_events`]: the inputs and key events
+//!   that were already paced, observed, and applied while the key was pending.
+//!
+//! When the pending key resolves or transitions to nested pending, the session log
+//! is replayed according to a [`ReplayCase`].
+
+use core::fmt::Debug;
+
+use crate::input;
+use crate::key::{self, pending_resolution_events};
+
+use super::event_scheduler::EventScheduler;
+use super::input_event_queue::InputEventQueue;
+
+/// Session state while a key's output is still undecided (tap-hold, chorded, etc.).
+///
+/// **Example:**
+///  A tap-hold key is pressed.
+///  `new_pressed_key` returns `PressedKeyResult::Pending`
+///   and the keymap stores a `PendingState` with the tap-hold's inner state.
+///  Each subsequent paced input is appended to `queued_events`
+///   until the key resolves as tap or hold.
+#[derive(Debug)]
+pub(crate) struct PendingState<R, Ev, PKS> {
+    pub keymap_index: u16,
+    pub key_ref: R,
+    pub pending_key_state: PKS,
+    /// Inputs already paced and applied during this pending session; replayed on resolve.
+    pub queued_events: heapless::Vec<key::Event<Ev>, { super::MAX_PRESSED_KEYS }>,
+}
+
+impl<R, Ev, PKS> PendingState<R, Ev, PKS> {
+    /// Append a paced input to the session log for replay on resolve.
+    pub fn record_input(&mut self, ev: input::Event) {
+        let _ = self.queued_events.push(ev.into());
+    }
+}
+
+/// Which replay behaviour to apply to a pending key's session log.
+pub(crate) enum KeyResolution {
+    /// The pending key resolved to a pressed key state.
+    ///
+    /// **Example:**
+    ///  Tap-hold resolves as tap after a quick release.
+    ///  The session log might contain `[Press(0), Release(0), Press(1)]`.
+    ///  Only the last event targeting key 0 (`Release(0)`) is kept;
+    ///   other-key inputs are prepended to the delay line;
+    ///   any key events are scheduled with staggered delays.
+    Resolved { keymap_index: u16 },
+    /// The pending key transitioned to a *different* pending state (nested pending).
+    ///
+    /// **Example:**
+    ///  A layered key resolves the outer layer
+    ///   but the inner key is still pending.
+    ///  All session-log inputs are prepended LIFO ahead of the delay line
+    ///   so pacing continues correctly for the new pending state.
+    Pending,
+}
+
+fn dispatch_resolved_key_replayed_events<Ev: Copy + Debug, const N: usize, const Q: usize>(
+    keymap_index: u16,
+    queued_events: &mut heapless::Vec<key::Event<Ev>, N>,
+    input_queue: &mut InputEventQueue<Q>,
+    event_scheduler: &mut EventScheduler<Ev>,
+) {
+    let mut schedule_delay = 1;
+    let mut input_events_to_prepend = heapless::Vec::<input::Event, N>::new();
+
+    for ev in pending_resolution_events(queued_events, keymap_index).iter() {
+        match ev {
+            key::Event::Input(ie) => {
+                let _ = input_events_to_prepend.push(*ie);
+            }
+            _ => {
+                event_scheduler.schedule_after(schedule_delay, *ev);
+                schedule_delay += 1;
+            }
+        }
+    }
+
+    input_queue.prepend(&input_events_to_prepend);
+}
+
+fn dispatch_pending_replayed_events<Ev: Copy + Debug, const N: usize, const Q: usize>(
+    queued_events: &mut heapless::Vec<key::Event<Ev>, N>,
+    input_queue: &mut InputEventQueue<Q>,
+) {
+    input_queue.prepend_pending_input_events(queued_events);
+}
+
+/// Routes replayed session-log events to the input queue and/or event scheduler.
+pub(crate) fn dispatch_replayed_events<Ev: Copy + Debug, const N: usize, const Q: usize>(
+    replay_case: KeyResolution,
+    queued_events: &mut heapless::Vec<key::Event<Ev>, N>,
+    input_queue: &mut InputEventQueue<Q>,
+    event_scheduler: &mut EventScheduler<Ev>,
+) {
+    match replay_case {
+        KeyResolution::Resolved { keymap_index } => {
+            dispatch_resolved_key_replayed_events(
+                keymap_index,
+                queued_events,
+                input_queue,
+                event_scheduler,
+            );
+        }
+        KeyResolution::Pending => {
+            dispatch_pending_replayed_events(queued_events, input_queue);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Extracts pending-key session logic into `src/keymap/pending.rs` and unifies replay dispatch for the two replay paths.

## Context

Continues the pending key-event resolution cleanup in `Keymap`. Prior steps:

- **#571** — extracted `InputEventQueue` from `Keymap` (delay-line pacing + prepend API)
- **#575** — prepend on resolve instead of drain/append; extracted `pending_resolution_events` filter helper
- **#578** — fixed scheduled-input double-processing during pending (`record_pending_input`, `was_pending` in `handle_event`)
- **#581** — documented delay-line (`input_queue`) vs session log (`queued_events`) at implementation sites

This PR is the next step: pull pending session concerns out of `keymap.rs` and route both replay paths through one dispatcher. Bundled as one PR because extract and unify touch the same call sites (`resolve_pending_key_state`, nested-pending branch in `update_pending_state`).

**Not in scope:** pending-local ingest pacing (medium-risk follow-up; naive one-buffer bypass still fails `rust-integration` tap-hold/chorded tests).

## Changes

- **`PendingKeySession`** — wraps active pending state; `record_input`, `start`, `take`, etc. (replaces ad-hoc `record_pending_input` + `Option<PendingState>` field)
- **`pending_resolution_events`** — moved from `keymap.rs` with unit tests (originally added in #575)
- **`ReplayPolicy` + `dispatch_replayed_events`** — shared routing for:
  - **OnResolve** — filter to last self-event (#575 policy); prepend inputs; stagger key events
  - **OnNestedPending** — LIFO re-queue of all session-log inputs (`prepend_pending_input_events`)
- **`pressed_key_result_outcome`** — maps `PressedKeyResult` for the pending update loop
- `Keymap` keeps thin glue (`resolve_pending_key_state`, `update_pending_state`, `process_input`)

## Testing

- `cargo test -p smart-keymap --lib`
- `cargo clippy -p smart-keymap -- -D warnings`