### PR TITLE
ncl: generate config field exprs as Nickel records

### DIFF
--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -24,6 +24,26 @@
   lib = {
     array_rust_expr = fun data =>
       "[%{data |> std.array.map (fun { rust_expr, .. } => rust_expr) |> std.string.join ", "}]",
+
+    # Build `Module::Config { field: expr, ..Module::Config::new() }` from a
+    # Nickel record of field name -> Rust value expression strings.
+    # Empty record emits `Module::Config::new()`.
+    config_rust_expr = fun module field_exprs =>
+      if field_exprs == {} then
+        "%{module}::Config::new()"
+      else
+        let fields =
+          field_exprs
+          |> std.record.to_array
+          |> std.array.map (fun { field, value } => "%{field}: %{value},")
+          |> std.string.join "\n"
+        in
+        m%"
+        %{module}::Config {
+            %{fields}
+            ..%{module}::Config::new()
+        }
+      "%,
   },
 
   smart_keymap,

--- a/ncl/smart_keys/automation/keymap-codegen.ncl
+++ b/ncl/smart_keys/automation/keymap-codegen.ncl
@@ -148,33 +148,31 @@
           instruction_duration | optional | Number,
         },
 
-        rust_expr =
+        expr =
           if std.record.has_field "automation" json_keymap.config then
-            let automation_config = json_keymap.config.automation in
-            let instructions_field_fragment =
-              if std.record.has_field "instructions" automation_config then
-                let instructions = automation_config.instructions in
-                m%"instructions: %{module}::instructions([
-                   %{instructions |> std.array.map instruction.rust_expr |> std.string.join ", "}
-                ]),"%
+            let c = json_keymap.config.automation in
+            (
+              if std.record.has_field "instructions" c then
+                {
+                  instructions = m%"%{module}::instructions([
+                   %{c.instructions |> std.array.map instruction.rust_expr |> std.string.join ", "}
+                ])"%,
+                }
               else
-                ""
-            in
-            let instruction_duration_field_fragment =
-              if std.record.has_field "instruction_duration" automation_config then
-                "instruction_duration: %{std.to_string automation_config.instruction_duration},"
+                {}
+            )
+            & (
+              if std.record.has_field "instruction_duration" c then
+                {
+                  instruction_duration = "%{std.to_string c.instruction_duration}",
+                }
               else
-                ""
-            in
-            m%"
-            %{module}::Config {
-                %{instructions_field_fragment}
-                %{instruction_duration_field_fragment}
-                ..%{module}::Config::new()
-            }
-          "%
+                {}
+            )
           else
-            "%{module}::Config::new()",
+            {},
+
+        rust_expr = lib.config_rust_expr module expr,
       },
 
       system = {

--- a/ncl/smart_keys/chorded/keymap-codegen.ncl
+++ b/ncl/smart_keys/chorded/keymap-codegen.ncl
@@ -200,44 +200,44 @@
           timeout | optional | Number,
         },
 
-        rust_expr =
+        expr =
           if std.record.has_field "chorded" json_keymap.config then
-            let chorded_config = json_keymap.config.chorded in
-            let required_idle_time_field_fragment =
-              if std.record.has_field "required_idle_time" chorded_config then
-                "required_idle_time: Some(%{std.to_string chorded_config.required_idle_time}),"
+            let c = json_keymap.config.chorded in
+            (
+              if std.record.has_field "required_idle_time" c then
+                {
+                  required_idle_time = "Some(%{std.to_string c.required_idle_time})",
+                }
               else
-                ""
-            in
-            let timeout_field_fragment =
-              if std.record.has_field "timeout" chorded_config then
-                "timeout: %{std.to_string chorded_config.timeout},"
+                {}
+            )
+            & (
+              if std.record.has_field "timeout" c then
+                {
+                  timeout = "%{std.to_string c.timeout}",
+                }
               else
-                ""
-            in
-            let chords_field_fragment =
-              if std.record.has_field "chords" chorded_config then
+                {}
+            )
+            & (
+              if std.record.has_field "chords" c then
                 let chords_fragment =
-                  chorded_config.chords
+                  c.chords
                   |> std.array.map (fun indices =>
                     "%{module}::ChordIndices::from_slice(&[%{indices |> std.array.map std.to_string |> std.string.join ", "}])"
                   )
                   |> std.string.join ","
                 in
-                "chords: smart_keymap::slice::Slice::from_slice(&[%{chords_fragment}]),"
+                {
+                  chords = "smart_keymap::slice::Slice::from_slice(&[%{chords_fragment}])",
+                }
               else
-                ""
-            in
-            m%"
-          %{module}::Config {
-              %{required_idle_time_field_fragment}
-              %{timeout_field_fragment}
-              %{chords_field_fragment}
-              ..%{module}::Config::new()
-          }
-        "%
+                {}
+            )
           else
