### PR TITLE
ncl: support named layers on layered keys

### DIFF
--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -1,3 +1,52 @@
+# keymap.ncl -> keymap.json
+#
+# This module is a multi-pass transform:
+#  author-facing fields are gradually rewritten
+#  into the dense JSON shape consumed by codegen / firmware.
+#
+# Pipeline (authored -> intermediate -> output)
+# -------------------------------------------
+#
+# - Authored inputs (keymap.ncl surface)
+#   - `keys` / `layers`   KeymapLayer: string tokens or Array Key
+#   - `chords`            [{ indices, key }, …]
+#   - `config`            optional per-feature config
+#   - `custom_keys`       extends token vocabulary for string layers
+#   Per-key sugar still present here:
+#     { layered = [Key|null, ...] }            # numbered layers (index i -> layer i+1)
+#     { named_layers = { name = Key|null } }   # named layers (lowered later)
+#     automation keys with instruction lists (e.g. string macros)
+#     ordinary composite keys (tap_hold, ...)
+#
+# - Intermediate key arrays (same length; each pass rewrites slots)
+#   - `layers_of_keys`     layers normalized to Array Key
+#   - `layered_keys`       multi-layer authoring folded into base & { layered }
+#                           (per-key `named_layers` still allowed)
+#   - `chorded_keys`       global `chords` attached as chorded / passthrough
+#   - `automation_transform`
+#       { automation_instructions, keys }
+#       macros flattened: keys hold { start, length } refs into the instruction list
+#
+# - Late key rewrites (inside `json_keymap`, after automation)
+#   - lower named layers
+#       named_layers -> dense `layered` array layout: [numbered slots…] ++ [named slots…]
+#       global name  -> index is alphabetical (see named_layer_*)
+#   - pad layered arrays   every layered key shares the same array length
+#   - to_json_value        per-key module projection (array-form layered only)
+#
+# - Output (`json_keymap`)
+#   {
+#     config = author config
+#              & { automation.instructions? }
+#              & { chorded.chords = indices },
+#     keys   = [ json key, … ],
+#   }
+#
+# Exported layer-index helpers (for layer_mod / docs; 1-based like layered[i]):
+#    numbered_layer_count, named_layer_names, named_layer_indices, max_layered_length
+#
+# Nesting: several passes walk composite keys via keymap_ncl.*.map_accum so
+# layered / named_layers / automation under tap_hold etc. are rewritten too.
 (import "smart_keys/automation/keymap-ncl-to-json.ncl")
 & (import "smart_keys/callback/keymap-ncl-to-json.ncl")
 & (import "smart_keys/caps_word/keymap-ncl-to-json.ncl")
@@ -446,6 +495,7 @@
     k
     |> match {
       { layered, .. } => keymap_ncl.layered.key_validator k,
+      { named_layers, .. } => keymap_ncl.layered.key_validator k,
       _ => keymap_ncl.nullable_key.key_validator k,
     },
 
@@ -484,21 +534,26 @@
           )
           (std.array.length base_keys),
 
-  # Longest `layered` array on any layered key in the tree (not only the first key).
-  # Nested layered keys under composites are found via map_accum.
-  layered_length_of = fun k =>
-    if k != null && std.is_record k && keymap_ncl.layered.is_key k then
-      std.array.length k.layered
-    else
-      0,
+  # Pre-lowering: only `layered` (array) contributes to N (numbered slots).
+  #
+  # Keys with only `named_layers` return 0 here. Their M slots are counted via
+  # named_layer_names_* and appended in lower_named_layers_on_key as:
+  #   [null * N] ++ [named slots in global order].
+  numbered_layered_length_of = fun k =>
+    k
+    |> match {
+      { layered, .. } if keymap_ncl.layered.is_key k => std.array.length layered,
+      _ => 0,
+    },
 
