### PR TITLE
ncl: add validators.all_ok for combining validation results

### DIFF
--- a/ncl/smart_keys/chorded/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/chorded/keymap-ncl-to-json.ncl
@@ -15,14 +15,13 @@
         k
         |> match {
           { chords = chords_, passthrough = passthrough_key } =>
-            let valid_chords = chords_ |> validators.array.validator (validators.tuple.validator [validators.is_number, keymap_ncl.key.key_validator]) in
-            let valid_passthrough_key = keymap_ncl.key.key_validator passthrough_key in
-            [valid_chords, valid_passthrough_key]
-            |> match {
-              ['Ok, 'Ok] => 'Ok,
-              [err, _] => err,
-              [_, err] => err,
-            },
+            validators.all_ok [
+              chords_
+              |> validators.array.validator (
+                validators.tuple.validator [validators.is_number, keymap_ncl.key.key_validator]
+              ),
+              keymap_ncl.key.key_validator passthrough_key,
+            ],
           _ => 'Error { message = "expected { chords = [[index, Key]], passthrough = Key }" },
         },
 

--- a/ncl/smart_keys/layered/keymap-codegen.ncl
+++ b/ncl/smart_keys/layered/keymap-codegen.ncl
@@ -114,14 +114,10 @@
                   hold
                   |> match {
                     [layer_index, kb_mods] =>
-                      let valid_layer_index = validators.is_number layer_index in
-                      let valid_kb_mods = validators.is_number kb_mods in
-                      [valid_layer_index, valid_kb_mods]
-                      |> match {
-                        ['Ok, 'Ok] => 'Ok,
-                        [err, 'Ok] => err,
-                        ['Ok, err] => err,
-                      },
+                      validators.all_ok [
+                        validators.is_number layer_index,
+                        validators.is_number kb_mods,
+                      ],
                     _ => 'Error { message = "expected Hold to be [layer_index, kb_mods]" },
                   },
                 Toggle = validators.is_number,

--- a/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
@@ -87,28 +87,19 @@
         |> match {
           { layer_modifier = { default_ } } => validators.is_number default_,
           { layer_modifier = { hold }, modifiers } =>
-            let layer_validation = validators.is_number hold in
-            let mods_validation = keyboard_modifiers.validator modifiers in
-            [layer_validation, mods_validation]
-            |> match {
-              ['Ok, 'Ok] => 'Ok,
-              [err, 'Ok] => err,
-              ['Ok, err] => err,
-            },
+            validators.all_ok [
+              validators.is_number hold,
+              keyboard_modifiers.validator modifiers,
+            ],
           { layer_modifier = { hold } } => validators.is_number hold,
           { layer_modifier = { sticky } } => validators.is_number sticky,
           { layer_modifier = { toggle } } => validators.all_of [validators.is_number, validators.is_greater_than 0] toggle,
           { layer_modifier = { set_active_layers_to } } => layer_indices_array set_active_layers_to,
           { layer_modifier = { set_active_layers_to, affected_layers } } =>
-            [
+            validators.all_ok [
               layer_indices_array set_active_layers_to,
               layer_indices_array affected_layers,
-            ]
-            |> match {
-              ['Ok, 'Ok] => 'Ok,
-              [err, _] => err,
-              [_, err] => err,
-            },
+            ],
           _ =>
             'Error {
               message = "expected { layer_modifier = { default_ } }, { hold }, { sticky }, { toggle }, { set_active_layers_to }, or { set_active_layers_to, affected_layers }",
@@ -198,19 +189,13 @@
         k
         |> match {
           { layered, ..base_key } =>
-            let valid_layered =
+            validators.all_ok [
               layered
               |> validators.array.validator (
                 validators.any_of [validators.is_null, keymap_ncl.key.key_validator]
-              )
-            in
-            let valid_base_key = keymap_ncl.key.key_validator base_key in
-            [valid_layered, valid_base_key]
-            |> match {
-              ['Ok, 'Ok] => 'Ok,
-              [err, _] => err,
-              [_, err] => err,
-            },
+              ),
+              keymap_ncl.key.key_validator base_key,
+            ],
           _ => 'Error { message = "expected { layered = Array Key, ..base_key }" },
         },
 

--- a/ncl/smart_keys/tap_dance/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/tap_dance/keymap-ncl-to-json.ncl
@@ -14,14 +14,10 @@
         k
         |> match {
           { tap_dances, ..tap_key } =>
-            let valid_tap_key = keymap_ncl.key.key_validator tap_key in
-            let valid_tap_dances = validators.array.validator keymap_ncl.key.key_validator tap_dances in
-            [valid_tap_dances, valid_tap_key]
-            |> match {
-              ['Ok, 'Ok] => 'Ok,
-              [err, _] => err,
-              [_, err] => err,
-            },
+            validators.all_ok [
+              validators.array.validator keymap_ncl.key.key_validator tap_dances,
+              keymap_ncl.key.key_validator tap_key,
+            ],
           _ => 'Error { message = "expected { tap_dances = [Key, ..], ..tap_key }" },
         },
 

--- a/ncl/smart_keys/tap_hold/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/tap_hold/keymap-ncl-to-json.ncl
@@ -60,14 +60,10 @@
         k
         |> match {
           { hold = hold_key, ..tap_key } =>
-            let valid_hold_key = keymap_ncl.key.key_validator hold_key in
-            let valid_tap_key = keymap_ncl.key.key_validator tap_key in
-            [valid_hold_key, valid_tap_key]
-            |> match {
-              ['Ok, 'Ok] => 'Ok,
-              [err, _] => err,
-              [_, err] => err,
-            },
+            validators.all_ok [
+              keymap_ncl.key.key_validator hold_key,
+              keymap_ncl.key.key_validator tap_key,
+            ],
           _ => 'Error { message = "expected { hold = Key, ..tap_key }" },
         },
 

--- a/ncl/validators.ncl
+++ b/ncl/validators.ncl
@@ -82,6 +82,7 @@
     },
   },
 
+  # Run each validator on the same value; first error wins.
   all_of = fun validators v =>
     validators
     |> match {
@@ -92,6 +93,39 @@
           'Ok => all_of validators v,
           err => err,
         },
+    },
+
+  checks.all_ok = {
+    empty_is_ok = {
+      expected = 'Ok,
+      actual = all_ok [],
+    },
+
+    all_ok_is_ok = {
+      expected = 'Ok,
+      actual = all_ok ['Ok, 'Ok, 'Ok],
+    },
+
+    first_error_wins = {
+      expected = 'Error { message = "a" },
+      actual =
+        all_ok [
+          'Ok,
+          'Error { message = "a" },
+          'Error { message = "b" },
+        ],
+    },
+  },
+
+  # Combine already-computed validation results; first error wins.
+  # Prefer this when validating several independent values (unlike all_of,
+  # which applies validators to one shared value).
+  all_ok = fun results =>
+    results
+    |> match {
+      [] => 'Ok,
+      ['Ok, ..rest] => all_ok rest,
+      [err, ..] => err,
     },
 
   checks.check_any_of = {


### PR DESCRIPTION
Factor a first-error-wins combinator for already-computed validation results (unlike all_of, which runs validators on one value). Use it in layered, tap_hold, tap_dance, and chorded key validators.