### PR TITLE
fix(ncl): harden automation key validator to require has_any_field_of

### DIFF
--- a/ncl/smart_keys/automation/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/automation/keymap-ncl-to-json.ncl
@@ -72,7 +72,10 @@
       key_validator =
         validators.record.validator {
           fields_validator =
-            validators.record.has_only_fields ["automation_instructions"],
+            validators.all_of [
+              validators.record.has_any_field_of ["automation_instructions"],
+              validators.record.has_only_fields ["automation_instructions"],
+            ],
           field_validators = {
             automation_instructions = key_instructions.ncl_validator,
           },


### PR DESCRIPTION
The previous has_only_fields alone would vacuously accept {} (empty record), causing automation.is_key({}) to succeed and hijack dispatch for the unit keyboard noop key.

Add has_any_field_of check so only records that actually carry automation_instructions are accepted as automation keys. This enables using {} as a keyboard unit key.