-            "%{module}::Config::new()",
+            {},
+
+        rust_expr = lib.config_rust_expr module expr,
       },
 
       system = {

--- a/ncl/smart_keys/layered/keymap-codegen.ncl
+++ b/ncl/smart_keys/layered/keymap-codegen.ncl
@@ -344,23 +344,19 @@
           sticky_timeout | optional | Number,
         },
 
-        rust_expr =
+        expr =
           if std.record.has_field "layered" json_keymap.config then
-            let layered_config = json_keymap.config.layered in
-            let sticky_timeout_field_fragment =
-              if std.record.has_field "sticky_timeout" layered_config then
-                "sticky_timeout: Some(%{std.to_string layered_config.sticky_timeout}),"
-              else
-                ""
-            in
-            m%"
-            %{module}::Config {
-                %{sticky_timeout_field_fragment}
-                ..%{module}::Config::new()
-            }
-          "%
+            let c = json_keymap.config.layered in
+            if std.record.has_field "sticky_timeout" c then
+              {
+                sticky_timeout = "Some(%{std.to_string c.sticky_timeout})",
+              }
+            else
+              {}
           else
-            "%{module}::Config::new()",
+            {},
+
+        rust_expr = lib.config_rust_expr module expr,
       },
 
       system = {

--- a/ncl/smart_keys/sticky/keymap-codegen.ncl
+++ b/ncl/smart_keys/sticky/keymap-codegen.ncl
@@ -90,37 +90,29 @@
             | StickyReleaseJson_,
         },
 
-        rust_expr =
+        expr =
           if std.record.has_field "sticky" json_keymap.config then
-            let sticky_config = json_keymap.config.sticky in
-            let activation_field_fragment =
-              if std.record.has_field "activation" sticky_config then
-                "activation: %{module}::StickyKeyActivation::%{sticky_config.activation},"
+            let c = json_keymap.config.sticky in
+            (
+              if std.record.has_field "activation" c then
+                {
+                  activation = "%{module}::StickyKeyActivation::%{c.activation}",
+                }
               else
-                ""
-            in
-            let release_field_fragment =
-              if std.record.has_field "release" sticky_config then
-                "release: %{module}::StickyKeyRelease::%{sticky_config.release},"
+                {}
+            )
+            & (
+              if std.record.has_field "release" c then
+                {
+                  release = "%{module}::StickyKeyRelease::%{c.release}",
+                }
               else
-                ""
-            in
-            let config_fragment =
-              [
-                activation_field_fragment,
-                release_field_fragment,
-                "..%{module}::Config::new()"
-              ]
-              |> std.array.filter ((!=) "")
-              |> std.string.join "\n"
-            in
-            m%"
-            %{module}::Config {
-                %{config_fragment}
-            }
-          "%
+                {}
+            )
           else
-            "%{module}::Config::new()",
+            {},
+
+        rust_expr = lib.config_rust_expr module expr,
       },
 
       system = {

--- a/ncl/smart_keys/tap_dance/keymap-codegen.ncl
+++ b/ncl/smart_keys/tap_dance/keymap-codegen.ncl
@@ -110,23 +110,19 @@
           timeout | optional | Number,
         },
 
-        rust_expr =
+        expr =
           if std.record.has_field "tap_dance" json_keymap.config then
-            let tap_dance_config = json_keymap.config.tap_dance in
-            let timeout_field_fragment =
-              if std.record.has_field "timeout" tap_dance_config then
-                "timeout: %{std.to_string tap_dance_config.timeout},"
-              else
-                ""
-            in
-            m%"
-            %{module}::Config {
-                %{timeout_field_fragment}
-                ..%{module}::Config::new()
-            }
-          "%
+            let c = json_keymap.config.tap_dance in
+            if std.record.has_field "timeout" c then
+              {
+                timeout = "%{std.to_string c.timeout}",
+              }
+            else
+              {}
           else
-            "%{module}::Config::new()",
+            {},
+
+        rust_expr = lib.config_rust_expr module expr,
       },
 
       system = {

--- a/ncl/smart_keys/tap_hold/keymap-codegen.ncl
+++ b/ncl/smart_keys/tap_hold/keymap-codegen.ncl
@@ -149,40 +149,41 @@
           required_idle_time | optional | Number,
         },
 