-  max_layered_length_accum = fun acc k =>
-    let len = layered_length_of k in
+  # Longest numbered layered array in a key tree (via map_accum for nesting).
+  max_numbered_layered_length_accum = fun acc k =>
+    let len = numbered_layered_length_of k in
     let acc = if len > acc then len else acc in
     let { acc, k = _ } =
       keymap_ncl.nullable_key.map_accum
         (fun acc k =>
-          let len = layered_length_of k in
+          let len = numbered_layered_length_of k in
           let acc = if len > acc then len else acc in
           { include acc, include k }
         )
@@ -507,24 +562,152 @@
     in
     acc,
 
+  # Alias used by padding / checks for dense array length after named-layer lowering
+  # (everything is array-form by then; pre-lowering this is intentionally numbered-only).
+  max_layered_length_accum = max_numbered_layered_length_accum,
+
+  # Collect named-layer field names into a record set { layer_name = true, ... }.
+  # std.record.fields of the result is alphabetically sorted (Nickel field order).
+  named_layer_names_from_key = fun k =>
+    k
+    |> match {
+      { named_layers, .. } if keymap_ncl.layered.is_key k =>
+        named_layers
+        |> std.record.fields
+        |> std.array.fold_left
+          (fun names layer_name => names & { "%{layer_name}" = true })
+          {},
+      _ => {},
+    },
+
+  named_layer_names_accum = fun acc_names k =>
+    let acc_names = acc_names & named_layer_names_from_key k in
+    let { acc = acc_names, k = _ } =
+      keymap_ncl.nullable_key.map_accum
+        (fun acc_names k =>
+          { acc = acc_names & named_layer_names_from_key k, include k }
+        )
+        acc_names
+        k
+    in
+    acc_names,
+
+  named_layer_names_from_keys = fun keys =>
+    keys
+    |> std.array.fold_left named_layer_names_accum {}
+    |> std.record.fields,
+
+  numbered_layer_count_from_keys = fun keys =>
+    keys |> std.array.fold_left max_numbered_layered_length_accum 0,
+
+  # Total dense layered array length = numbered slots + named slots (named after numbered).
+  total_layered_length_from_keys = fun keys =>
+    let numbered = numbered_layer_count_from_keys keys in
+    let named = named_layer_names_from_keys keys in
+    numbered + std.array.length named,
+
+  named_layer_names
+    | doc "Alphabetically sorted named layer names used in the keymap."
+    = named_layer_names_from_keys layered_keys,
+
+  numbered_layer_count
+    | doc "Max numbered (`layered` array) length across the keymap."
+    = numbered_layer_count_from_keys layered_keys,
+
   max_layered_length
