### PR TITLE
ncl: find max layered length across all keys

### DIFF
--- a/ncl/inputs-to-json.ncl
+++ b/ncl/inputs-to-json.ncl
@@ -3,6 +3,23 @@
 
   layered_keys,
 
+  # From keymap-ncl-to-json: longest `layered` array across all keys.
+  # Falls back to scanning layered_keys if not merged from that module.
+  max_layered_length | default =
+    layered_keys
+    |> std.array.fold_left
+      (fun acc k =>
+        let len =
+          k
+          |> match {
+            { layered, .. } => std.array.length layered,
+            _ => 0,
+          }
+        in
+        if len > acc then len else acc
+      )
+      0,
+
   # Construct [smart_keymap::input::Event(kmi)]
   # from ['Press k | 'Release k],
   # where 'k is a keymap.ncl key def
@@ -50,13 +67,9 @@
       }
     in
     let initial_layer_state =
+      # Use max layered length across all keys (not only the first key).
       let initial_active_layers =
-        layered_keys
-        |> std.array.first
-        |> match {
-          { layered, .. } => std.array.map (std.function.const false) layered,
-          _ => [],
-        }
+        std.array.generate (std.function.const false) max_layered_length
       in
       { default_layer = 0, active_layers = initial_active_layers }
     in

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -338,26 +338,24 @@
         std.array.reduce_left (fun x y => if x > y then x else y) max_td_defs
       in
       let num_layers =
-        let max_layered_lengths =
-          std.array.map
-            (fun cv =>
-              smart_key.traverse
-                (fun acc cv =>
-                  cv
-                  |> match {
-                    { nested = { layered, .. }, .. } =>
-                      let len = std.array.length layered in
-                      if len > acc then len else acc,
-                    _ => acc,
-                  }
-                )
-                0
+        # Longest layered array across every key tree (not only the first layered key).
+        key_codegen_values
+        |> std.array.fold_left
+          (fun acc cv =>
+            smart_key.traverse
+              (fun acc cv =>
                 cv
-            )
-            key_codegen_values
-        in
-        # Compute the max over all
-        std.array.reduce_left (fun x y => if x > y then x else y) max_layered_lengths
+                |> match {
+                  { nested = { layered, .. }, .. } =>
+                    let len = std.array.length layered in
+                    if len > acc then len else acc,
+                  _ => acc,
+                }
+              )
+              acc
+              cv
+          )
+          0
       in
       let chords = ((json_keymap.config & { chorded | default = {} }).chorded & { chords | default = [] }).chords in
       let chord_count = chords |> std.array.length in

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -238,7 +238,8 @@
     },
 
     map_accum = fun f acc k =>
