### PR TITLE
ci: add fmt and clippy checks for firmware packages

### DIFF
--- a/.github/workflows/rust-stm32f4.yaml
+++ b/.github/workflows/rust-stm32f4.yaml
@@ -40,6 +40,43 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  cargo-fmt-clippy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Nickel
+        uses: ./.github/actions/setup-nickel
+        with:
+          version: ${{ env.NICKEL_VERSION }}
+
+      - name: Install Rust lint components
+        run: rustup component add clippy rustfmt
+
+      - name: Rust Add Target
+        run: rustup target add thumbv7em-none-eabihf
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          shared-key: rust-stm32f4
+          cache-targets: thumbv7em-none-eabihf
+
+      - name: Run Cargo Fmt
+        run: cargo fmt --all -- --check
+
+      - name: Run Cargo Clippy
+        run: |
+          cargo clippy \
+            --target=thumbv7em-none-eabihf \
+            --package=stm32f4-rtic-smart-keyboard \
+            --package=stm32-embassy-smart-keyboard \
+            --examples \
+            --bins \
+            -- -D warnings
+
   cargo-build-target-thumbv7em-none-eabihf:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/rust-thumbv6m-none-eabi.yaml
+++ b/.github/workflows/rust-thumbv6m-none-eabi.yaml
@@ -40,6 +40,42 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  cargo-fmt-clippy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Nickel
+        uses: ./.github/actions/setup-nickel
+        with:
+          version: ${{ env.NICKEL_VERSION }}
+
+      - name: Install Rust lint components
+        run: rustup component add clippy rustfmt
+
+      - name: Rust Add Target
+        run: rustup target add thumbv6m-none-eabi
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          shared-key: rust-thumbv6m
+          cache-targets: thumbv6m-none-eabi
+
+      - name: Run Cargo Fmt
+        run: cargo fmt --all -- --check
+
+      - name: Run Cargo Clippy
+        run: |
+          cargo clippy \
+            --target=thumbv6m-none-eabi \
+            --package=rp2040-rtic-smart-keyboard \
+            --examples \
+            --bins \
+            -- -D warnings
+
   cargo-build-target-thumbv6m-none-eabi:
     runs-on: ubuntu-latest
 