-    | doc "Longest layered-keys array length across the keymap (for layer count / padding)."
-    = layered_keys |> std.array.fold_left max_layered_length_accum 0,
+    | doc "Dense layered array length after named layers are appended (numbered + named)."
+    = numbered_layer_count + std.array.length named_layer_names,
+
+  # 1-based layer indices for layer_mod.* (layered[i] <-> layer i+1).
+  # Named layers start after numbered slots: first named layer -> numbered_layer_count + 1.
+  named_layer_indices
+    | doc "Record of named layer name -> 1-based layer index (for layer_mod)."
+    =
+      named_layer_names
+      |> std.array.map_with_index (fun i layer_name => { "%{layer_name}" = numbered_layer_count + i + 1 })
+      |> std.array.fold_left (&) {},
+
+  # Pad or truncate a numbered `layered` array to exactly `target_len`.
+  pad_or_slice_layered = fun target_len layered =>
+    let len = std.array.length layered in
+    if len >= target_len then
+      std.array.slice 0 target_len layered
+    else
+      layered @ std.array.generate (std.function.const null) (target_len - len),
+
+  # Look up each global named-layer name in `named_rec`; missing -> null (transparency).
+  named_slots_from = fun named_names named_rec =>
+    let filled =
+      named_names
+      |> std.array.fold_left
+        (fun acc layer_name => acc & { "%{layer_name}" | default = null })
+        named_rec
+    in
+    named_names |> std.array.map (fun layer_name => std.record.get layer_name filled),
+
+  # Scope: one key record (no nested walk).
+  # Merge layered (numbered) + named_layers into a dense layered array.
+  # Named layers occupy indices [numbered_len, numbered_len + |names|).
+  # Strips named_layers. Non-layered keys (and null) pass through unchanged.
+  lower_named_layers_on_key = fun numbered_len named_names k =>
+    k
+    |> match {
+      k if !(std.is_record k && keymap_ncl.layered.is_key k) => k,
+      { layered = numbered, named_layers = named, ..base_key } =>
+        base_key
+        & {
+          layered =
+            pad_or_slice_layered numbered_len numbered
+            @ named_slots_from named_names named,
+        },
+      { layered = numbered, ..base_key } =>
+        base_key
+        & {
+          layered =
+            pad_or_slice_layered numbered_len numbered
+            @ named_slots_from named_names {},
+        },
+      { named_layers = named, ..base_key } =>
+        base_key
+        & {
+          layered =
+            std.array.generate (std.function.const null) numbered_len
+            @ named_slots_from named_names named,
+        },
+    },
+
+  # Scope: one key tree (self, then nested via map_accum).
+  lower_named_layers_in_key_tree = fun numbered_len named_names k =>
+    let lower_f = fun acc key =>
+      let lowered = lower_named_layers_on_key numbered_len named_names key in
+      { include acc, k = lowered }
+    in
+    let k = lower_named_layers_on_key numbered_len named_names k in
+    let { acc = _, k } = keymap_ncl.nullable_key.map_accum lower_f null k in
+    k,
+
+  # Scope: array of key trees (pipeline pass). No-op when no named layers used.
+  lower_named_layers_on_keys = fun keys =>
+    let named_names = named_layer_names_from_keys keys in
+    named_names
+    |> match {
+      [] => keys,
+      _ =>
+        let numbered_len = numbered_layer_count_from_keys keys in
+        keys |> std.array.map (lower_named_layers_in_key_tree numbered_len named_names),
+    },
 
   # Pad a layered key's `layered` array with null (transparency) up to `target_len`.
+  # Expects post-lowering form (array `layered` only; no `named_layers`).
   pad_layered_key = fun target_len k =>
-    if k != null && std.is_record k && keymap_ncl.layered.is_key k then
-      let { layered, ..base_key } = k in
-      let len = std.array.length layered in
-      let padded_layered =
-        if len >= target_len then
-          layered
-        else
-          layered @ std.array.generate (std.function.const null) (target_len - len)
-      in
-      base_key & { layered = padded_layered }
-    else
-      k,
+    k
+    |> match {
+      { named_layers = _, .. } =>
+        std.fail_with "pad_layered_key expects array-form layered (lower named layers first)",
+      { layered = numbered, ..base_key } =>
+        base_key & { layered = pad_or_slice_layered target_len numbered },
+      k => k,
+    },
 
   # Pad every layered key in a key tree to `target_len` (self, then nested via map_accum).
   pad_key_layered_arrays = fun target_len k =>