-      match {
+      k
+      |> match {
         k if keymap_ncl.key.is_key k => keymap_ncl.key.map_accum f acc k,
         k if keymap_ncl.null_.is_key k => keymap_ncl.null_.map_accum f acc k,
         _ => std.fail_with "unsupported nullable_key item in keymap.ncl",
@@ -482,6 +483,123 @@
           )
           (std.array.length base_keys),
 
+  # Longest `layered` array on any layered key in the tree (not only the first key).
+  # Nested layered keys under composites are found via map_accum.
+  layered_length_of = fun k =>
+    if k != null && std.is_record k && keymap_ncl.layered.is_key k then
+      std.array.length k.layered
+    else
+      0,
+
+  max_layered_length_accum = fun acc k =>
+    let len = layered_length_of k in
+    let acc = if len > acc then len else acc in
+    let { acc, k = _ } =
+      keymap_ncl.nullable_key.map_accum
+        (fun acc k =>
+          let len = layered_length_of k in
+          let acc = if len > acc then len else acc in
+          { include acc, include k }
+        )
+        acc
+        k
+    in
+    acc,
+
+  max_layered_length
+    | doc "Longest layered-keys array length across the keymap (for layer count / padding)."
+    = layered_keys |> std.array.fold_left max_layered_length_accum 0,
+
+  # Pad a layered key's `layered` array with null (transparency) up to `target_len`.
+  pad_layered_key = fun target_len k =>
+    if k != null && std.is_record k && keymap_ncl.layered.is_key k then
+      let { layered, ..base_key } = k in
+      let len = std.array.length layered in
+      let padded_layered =
+        if len >= target_len then
+          layered
+        else
+          layered @ std.array.generate (std.function.const null) (target_len - len)
+      in
+      base_key & { layered = padded_layered }
+    else
+      k,
+
+  # Pad every layered key in a key tree to `target_len` (self, then nested via map_accum).
+  pad_key_layered_arrays = fun target_len k =>
+    let pad_f = fun acc key =>
+      let padded = pad_layered_key target_len key in
+      { include acc, k = padded }
+    in
+    let k = pad_layered_key target_len k in
+    let { acc = _, k } = keymap_ncl.nullable_key.map_accum pad_f null k in
+    k,
+
+  checks.check_max_layered_length =
+    let K = import "keys.ncl" in
+    {
+      check_unequal_lengths_uses_longest = {
+        actual =
+          [
+            K.A & { layered = [K.B] },
+            K.C & { layered = [ null, K.D] },
+          ]
+          |> std.array.fold_left max_layered_length_accum 0,
+        expected = 2,
+      },
+
+      check_first_key_not_layered = {
+        actual =
+          [
+            K.layer_mod.hold 1,
+            K.A & { layered = [ null, K.B] },
+          ]
+          |> std.array.fold_left max_layered_length_accum 0,
+        expected = 2,
+      },
+
+      check_no_layered_keys = {
+        actual = [K.A, K.B] |> std.array.fold_left max_layered_length_accum 0,
+        expected = 0,
+      },
+
+      check_pad_shorter_layered_array = {
+        actual =
+          pad_layered_key 3 (K.A & { layered = [K.B] }),
+        expected = K.A & { layered = [K.B, null, null ] },
+      },
+
+      check_json_pads_unequal_layered_lengths =
+        let keys = [
+          K.A & { layered = [K.B] },
+          K.C & { layered = [ null, K.D] },
+        ]
+        in
+        let layer_count = keys |> std.array.fold_left max_layered_length_accum 0 in
+        {
+          actual =
+            keys
+            |> std.array.map (pad_key_layered_arrays layer_count)
+            |> std.array.map keymap_ncl.key.to_json_value,
+          expected = [
+            {
+              base = { key_code = 4 },
+              layered = [
+                { key_code = 5 },
+                null,
+              ],
+            },
+            {
+              base = { key_code = 6 },
+              layered = [
+                null,
+                { key_code = 7 },
+              ],
+            },
+          ],
+        },
+    },
+
   chorded_keys
     | Array ChordedKeyElement
     =
@@ -556,7 +674,16 @@
         else
           {}
       in
-      let keys_json = keys |> std.array.map keymap_ncl.key.to_json_value in
+      # Equalise layered array lengths (pad shorter with null / transparency) so
+      # consumers need not assume the first layered key is the longest.
+      let layer_count =
+        keys |> std.array.fold_left max_layered_length_accum 0
+      in
+      let keys_json =
+        keys
+        |> std.array.map (pad_key_layered_arrays layer_count)
+        |> std.array.map keymap_ncl.key.to_json_value
+      in
       let { chorded = km_config_chorded, ..km_config } = config & { chorded = {} } in
       let chord_indices = chords |> std.array.map (fun { key, indices, .. } => indices) in
       let config_json_value =


### PR DESCRIPTION
## Summary

- Relax the assumption that every layered key’s `layered` array is as long as the first key’s.
- In `keymap-ncl-to-json`, fold/`map_accum` over keys to find the longest `layered` length, then pad shorter arrays with `null` (transparency) before JSON export.
- In `inputs-to-json`, size `active_layers` from that max length instead of `std.array.first`.
- In `keymap-codegen`, fold over all key trees for `LAYERED_LAYER_COUNT` (also safe for empty keymaps).
- Fix `nullable_key.map_accum` so the match is applied to `k`.

## Test plan

- [x] `ncl/scripts/run-ncl-checks.sh` (includes new unequal-length / padding checks)
- [x] Manual export with mixed-length layered keys pads to max and sets `LAYERED_LAYER_COUNT` correctly
- [x] Existing layered keymap fixtures regenerate with no snapshot diffs