--- a/rp2040-rtic-smart-keyboard/examples/pico42.rs
+++ b/rp2040-rtic-smart-keyboard/examples/pico42.rs
@@ -36,6 +36,7 @@ mod board {
 
     pub type PressedKeys = keyberon_smart_keyboard::input::PressedKeys<COLS, ROWS>;
 
+    #[allow(clippy::too_many_arguments)]
     pub fn cols(
         gp0: UnconfiguredPin<bank0::Gpio0>,
         gp1: UnconfiguredPin<bank0::Gpio1>,
@@ -196,9 +197,7 @@ mod app {
             &mut ctx.device.RESETS,
         );
         board::rows_and_cols!(gpio_pins, cols, rows);
-        let Ok(mut matrix) = DelayedMatrix::new(cols, rows, timer, 5, 5) else {
-            panic!("matrix init failed");
-        };
+        let mut matrix = DelayedMatrix::new(cols, rows, timer, 5, 5).expect("matrix init failed");
 
         // Check if bootloader pressed
         if matrix.is_boot_key_pressed() {
@@ -234,16 +233,12 @@ mod app {
             usb_serial,
             usb_class,
         } = c.shared;
-        (usb_dev, usb_serial, usb_class)
-            .lock(|mut ud, mut us, mut uc| usb_poll(&mut ud, &mut us, &mut uc));
+        (usb_dev, usb_serial, usb_class).lock(usb_poll);
     }
 
-    #[task(binds = TIMER_IRQ_0, priority = 1, shared = [usb_class, usb_serial], local = [keyboard, backend, alarm])]
+    #[task(binds = TIMER_IRQ_0, priority = 1, shared = [usb_class], local = [keyboard, backend, alarm])]
     fn tick(c: tick::Context) {
-        let tick::SharedResources {
-            mut usb_class,
-            mut usb_serial,
-        } = c.shared;
+        let tick::SharedResources { mut usb_class } = c.shared;
         let tick::LocalResources {
             alarm,
             keyboard,

--- a/rp2040-rtic-smart-keyboard/src/main.rs
+++ b/rp2040-rtic-smart-keyboard/src/main.rs
@@ -148,9 +148,7 @@ mod app {
             &mut ctx.device.RESETS,
         );
         board::rows_and_cols!(gpio_pins, cols, rows);
-        let Ok(mut matrix) = DelayedMatrix::new(cols, rows, timer, 5, 5) else {
-            panic!("matrix init failed");
-        };
+        let mut matrix = DelayedMatrix::new(cols, rows, timer, 5, 5).expect("matrix init failed");
 
         // Check if bootloader pressed
         if matrix.is_boot_key_pressed() {
@@ -200,12 +198,9 @@ mod app {
         (usb_dev, usb_serial, usb_class).lock(usb_poll);
     }
 
-    #[task(binds = TIMER_IRQ_0, priority = 1, shared = [usb_class, usb_serial], local = [keyboard, backend, alarm, report_success, previous_consumer])]
+    #[task(binds = TIMER_IRQ_0, priority = 1, shared = [usb_class], local = [keyboard, backend, alarm, report_success, previous_consumer])]
     fn tick(c: tick::Context) {
-        let tick::SharedResources {
-            mut usb_class,
-            mut usb_serial,
-        } = c.shared;
+        let tick::SharedResources { mut usb_class } = c.shared;
         let tick::LocalResources {
             alarm,
             keyboard,

--- a/stm32-embassy-smart-keyboard/examples/minif4_36-rev2021_5-lhs.rs
+++ b/stm32-embassy-smart-keyboard/examples/minif4_36-rev2021_5-lhs.rs
@@ -12,9 +12,7 @@ use embassy_stm32::{bind_interrupts, peripherals, usart, usb, Config};
 use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex;
 use embassy_sync::channel::{Channel, Sender};
 use embassy_time::Timer;
-use embassy_usb::class::hid::{
-    HidReader, HidReaderWriter, HidWriter, ReportId, RequestHandler, State,
-};
+use embassy_usb::class::hid::{HidReaderWriter, HidWriter, ReportId, RequestHandler, State};
 use embassy_usb::control::OutResponse;
 use embassy_usb::Builder;
 use panic_halt as _;
@@ -403,7 +401,7 @@ async fn keyboard_backend(
                 let consumer_code = backend
                     .keymap_output()
                     .pressed_consumer_codes()
-                    .get(0)
+                    .first()
                     .copied()
                     .unwrap_or(0);
                 let consumer_report = MediaKeyboardReport {
@@ -479,7 +477,7 @@ impl<'d> TransportReader<'d> {
 
     pub async fn read(&mut self) -> Option<Event> {
         let mut buf: [u8; BUFFER_SIZE] = [0; BUFFER_SIZE];
-        if let Ok(_) = self.uart.read(&mut buf).await {
+        if self.uart.read(&mut buf).await.is_ok() {
             Message::deserialize(&buf)
                 .ok()
                 .map(|Message { input_event }: Message| input_event)

--- a/stm32-embassy-smart-keyboard/src/main.rs
+++ b/stm32-embassy-smart-keyboard/src/main.rs
@@ -248,7 +248,7 @@ async fn main(_spawner: Spawner) {
             let consumer_code = backend
                 .keymap_output()
                 .pressed_consumer_codes()
-                .get(0)
+                .first()
                 .copied()
                 .unwrap_or(0);
             let consumer_report = MediaKeyboardReport {


### PR DESCRIPTION
## Summary

The host `rust.yaml` clippy job deliberately excludes the embedded firmware crates (`rp2040-rtic-smart-keyboard`, `stm32f4-rtic-smart-keyboard`, `stm32-embassy-smart-keyboard`). Path filters also mean firmware-only changes may never hit that workflow's `cargo fmt` check.

This PR closes that gap by adding `cargo-fmt-clippy` jobs to the firmware target workflows, and fixes existing clippy findings so the new guards pass with `-D warnings`.

### Changes

1. **`rp2040-rtic-smart-keyboard`** — clippy cleanups for the `thumbv6m-none-eabi` target (matrix init, unused shared resources, pin-setup `too_many_arguments`, `usb_poll` locking).
2. **`stm32-embassy-smart-keyboard`** — clippy cleanups for the `thumbv7em-none-eabihf` target (`first()` vs `get(0)`, `is_ok()`, unused import).
3. **CI**
   - `rust-thumbv6m-none-eabi.yaml`: fmt + clippy for `rp2040-rtic-smart-keyboard` (`--examples --bins`).
   - `rust-stm32f4.yaml`: fmt + clippy for `stm32f4-rtic-smart-keyboard` and `stm32-embassy-smart-keyboard` (`--examples --bins`).

`stm32f4-rtic-smart-keyboard` was already clippy-clean; no source changes needed there.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --target thumbv6m-none-eabi -p rp2040-rtic-smart-keyboard --examples --bins -- -D warnings`
- [x] `cargo clippy --target thumbv7em-none-eabihf -p stm32f4-rtic-smart-keyboard -p stm32-embassy-smart-keyboard --examples --bins -- -D warnings`
- [ ] Confirm new `cargo-fmt-clippy` jobs pass on this PR's firmware workflows