### PR TITLE
ncl: resolve named layer strings in layer_mod

### DIFF
--- a/ncl/inputs-to-json.ncl
+++ b/ncl/inputs-to-json.ncl
@@ -3,7 +3,12 @@
 
   layered_keys,
 
-  # From keymap-ncl-to-json: longest `layered` array across all keys.
+  # From keymap-ncl-to-json (merged): named-layer prepare + name→index resolution.
+  prepare_keys_named_layers | default = fun keys => keys,
+  named_layer_indices_from_keys | default = fun _keys => {},
+  resolve_layer_modifier_names | default = fun _name_to_idx k => k,
+
+  # From keymap-ncl-to-json: longest dense layered array after named-layer prepare.
   # Falls back to scanning layered_keys if not merged from that module.
   max_layered_length | default =
     layered_keys
@@ -12,7 +17,7 @@
         let len =
           k
           |> match {
-            { layered, .. } => std.array.length layered,
+            { layered, .. } if std.is_array layered => std.array.length layered,
             _ => 0,
           }
         in
@@ -26,8 +31,23 @@
   #  (either LK, or the K of active layer).
   inputs_as_json_value_input_events =
     let LK = import "layered-key.ncl" in
+    # Lower named_layers and resolve layer_mod name strings so
+    # active_key / set_active_layers see dense arrays and numeric indices.
+    let name_to_idx = named_layer_indices_from_keys layered_keys in
+    let keys = prepare_keys_named_layers layered_keys in
+    let resolve_key = fun k => resolve_layer_modifier_names name_to_idx k in
+    let resolve_input = fun input =>
+      input
+      |> match {
+        'Press k => 'Press (resolve_key k),
+        'Release k => 'Release (resolve_key k),
+        'Tap k => 'Tap (resolve_key k),
+        other => other,
+      }
+    in
     let lookup_keymap_index = fun layer_state @ { active_layers, .. } k =>
-      layered_keys
+      let k = resolve_key k in
+      keys
       |> std.array.map_with_index (fun idx lk =>
         if lk == k then
           idx
@@ -50,7 +70,7 @@
                %{k |> std.serialize 'Json}
 
                layered_keys=
-               %{layered_keys |> std.serialize 'Json}
+               %{keys |> std.serialize 'Json}
                "%
       }
     in
@@ -79,6 +99,7 @@
           # Assumes all `press lmod` in input_enum is
           #  where lmod is not layered.
           # e.g. unhandled case ['Press LMod 0, 'Press { layered = [LMod 1] }, ..]
+          let input = resolve_input input in
           {
             layer_state = LK.update_layer_state_for_input input ls,
             json_value = jv @ [input_as_json ls input]

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -697,6 +697,81 @@
         keys |> std.array.map (lower_named_layers_in_key_tree numbered_len named_names),
     },
 
+  # name → 1-based layer index from a key list (same rules as named_layer_indices).
+  named_layer_indices_from_keys = fun keys =>
+    let numbered = numbered_layer_count_from_keys keys in
+    named_layer_names_from_keys keys
+    |> std.array.map_with_index (fun i layer_name => { "%{layer_name}" = numbered + i + 1 })
+    |> std.array.fold_left (&) {},
+
+  # Resolve a single layer index: numbers pass through; strings look up name_to_idx.
+  resolve_layer_index = fun name_to_idx idx_or_name =>
+    idx_or_name
+    |> match {
+      n if std.is_number n => n,
+      name if std.is_string name =>
+        if std.record.has_field name name_to_idx then
+          std.record.get name name_to_idx
+        else
+          std.fail_with "unknown named layer: %{name}",
+      _ => std.fail_with "expected layer index number or name string",
+    },
+
+  resolve_layer_indices = fun name_to_idx arr =>
+    std.array.map (resolve_layer_index name_to_idx) arr,
+
+  # Rewrite layer_modifier fields that use named-layer strings into numeric indices.
+  resolve_layer_modifier_names = fun name_to_idx k =>
+    k
+    |> match {
+      { layer_modifier = { default_ = d } } =>
+        { layer_modifier = { default_ = resolve_layer_index name_to_idx d } },
+      { layer_modifier = { hold = h }, modifiers = m } =>
+        {
+          layer_modifier = { hold = resolve_layer_index name_to_idx h },
+          modifiers = m,
+        },
+      { layer_modifier = { hold = h } } =>
+        { layer_modifier = { hold = resolve_layer_index name_to_idx h } },
+      { layer_modifier = { sticky = s } } =>
+        { layer_modifier = { sticky = resolve_layer_index name_to_idx s } },
+      { layer_modifier = { toggle = t } } =>
+        { layer_modifier = { toggle = resolve_layer_index name_to_idx t } },
+      { layer_modifier = { set_active_layers_to = active, affected_layers = mask } } =>
+        {
+          layer_modifier = {
+            set_active_layers_to = resolve_layer_indices name_to_idx active,
+            affected_layers = resolve_layer_indices name_to_idx mask,
+          },
+        },
+      { layer_modifier = { set_active_layers_to = active } } =>
+        {
+          layer_modifier = {
+            set_active_layers_to = resolve_layer_indices name_to_idx active,
+          },
+        },
+      _ => k,
+    },
+
+  # Resolve named-layer strings in layer_modifier fields (and nested keys).
+  resolve_named_layer_refs_in_key = fun name_to_idx k =>
+    let resolve_f = fun acc key =>
+      { include acc, k = resolve_layer_modifier_names name_to_idx key }
+    in
+    let k = resolve_layer_modifier_names name_to_idx k in
+    let { acc = _, k } = keymap_ncl.nullable_key.map_accum resolve_f null k in
+    k,
+
+  resolve_keys_named_layer_refs = fun name_to_idx keys =>
+    keys |> std.array.map (resolve_named_layer_refs_in_key name_to_idx),
+
+  # Lower named_layers to dense arrays, then resolve layer_mod name strings.
+  # Indices for names are taken from the pre-lowered key list so they stay stable.
+  prepare_keys_named_layers = fun keys =>
+    let name_to_idx = named_layer_indices_from_keys keys in
+    let keys = lower_named_layers_on_keys keys in
+    resolve_keys_named_layer_refs name_to_idx keys,
+
   # Pad a layered key's `layered` array with null (transparency) up to `target_len`.
   # Expects post-lowering form (array `layered` only; no `named_layers`).
   pad_layered_key = fun target_len k =>
@@ -919,6 +994,100 @@
             },
           ],
         },