@@ -595,6 +778,143 @@
               layered = [
                 null,
                 { key_code = 7 },
+              ],
+            },
+          ],
+        },
+    },
+
+  checks.check_named_layers =
+    let K = import "keys.ncl" in
+    {
+      check_named_layer_names_sorted = {
+        actual =
+          named_layer_names_from_keys [
+            K.A & { named_layers = { windows = K.B, linux = K.C } },
+            K.D & { named_layers = { macos = K.E } },
+          ],
+        expected = ["linux", "macos", "windows"],
+      },
+
+      check_named_layer_indices_after_numbered =
+        let keys = [
+          K.A & { layered = [ null, K.B] },
+          K.C & { named_layers = { windows = K.D, linux = K.E } },
+        ]
+        in
+        let numbered = numbered_layer_count_from_keys keys in
+        let names = named_layer_names_from_keys keys in
+        {
+          actual =
+            names
+            |> std.array.map_with_index (fun i layer_name => { "%{layer_name}" = numbered + i + 1 })
+            |> std.array.fold_left (&) {},
+          # numbered length 2 -> linux=3, windows=4
+          expected = { linux = 3, windows = 4 },
+        },
+
+      check_total_length_numbered_plus_named = {
+        actual =
+          total_layered_length_from_keys [
+            K.A & { layered = [K.B] },
+            K.C & { named_layers = { nav = K.D } },
+          ],
+        expected = 2,
+      },
+
+      check_lower_named_only =
+        let keys = [K.A & { named_layers = { fn = K.B, nav = K.C } }] in
+        {
+          actual = lower_named_layers_on_keys keys |> std.array.map keymap_ncl.key.to_json_value,
+          expected = [
+            {
+              base = { key_code = 4 },
+              # named sorted: fn, nav -> indices 0, 1
+              layered = [
+                { key_code = 5 },
+                { key_code = 6 },
+              ],
+            },
+          ],
+        },
+
+      check_lower_numbered_then_named =
+        let keys = [
+          K.A & { layered = [ null, K.B] },
+          K.C & { named_layers = { windows = K.D } },
+        ]
+        in
+        {
+          actual = lower_named_layers_on_keys keys |> std.array.map keymap_ncl.key.to_json_value,
+          expected = [
+            {
+              base = { key_code = 4 },
+              # numbered [null, B] + named slot windows
+              layered = [
+                null,
+                { key_code = 5 },
+                null,
+              ],
+            },
+            {
+              base = { key_code = 6 },
+              # numbered padding + windows = D
+              layered = [
+                null,
+                null,
+                { key_code = 7 },
+              ],
+            },
+          ],
+        },
+
+      check_lower_partial_named_union =
+        let keys = [
+          K.A & { named_layers = { linux = K.B, windows = K.C } },
+          K.D & { named_layers = { macos = K.E } },
+        ]
+        in
+        {
+          actual = lower_named_layers_on_keys keys |> std.array.map keymap_ncl.key.to_json_value,
+          expected = [
+            {
+              base = { key_code = 4 },
+              # sorted: linux, macos, windows
+              layered = [
+                { key_code = 5 },
+                null,
+                { key_code = 6 },
+              ],
+            },
+            {
+              base = { key_code = 7 },
+              layered = [
+                null,
+                { key_code = 8 },
+                null,
+              ],
+            },
+          ],
+        },
+
+      # Numbered + named on the same key (composable via `&`).
+      check_lower_both_on_same_key =
+        let keys = [
+          K.A
+          & { layered = [ null, K.B] }
+          & { named_layers = { fn = K.C } },
+        ]
+        in
+        {
+          actual = lower_named_layers_on_keys keys |> std.array.map keymap_ncl.key.to_json_value,
+          expected = [
+            {
+              base = { key_code = 4 },
+              # numbered [null, B] + named fn = C
+              layered = [
+                null,
+                { key_code = 5 },
+                { key_code = 6 },
               ],
             },
           ],
@@ -675,8 +995,11 @@
         else
           {}
       in
-      # Equalise layered array lengths (pad shorter with null / transparency) so
-      # consumers need not assume the first layered key is the longest.
+      # named_layers -> dense array after numbered `layered` slots:
+      #   layered = [ numbered slots… ] ++ [ named slots… ]
+      # Named order is alphabetical (Nickel record field order). Skipped if unused.
+      let keys = lower_named_layers_on_keys keys in
+      # Equalise layered array lengths (pad shorter with null / transparency).
       let layer_count =
         keys |> std.array.fold_left max_layered_length_accum 0
       in

--- a/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
@@ -174,6 +174,17 @@
           ],
         },
       },
