### PR TITLE
keyberon-smart-keyboard: lift Keymap generics on KeyboardBackend

### DIFF
--- a/keyberon-smart-keyboard/src/input/smart_keymap.rs
+++ b/keyberon-smart-keyboard/src/input/smart_keymap.rs
@@ -1,3 +1,10 @@
+use core::fmt::Debug;
+use core::ops::Index;
+
+use smart_keymap::input;
+use smart_keymap::key;
+use smart_keymap::keymap::{self, Keymap, KeymapOutput, SetKeymapContext};
+
 /// Callbacks for the keymap.
 pub struct KeymapCallbacks {
     /// Callback for resetting keyboard state.
@@ -9,10 +16,20 @@ pub struct KeymapCallbacks {
 /// The keyboard "backend", manages the keyboard from the events received
 /// (presses/releases of coordinates on a keyboard layout).
 /// through to listing HID scancodes to report using HIDs.
+///
+/// Type parameters match [Keymap].
 #[derive(Debug)]
-pub struct KeyboardBackend {
-    keymap: smart_keymap::Keymap,
-    keymap_output: smart_keymap::keymap::KeymapOutput,
+pub struct KeyboardBackend<
+    I: Index<usize, Output = R> = [smart_keymap::init::Ref; smart_keymap::init::KEY_COUNT],
+    R = smart_keymap::init::Ref,
+    Ctx = smart_keymap::init::Context,
+    Ev: Debug = smart_keymap::init::Event,
+    PKS = smart_keymap::init::PendingKeyState,
+    KS = smart_keymap::init::KeyState,
+    S = smart_keymap::init::System,
+> {
+    keymap: Keymap<I, R, Ctx, Ev, PKS, KS, S>,
+    keymap_output: KeymapOutput,
 }
 
 impl Default for KeyboardBackend {
@@ -22,22 +39,40 @@ impl Default for KeyboardBackend {
 }
 
 impl KeyboardBackend {
-    /// Constructs a new keyboard backend.
+    /// Constructs a new keyboard backend using the board keymap
+    ///  ([smart_keymap::new_keymap]).
     pub fn new() -> Self {
         Self::new_with_keymap(smart_keymap::new_keymap())
     }
+}
 
+impl<I, R, Ctx, Ev, PKS, KS, S> KeyboardBackend<I, R, Ctx, Ev, PKS, KS, S>
+where
+    I: Index<usize, Output = R>,
+    Ev: Debug,
+{
     /// Constructs a new keyboard backend with the given keymap.
-    pub fn new_with_keymap(keymap: smart_keymap::Keymap) -> Self {
+    pub fn new_with_keymap(keymap: Keymap<I, R, Ctx, Ev, PKS, KS, S>) -> Self {
         Self {
             keymap,
-            keymap_output: smart_keymap::keymap::KeymapOutput::default(),
+            keymap_output: KeymapOutput::default(),
         }
     }
+}
 
+impl<I, R, Ctx, Ev, PKS, KS, S> KeyboardBackend<I, R, Ctx, Ev, PKS, KS, S>
+where
+    I: Debug + Index<usize, Output = R>,
+    R: Copy + Debug,
+    Ctx: Debug + key::Context<Event = Ev> + SetKeymapContext,
+    Ev: Copy + Debug,
+    PKS: Debug,
+    KS: Copy + Debug + From<key::NoOpKeyState>,
+    S: key::System<R, Ref = R, Context = Ctx, Event = Ev, PendingKeyState = PKS, KeyState = KS>,
+{
     /// Set the keymap callbacks.
     pub fn set_callbacks(&mut self, callbacks: KeymapCallbacks) {
-        use smart_keymap::keymap::KeymapCallback;
+        use keymap::KeymapCallback;
         if let Some(callback_fn) = callbacks.reset {
             self.keymap.set_callback(KeymapCallback::Reset, callback_fn);
         }
@@ -48,7 +83,7 @@ impl KeyboardBackend {
     }
 
     /// Register a key event.
-    pub fn event(&mut self, event: smart_keymap::input::Event) {
+    pub fn event(&mut self, event: input::Event) {
         self.keymap.handle_input(event);
     }
 
@@ -67,21 +102,22 @@ impl KeyboardBackend {
         old_keymap_output != self.keymap_output
     }
 
-    pub fn keymap_output(&self) -> &smart_keymap::keymap::KeymapOutput {
+    /// Returns the current keymap output.
+    pub fn keymap_output(&self) -> &KeymapOutput {
         &self.keymap_output
     }
 }
 
-/// Constructs a [smart_keymap::input::Event] from a [keyberon::layout::Event],
+/// Constructs a [input::Event] from a [keyberon::layout::Event],
 ///  using a map from row, column to (maybe) keymap index.
 pub fn keymap_index_of<const COLS: usize, const ROWS: usize>(
     indices: &[[Option<u16>; COLS]; ROWS],
     ev: keyberon::layout::Event,
-) -> Option<smart_keymap::input::Event> {
+) -> Option<input::Event> {
     match ev {
         keyberon::layout::Event::Press(r, c) => indices[r as usize][c as usize]
-            .map(|keymap_index| smart_keymap::input::Event::Press { keymap_index }),
+            .map(|keymap_index| input::Event::Press { keymap_index }),
         keyberon::layout::Event::Release(r, c) => indices[r as usize][c as usize]
-            .map(|keymap_index| smart_keymap::input::Event::Release { keymap_index }),
+            .map(|keymap_index| input::Event::Release { keymap_index }),
     }
 }


### PR DESCRIPTION
## Summary

Lift the type parameters of `keymap::Keymap` onto `keyberon_smart_keyboard::input::smart_keymap::KeyboardBackend`, instead of hardcoding the board type alias `smart_keymap::Keymap`.

Existing call sites (`KeyboardBackend`, `KeyboardBackend::new()`) keep working via default type parameters.

## Motivation

`KeyboardBackend` previously owned a concrete `smart_keymap::Keymap`:

```rust
pub struct KeyboardBackend {
    keymap: smart_keymap::Keymap,
    keymap_output: smart_keymap::keymap::KeymapOutput,
}
```

`smart_keymap::Keymap` is itself an alias over the generic `keymap::Keymap<I, R, Ctx, Ev, PKS, KS, S>`. Hiding those parameters on the firmware-facing backend meant:

- custom / non-`init` keymaps could not be wrapped without going through the board alias
- the backend did not match the pattern already used by `ObservedKeymap`, which *does* lift the same parameters

## How it works

### Type parameters

`KeyboardBackend` now mirrors `Keymap` / `ObservedKeymap`:

| Param | Role | Default (board keymap) |
|-------|------|------------------------|
| `I` | key-ref storage (`Index<usize, Output = R>`) | `[init::Ref; init::KEY_COUNT]` |
| `R` | key ref | `init::Ref` |
| `Ctx` | system context | `init::Context` |
| `Ev` | key event | `init::Event` |
| `PKS` | pending key state | `init::PendingKeyState` |
| `KS` | key state | `init::KeyState` |
| `S` | key system | `init::System` |

```rust
pub struct KeyboardBackend<I, R, Ctx, Ev, PKS, KS, S = ...> {
    keymap: Keymap<I, R, Ctx, Ev, PKS, KS, S>,
    keymap_output: KeymapOutput,
}
```

Defaults are the types from `smart_keymap::init`, so bare `KeyboardBackend` is still the board keymap backend.

### Impl split

1. **`impl KeyboardBackend` (all defaults)** — `new()` / `Default` call `smart_keymap::new_keymap()`.
2. **`new_with_keymap`** — generic over any `Keymap<I, R, Ctx, Ev, PKS, KS, S>` (light bounds).
3. **Event / tick / callbacks / output** — same method bounds as `Keymap` / `ObservedKeymap` (`key::System`, `SetKeymapContext`, etc.).

Firmware that only uses `KeyboardBackend::new()` is unchanged. Code that builds a custom `Keymap` can use `KeyboardBackend::new_with_keymap(keymap)` without monomorphizing through the `smart_keymap::Keymap` alias.

## Test plan

- [x] `cargo check -p keyberon-smart-keyboard`
- [x] `cargo check -p rp2040-rtic-smart-keyboard --target thumbv6m-none-eabi`
- [x] `cargo check -p stm32f4-rtic-smart-keyboard --target thumbv7em-none-eabihf`