+
+      # Named-layer refs in layer_mod: exclusive switch by name + named_layers payload.
+      # Names sort alphabetically: fn=1, nav=2, sym=3 when no numbered layers.
+      check_prepare_named_layer_mod_refs =
+        let names = ["fn", "nav", "sym"] in
+        let keys = [
+          K.layer_mod.set_active_layers_amongst {
+            set_active_layers_to = ["sym"],
+            affected_layers = names,
+          },
+          K.layer_mod.set_active_layers_amongst {
+            set_active_layers_to = ["fn"],
+            affected_layers = names,
+          },
+          { named_layers = { sym = K.A, fn = K.B, nav = K.C } },
+        ]
+        in
+        {
+          actual = prepare_keys_named_layers keys |> std.array.map keymap_ncl.key.to_json_value,
+          expected = [
+            {
+              SetActiveLayers = {
+                layers = std.number.pow 2 3,
+                mask =
+                  (std.number.pow 2 1)
+                  + (std.number.pow 2 2)
+                  + (std.number.pow 2 3),
+              },
+            },
+            {
+              SetActiveLayers = {
+                layers = std.number.pow 2 1,
+                mask =
+                  (std.number.pow 2 1)
+                  + (std.number.pow 2 2)
+                  + (std.number.pow 2 3),
+              },
+            },
+            {
+              base = { key_code = 0 },
+              # alphabetical: fn, nav, sym
+              layered = [
+                { key_code = 5 },
+                { key_code = 6 },
+                { key_code = 4 },
+              ],
+            },
+          ],
+        },
+
+      check_prepare_named_layer_mod_refs_with_numbered =
+        # Numbered length 1 → named fn=2, nav=3, sym=4
+        let names = ["fn", "nav", "sym"] in
+        let keys = [
+          K.layer_mod.set_active_layers_amongst {
+            set_active_layers_to = ["sym"],
+            affected_layers = names,
+          },
+          K.D & { layered = [K.E] },
+          { named_layers = { sym = K.A, fn = K.B, nav = K.C } },
+        ]
+        in
+        {
+          actual = prepare_keys_named_layers keys |> std.array.map keymap_ncl.key.to_json_value,
+          expected = [
+            {
+              SetActiveLayers = {
+                layers = std.number.pow 2 4,
+                mask =
+                  (std.number.pow 2 2)
+                  + (std.number.pow 2 3)
+                  + (std.number.pow 2 4),
+              },
+            },
+            {
+              base = { key_code = 7 },
+              layered = [
+                { key_code = 8 },
+                null,
+                null,
+                null,
+              ],
+            },
+            {
+              base = { key_code = 0 },
+              layered = [
+                null,
+                { key_code = 5 },
+                { key_code = 6 },
+                { key_code = 4 },
+              ],
+            },
+          ],
+        },
     },
 
   chorded_keys
@@ -998,7 +1167,8 @@
       # named_layers -> dense array after numbered `layered` slots:
       #   layered = [ numbered slots… ] ++ [ named slots… ]
       # Named order is alphabetical (Nickel record field order). Skipped if unused.
-      let keys = lower_named_layers_on_keys keys in
+      # Layer_mod fields may use those names as strings; resolve to 1-based indices.
+      let keys = prepare_keys_named_layers keys in
       # Equalise layered array lengths (pad shorter with null / transparency).
       let layer_count =
         keys |> std.array.fold_left max_layered_length_accum 0

--- a/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
@@ -49,9 +49,36 @@
         actual = layer_indices_array [3, 3],
         expected = 'Error { message = "layer indices must be unique" },
       },