+
+      check_named_layers_is_key =
+        let key = K.A & { named_layers = { nav = K.B, fn = K.C } } in
+        keymap_ncl.layered.is_key key,
+
+      check_named_layers_validator_ok =
+        keymap_ncl.layered.key_validator (K.A & { named_layers = { windows = K.B } }) == 'Ok,
+
+      check_layered_and_named_layers_is_key =
+        let key = K.A & { layered = [ null, K.B], named_layers = { fn = K.C } } in
+        keymap_ncl.layered.is_key key,
     },
 
   keymap_ncl.layered
@@ -185,44 +196,113 @@
 
       Key = std.contract.from_validator key_validator,
 
+      # Element of a layered / named_layers slot: Key or transparent null.
+      layer_element_validator =
+        validators.any_of [validators.is_null, keymap_ncl.key.key_validator],
+
+      layered_array_validator =
+        validators.array.validator layer_element_validator,
+
+      # named_layers: Record String -> (Key|null)
+      named_layers_validator =
+        validators.all_of [
+          validators.is_record,
+          fun r => r |> std.record.values |> layered_array_validator,
+        ],
+
+      # A layered key has at least one of:
+      # - `layered` = Array (Key|null): numbered layers (layer index 1 + i)
+      # - `named_layers` = Record { layer_name = Key|null, ... }: named layers
+      #   (indices after all numbered layers; lowered before JSON)
+      # Both may be present on the same key (numbered + named compose via `&`).
       key_validator = fun k =>
         k
         |> match {
-          { layered, ..base_key } =>
+          { layered, named_layers, ..base_key } =>
             validators.all_ok [
-              layered
-              |> validators.array.validator (
-                validators.any_of [validators.is_null, keymap_ncl.key.key_validator]
-              ),
+              layered_array_validator layered,
+              named_layers_validator named_layers,
               keymap_ncl.key.key_validator base_key,
             ],
-          _ => 'Error { message = "expected { layered = Array Key, ..base_key }" },
+          { layered, ..base_key } =>
+            validators.all_ok [
+              layered_array_validator layered,
+              keymap_ncl.key.key_validator base_key,
+            ],
+          { named_layers, ..base_key } =>
+            validators.all_ok [
+              named_layers_validator named_layers,
+              keymap_ncl.key.key_validator base_key,
+            ],
+          _ =>
+            'Error {
+              message = "expected { layered = Array Key and/or named_layers = Record String -> Key, ..base_key }",
+            },
         },
 
       is_key = fun k => 'Ok == key_validator k,
 
-      to_json_value = fun { layered = layered_keys, ..base_key } =>
-        {
-          base = keymap_ncl.key.to_json_value base_key,
-          layered =
-            std.array.map
-              (fun k => if k != null then keymap_ncl.key.to_json_value k else null)
-              layered_keys,
+      # JSON projection expects dense array form only (`layered` array, no `named_layers`).
+      # Named layers must be lowered first (see keymap-ncl-to-json named layer transform).
+      to_json_value = fun k =>
+        k
+        |> match {
+          { named_layers = _, .. } =>
+            std.fail_with "named_layers must be lowered to array form before to_json_value",
+          { layered = layered_keys, ..base_key } =>
+            {
+              base = keymap_ncl.key.to_json_value base_key,
+              layered =
+                std.array.map
+                  (fun k => if k != null then keymap_ncl.key.to_json_value k else null)
+                  layered_keys,
+            },
         },
 
-      map_accum = fun f acc k @ { layered, ..base_key } =>
-        let { acc, layered } =
-          layered
-          |> std.array.fold_left
-            (fun { acc, layered } k =>
-              let { acc, k } = f acc k in
-              let layered = layered @ [k] in
-              { include acc, include layered }
-            )
-            { include acc, layered = [] }
-        in
-        let { acc, k = base_key } = f acc base_key in
-        # n.b.: `.. base_key` results in format error.
-        { include acc, k = { include layered, } & base_key, },
+      # Visit children under `layered` (array) and/or `named_layers` (record), then base.
+      # Assumes a valid layered key shape (is_key); no defensive has_field checks.
+      map_layered_array = fun f acc layered =>
+        layered
+        |> std.array.fold_left
+          (fun { acc, layered } child =>
+            let { acc, k } = f acc child in
+            # let-bind before record: record fields are recursive by default.
+            let layered = layered @ [k] in
+            { include acc, include layered }
+          )
+          { include acc, layered = [] },
+
+      map_named_layers = fun f acc named_layers =>
+        std.record.fields named_layers
+        |> std.array.fold_left
+          (fun { acc, named_layers = parts } layer_name =>
+            let child = std.record.get layer_name named_layers in
+            let { acc, k = new_child } = f acc child in
+            let named_layers = parts & { "%{layer_name}" = new_child } in
+            { include acc, include named_layers }
+          )
+          { include acc, named_layers = {} },
+
+      map_accum = fun f acc k =>
+        k
+        |> match {
+          { layered = numbered, named_layers = named, ..base_key } =>
+            let { acc, layered } = map_layered_array f acc numbered in
+            let { acc, named_layers } = map_named_layers f acc named in
+            let { acc, k = base_key } = f acc base_key in
+            # n.b.: `.. base_key` results in format error.
+            {
+              include acc,
+              k = base_key & { include layered, include named_layers },
+            },
+          { layered = numbered, ..base_key } =>
+            let { acc, layered } = map_layered_array f acc numbered in
+            let { acc, k = base_key } = f acc base_key in
+            { include acc, k = base_key & { include layered } },
+          { named_layers = named, ..base_key } =>
+            let { acc, named_layers } = map_named_layers f acc named in
+            let { acc, k = base_key } = f acc base_key in
+            { include acc, k = base_key & { include named_layers } },
+        },
     },
 }


