### PR TITLE
test: expand pending delay-line vs session-log coverage

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -27,6 +27,18 @@ pub enum Event {
     },
 }
 
+impl Event {
+    /// Physical press of the key at `keymap_index`.
+    pub const fn press(keymap_index: u16) -> Self {
+        Self::Press { keymap_index }
+    }
+
+    /// Physical release of the key at `keymap_index`.
+    pub const fn release(keymap_index: u16) -> Self {
+        Self::Release { keymap_index }
+    }
+}
+
 /// A struct for associating a key ref with a [crate::key::KeyState].
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PressedKey<R, S> {

--- a/src/key.rs
+++ b/src/key.rs
@@ -880,12 +880,8 @@ mod tests {
     #[test]
     fn pending_resolution_events_other_key_events_all_included() {
         let mut queued: heapless::Vec<Event<()>, 16> = heapless::Vec::new();
-        queued
-            .push(Event::Input(input::Event::Press { keymap_index: 1 }))
-            .unwrap();
-        queued
-            .push(Event::Input(input::Event::Release { keymap_index: 2 }))
-            .unwrap();
+        queued.push(input::Event::press(1).into()).unwrap();
+        queued.push(input::Event::release(2).into()).unwrap();
         let result = pending_resolution_events(&queued, 0);
         assert_eq!(2, result.len());
     }
@@ -893,41 +889,22 @@ mod tests {
     #[test]
     fn pending_resolution_events_resolving_key_only_last_included() {
         let mut queued: heapless::Vec<Event<()>, 16> = heapless::Vec::new();
-        queued
-            .push(Event::Input(input::Event::Press { keymap_index: 0 }))
-            .unwrap();
-        queued
-            .push(Event::Input(input::Event::Release { keymap_index: 0 }))
-            .unwrap();
+        queued.push(input::Event::press(0).into()).unwrap();
+        queued.push(input::Event::release(0).into()).unwrap();
         let result = pending_resolution_events(&queued, 0);
         assert_eq!(1, result.len());
-        assert_eq!(
-            Event::Input(input::Event::Release { keymap_index: 0 }),
-            result[0]
-        );
+        assert_eq!(Event::from(input::Event::release(0)), result[0]);
     }
 
     #[test]
     fn pending_resolution_events_mix_other_and_resolving_key() {
         let mut queued: heapless::Vec<Event<()>, 16> = heapless::Vec::new();
-        queued
-            .push(Event::Input(input::Event::Press { keymap_index: 1 }))
-            .unwrap();
-        queued
-            .push(Event::Input(input::Event::Press { keymap_index: 0 }))
-            .unwrap();
-        queued
-            .push(Event::Input(input::Event::Release { keymap_index: 0 }))
-            .unwrap();
+        queued.push(input::Event::press(1).into()).unwrap();
+        queued.push(input::Event::press(0).into()).unwrap();
+        queued.push(input::Event::release(0).into()).unwrap();
         let result = pending_resolution_events(&queued, 0);
         assert_eq!(2, result.len());
-        assert_eq!(
-            Event::Input(input::Event::Press { keymap_index: 1 }),
-            result[0]
-        );
-        assert_eq!(
-            Event::Input(input::Event::Release { keymap_index: 0 }),
-            result[1]
-        );
+        assert_eq!(Event::from(input::Event::press(1)), result[0]);
+        assert_eq!(Event::from(input::Event::release(0)), result[1]);
     }
 }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -762,10 +762,38 @@ impl<
         S: key::System<R, Ref = R, Context = Ctx, Event = Ev, PendingKeyState = PKS, KeyState = KS>,
     > Keymap<I, R, Ctx, Ev, PKS, KS, S>
 {
+    pub(crate) fn test_is_pending(&self) -> bool {
+        self.pending_state.is_some()
+    }
+
     pub(crate) fn test_pending_queued_events_len(&self) -> Option<usize> {
         self.pending_state
             .as_ref()
             .map(|pending_state| pending_state.queued_events.len())
+    }
+
+    /// Session-log input events (only `Event::Input` variants),
+    ///  in log order.
+    pub(crate) fn test_pending_session_log_inputs(
+        &self,
+    ) -> Option<heapless::Vec<input::Event, 16>> {
+        self.pending_state.as_ref().map(|pending_state| {
+            let mut inputs = heapless::Vec::new();
+            for ev in pending_state.queued_events.iter() {
+                if let key::Event::Input(ie) = ev {
+                    let _ = inputs.push(*ie);
+                }
+            }
+            inputs
+        })
+    }
+
+    pub(crate) fn test_input_queue_len(&self) -> usize {
+        self.input_queue.len()
+    }
+
+    pub(crate) fn test_input_queue_delay(&self) -> u8 {
+        self.input_queue.delay_counter()
     }
 
     pub(crate) fn test_handle_scheduled_key_event(&mut self, ev: key::Event<Ev>) {
@@ -935,25 +963,38 @@ mod tests {
         }};
     }
 
+    fn tap_hold_timeout_event() -> key::Event<crate::key::composite::Event> {
+        key::Event::Key {
+            keymap_index: 0,
+            key_event: crate::key::composite::Event::TapHold(
+                crate::key::tap_hold::Event::TapHoldTimeout,
+            ),
+        }
+    }
+
     /// `queued_events` gets one entry per processed input;
-    /// tick delay defers the second physical `handle_input` until `tick()`.
+    ///  tick delay defers the second physical `handle_input` until `tick()`.
+    ///
+    /// Motivating smart key: **tap-hold** (control for #578).
     #[test]
     fn physical_input_during_pending_records_once_in_queued_events() {
         use crate::key::tap_hold::InterruptResponse;
 
+        // Assemble
         let mut keymap = tap_hold_interrupt_keymap(InterruptResponse::Ignore);
-
         keymap.handle_input(input::Event::Press { keymap_index: 0 });
         let baseline = keymap
             .test_pending_queued_events_len()
             .expect("tap-hold pending");
 
+        // Act -- deferred interrupt press, then pace it in.
         keymap.handle_input(input::Event::Press { keymap_index: 1 });
         assert_eq!(Some(baseline), keymap.test_pending_queued_events_len());
-
         // First tick clears delay; second tick dequeues the deferred press.
         keymap.tick();
         keymap.tick();
+
+        // Assert
         assert_eq!(Some(baseline + 1), keymap.test_pending_queued_events_len());
     }
 
@@ -963,19 +1004,23 @@ mod tests {
     /// With `HoldOnKeyPress`,
     ///  the interrupt should resolve the tap-hold to hold
     ///  without also pressing the interrupting key.
+    ///
+    /// Motivating smart key: **tap-hold** (`HoldOnKeyPress` home-row mods; #578).
     #[test]
     fn scheduled_input_during_pending_does_not_reprocess_as_physical_press() {
         use crate::key::tap_hold::InterruptResponse;
 
+        // Assemble
         let mut keymap = tap_hold_interrupt_keymap(InterruptResponse::HoldOnKeyPress);
-
         keymap.handle_input(input::Event::Press { keymap_index: 0 });
         assert!(keymap.test_pending_queued_events_len().is_some());
 
+        // Act
         keymap.test_handle_scheduled_key_event(key::Event::Input(input::Event::Press {
             keymap_index: 1,
         }));
 
+        // Assert -- hold only; interrupt key not pressed (#578).
         let hold = key::KeyOutput::from_key_code(0xE0);
         let interrupt_key = key::KeyOutput::from_key_code(0x05);
         assert_eq!(
@@ -983,6 +1028,329 @@ mod tests {
             keymap.pressed_keys()
         );
         assert!(!keymap.pressed_keys().contains(&interrupt_key));
+    }
+
+    /// Creating a pending key sets the delay
+    ///  so the *next* physical input is deferred.
+    ///
+    /// Motivating smart key: **tap-hold**
+    ///  (`key_uninterrupted_tap_is_reported` / interrupt pacing).
+    #[test]
+    fn pending_creation_defers_next_physical_input_by_one_delay() {
+        use crate::key::tap_hold::InterruptResponse;
+
+        // Assemble
+        let mut keymap = tap_hold_interrupt_keymap(InterruptResponse::Ignore);
+        keymap.handle_input(input::Event::Press { keymap_index: 0 });
+        assert!(keymap.test_is_pending());
+        assert_eq!(INPUT_QUEUE_TICK_DELAY, keymap.test_input_queue_delay());
+
+        // Act -- interrupt without waiting for ticks.
+        keymap.handle_input(input::Event::Press { keymap_index: 1 });
+
+        // Assert -- still only in the delay line, not the session log.
+        assert_eq!(1, keymap.test_input_queue_len());
+        assert_eq!(Some(0), keymap.test_pending_queued_events_len());
+        assert!(keymap.pressed_keys().is_empty());
+    }
+
+    /// Physical inputs while delay > 0 sit in the delay line
+    ///  and are not yet recorded in the session log.
+    ///
+    /// Motivating smart key: **tap-hold**
+    ///  (interrupts must not enter the session log until paced).
+    #[test]
+    fn physical_inputs_while_delay_active_stay_in_delay_line() {
+        use crate::key::tap_hold::InterruptResponse;
+
+        // Assemble -- pending with delay set.
+        let mut keymap = tap_hold_interrupt_keymap(InterruptResponse::Ignore);
+        keymap.handle_input(input::Event::Press { keymap_index: 0 });
+        assert_eq!(INPUT_QUEUE_TICK_DELAY, keymap.test_input_queue_delay());
+
+        // Act
+        keymap.handle_input(input::Event::Press { keymap_index: 1 });
+        keymap.handle_input(input::Event::Release { keymap_index: 1 });
+
+        // Assert
+        assert_eq!(2, keymap.test_input_queue_len());
+        assert_eq!(Some(0), keymap.test_pending_queued_events_len());
+    }
+
+    /// While pending, the first tick after a delay only clears the delay;
+    ///  it does not dequeue the next delay-line input.
+    ///
+    /// Motivating smart key: **tap-hold**
+    ///  (one-input-per-tick spacing for interrupt detection).
+    #[test]
+    fn first_tick_while_pending_only_clears_delay() {
+        use crate::key::tap_hold::InterruptResponse;
+
+        // Assemble -- pending with two events waiting in the delay line.
+        let mut keymap = tap_hold_interrupt_keymap(InterruptResponse::Ignore);
+        keymap.handle_input(input::Event::Press { keymap_index: 0 });
+        keymap.handle_input(input::Event::Press { keymap_index: 1 });
+        keymap.handle_input(input::Event::Release { keymap_index: 1 });
+        assert_eq!(2, keymap.test_input_queue_len());
+
+        // Act
+        keymap.tick();
+
+        // Assert
+        assert_eq!(2, keymap.test_input_queue_len());
+        assert_eq!(Some(0), keymap.test_pending_queued_events_len());
+        assert_eq!(0, keymap.test_input_queue_delay());
+    }
+
+    /// When delay is already 0, a tick moves exactly one delay-line input
+    ///  into the session log.
+    ///
+    /// Motivating smart key: **tap-hold**
+    ///  (paced interrupt press then release land in separate ticks).
+    #[test]
+    fn tick_when_delay_zero_moves_one_input_into_session_log() {
+        use crate::key::tap_hold::InterruptResponse;
+
+        // Assemble -- delay cleared; Press(1) and Release(1) still queued.
+        let mut keymap = tap_hold_interrupt_keymap(InterruptResponse::Ignore);
+        keymap.handle_input(input::Event::Press { keymap_index: 0 });
+        keymap.handle_input(input::Event::Press { keymap_index: 1 });
+        keymap.handle_input(input::Event::Release { keymap_index: 1 });
+        keymap.tick(); // clear delay
+        assert_eq!(0, keymap.test_input_queue_delay());
+        assert_eq!(2, keymap.test_input_queue_len());
+
+        // Act
+        keymap.tick();
+
+        // Assert -- Press(1) entered the session log; Release still delayed.
+        assert_eq!(1, keymap.test_input_queue_len());
+        assert_eq!(Some(1), keymap.test_pending_queued_events_len());
+        let log = keymap.test_pending_session_log_inputs().unwrap();
+        assert_eq!(&[input::Event::Press { keymap_index: 1 }], log.as_slice());
+    }
+
+    /// Resolve via timeout does not drain the delay line:
+    ///  never-logged inputs stay queued for post-resolve pacing.
+    ///
+    /// Motivating smart key: **tap-hold**
+    ///  (timeout-to-hold while an interrupt is still only delayed).
+    #[test]
+    fn resolve_by_timeout_leaves_delay_line_inputs_queued() {
+        use crate::key::tap_hold::InterruptResponse;
+
+        // Assemble -- interrupt still only in the delay line (not session log).
+        let mut keymap = tap_hold_interrupt_keymap(InterruptResponse::Ignore);
+        keymap.handle_input(input::Event::Press { keymap_index: 0 });
+        keymap.handle_input(input::Event::Press { keymap_index: 1 });
+        assert_eq!(1, keymap.test_input_queue_len());
+        assert_eq!(Some(0), keymap.test_pending_queued_events_len());
+
+        // Act
+        keymap.test_handle_scheduled_key_event(tap_hold_timeout_event());
+
+        // Assert -- hold; delay-line Press(1) still queued, not applied as a press.
+        assert!(!keymap.test_is_pending());
+        assert_eq!(1, keymap.test_input_queue_len());
+        let hold = key::KeyOutput::from_key_code(0xE0);
+        assert_eq!(
+            heapless::Vec::<key::KeyOutput, { MAX_PRESSED_KEYS }>::from_slice(&[hold]).unwrap(),
+            keymap.pressed_keys()
+        );
+        assert!(!keymap
+            .pressed_keys()
+            .contains(&key::KeyOutput::from_key_code(0x05)));
+    }
+
+    /// After resolve, paced ticks drain the former delay-line input
+    ///  as a normal press.
+    ///
+    /// Motivating smart key: **tap-hold**
+    ///  (post-hold interrupt key still registers as a normal press).
+    #[test]
+    fn post_resolve_ticks_drain_delay_line_as_normal_press() {
+        use crate::key::tap_hold::InterruptResponse;
+
+        // Assemble -- resolve while Press(1) is still only in the delay line.
+        let mut keymap = tap_hold_interrupt_keymap(InterruptResponse::Ignore);
+        keymap.handle_input(input::Event::Press { keymap_index: 0 });
+        keymap.handle_input(input::Event::Press { keymap_index: 1 });
+        keymap.test_handle_scheduled_key_event(tap_hold_timeout_event());
+        assert!(!keymap.test_is_pending());
+        assert_eq!(1, keymap.test_input_queue_len());
+
+        // Act -- post-resolve pacing.
+        keymap.tick();
+        keymap.tick();
+        if keymap.test_input_queue_len() > 0 {
+            keymap.tick();
+            keymap.tick();
+        }
+
+        // Assert
+        assert_eq!(0, keymap.test_input_queue_len());
+        assert!(keymap
+            .pressed_keys()
+            .contains(&key::KeyOutput::from_key_code(0x05)));
+    }
+
+    /// Inputs still only in the delay line at resolve time
+    ///  are excluded from the session log,
+    ///  so they are not absorbed into resolve replay.
+    ///
+    /// After a processing `tick`,
+    ///  delay ends at 0 (set DELAY then `tick_delay` in the same tick),
+    ///  so the next queued event is ready but not yet popped
+    ///  until the next `tick`/`handle_input`.
+    ///
+    /// Motivating smart key: **tap-hold**
+    ///  (partially paced interrupt release must survive resolve).
+    #[test]
+    fn resolve_leaves_never_logged_delay_line_inputs_queued() {
+        use crate::key::tap_hold::InterruptResponse;
+
+        // Assemble -- pace Press(1) into the session log; leave Release(1) queued.
+        let mut keymap = tap_hold_interrupt_keymap(InterruptResponse::Ignore);
+        keymap.handle_input(input::Event::Press { keymap_index: 0 });
+        keymap.handle_input(input::Event::Press { keymap_index: 1 });
+        keymap.handle_input(input::Event::Release { keymap_index: 1 });
+        keymap.tick(); // clear delay
+        keymap.tick(); // process Press(1)
+        assert_eq!(Some(1), keymap.test_pending_queued_events_len());
+        assert_eq!(1, keymap.test_input_queue_len());
+        assert_eq!(0, keymap.test_input_queue_delay());
+
+        // Act -- resolve without processing remaining Release(1).
+        keymap.test_handle_scheduled_key_event(tap_hold_timeout_event());
+
+        // Assert -- never-logged Release(1) remains queued
+        //  (session log may also prepend Press(1) ahead of it).
+        assert!(!keymap.test_is_pending());
+        assert!(
+            keymap.test_input_queue_len() >= 1,
+            "at least the never-logged Release(1) should remain queued after resolve"
+        );
+    }
+
+    /// A scheduled `Event::Input` during pending is applied immediately
+    ///  and recorded when still pending,
+    ///  while a concurrent physical input stays in the delay line.
+    ///
+    /// Motivating smart key: **tap-hold**
+    ///  (scheduled vs physical dual paths during pending; #578 family).
+    #[test]
+    fn scheduled_input_during_pending_records_while_physical_stays_delayed() {
+        use crate::key::tap_hold::InterruptResponse;
+
+        // Assemble -- pending; physical interrupt already in the delay line.
+        // Ignore so the scheduled interrupt does not resolve.
+        let mut keymap = tap_hold_interrupt_keymap(InterruptResponse::Ignore);
+        keymap.handle_input(input::Event::Press { keymap_index: 0 });
+        keymap.handle_input(input::Event::Press { keymap_index: 1 });
+        assert_eq!(1, keymap.test_input_queue_len());
+        assert_eq!(Some(0), keymap.test_pending_queued_events_len());
+
+        // Act
+        keymap.test_handle_scheduled_key_event(key::Event::Input(input::Event::Press {
+            keymap_index: 1,
+        }));
+
+        // Assert -- scheduled recorded; physical still waiting (not double-processed).
+        assert!(keymap.test_is_pending());
+        assert_eq!(Some(1), keymap.test_pending_queued_events_len());
+        assert_eq!(1, keymap.test_input_queue_len());
+    }
+
+    /// When pending resolves inside a `tick` that pops from the delay line,
+    ///  `tick` ends with `set_delay(DELAY)` then `tick_delay()`,
+    ///  so delay is 0 after resolve.
+    /// Resolve also prepends filtered session-log inputs onto the queue.
+    ///
+    /// Motivating smart key: **tap-hold**
+    ///  (release-as-tap path; delay-after-resolve timing for observed reports).
+    #[test]
+    fn resolve_via_tick_leaves_delay_zero_and_queues_replay() {
+        use crate::key::tap_hold::InterruptResponse;
+
+        // Assemble -- pending release waiting in the delay line.
+        let mut keymap = tap_hold_interrupt_keymap(InterruptResponse::Ignore);
+        keymap.handle_input(input::Event::Press { keymap_index: 0 });
+        keymap.handle_input(input::Event::Release { keymap_index: 0 });
+        assert!(keymap.test_is_pending());
+        keymap.tick(); // clear delay
+
+        // Act -- process release → resolve as tap; prepend last self Release.
+        keymap.tick();
+
+        // Assert
+        assert!(!keymap.test_is_pending());
+        assert_eq!(
+            0,
+            keymap.test_input_queue_delay(),
+            "tick sets DELAY then tick_delay in the same call"
+        );
+        assert!(
+            keymap.test_input_queue_len() >= 1,
+            "resolve prepends filtered session-log inputs onto the delay line"
+        );
+    }
+
+    /// When resolve happens inside `handle_input`
+    ///  (HoldOnKeyPress interrupt popped in that call),
+    ///  DELAY is set without a same-call `tick_delay`,
+    ///  so the next physical input is deferred —
+    ///  a different delay state than resolve-via-tick.
+    ///
+    /// Motivating smart key: **tap-hold** (`HoldOnKeyPress`; #578).
+    #[test]
+    fn resolve_inside_handle_input_sets_delay_for_next_physical() {
+        use crate::key::tap_hold::InterruptResponse;
+
+        // Assemble -- pending; delay cleared so next handle_input can resolve.
+        let mut keymap = tap_hold_interrupt_keymap(InterruptResponse::HoldOnKeyPress);
+        keymap.handle_input(input::Event::Press { keymap_index: 0 });
+        assert!(keymap.test_is_pending());
+        keymap.tick();
+        assert_eq!(0, keymap.test_input_queue_delay());
+
+        // Act -- interrupt resolves hold inside handle_input.
+        keymap.handle_input(input::Event::Press { keymap_index: 1 });
+
+        // Assert -- DELAY set again; interrupt not applied as a normal press (#578).
+        assert!(!keymap.test_is_pending());
+        assert_eq!(INPUT_QUEUE_TICK_DELAY, keymap.test_input_queue_delay());
+        assert!(!keymap
+            .pressed_keys()
+            .contains(&key::KeyOutput::from_key_code(0x05)));
+    }
+
+    /// After resolve-inside-`handle_input`, the next physical event
+    ///  is deferred onto the delay line because DELAY is still set.
+    ///
+    /// Motivating smart key: **tap-hold** (`HoldOnKeyPress`; #578).
+    #[test]
+    fn post_resolve_inside_handle_input_defers_next_physical() {
+        use crate::key::tap_hold::InterruptResponse;
+
+        // Assemble -- resolve via HoldOnKeyPress interrupt inside handle_input.
+        let mut keymap = tap_hold_interrupt_keymap(InterruptResponse::HoldOnKeyPress);
+        keymap.handle_input(input::Event::Press { keymap_index: 0 });
+        keymap.tick();
+        keymap.handle_input(input::Event::Press { keymap_index: 1 });
+        assert!(!keymap.test_is_pending());
+        assert_eq!(INPUT_QUEUE_TICK_DELAY, keymap.test_input_queue_delay());
+        // Session log may have prepended Press(1); queue non-empty is ok.
+        let queue_after_resolve = keymap.test_input_queue_len();
+
+        // Act
+        keymap.handle_input(input::Event::Release { keymap_index: 1 });
+
+        // Assert
+        assert_eq!(
+            queue_after_resolve + 1,
+            keymap.test_input_queue_len(),
+            "post-resolve delay defers the next physical event onto the delay line"
+        );
     }
 
     #[test]

--- a/src/keymap/input_event_queue.rs
+++ b/src/keymap/input_event_queue.rs
@@ -43,6 +43,10 @@ impl<const N: usize> InputEventQueue<N> {
         self.delay_counter = delay_counter;
     }
 
+    pub fn delay_counter(&self) -> u8 {
+        self.delay_counter
+    }
+
     pub fn tick_delay(&mut self) {
         if self.delay_counter > 0 {
             self.delay_counter -= 1;

--- a/src/keymap/input_event_queue.rs
+++ b/src/keymap/input_event_queue.rs
@@ -74,7 +74,7 @@ impl<const N: usize> InputEventQueue<N> {
 
     /// Removes and returns every queued event, leaving the queue empty.
     pub fn take_all(&mut self) -> heapless::Deque<input::Event, N> {
-        core::mem::replace(&mut self.events, heapless::Deque::new())
+        core::mem::take(&mut self.events)
     }
 
     /// Appends every event from `other` to the back of this queue.
@@ -125,94 +125,79 @@ mod tests {
 
     const CAPACITY: usize = 4;
 
-    fn press(index: u16) -> input::Event {
-        input::Event::Press {
-            keymap_index: index,
-        }
-    }
-
-    fn release(index: u16) -> input::Event {
-        input::Event::Release {
-            keymap_index: index,
-        }
-    }
-
     #[test]
     fn push_back_and_pop_front_if_ready_respects_delay() {
         let mut queue = InputEventQueue::<CAPACITY>::new();
 
-        queue.push_back(press(0)).unwrap();
-        assert_eq!(queue.pop_front_if_ready(), Some(press(0)));
+        queue.push_back(input::Event::press(0)).unwrap();
+        assert_eq!(queue.pop_front_if_ready(), Some(input::Event::press(0)));
         queue.set_delay_counter(INPUT_QUEUE_TICK_DELAY);
 
-        queue.push_back(release(0)).unwrap();
+        queue.push_back(input::Event::release(0)).unwrap();
         assert_eq!(queue.pop_front_if_ready(), None);
 
         queue.tick_delay();
-        assert_eq!(queue.pop_front_if_ready(), Some(release(0)));
+        assert_eq!(queue.pop_front_if_ready(), Some(input::Event::release(0)));
     }
 
     #[test]
     fn take_all_drains_queue_preserving_order() {
         let mut queue = InputEventQueue::<CAPACITY>::new();
-        queue.push_back(press(0)).unwrap();
-        queue.push_back(release(0)).unwrap();
+        queue.push_back(input::Event::press(0)).unwrap();
+        queue.push_back(input::Event::release(0)).unwrap();
 
         let mut taken = queue.take_all();
         assert!(queue.is_empty());
-        assert_eq!(taken.pop_front(), Some(press(0)));
-        assert_eq!(taken.pop_front(), Some(release(0)));
+        assert_eq!(taken.pop_front(), Some(input::Event::press(0)));
+        assert_eq!(taken.pop_front(), Some(input::Event::release(0)));
         assert_eq!(taken.pop_front(), None);
     }
 
     #[test]
     fn append_all_extends_back_in_order() {
         let mut queue = InputEventQueue::<CAPACITY>::new();
-        queue.push_back(press(0)).unwrap();
+        queue.push_back(input::Event::press(0)).unwrap();
 
         let mut other = heapless::Deque::new();
-        other.push_back(release(0)).unwrap();
-        other.push_back(press(1)).unwrap();
+        other.push_back(input::Event::release(0)).unwrap();
+        other.push_back(input::Event::press(1)).unwrap();
 
         queue.append_all(&mut other);
         assert_eq!(queue.len(), 3);
-        assert_eq!(queue.pop_front_if_ready(), Some(press(0)));
+        assert_eq!(queue.pop_front_if_ready(), Some(input::Event::press(0)));
         queue.set_delay_counter(0);
-        assert_eq!(queue.pop_front_if_ready(), Some(release(0)));
-        assert_eq!(queue.pop_front_if_ready(), Some(press(1)));
+        assert_eq!(queue.pop_front_if_ready(), Some(input::Event::release(0)));
+        assert_eq!(queue.pop_front_if_ready(), Some(input::Event::press(1)));
     }
 
     #[test]
     fn prepend_inserts_events_at_front_in_order() {
         let mut queue = InputEventQueue::<CAPACITY>::new();
-        queue.push_back(press(1)).unwrap();
-        queue.prepend(&[press(0), release(0)]);
+        queue.push_back(input::Event::press(1)).unwrap();
+        queue.prepend(&[input::Event::press(0), input::Event::release(0)]);
 
-        assert_eq!(queue.pop_front_if_ready(), Some(press(0)));
-        assert_eq!(queue.pop_front_if_ready(), Some(release(0)));
-        assert_eq!(queue.pop_front_if_ready(), Some(press(1)));
+        assert_eq!(queue.pop_front_if_ready(), Some(input::Event::press(0)));
+        assert_eq!(queue.pop_front_if_ready(), Some(input::Event::release(0)));
+        assert_eq!(queue.pop_front_if_ready(), Some(input::Event::press(1)));
     }
 
     #[test]
     fn prepend_pending_input_events_replays_lifo_then_restores_tail() {
         let mut queue = InputEventQueue::<CAPACITY>::new();
-        queue.push_back(press(9)).unwrap();
+        queue.push_back(input::Event::press(9)).unwrap();
 
         let mut pending_events: heapless::Vec<key::Event<()>, 4> = heapless::Vec::new();
-        pending_events.push(key::Event::Input(press(0))).unwrap();
-        pending_events.push(key::Event::Input(release(0))).unwrap();
+        pending_events.push(input::Event::press(0).into()).unwrap();
         pending_events
-            .push(key::Event::Key {
-                keymap_index: 0,
-                key_event: (),
-            })
+            .push(input::Event::release(0).into())
             .unwrap();
+        pending_events.push(key::Event::key_event(0, ())).unwrap();
 
         queue.prepend_pending_input_events(&mut pending_events);
 
-        assert_eq!(queue.pop_front_if_ready(), Some(release(0)));
-        assert_eq!(queue.pop_front_if_ready(), Some(press(0)));
-        assert_eq!(queue.pop_front_if_ready(), Some(press(9)));
+        assert_eq!(queue.pop_front_if_ready(), Some(input::Event::release(0)));
+        assert_eq!(queue.pop_front_if_ready(), Some(input::Event::press(0)));
+        assert_eq!(queue.pop_front_if_ready(), Some(input::Event::press(9)));
         assert!(queue.is_empty());
     }
 
@@ -220,33 +205,33 @@ mod tests {
     fn is_full_when_at_capacity() {
         let mut queue = InputEventQueue::<CAPACITY>::new();
         for index in 0..CAPACITY {
-            queue.push_back(press(index as u16)).unwrap();
+            queue.push_back(input::Event::press(index as u16)).unwrap();
         }
         assert!(queue.is_full());
-        assert!(queue.push_back(press(99)).is_err());
+        assert!(queue.push_back(input::Event::press(99)).is_err());
     }
 
     #[test]
     fn push_back_or_ignore_drops_when_at_capacity() {
         let mut queue = InputEventQueue::<2>::new();
-        queue.push_back(press(0)).unwrap();
-        queue.push_back_or_ignore(press(1));
-        queue.push_back_or_ignore(press(2));
+        queue.push_back(input::Event::press(0)).unwrap();
+        queue.push_back_or_ignore(input::Event::press(1));
+        queue.push_back_or_ignore(input::Event::press(2));
 
-        assert_eq!(queue.pop_front_if_ready(), Some(press(0)));
-        assert_eq!(queue.pop_front_if_ready(), Some(press(1)));
+        assert_eq!(queue.pop_front_if_ready(), Some(input::Event::press(0)));
+        assert_eq!(queue.pop_front_if_ready(), Some(input::Event::press(1)));
         assert_eq!(queue.pop_front_if_ready(), None);
     }
 
     #[test]
     fn push_front_or_ignore_drops_when_at_capacity() {
         let mut queue = InputEventQueue::<2>::new();
-        queue.push_back(press(0)).unwrap();
-        queue.push_front_or_ignore(press(1));
-        queue.push_front_or_ignore(press(2));
+        queue.push_back(input::Event::press(0)).unwrap();
+        queue.push_front_or_ignore(input::Event::press(1));
+        queue.push_front_or_ignore(input::Event::press(2));
 
-        assert_eq!(queue.pop_front_if_ready(), Some(press(1)));
-        assert_eq!(queue.pop_front_if_ready(), Some(press(0)));
+        assert_eq!(queue.pop_front_if_ready(), Some(input::Event::press(1)));
+        assert_eq!(queue.pop_front_if_ready(), Some(input::Event::press(0)));
         assert_eq!(queue.pop_front_if_ready(), None);
     }
 }

--- a/src/keymap/pending.rs
+++ b/src/keymap/pending.rs
@@ -123,3 +123,153 @@ pub(crate) fn dispatch_replayed_events<Ev: Copy + Debug, const N: usize, const Q
         }
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    /// Resolve keeps other-key inputs and the last self event,
+    ///  then prepends them *before* any existing delay-line tail.
+    ///
+    /// Motivating smart keys: **tap-hold** (esp. rolling `HoldOnKeyTap`)
+    ///  and **chorded** over tap-hold — without prepend-before-tail,
+    ///  `tests/rust/tap_hold/hold_on_interrupt_tap` and
+    ///  `tests/rust/chorded/{tap_hold,tap_hold_over_tap_hold,over_layered_tap_hold}`
+    ///  fail.
+    #[test]
+    fn resolve_replay_prepends_filtered_inputs_before_delay_line_tail() {
+        // Assemble -- session log: Press(0), Press(1), Release(0);
+        //  delay-line tail: Press(9).
+        let mut queued: heapless::Vec<key::Event<()>, 8> = heapless::Vec::new();
+        queued.push(input::Event::press(0).into()).unwrap();
+        queued.push(input::Event::press(1).into()).unwrap();
+        queued.push(input::Event::release(0).into()).unwrap();
+
+        let mut input_queue = InputEventQueue::<8>::new();
+        input_queue.push_back(input::Event::press(9)).unwrap();
+
+        let mut event_scheduler = EventScheduler::new();
+
+        // Act -- resolve key 0 → keep Press(1) + last self event Release(0).
+        dispatch_replayed_events(
+            KeyResolution::Resolved { keymap_index: 0 },
+            &mut queued,
+            &mut input_queue,
+            &mut event_scheduler,
+        );
+
+        // Assert -- replay batch, then original tail.
+        assert_eq!(
+            input_queue.pop_front_if_ready(),
+            Some(input::Event::press(1))
+        );
+        assert_eq!(
+            input_queue.pop_front_if_ready(),
+            Some(input::Event::release(0))
+        );
+        assert_eq!(
+            input_queue.pop_front_if_ready(),
+            Some(input::Event::press(9))
+        );
+        assert!(input_queue.is_empty());
+    }
+
+    /// Non-input session-log events are scheduled with staggered delay,
+    ///  not prepended to the delay line.
+    ///
+    /// Motivating smart keys: any pending key that records non-input
+    ///  `Event::Key` traffic in the session log before resolve
+    ///  (e.g. **tap-hold** / **chorded** composites that schedule key events).
+    ///  Stagger keeps HID reports one tick apart after resolve.
+    #[test]
+    fn resolve_replay_schedules_non_input_events_with_staggered_delay() {
+        // Assemble
+        let mut queued: heapless::Vec<key::Event<()>, 8> = heapless::Vec::new();
+        queued.push(input::Event::press(1).into()).unwrap();
+        queued.push(key::Event::key_event(2, ())).unwrap();
+        queued.push(key::Event::key_event(3, ())).unwrap();
+
+        let mut input_queue = InputEventQueue::<8>::new();
+        let mut event_scheduler = EventScheduler::new();
+
+        // Act
+        dispatch_replayed_events(
+            KeyResolution::Resolved { keymap_index: 0 },
+            &mut queued,
+            &mut input_queue,
+            &mut event_scheduler,
+        );
+
+        // Assert -- other-key input prepended; key events scheduled.
+        assert_eq!(
+            input_queue.pop_front_if_ready(),
+            Some(input::Event::press(1))
+        );
+        assert!(input_queue.is_empty());
+        assert!(event_scheduler.next_event_time().is_some());
+        event_scheduler.tick(1);
+        assert_eq!(
+            event_scheduler.dequeue(),
+            Some(key::Event::key_event(2, ()))
+        );
+        event_scheduler.tick(1);
+        assert_eq!(
+            event_scheduler.dequeue(),
+            Some(key::Event::key_event(3, ()))
+        );
+    }
+
+    /// Nested-pending policy: LIFO over input events only
+    ///  (key events dropped),
+    ///  prepended before any existing delay-line tail.
+    ///
+    /// Motivating smart keys: **chorded → passthrough pending**
+    ///  (e.g. chorded over tap-hold) and other pending→pending
+    ///  transitions (layered outer resolving into an inner pending key).
+    ///  LIFO vs FIFO is not yet covered by `rust-integration` HID reports;
+    ///  this unit test pins the historical re-queue policy.
+    #[test]
+    fn nested_pending_replay_prepends_inputs_lifo_before_delay_line_tail() {
+        // Assemble -- log: Press(0), KeyEvent, Release(0), Press(1);
+        //  delay-line tail: Press(9).
+        let mut queued: heapless::Vec<key::Event<()>, 8> = heapless::Vec::new();
+        queued.push(input::Event::press(0).into()).unwrap();
+        queued.push(key::Event::key_event(0, ())).unwrap();
+        queued.push(input::Event::release(0).into()).unwrap();
+        queued.push(input::Event::press(1).into()).unwrap();
+
+        let mut input_queue = InputEventQueue::<8>::new();
+        input_queue.push_back(input::Event::press(9)).unwrap();
+
+        let mut event_scheduler = EventScheduler::new();
+
+        // Act
+        dispatch_replayed_events(
+            KeyResolution::Pending,
+            &mut queued,
+            &mut input_queue,
+            &mut event_scheduler,
+        );
+
+        // Assert -- LIFO inputs, then original tail; no key-event scheduling.
+        assert_eq!(
+            input_queue.pop_front_if_ready(),
+            Some(input::Event::press(1))
+        );
+        assert_eq!(
+            input_queue.pop_front_if_ready(),
+            Some(input::Event::release(0))
+        );
+        assert_eq!(
+            input_queue.pop_front_if_ready(),
+            Some(input::Event::press(0))
+        );
+        assert_eq!(
+            input_queue.pop_front_if_ready(),
+            Some(input::Event::press(9))
+        );
+        assert!(input_queue.is_empty());
+        assert!(event_scheduler.next_event_time().is_none());
+    }
+}


### PR DESCRIPTION
## Summary

Expands unit test coverage for the delay-line vs session-log interactions around pending key resolution, as recommended in `sketch-pending-event-resolution.md` before another pending-local ingest pacing attempt.

These tests pin contracts that were easy to break in the 2026-07-08 pacing spike (when replays run relative to the delay line, what is and is not in the session log, and how the delay counter differs after resolve-via-tick vs resolve-inside-`handle_input`).

Keymap pacing tests are structured as focused AAA unit tests (one action / one property each), not multi-phase sagas. They stay under `#[cfg(test)]` rather than `tests/rust` because they inspect white-box queue/session-log state; `ObservedKeymap` auto-ticks and only exposes HID reports.

### Test hooks

- `test_is_pending`, `test_input_queue_len`, `test_input_queue_delay`
- `test_pending_session_log_inputs` (session-log `Event::Input`s only)
- `InputEventQueue::delay_counter()`

### Coverage

**Replay policy** (`pending.rs`):

- Resolve: filtered session-log inputs prepended *before* existing delay-line tail
- Resolve: non-input events scheduled with staggered delays
- Nested pending: LIFO input prepend (key events dropped)

**Keymap pacing / resolve** (`keymap.rs`):

| Test | Contract |
|------|----------|
| `pending_creation_defers_next_physical_input_by_one_delay` | Fresh pending sets delay; next physical stays in delay line |
| `physical_inputs_while_delay_active_stay_in_delay_line` | While delay > 0, physical inputs do not enter the session log |
| `first_tick_while_pending_only_clears_delay` | First tick clears delay without dequeuing |
| `tick_when_delay_zero_moves_one_input_into_session_log` | One delay-line input advances into the session log per processing tick |
| `resolve_by_timeout_leaves_delay_line_inputs_queued` | Never-logged delay-line inputs are not part of resolve replay |
| `post_resolve_ticks_drain_delay_line_as_normal_press` | Post-resolve pacing drains the delay line as a normal press |
| `resolve_leaves_never_logged_delay_line_inputs_queued` | Queue tail that never entered the session log survives resolve |
| `scheduled_input_during_pending_records_while_physical_stays_delayed` | Scheduled input records immediately; concurrent physical stays delayed |
| `resolve_via_tick_leaves_delay_zero_and_queues_replay` | Resolve-in-tick ends delay at 0; replay may remain queued |
| `resolve_inside_handle_input_sets_delay_for_next_physical` | Resolve-in-`handle_input` leaves DELAY set (contrast with tick path) |
| `post_resolve_inside_handle_input_defers_next_physical` | After that path, the next physical input is deferred |

Also keeps the existing #578 regression tests (`scheduled_input_during_pending_*`, `physical_input_during_pending_*`).

## Test plan

- [x] `cargo test -p smart-keymap --lib` (96 passed)