### PR TITLE
rust: add optional sticky layer timeout

### DIFF
--- a/features/keymap/key/layer_modifier-sticky-config-timeout.feature
+++ b/features/keymap/key/layer_modifier-sticky-config-timeout.feature
@@ -1,0 +1,57 @@
+Feature: Layer Modifier: Sticky (configure sticky layer timeout)
+
+  After a sticky layer is activated by tapping the sticky layer
+   modifier, it normally stays active until another key is used.
+
+  Setting `config.layered.sticky_timeout` (milliseconds) deactivates
+   the sticky layer if no key is pressed before the timeout.
+
+  This is similar to ZMK sticky layer `release-after-ms`.
+
+  Background:
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        config.layered.sticky_timeout = 100,
+        layers = [
+          [K.layer_mod.sticky 1, K.A, K.B],
+          [K.TTTT, K.X, K.Y],
+        ],
+      }
+      """
+
+  Example: sticky layer deactivates after timeout without a key press
+
+    When the keymap registers the following input
+      """
+      [
+        tap (K.layer_mod.sticky 1),
+        wait 110,
+        tap_keymap_index 1,
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        tap (K.A),
+      ]
+      """
+
+  Example: sticky layer still applies if a key is pressed before timeout
+
+    When the keymap registers the following input
+      """
+      [
+        tap (K.layer_mod.sticky 1),
+        wait 50,
+        tap_keymap_index 1,
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        tap (K.X),
+      ]
+      """

--- a/features/scripts/generate-doc.sh
+++ b/features/scripts/generate-doc.sh
@@ -28,6 +28,7 @@ keymap_key_features=(
     "layer_modifier-set_active_layers"
     "layer_modifier-set_active_layers_mask"
     "layer_modifier-sticky"
+    "layer_modifier-sticky-config-timeout"
     "layer_modifier-toggle"
     "mouse"
     "sticky_modifiers"

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -214,6 +214,7 @@
       Json = {
         automation | optional | smart_keymap.automation.config.Json,
         chorded | optional | smart_keymap.chorded.config.Json,
+        layered | optional | smart_keymap.layered.config.Json,
         sticky | optional | smart_keymap.sticky.config.Json,
         tap_dance | optional | smart_keymap.tap_dance.config.Json,
         tap_hold | optional | smart_keymap.tap_hold.config.Json,
@@ -222,6 +223,7 @@
       rust_expr = m%"smart_keymap::key::composite::Config {
             automation: %{smart_keymap.automation.config.rust_expr},
             chorded: %{smart_keymap.chorded.config.rust_expr},
+            layered: %{smart_keymap.layered.config.rust_expr},
             sticky: %{smart_keymap.sticky.config.rust_expr},
             tap_dance: %{smart_keymap.tap_dance.config.rust_expr},
             tap_hold: %{smart_keymap.tap_hold.config.rust_expr},

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -18,6 +18,7 @@
   Config = {
     automation | optional | keymap_ncl.automation.Config,
     chorded | optional | keymap_ncl.chorded.Config,
+    layered | optional | keymap_ncl.layered.Config,
     sticky | optional | keymap_ncl.sticky.Config,
     tap_dance | optional | keymap_ncl.tap_dance.Config,
     tap_hold | optional | keymap_ncl.tap_hold.Config,

--- a/ncl/smart_keys/layered/keymap-codegen.ncl
+++ b/ncl/smart_keys/layered/keymap-codegen.ncl
@@ -3,6 +3,8 @@
 
   lib,
 
+  json_keymap,
+
   key_data_and_refs,
 
   smart_key,
@@ -339,6 +341,30 @@
               rust_expr = "%{module}::Ref::%{variant}(%{std.to_string new_index})",
             },
           },
+      },
+
+      config = {
+        Json = {
+          sticky_timeout | optional | Number,
+        },
+
+        rust_expr =
+          if std.record.has_field "layered" json_keymap.config then
+            let layered_config = json_keymap.config.layered in
+            let sticky_timeout_field_fragment =
+              if std.record.has_field "sticky_timeout" layered_config then
+                "sticky_timeout: Some(%{std.to_string layered_config.sticky_timeout}),"
+              else
+                ""
+            in
+            m%"
+            %{module}::Config {
+                %{sticky_timeout_field_fragment}
+                ..%{module}::Config::new()
+            }
+          "%
+          else
+            "%{module}::Config::new()",
       },
 
       system = {

--- a/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
@@ -188,6 +188,10 @@
   keymap_ncl.layered
     | doc "for key::layered::LayeredKey."
     = {
+      Config = {
+        sticky_timeout | optional | Number,
+      },
+
       Key = std.contract.from_validator key_validator,
 
       key_validator = fun k =>

--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -155,6 +155,8 @@ pub type LayeredKey = key::layered::LayeredKey<Ref, LAYERED_LAYER_COUNT>;
 /// Type aliases for convenience.
 pub type LayeredModifierKey = key::layered::ModifierKey;
 /// Type aliases for convenience.
+pub type LayeredConfig = key::layered::Config;
+/// Type aliases for convenience.
 pub type LayeredContext = key::layered::Context<LAYERED_LAYER_COUNT>;
 /// Type aliases for convenience.
 pub type LayeredEvent = key::layered::LayerEvent;
@@ -274,6 +276,9 @@ pub struct Config {
     /// The chorded configuration.
     #[serde(default)]
     pub chorded: key::chorded::Config<CHORDED_MAX_CHORDS, CHORDED_MAX_CHORD_SIZE>,
+    /// The layered / sticky-layer configuration.
+    #[serde(default)]
+    pub layered: LayeredConfig,
     /// The sticky modifier configuration
     #[serde(default)]
     pub sticky: StickyConfig,
@@ -297,6 +302,7 @@ impl Config {
         Config {
             automation: key::automation::Config::new(),
             chorded: key::chorded::Config::new(),
+            layered: key::layered::Config::new(),
             sticky: key::sticky::Config::new(),
             tap_dance: key::tap_dance::Config::new(),
             tap_hold: key::tap_hold::Config::new(),
@@ -334,7 +340,7 @@ impl Context {
             consumer: key::consumer::Context,
             custom: key::custom::Context,
             keyboard: key::keyboard::Context,
-            layered: key::layered::Context::new(),
+            layered: key::layered::Context::from_config(config.layered),
             mouse: key::mouse::Context,
             sticky: key::sticky::Context::from_config(config.sticky),
             tap_dance: key::tap_dance::Context::from_config(config.tap_dance),

--- a/src/key/layered.rs
+++ b/src/key/layered.rs
@@ -260,18 +260,54 @@ impl<const LAYER_COUNT: usize> core::fmt::Debug for ActiveLayersDebugHelper<'_, 
     }
 }
 
+/// Configuration for layered keys / sticky layers.
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
+pub struct Config {
+    /// Timeout (ms) after which an unused sticky layer deactivates.
+    ///
+    /// When [None], sticky layers stay active until another key is used.
+    ///
+    /// The timeout starts when a sticky layer modifier is *released*
+    /// without interruption (sticky committed). If another key is pressed
+    /// while sticky is active, the timeout is cancelled / ignored.
+    #[serde(default)]
+    pub sticky_timeout: Option<u16>,
+}
+
+/// Default layered config (no sticky timeout).
+pub const DEFAULT_CONFIG: Config = Config {
+    sticky_timeout: None,
+};
+
+impl Config {
+    /// Constructs a new default [Config].
+    pub const fn new() -> Self {
+        DEFAULT_CONFIG
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// [crate::key::Context] for [LayeredKey] that tracks active layers.
 #[derive(Clone, Copy)]
 pub struct Context<const LAYER_COUNT: usize> {
+    config: Config,
     default_layer: Option<LayerIndex>,
     active_layers: [Activity; LAYER_COUNT],
     // Keymap index which was pressed while a layer was sticky.
     pressed_keymap_index: Option<u16>,
+    // Invalidates pending sticky-timeout events when advanced.
+    sticky_timeout_id: u8,
 }
 
 impl<const LAYER_COUNT: usize> Debug for Context<LAYER_COUNT> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Context")
+            .field("config", &self.config)
             .field("default_layer", &self.default_layer)
             .field(
                 "active_layers",
@@ -280,6 +316,7 @@ impl<const LAYER_COUNT: usize> Debug for Context<LAYER_COUNT> {
                 },
             )
             .field("pressed_keymap_index", &self.pressed_keymap_index)
+            .field("sticky_timeout_id", &self.sticky_timeout_id)
             .finish()
     }
 }
@@ -287,11 +324,28 @@ impl<const LAYER_COUNT: usize> Debug for Context<LAYER_COUNT> {
 impl<const LAYER_COUNT: usize> Context<LAYER_COUNT> {
     /// Create a new [Context].
     pub const fn new() -> Self {
+        Self::from_config(DEFAULT_CONFIG)
+    }
+
+    /// Constructs a context from the given config.
+    pub const fn from_config(config: Config) -> Self {
         Context {
+            config,
             default_layer: None,
             active_layers: [Activity::Inactive; LAYER_COUNT],
             pressed_keymap_index: None,
+            sticky_timeout_id: 0,
         }
+    }
+
+    fn invalidate_sticky_timeouts(&mut self) {
+        self.sticky_timeout_id = self.sticky_timeout_id.wrapping_add(1);
+    }
+
+    fn deactivate_sticky_layer(&mut self, layer: LayerIndex) {
+        self.active_layers.deactivate(layer);
+        self.pressed_keymap_index = None;
+        self.invalidate_sticky_timeouts();
     }
 }
 
@@ -315,17 +369,54 @@ impl<const LAYER_COUNT: usize> Context<LAYER_COUNT> {
     }
 
     /// Updates the context with the [LayerEvent].
-    fn handle_layer_event(&mut self, event: LayerEvent) {
+    ///
+    /// Returns scheduled events (e.g. sticky timeout).
+    fn handle_layer_event(&mut self, event: LayerEvent) -> key::KeyEvents<LayerEvent> {
         match event {
             LayerEvent::Activated(layer) => {
                 self.active_layers.activate(layer, ActivationStyle::Regular);
+                // Sticky cancelled / converted to hold — drop any sticky timeout.
+                self.invalidate_sticky_timeouts();
+                key::KeyEvents::no_events()
             }
             LayerEvent::Deactivated(layer) => {
                 self.active_layers.deactivate(layer);
+                self.invalidate_sticky_timeouts();
+                key::KeyEvents::no_events()
             }
             LayerEvent::StickyActivated(layer) => {
                 self.active_layers.activate(layer, ActivationStyle::Sticky);
                 self.pressed_keymap_index = None;
+                // Previous sticky wait is superseded while this sticky key is held.
+                self.invalidate_sticky_timeouts();
+                key::KeyEvents::no_events()
+            }
+            LayerEvent::StickyReleased => {
+                // Sticky key released without interruption: layer stays sticky.
+                // Arm optional timeout for "no next key pressed".
+                if self.sticky_layer().is_none() {
+                    key::KeyEvents::no_events()
+                } else {
+                    self.invalidate_sticky_timeouts();
+                    let timeout_id = self.sticky_timeout_id;
+                    match self.config.sticky_timeout {
+                        Some(timeout) => {
+                            key::KeyEvents::scheduled_event(key::ScheduledEvent::after(
+                                timeout,
+                                key::Event::key_event(0, LayerEvent::StickyTimeout(timeout_id)),
+                            ))
+                        }
+                        None => key::KeyEvents::no_events(),
+                    }
+                }
+            }
+            LayerEvent::StickyTimeout(timeout_id) => {
+                if timeout_id == self.sticky_timeout_id && self.pressed_keymap_index.is_none() {
+                    if let Some(layer) = self.sticky_layer() {
+                        self.deactivate_sticky_layer(layer);
+                    }
+                }
+                key::KeyEvents::no_events()
             }
             LayerEvent::Toggled(layer) => {
                 if self.active_layers[layer as usize - 1].is_active() {
@@ -333,6 +424,7 @@ impl<const LAYER_COUNT: usize> Context<LAYER_COUNT> {
                 } else {
                     self.active_layers.activate(layer, ActivationStyle::Regular);
                 }
+                key::KeyEvents::no_events()
             }
             LayerEvent::Set(ModifierBitset { layers, mask }) => {
                 let max_layer = 1 + LAYER_COUNT.min(MAX_BITSET_LAYER);
@@ -348,39 +440,46 @@ impl<const LAYER_COUNT: usize> Context<LAYER_COUNT> {
                         }
                     }
                 }
+                key::KeyEvents::no_events()
             }
-            LayerEvent::SetDefault(0) => self.default_layer = None,
-            LayerEvent::SetDefault(layer) => self.default_layer = Some(layer),
+            LayerEvent::SetDefault(0) => {
+                self.default_layer = None;
+                key::KeyEvents::no_events()
+            }
+            LayerEvent::SetDefault(layer) => {
+                self.default_layer = Some(layer);
+                key::KeyEvents::no_events()
+            }
         }
     }
 
     /// Updates the context with the [key::Event].
-    fn handle_event(&mut self, event: key::Event<LayerEvent>) {
+    fn handle_event(&mut self, event: key::Event<LayerEvent>) -> key::KeyEvents<LayerEvent> {
         match event {
             key::Event::Input(input::Event::Press { keymap_index, .. }) => {
                 if let Some(sticky_layer_index) = self.sticky_layer() {
                     if self.pressed_keymap_index.is_some() {
                         // The sticky layer modifier has already been used;
                         // the sticky layer should be deactivated for subsequent presses.
-                        self.active_layers.deactivate(sticky_layer_index);
-                        self.pressed_keymap_index = None;
+                        self.deactivate_sticky_layer(sticky_layer_index);
                     } else {
+                        // Next key is using the sticky layer; cancel timeout.
+                        self.invalidate_sticky_timeouts();
                         self.pressed_keymap_index = Some(keymap_index);
                     }
                 }
+                key::KeyEvents::no_events()
             }
             key::Event::Input(input::Event::Release { keymap_index, .. }) => {
                 if let Some(sticky_layer_index) = self.sticky_layer() {
                     if self.pressed_keymap_index == Some(keymap_index) {
-                        self.active_layers.deactivate(sticky_layer_index);
-                        self.pressed_keymap_index = None;
+                        self.deactivate_sticky_layer(sticky_layer_index);
                     }
                 }
+                key::KeyEvents::no_events()
             }
-            key::Event::Key { key_event, .. } => {
-                self.handle_layer_event(key_event);
-            }
-            _ => {}
+            key::Event::Key { key_event, .. } => self.handle_layer_event(key_event),
+            _ => key::KeyEvents::no_events(),
         }
     }
 }
@@ -389,8 +488,7 @@ impl<const LAYER_COUNT: usize> key::Context for Context<LAYER_COUNT> {
     type Event = LayerEvent;
 
     fn handle_event(&mut self, event: key::Event<Self::Event>) -> key::KeyEvents<Self::Event> {
-        self.handle_event(event);
-        key::KeyEvents::no_events()
+        self.handle_event(event)
     }
 }
 
@@ -524,8 +622,14 @@ pub enum LayerEvent {
     Deactivated(LayerIndex),
     /// Toggles the given layer.
     Toggled(LayerIndex),
-    /// Activates the given layer.
+    /// Activates the given layer as sticky (on sticky-mod press).
     StickyActivated(LayerIndex),
+    /// Sticky layer modifier released without interruption (sticky committed).
+    StickyReleased,
+    /// Sticky layer timed out while unused.
+    ///
+    /// The payload is a generation id used to ignore stale timeouts.
+    StickyTimeout(u8),
     /// Sets the active layers to the given set of layers.
     Set(ModifierBitset),
     /// Changes the default layer.
@@ -603,9 +707,14 @@ impl ModifierKeyState {
                     }
                 }
                 key::Event::Input(input::Event::Release { keymap_index: ki })
-                    if keymap_index == ki && self.behavior == Behavior::Regular =>
+                    if keymap_index == ki =>
                 {
-                    Some(LayerEvent::Deactivated(*layer))
+                    match self.behavior {
+                        Behavior::Regular => Some(LayerEvent::Deactivated(*layer)),
+                        // Sticky key tapped (released without interruption):
+                        // layer stays sticky; arm optional timeout via context.
+                        Behavior::Sticky => Some(LayerEvent::StickyReleased),
+                    }
                 }
                 _ => None,
             },

--- a/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
+++ b/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
@@ -72,6 +72,7 @@ pub mod init {
             chords: smart_keymap::slice::Slice::from_slice(&[]),
             ..smart_keymap::key::chorded::Config::new()
         },
+        layered: smart_keymap::key::layered::Config::new(),
         sticky: smart_keymap::key::sticky::Config::new(),
         tap_dance: smart_keymap::key::tap_dance::Config::new(),
         tap_hold: smart_keymap::key::tap_hold::Config::new(),
@@ -86,6 +87,7 @@ pub mod init {
                 chords: smart_keymap::slice::Slice::from_slice(&[]),
                 ..smart_keymap::key::chorded::Config::new()
             },
+            layered: smart_keymap::key::layered::Config::new(),
             sticky: smart_keymap::key::sticky::Config::new(),
             tap_dance: smart_keymap::key::tap_dance::Config::new(),
             tap_hold: smart_keymap::key::tap_hold::Config::new(),

--- a/tests/ncl/keymap-1key-abbrev-ent/expected.rs
+++ b/tests/ncl/keymap-1key-abbrev-ent/expected.rs
@@ -72,6 +72,7 @@ pub mod init {
             chords: smart_keymap::slice::Slice::from_slice(&[]),
             ..smart_keymap::key::chorded::Config::new()
         },
+        layered: smart_keymap::key::layered::Config::new(),
         sticky: smart_keymap::key::sticky::Config::new(),
         tap_dance: smart_keymap::key::tap_dance::Config::new(),
         tap_hold: smart_keymap::key::tap_hold::Config::new(),
@@ -86,6 +87,7 @@ pub mod init {
                 chords: smart_keymap::slice::Slice::from_slice(&[]),
                 ..smart_keymap::key::chorded::Config::new()
             },
+            layered: smart_keymap::key::layered::Config::new(),
             sticky: smart_keymap::key::sticky::Config::new(),
             tap_dance: smart_keymap::key::tap_dance::Config::new(),
             tap_hold: smart_keymap::key::tap_hold::Config::new(),

--- a/tests/ncl/keymap-1key-automation/expected.rs
+++ b/tests/ncl/keymap-1key-automation/expected.rs
@@ -82,6 +82,7 @@ pub mod init {
             chords: smart_keymap::slice::Slice::from_slice(&[]),
             ..smart_keymap::key::chorded::Config::new()
         },
+        layered: smart_keymap::key::layered::Config::new(),
         sticky: smart_keymap::key::sticky::Config::new(),
         tap_dance: smart_keymap::key::tap_dance::Config::new(),
         tap_hold: smart_keymap::key::tap_hold::Config::new(),
@@ -106,6 +107,7 @@ pub mod init {
                 chords: smart_keymap::slice::Slice::from_slice(&[]),
                 ..smart_keymap::key::chorded::Config::new()
             },
+            layered: smart_keymap::key::layered::Config::new(),
             sticky: smart_keymap::key::sticky::Config::new(),
             tap_dance: smart_keymap::key::tap_dance::Config::new(),
             tap_hold: smart_keymap::key::tap_hold::Config::new(),

--- a/tests/ncl/keymap-1key-callback-custom/expected.rs
+++ b/tests/ncl/keymap-1key-callback-custom/expected.rs
@@ -72,6 +72,7 @@ pub mod init {
             chords: smart_keymap::slice::Slice::from_slice(&[]),
             ..smart_keymap::key::chorded::Config::new()
         },
+        layered: smart_keymap::key::layered::Config::new(),
         sticky: smart_keymap::key::sticky::Config::new(),
         tap_dance: smart_keymap::key::tap_dance::Config::new(),
         tap_hold: smart_keymap::key::tap_hold::Config::new(),
@@ -86,6 +87,7 @@ pub mod init {
                 chords: smart_keymap::slice::Slice::from_slice(&[]),
                 ..smart_keymap::key::chorded::Config::new()
             },
+            layered: smart_keymap::key::layered::Config::new(),
             sticky: smart_keymap::key::sticky::Config::new(),
             tap_dance: smart_keymap::key::tap_dance::Config::new(),
             tap_hold: smart_keymap::key::tap_hold::Config::new(),

--- a/tests/ncl/keymap-1key-custom/expected.rs
+++ b/tests/ncl/keymap-1key-custom/expected.rs
@@ -72,6 +72,7 @@ pub mod init {
             chords: smart_keymap::slice::Slice::from_slice(&[]),
             ..smart_keymap::key::chorded::Config::new()
         },
+        layered: smart_keymap::key::layered::Config::new(),
         sticky: smart_keymap::key::sticky::Config::new(),
         tap_dance: smart_keymap::key::tap_dance::Config::new(),
         tap_hold: smart_keymap::key::tap_hold::Config::new(),
@@ -86,6 +87,7 @@ pub mod init {
                 chords: smart_keymap::slice::Slice::from_slice(&[]),
                 ..smart_keymap::key::chorded::Config::new()
             },
+            layered: smart_keymap::key::layered::Config::new(),
             sticky: smart_keymap::key::sticky::Config::new(),
             tap_dance: smart_keymap::key::tap_dance::Config::new(),
             tap_hold: smart_keymap::key::tap_hold::Config::new(),

--- a/tests/ncl/keymap-1key-simple/expected.rs
+++ b/tests/ncl/keymap-1key-simple/expected.rs
@@ -69,6 +69,7 @@ pub mod init {
     pub const CONFIG: smart_keymap::key::composite::Config = smart_keymap::key::composite::Config {
         automation: smart_keymap::key::automation::Config::new(),
         chorded: smart_keymap::key::chorded::Config::new(),
+        layered: smart_keymap::key::layered::Config::new(),
         sticky: smart_keymap::key::sticky::Config::new(),
         tap_dance: smart_keymap::key::tap_dance::Config::new(),
         tap_hold: smart_keymap::key::tap_hold::Config::new(),
@@ -80,6 +81,7 @@ pub mod init {
         smart_keymap::key::composite::Context::from_config(smart_keymap::key::composite::Config {
             automation: smart_keymap::key::automation::Config::new(),
             chorded: smart_keymap::key::chorded::Config::new(),
+            layered: smart_keymap::key::layered::Config::new(),
             sticky: smart_keymap::key::sticky::Config::new(),
             tap_dance: smart_keymap::key::tap_dance::Config::new(),
             tap_hold: smart_keymap::key::tap_hold::Config::new(),

--- a/tests/ncl/keymap-1key-tap_dance/expected.rs
+++ b/tests/ncl/keymap-1key-tap_dance/expected.rs
@@ -69,6 +69,7 @@ pub mod init {
     pub const CONFIG: smart_keymap::key::composite::Config = smart_keymap::key::composite::Config {
         automation: smart_keymap::key::automation::Config::new(),
         chorded: smart_keymap::key::chorded::Config::new(),
+        layered: smart_keymap::key::layered::Config::new(),
         sticky: smart_keymap::key::sticky::Config::new(),
         tap_dance: smart_keymap::key::tap_dance::Config::new(),
         tap_hold: smart_keymap::key::tap_hold::Config::new(),
@@ -80,6 +81,7 @@ pub mod init {
         smart_keymap::key::composite::Context::from_config(smart_keymap::key::composite::Config {
             automation: smart_keymap::key::automation::Config::new(),
             chorded: smart_keymap::key::chorded::Config::new(),
+            layered: smart_keymap::key::layered::Config::new(),
             sticky: smart_keymap::key::sticky::Config::new(),
             tap_dance: smart_keymap::key::tap_dance::Config::new(),
             tap_hold: smart_keymap::key::tap_hold::Config::new(),

--- a/tests/ncl/keymap-1key-tap_hold/expected.rs
+++ b/tests/ncl/keymap-1key-tap_hold/expected.rs
@@ -69,6 +69,7 @@ pub mod init {
     pub const CONFIG: smart_keymap::key::composite::Config = smart_keymap::key::composite::Config {
         automation: smart_keymap::key::automation::Config::new(),
         chorded: smart_keymap::key::chorded::Config::new(),
+        layered: smart_keymap::key::layered::Config::new(),
         sticky: smart_keymap::key::sticky::Config::new(),
         tap_dance: smart_keymap::key::tap_dance::Config::new(),
         tap_hold: smart_keymap::key::tap_hold::Config::new(),
@@ -80,6 +81,7 @@ pub mod init {
         smart_keymap::key::composite::Context::from_config(smart_keymap::key::composite::Config {
             automation: smart_keymap::key::automation::Config::new(),
             chorded: smart_keymap::key::chorded::Config::new(),
+            layered: smart_keymap::key::layered::Config::new(),
             sticky: smart_keymap::key::sticky::Config::new(),
             tap_dance: smart_keymap::key::tap_dance::Config::new(),
             tap_hold: smart_keymap::key::tap_hold::Config::new(),

--- a/tests/ncl/keymap-2key-2layer-composite/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-composite/expected.rs
@@ -73,6 +73,7 @@ pub mod init {
             chords: smart_keymap::slice::Slice::from_slice(&[]),
             ..smart_keymap::key::chorded::Config::new()
         },
+        layered: smart_keymap::key::layered::Config::new(),
         sticky: smart_keymap::key::sticky::Config::new(),
         tap_dance: smart_keymap::key::tap_dance::Config::new(),
         tap_hold: smart_keymap::key::tap_hold::Config::new(),
@@ -87,6 +88,7 @@ pub mod init {
                 chords: smart_keymap::slice::Slice::from_slice(&[]),
                 ..smart_keymap::key::chorded::Config::new()
             },
+            layered: smart_keymap::key::layered::Config::new(),
             sticky: smart_keymap::key::sticky::Config::new(),
             tap_dance: smart_keymap::key::tap_dance::Config::new(),
             tap_hold: smart_keymap::key::tap_hold::Config::new(),

--- a/tests/ncl/keymap-2key-2layer-simple/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-simple/expected.rs
@@ -73,6 +73,7 @@ pub mod init {
             chords: smart_keymap::slice::Slice::from_slice(&[]),
             ..smart_keymap::key::chorded::Config::new()
         },
+        layered: smart_keymap::key::layered::Config::new(),
         sticky: smart_keymap::key::sticky::Config::new(),
         tap_dance: smart_keymap::key::tap_dance::Config::new(),
         tap_hold: smart_keymap::key::tap_hold::Config::new(),
@@ -87,6 +88,7 @@ pub mod init {
                 chords: smart_keymap::slice::Slice::from_slice(&[]),
                 ..smart_keymap::key::chorded::Config::new()
             },
+            layered: smart_keymap::key::layered::Config::new(),
             sticky: smart_keymap::key::sticky::Config::new(),
             tap_dance: smart_keymap::key::tap_dance::Config::new(),
             tap_hold: smart_keymap::key::tap_hold::Config::new(),

--- a/tests/ncl/keymap-2key-chorded/expected.rs
+++ b/tests/ncl/keymap-2key-chorded/expected.rs
@@ -75,6 +75,7 @@ pub mod init {
             ]),
             ..smart_keymap::key::chorded::Config::new()
         },
+        layered: smart_keymap::key::layered::Config::new(),
         sticky: smart_keymap::key::sticky::Config::new(),
         tap_dance: smart_keymap::key::tap_dance::Config::new(),
         tap_hold: smart_keymap::key::tap_hold::Config::new(),
@@ -91,6 +92,7 @@ pub mod init {
                 ]),
                 ..smart_keymap::key::chorded::Config::new()
             },
+            layered: smart_keymap::key::layered::Config::new(),
             sticky: smart_keymap::key::sticky::Config::new(),
             tap_dance: smart_keymap::key::tap_dance::Config::new(),
             tap_hold: smart_keymap::key::tap_hold::Config::new(),

--- a/tests/ncl/keymap-34key-seniply/expected.rs
+++ b/tests/ncl/keymap-34key-seniply/expected.rs
@@ -105,6 +105,7 @@ pub mod init {
             chords: smart_keymap::slice::Slice::from_slice(&[]),
             ..smart_keymap::key::chorded::Config::new()
         },
+        layered: smart_keymap::key::layered::Config::new(),
         sticky: smart_keymap::key::sticky::Config::new(),
         tap_dance: smart_keymap::key::tap_dance::Config::new(),
         tap_hold: smart_keymap::key::tap_hold::Config::new(),
@@ -119,6 +120,7 @@ pub mod init {
                 chords: smart_keymap::slice::Slice::from_slice(&[]),
                 ..smart_keymap::key::chorded::Config::new()
             },
+            layered: smart_keymap::key::layered::Config::new(),
             sticky: smart_keymap::key::sticky::Config::new(),
             tap_dance: smart_keymap::key::tap_dance::Config::new(),
             tap_hold: smart_keymap::key::tap_hold::Config::new(),

--- a/tests/ncl/keymap-48key-basic/expected.rs
+++ b/tests/ncl/keymap-48key-basic/expected.rs
@@ -119,6 +119,7 @@ pub mod init {
             chords: smart_keymap::slice::Slice::from_slice(&[]),
             ..smart_keymap::key::chorded::Config::new()
         },
+        layered: smart_keymap::key::layered::Config::new(),
         sticky: smart_keymap::key::sticky::Config::new(),
         tap_dance: smart_keymap::key::tap_dance::Config::new(),
         tap_hold: smart_keymap::key::tap_hold::Config::new(),
@@ -133,6 +134,7 @@ pub mod init {
                 chords: smart_keymap::slice::Slice::from_slice(&[]),
                 ..smart_keymap::key::chorded::Config::new()
             },
+            layered: smart_keymap::key::layered::Config::new(),
             sticky: smart_keymap::key::sticky::Config::new(),
             tap_dance: smart_keymap::key::tap_dance::Config::new(),
             tap_hold: smart_keymap::key::tap_hold::Config::new(),

--- a/tests/ncl/keymap-48key-rgoulter/expected.rs
+++ b/tests/ncl/keymap-48key-rgoulter/expected.rs
@@ -124,6 +124,7 @@ pub mod init {
             ]),
             ..smart_keymap::key::chorded::Config::new()
         },
+        layered: smart_keymap::key::layered::Config::new(),
         sticky: smart_keymap::key::sticky::Config::new(),
         tap_dance: smart_keymap::key::tap_dance::Config::new(),
         tap_hold: smart_keymap::key::tap_hold::Config {
@@ -147,6 +148,7 @@ pub mod init {
                 ]),
                 ..smart_keymap::key::chorded::Config::new()
             },
+            layered: smart_keymap::key::layered::Config::new(),
             sticky: smart_keymap::key::sticky::Config::new(),
             tap_dance: smart_keymap::key::tap_dance::Config::new(),
             tap_hold: smart_keymap::key::tap_hold::Config {

--- a/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
@@ -139,6 +139,7 @@ pub mod init {
             chords: smart_keymap::slice::Slice::from_slice(&[]),
             ..smart_keymap::key::chorded::Config::new()
         },
+        layered: smart_keymap::key::layered::Config::new(),
         sticky: smart_keymap::key::sticky::Config::new(),
         tap_dance: smart_keymap::key::tap_dance::Config::new(),
         tap_hold: smart_keymap::key::tap_hold::Config::new(),
@@ -153,6 +154,7 @@ pub mod init {
                 chords: smart_keymap::slice::Slice::from_slice(&[]),
                 ..smart_keymap::key::chorded::Config::new()
             },
+            layered: smart_keymap::key::layered::Config::new(),
             sticky: smart_keymap::key::sticky::Config::new(),
             tap_dance: smart_keymap::key::tap_dance::Config::new(),
             tap_hold: smart_keymap::key::tap_hold::Config::new(),

--- a/tests/ncl/keymap-60key-dvorak-simple/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple/expected.rs
@@ -139,6 +139,7 @@ pub mod init {
             chords: smart_keymap::slice::Slice::from_slice(&[]),
             ..smart_keymap::key::chorded::Config::new()
         },
+        layered: smart_keymap::key::layered::Config::new(),
         sticky: smart_keymap::key::sticky::Config::new(),
         tap_dance: smart_keymap::key::tap_dance::Config::new(),
         tap_hold: smart_keymap::key::tap_hold::Config::new(),
@@ -153,6 +154,7 @@ pub mod init {
                 chords: smart_keymap::slice::Slice::from_slice(&[]),
                 ..smart_keymap::key::chorded::Config::new()
             },
+            layered: smart_keymap::key::layered::Config::new(),
             sticky: smart_keymap::key::sticky::Config::new(),
             tap_dance: smart_keymap::key::tap_dance::Config::new(),
             tap_hold: smart_keymap::key::tap_hold::Config::new(),

--- a/tests/rust/layered.rs
+++ b/tests/rust/layered.rs
@@ -1,6 +1,7 @@
 mod modified_hold;
 mod set_active_layers;
 mod sticky;
+mod sticky_timeout;
 mod tap_hold;
 mod toggle;
 

--- a/tests/rust/layered/sticky_timeout.rs
+++ b/tests/rust/layered/sticky_timeout.rs
@@ -1,0 +1,106 @@
+use smart_keymap::input;
+use smart_keymap::keymap::ObservedKeymap;
+
+use crate::hid_keycodes::*;
+use smart_keymap_macros::keymap;
+
+#[test]
+fn sticky_layer_deactivates_after_timeout_without_key_press() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.layered.sticky_timeout = 100,
+                layers = [
+                    [K.layer_mod.sticky 1, K.A, K.B],
+                    [K.TTTT, K.K, K.L],
+                ],
+            }
+        "#
+    ));
+
+    // Act — tap sticky layer mod, wait past timeout, press base key
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+
+    for _ in 0..101 {
+        keymap.tick();
+    }
+
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert — sticky expired; key is base layer A, not layered K
+    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, KC_A, 0, 0, 0, 0, 0]];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn sticky_layer_still_applies_if_key_pressed_before_timeout() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.layered.sticky_timeout = 100,
+                layers = [
+                    [K.layer_mod.sticky 1, K.A, K.B],
+                    [K.TTTT, K.K, K.L],
+                ],
+            }
+        "#
+    ));
+
+    // Act — tap sticky, wait under timeout, press layered key
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+
+    for _ in 0..50 {
+        keymap.tick();
+    }
+
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert — sticky still active
+    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, KC_K, 0, 0, 0, 0, 0]];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn sticky_layer_without_timeout_config_remains_active() {
+    // Assemble — omit sticky_timeout (default None)
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                layers = [
+                    [K.layer_mod.sticky 1, K.A, K.B],
+                    [K.TTTT, K.K, K.L],
+                ],
+            }
+        "#
+    ));
+
+    // Act — tap sticky, wait a long time, press key
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+
+    for _ in 0..500 {
+        keymap.tick();
+    }
+
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert — sticky still active without configured timeout
+    let expected_reports: &[[u8; 8]] = &[[0, 0, 0, 0, 0, 0, 0, 0], [0, 0, KC_K, 0, 0, 0, 0, 0]];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}


### PR DESCRIPTION
## Summary

Allow sticky layers to expire after an optional idle timeout, instead of staying active indefinitely until another key is used.

- New config: `config.layered.sticky_timeout` (milliseconds)
- Default is **unset / `None`** — previous behaviour (sticky stays until used)
- When set, timeout starts when the sticky layer modifier is **released without interruption** (sticky committed)
- If no key is pressed before the timeout, the sticky layer deactivates
- Pressing a key before the timeout still applies the sticky layer (and cancels the timeout)

Similar to ZMK sticky-layer [`release-after-ms`](https://zmk.dev/docs/keymaps/behaviors/sticky-layer).

## Motivation

Tapping `K.layer_mod.sticky` activates a layer for the next key. Without a timeout, that sticky activation can linger if the user changes their mind and types nothing for a long time — the next key later is still modified by the sticky layer.

## How it works

### Config surface

```ncl
{
  config.layered.sticky_timeout = 1000,  # e.g. 1 second
  layers = [
    [K.layer_mod.sticky 1, K.A, K.B],
    [K.TTTT, K.X, K.Y],
  ],
}
```

### Rust (`src/key/layered.rs`)

1. **`layered::Config`** with `sticky_timeout: Option<u16>` (default `None`).
2. Wired through **`composite::Config.layered`** and `Context::from_config`.
3. On sticky-mod **press**: still emits `StickyActivated` (layer becomes sticky); any prior timeout generation is invalidated.
4. On sticky-mod **release** while still sticky (not interrupted into hold): emits **`StickyReleased`**.
5. Context handles `StickyReleased` by arming a scheduled **`StickyTimeout(generation_id)`** when `sticky_timeout` is `Some`.
6. On `StickyTimeout`: if the generation is still current, no key has used the sticky layer yet (`pressed_keymap_index` is `None`), and a sticky layer is still active → deactivate it.
7. Generation ids cancel stale timeouts when sticky is used, re-armed, converted to hold, or otherwise deactivated.

### Nickel

- `keymap-ncl-to-json` / codegen accept `config.layered.sticky_timeout`
- Codegen emits `sticky_timeout: Some(N)` when set, else `..Config::new()`
- Snapshot `expected.rs` files updated for the new `layered:` config field in composite config

### Tests / docs

- Integration tests: timeout expires / still applies before timeout / no config = no timeout
- Cucumber: two illustrative scenarios (docs)

## Test plan

- [x] `cargo test --test rust-integration layered`
- [x] `cargo test --test cucumber-keymap -- -i '**/layer_modifier-sticky*.feature'`
- [x] `make test-ncl`