+
+      # Authoring form: named-layer strings in layer_mod (resolved at km→json).
+      check_named_layer_mod_strings = {
+        actual =
+          K.layer_mod.set_active_layers_amongst {
+            set_active_layers_to = ["nav"],
+            affected_layers = ["fn", "nav", "sym"],
+          },
+        expected = {
+          layer_modifier = {
+            set_active_layers_to = ["nav"],
+            affected_layers = ["fn", "nav", "sym"],
+          },
+        },
+      },
+
+      check_named_layer_mod_strings_is_key =
+        keymap_ncl.layer_modifier.is_key (
+          K.layer_mod.set_active_layers_amongst {
+            set_active_layers_to = ["nav"],
+            affected_layers = ["fn", "nav"],
+          }
+        ),
     },
 
-  unique_number_array = fun arr =>
+  # Layer index: numeric (1-based) or named-layer string (resolved before to_json_value).
+  layer_index =
+    validators.any_of [validators.is_number, validators.is_string],
+
+  unique_layer_index_array = fun arr =>
     if !std.is_array arr then
       'Error { message = "Expected array" }
     else
@@ -68,9 +95,12 @@
 
   layer_indices_array =
     validators.all_of [
-      (validators.array.validator validators.is_number),
-      unique_number_array,
+      (validators.array.validator layer_index),
+      unique_layer_index_array,
     ],
+
+  # Back-compat alias used by some checks.
+  unique_number_array = unique_layer_index_array,
 
   layer_indices_to_bitset = fun layer_indices =>
     layer_indices
@@ -85,15 +115,20 @@
       key_validator = fun k =>
         k
         |> match {
-          { layer_modifier = { default_ } } => validators.is_number default_,
+          { layer_modifier = { default_ } } => layer_index default_,
           { layer_modifier = { hold }, modifiers } =>
             validators.all_ok [
-              validators.is_number hold,
+              layer_index hold,
               keyboard_modifiers.validator modifiers,
             ],
-          { layer_modifier = { hold } } => validators.is_number hold,
-          { layer_modifier = { sticky } } => validators.is_number sticky,
-          { layer_modifier = { toggle } } => validators.all_of [validators.is_number, validators.is_greater_than 0] toggle,
+          { layer_modifier = { hold } } => layer_index hold,
+          { layer_modifier = { sticky } } => layer_index sticky,
+          { layer_modifier = { toggle } } =>
+            # Named layers: string ok; numeric toggle still requires > 0.
+            if std.is_string toggle then
+              'Ok
+            else
+              validators.all_of [validators.is_number, validators.is_greater_than 0] toggle,
           { layer_modifier = { set_active_layers_to } } => layer_indices_array set_active_layers_to,
           { layer_modifier = { set_active_layers_to, affected_layers } } =>
             validators.all_ok [
@@ -108,6 +143,8 @@
 
       is_key = fun k => 'Ok == key_validator k,
 
+      # JSON projection expects numeric layer indices. Named-layer strings must be
+      # resolved (see keymap-ncl-to-json resolve_named_layer_refs) before to_json_value.
       to_json_value = fun layer_modifier_key =>
         layer_modifier_key
         |> match {
@@ -185,6 +222,21 @@
       check_layered_and_named_layers_is_key =
         let key = K.A & { layered = [ null, K.B], named_layers = { fn = K.C } } in
         keymap_ncl.layered.is_key key,
+
+      # Pure layered form (unit {} base) serializes with key_code 0 base.
+      check_pure_layered_unit_base = {
+        actual = { layered = [ null, null, K.A, K.B, K.C] } |> keymap_ncl.key.to_json_value,
+        expected = {
+          base = { key_code = 0 },
+          layered = [
+            null,
+            null,
+            { key_code = 4 },
+            { key_code = 5 },
+            { key_code = 6 },
+          ],
+        },
+      },
     },
 
   keymap_ncl.layered


### PR DESCRIPTION
## Summary

Follow-up to #594 (`ncl: support named layers on layered keys`).

That PR made it possible to **declare** named layers and lower them to dense `layered` arrays for JSON. Layer modifiers still only accepted **numeric** indices, so referring to a named layer from `layer_mod` required hard-coding the assigned index.

This PR finishes that authoring path:

- Accept `Number | String` layer indices on `layer_mod` (hold / sticky / toggle / set_active_layers_*)
- After lowering named layers, **resolve** name strings to the global 1-based indices (`prepare_keys_named_layers`)
- Run the same prepare path in `inputs-to-json` so cucumber / input sim match keymap JSON

Example after this change:

```nickel
K.A & { named_layers = { nav = K.B } }
K.layer_mod.hold "nav"
# or exclusive switch within a named group:
K.layer_mod.set_active_layers_amongst {
  set_active_layers_to = ["nav"],
  affected_layers = ["fn", "nav", "sym"],
}
```

Out of scope (intentionally, for later PRs on `semantic-keys-nickel-sugar`):

- `K.semantic` / `set_semantic_variant_to` authoring sugar
- OS desktop cucumber demo

## Related

- Builds on: https://github.com/rgoulter/smart-keymap/pull/594
- Next: semantic sugar + OS desktop feature demo (branch `semantic-keys-nickel-sugar` / #570)

## Test plan

- [x] `make test-ncl-checks`
- [ ] CI green