-        rust_expr =
+        expr =
           if std.record.has_field "tap_hold" json_keymap.config then
-            let tap_hold_config = json_keymap.config.tap_hold in
-            let timeout_field_fragment =
-              if std.record.has_field "timeout" tap_hold_config then
-                if tap_hold_config.timeout == null then
-                  "timeout: None,"
-                else
-                  "timeout: Some(%{std.to_string tap_hold_config.timeout}),"
+            let c = json_keymap.config.tap_hold in
+            (
+              if std.record.has_field "timeout" c then
+                {
+                  timeout =
+                    if c.timeout == null then
+                      "None"
+                    else
+                      "Some(%{std.to_string c.timeout})",
+                }
               else
-                ""
-            in
-            let interrupt_response_field_fragment =
-              if std.record.has_field "interrupt_response" tap_hold_config then
-                "interrupt_response: %{module}::InterruptResponse::%{tap_hold_config.interrupt_response},"
+                {}
+            )
+            & (
+              if std.record.has_field "interrupt_response" c then
+                {
+                  interrupt_response = "%{module}::InterruptResponse::%{c.interrupt_response}",
+                }
               else
-                ""
-            in
-            let required_idle_time_field_fragment =
-              if std.record.has_field "required_idle_time" tap_hold_config then
-                "required_idle_time: Some(%{std.to_string tap_hold_config.required_idle_time}),"
+                {}
+            )
+            & (
+              if std.record.has_field "required_idle_time" c then
+                {
+                  required_idle_time = "Some(%{std.to_string c.required_idle_time})",
+                }
               else
-                ""
-            in
-            m%"
-            %{module}::Config {
-                %{timeout_field_fragment}
-                %{interrupt_response_field_fragment}
-                %{required_idle_time_field_fragment}
-                ..%{module}::Config::new()
-            }
-          "%
+                {}
+            )
           else
-            "%{module}::Config::new()",
+            {},
+
+        rust_expr = lib.config_rust_expr module expr,
       },
 
       system = {

--- a/tests/ncl/keymap-1key-automation/expected.rs
+++ b/tests/ncl/keymap-1key-automation/expected.rs
@@ -75,7 +75,6 @@ pub mod init {
                     ),
                 ),
             ]),
-
             ..smart_keymap::key::automation::Config::new()
         },
         chorded: smart_keymap::key::chorded::Config {
@@ -100,7 +99,6 @@ pub mod init {
                         ),
                     ),
                 ]),
-
                 ..smart_keymap::key::automation::Config::new()
             },
             chorded: smart_keymap::key::chorded::Config {

--- a/tests/ncl/keymap-48key-rgoulter/expected.rs
+++ b/tests/ncl/keymap-48key-rgoulter/expected.rs
@@ -129,7 +129,6 @@ pub mod init {
         tap_dance: smart_keymap::key::tap_dance::Config::new(),
         tap_hold: smart_keymap::key::tap_hold::Config {
             interrupt_response: smart_keymap::key::tap_hold::InterruptResponse::HoldOnKeyTap,
-
             ..smart_keymap::key::tap_hold::Config::new()
         },
         ..smart_keymap::key::composite::Config::new()
@@ -153,7 +152,6 @@ pub mod init {
             tap_dance: smart_keymap::key::tap_dance::Config::new(),
             tap_hold: smart_keymap::key::tap_hold::Config {
                 interrupt_response: smart_keymap::key::tap_hold::InterruptResponse::HoldOnKeyTap,
-
                 ..smart_keymap::key::tap_hold::Config::new()
             },
             ..smart_keymap::key::composite::Config::new()


### PR DESCRIPTION
## Summary

- Per-key Nickel config codegen no longer builds Rust via string `_field_fragment`s.
- Each `config` now exposes an `expr` Nickel record (`field_name -> rust value expr`), and `rust_expr` is derived with a shared `lib.config_rust_expr`.
- Touched modules: automation, chorded, layered, sticky, tap_dance, tap_hold.
- Snapshot fixtures updated only where incidental blank lines from empty fragments disappeared.

## Motivation

Field fragments mixed structure (which optional fields are set) with Rust string assembly. A Nickel record of field expressions is easier to read/extend, and a single helper owns the `Module::Config { …, ..Config::new() }` / `Config::new()` shape.

## Test plan

- [x] `ncl/scripts/run-ncl-checks.sh`
- [x] `ncl/scripts/run-snapshots.sh` (diff + cargo-check per fixture)
- [x] pre-commit (nickel format, clippy, cargo check)