### PR DESCRIPTION
## Summary

Adds **named layers** as a first-class form of `layered` on keys in `keymap.ncl` → JSON.

### Numbered vs named

```nickel
# Numbered (existing): array slots → layers 1..N
K.A & { layered = [null, K.B, K.C] }

# Named (new): name → key record → layers after numbered
K.NO & { layered = { linux = K.PageUp, macos = K.Left } }
```

### Dense layout (what JSON / codegen see)

```
base
+ numbered layers 1..N     (array-form `layered`)
+ named layers   N+1..N+M  (record-form names, alphabetical)
```

No reserved gap before named layers. If there are no numbered layers, named layers start at layer **1**. (Earlier semantic-key sketches that hard-coded windows=3 / linux=4 / macos=5 were the wrong model.)

Example with both:

```nickel
keys = [
  K.D & { layered = [null, K.E] },   # N = 2
  K.NO & { layered = { windows = K.A, linux = K.B, macos = K.C } },
]
```

Named names sorted: `linux`, `macos`, `windows` → layers **3, 4, 5**.

### Lowering pass

Authoring keeps the record. One pass in `json_keymap` materialises dense arrays so every key shares the same global name → index assignment (including keys that only define a subset of the names).

**Skipped entirely** when no key uses the record form — no extra walk for ordinary keymaps.

Pipeline:

1. Collect named-layer field names across keys (nested via `map_accum`)
2. Sort alphabetically (Nickel `std.record.fields`)
3. Lower each layered key: numbered slots, then named slots (`null` where undefined)
4. Pad to global max length (existing behaviour)
5. `to_json_value` (array form only)

### Exported helpers

| Field | Meaning |
|-------|---------|
| `named_layer_names` | Sorted name list |
| `named_layer_indices` | name → 1-based layer index (for `layer_mod.*`) |
| `numbered_layer_count` | Max array-form length N |
| `max_layered_length` | N + M |

### Follow-ups (not in this PR)

- Keymap-level control of named-layer order (override alpha)
- OS-desktop / semantic sugar (#570) should build on **names**, not hard-coded indices
- Optional: `layer_mod` accepting a layer name string

## Test plan

- [x] `ncl/scripts/run-ncl-checks.sh` (named-layer checks + existing)
- [x] Mixed numbered + named JSON export
- [x] Lowering no-op when only array-form layered keys
- [x] Rebased on current `origin/master`