### PR TITLE
ncl: support {} as unit keyboard key (noop)

### DIFF
--- a/ncl/smart_keys/keyboard/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/keyboard/keymap-ncl-to-json.ncl
@@ -15,6 +15,11 @@
         actual = K.A |> keymap_ncl.key.to_json_value,
         expected = { key_code = 4 },
       },
+
+      check_unit_key_noop_json = {
+        actual = {} |> keymap_ncl.key.to_json_value,
+        expected = { key_code = 0 },
+      },
     },
 
   keymap_ncl.keyboard
@@ -22,22 +27,28 @@
     = {
       Key = std.contract.from_validator key_validator,
 
-      key_validator =
-        validators.record.validator {
-          fields_validator =
-            validators.all_of [
-              validators.record.has_any_field_of ["key_code", "modifiers"],
-              validators.record.has_only_fields ["key_code", "modifiers"],
-            ],
-          field_validators = {
-            key_code = validators.is_number,
-            modifiers = keyboard_modifiers.validator,
-          },
-        },
+      key_validator = fun k =>
+        if k == {} then
+          'Ok
+        else
+          validators.record.validator
+            {
+              fields_validator =
+                validators.all_of [
+                  validators.record.has_any_field_of ["key_code", "modifiers"],
+                  validators.record.has_only_fields ["key_code", "modifiers"],
+                ],
+              field_validators = {
+                key_code = validators.is_number,
+                modifiers = keyboard_modifiers.validator,
+              },
+            }
+            k,
 
       is_key = fun k => 'Ok == key_validator k,
 
       to_json_value = match {
+        {} => { key_code = 0 },
         { modifiers = km, ..k } => k & { modifiers = keyboard_modifiers.to_json_value km },
         k => k,
       },


### PR DESCRIPTION
Introduce special case handling for the bare record {} :

- key_validator treats {} as Ok (keyboard noop, equivalent to K.NO for base).
- to_json_value maps {} -> { key_code = 0 }.

Add check_unit_key_noop_json.

This allows LayeredKey and K.semantic to use bare {} (or implicit) as base without awkward K.NO & prefixes in the Nickel API.