### PR TITLE
rust: factor out cargo package metadata to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,18 @@ members = [
     "stm32f4-rtic-smart-keyboard",
 ]
 
+[workspace.package]
+version = "0.15.0-dev"
+authors = ["Richard Goulter <richard.goulter@gmail.com>"]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
 [package]
 name = "smart-keymap"
-version = "0.15.0-dev"
-license = "MIT OR Apache-2.0"
-edition = "2021"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+authors.workspace = true
 
 [features]
 default = ["std"]

--- a/keyberon-smart-keyboard/Cargo.toml
+++ b/keyberon-smart-keyboard/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "keyberon-smart-keyboard"
-version = "0.15.0-dev"
-license = "MIT OR Apache-2.0"
-authors = ["Richard Goulter <richard.goulter@gmail.com>"]
-edition = "2021"
+version.workspace = true
+license.workspace = true
+authors.workspace = true
+edition.workspace = true
+publish = false
 
 [dependencies]
 cortex-m = "0.7"

--- a/rp2040-rtic-smart-keyboard/Cargo.toml
+++ b/rp2040-rtic-smart-keyboard/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "rp2040-rtic-smart-keyboard"
-version = "0.15.0-dev"
-license = "MIT OR Apache-2.0"
-authors = ["Richard Goulter <richard.goulter@gmail.com>"]
-edition = "2021"
+version.workspace = true
+license.workspace = true
+authors.workspace = true
+edition.workspace = true
+publish = false
 
 [dependencies]
 rp-pico = "0.9"

--- a/smart-keymap-macros/Cargo.toml
+++ b/smart-keymap-macros/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "smart-keymap-macros"
 version = "0.1.0"
-license = "MIT OR Apache-2.0"
-edition = "2021"
+license.workspace = true
+edition.workspace = true
+authors.workspace = true
 build = "build.rs"
 
 [lib]

--- a/smart-keymap-nickel-helper/Cargo.toml
+++ b/smart-keymap-nickel-helper/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "smart-keymap-nickel-helper"
-version = "0.15.0-dev"
-license = "MIT OR Apache-2.0"
-edition = "2021"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+authors.workspace = true
 
 [dependencies]

--- a/smart_keymap/Cargo.toml
+++ b/smart_keymap/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "smart_keymap"
-version = "0.15.0-dev"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+publish = false
 
 [lib]
 crate-type = ["staticlib"]

--- a/stm32-embassy-smart-keyboard/Cargo.toml
+++ b/stm32-embassy-smart-keyboard/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
-edition = "2021"
 name = "stm32-embassy-smart-keyboard"
-version = "0.15.0-dev"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+authors.workspace = true
+publish = false
 
 [dependencies]
 embassy-stm32 = { version = "0.2.0", features = ["stm32f401cc", "unstable-pac", "time-driver-tim4", "exti", "chrono"] }

--- a/stm32f4-rtic-smart-keyboard/Cargo.toml
+++ b/stm32f4-rtic-smart-keyboard/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "stm32f4-rtic-smart-keyboard"
-version = "0.15.0-dev"
-license = "MIT OR Apache-2.0"
-authors = ["Richard Goulter <richard.goulter@gmail.com>"]
-edition = "2021"
+version.workspace = true
+license.workspace = true
+authors.workspace = true
+edition.workspace = true
+publish = false
 
 [dependencies]
 embedded-hal = "1.0"


### PR DESCRIPTION
We're using the same version across all packages for this repo.

Factoring them out better reflects that, and simplifies diffs for releases.