### PR TITLE
keymap: represent input-queue pacing as a bool

### DIFF
--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -37,9 +37,6 @@ pub const MAX_PRESSED_KEYS: usize = 16;
 
 const MAX_QUEUED_INPUT_EVENTS: usize = 32;
 
-/// Number of ticks before the next input event is processed in tick().
-pub const INPUT_QUEUE_TICK_DELAY: u8 = 1;
-
 /// Constructs an HID report or a sequence of key codes from the given sequence of [key::KeyOutput].
 #[derive(Debug, Default, PartialEq)]
 pub struct KeymapOutput {
@@ -377,7 +374,7 @@ impl<
     /// Handles input events.
     ///
     /// All inputs enter `input_queue` first
-    ///  so at most one is processed per tick ([`INPUT_QUEUE_TICK_DELAY`]),
+    ///  so at most one is processed per tick (one-tick pacing gate),
     ///  including while a key is pending.
     /// Tap-hold and chorded interrupt logic depend on that spacing;
     ///  do not bypass the queue during pending without equivalent pacing
@@ -390,7 +387,7 @@ impl<
 
         if let Some(ie) = self.input_queue.pop_front_if_ready() {
             self.process_input(ie);
-            self.input_queue.set_delay_counter(INPUT_QUEUE_TICK_DELAY);
+            self.input_queue.set_delay();
         }
     }
 
@@ -662,7 +659,7 @@ impl<
 
         if let Some(ie) = self.input_queue.pop_front_if_ready() {
             self.process_input(ie);
-            self.input_queue.set_delay_counter(INPUT_QUEUE_TICK_DELAY);
+            self.input_queue.set_delay();
         }
 
         self.input_queue.tick_delay();
@@ -792,8 +789,8 @@ impl<
         self.input_queue.len()
     }
 
-    pub(crate) fn test_input_queue_delay(&self) -> u8 {
-        self.input_queue.delay_counter()
+    pub(crate) fn test_input_queue_delay(&self) -> bool {
+        self.input_queue.delay()
     }
 
     pub(crate) fn test_handle_scheduled_key_event(&mut self, ev: key::Event<Ev>) {
@@ -1043,7 +1040,7 @@ mod tests {
         let mut keymap = tap_hold_interrupt_keymap(InterruptResponse::Ignore);
         keymap.handle_input(input::Event::Press { keymap_index: 0 });
         assert!(keymap.test_is_pending());
-        assert_eq!(INPUT_QUEUE_TICK_DELAY, keymap.test_input_queue_delay());
+        assert!(keymap.test_input_queue_delay());
 
         // Act -- interrupt without waiting for ticks.
         keymap.handle_input(input::Event::Press { keymap_index: 1 });
@@ -1054,7 +1051,7 @@ mod tests {
         assert!(keymap.pressed_keys().is_empty());
     }
 
-    /// Physical inputs while delay > 0 sit in the delay line
+    /// Physical inputs while the delay gate is armed sit in the delay line
     ///  and are not yet recorded in the session log.
     ///
     /// Motivating smart key: **tap-hold**
@@ -1066,7 +1063,7 @@ mod tests {
         // Assemble -- pending with delay set.
         let mut keymap = tap_hold_interrupt_keymap(InterruptResponse::Ignore);
         keymap.handle_input(input::Event::Press { keymap_index: 0 });
-        assert_eq!(INPUT_QUEUE_TICK_DELAY, keymap.test_input_queue_delay());
+        assert!(keymap.test_input_queue_delay());
 
         // Act
         keymap.handle_input(input::Event::Press { keymap_index: 1 });
@@ -1099,10 +1096,10 @@ mod tests {
         // Assert
         assert_eq!(2, keymap.test_input_queue_len());
         assert_eq!(Some(0), keymap.test_pending_queued_events_len());
-        assert_eq!(0, keymap.test_input_queue_delay());
+        assert!(!keymap.test_input_queue_delay());
     }
 
-    /// When delay is already 0, a tick moves exactly one delay-line input
+    /// When delay is already cleared, a tick moves exactly one delay-line input
     ///  into the session log.
     ///
     /// Motivating smart key: **tap-hold**
@@ -1117,7 +1114,7 @@ mod tests {
         keymap.handle_input(input::Event::Press { keymap_index: 1 });
         keymap.handle_input(input::Event::Release { keymap_index: 1 });
         keymap.tick(); // clear delay
-        assert_eq!(0, keymap.test_input_queue_delay());
+        assert!(!keymap.test_input_queue_delay());
         assert_eq!(2, keymap.test_input_queue_len());
 
         // Act
@@ -1199,7 +1196,7 @@ mod tests {
     ///  so they are not absorbed into resolve replay.
     ///
     /// After a processing `tick`,
-    ///  delay ends at 0 (set DELAY then `tick_delay` in the same tick),
+    ///  delay ends cleared (`set_delay` then `tick_delay` in the same tick),
     ///  so the next queued event is ready but not yet popped
     ///  until the next `tick`/`handle_input`.
     ///
@@ -1218,7 +1215,7 @@ mod tests {
         keymap.tick(); // process Press(1)
         assert_eq!(Some(1), keymap.test_pending_queued_events_len());
         assert_eq!(1, keymap.test_input_queue_len());
-        assert_eq!(0, keymap.test_input_queue_delay());
+        assert!(!keymap.test_input_queue_delay());
 
         // Act -- resolve without processing remaining Release(1).
         keymap.test_handle_scheduled_key_event(tap_hold_timeout_event());
@@ -1262,8 +1259,8 @@ mod tests {
     }
 
     /// When pending resolves inside a `tick` that pops from the delay line,
-    ///  `tick` ends with `set_delay(DELAY)` then `tick_delay()`,
-    ///  so delay is 0 after resolve.
+    ///  `tick` ends with `set_delay` then `tick_delay`,
+    ///  so delay is cleared after resolve.
     /// Resolve also prepends filtered session-log inputs onto the queue.
     ///
     /// Motivating smart key: **tap-hold**
@@ -1284,10 +1281,9 @@ mod tests {
 
         // Assert
         assert!(!keymap.test_is_pending());
-        assert_eq!(
-            0,
-            keymap.test_input_queue_delay(),
-            "tick sets DELAY then tick_delay in the same call"
+        assert!(
+            !keymap.test_input_queue_delay(),
+            "tick sets delay then tick_delay in the same call"
         );
         assert!(
             keymap.test_input_queue_len() >= 1,
@@ -1297,7 +1293,7 @@ mod tests {
 
     /// When resolve happens inside `handle_input`
     ///  (HoldOnKeyPress interrupt popped in that call),
-    ///  DELAY is set without a same-call `tick_delay`,
+    ///  delay is set without a same-call `tick_delay`,
     ///  so the next physical input is deferred —
     ///  a different delay state than resolve-via-tick.
     ///
@@ -1311,21 +1307,21 @@ mod tests {
         keymap.handle_input(input::Event::Press { keymap_index: 0 });
         assert!(keymap.test_is_pending());
         keymap.tick();
-        assert_eq!(0, keymap.test_input_queue_delay());
+        assert!(!keymap.test_input_queue_delay());
 
         // Act -- interrupt resolves hold inside handle_input.
         keymap.handle_input(input::Event::Press { keymap_index: 1 });
 
-        // Assert -- DELAY set again; interrupt not applied as a normal press (#578).
+        // Assert -- delay armed again; interrupt not applied as a normal press (#578).
         assert!(!keymap.test_is_pending());
-        assert_eq!(INPUT_QUEUE_TICK_DELAY, keymap.test_input_queue_delay());
+        assert!(keymap.test_input_queue_delay());
         assert!(!keymap
             .pressed_keys()
             .contains(&key::KeyOutput::from_key_code(0x05)));
     }
 
     /// After resolve-inside-`handle_input`, the next physical event
-    ///  is deferred onto the delay line because DELAY is still set.
+    ///  is deferred onto the delay line because delay is still armed.
     ///
     /// Motivating smart key: **tap-hold** (`HoldOnKeyPress`; #578).
     #[test]
@@ -1338,7 +1334,7 @@ mod tests {
         keymap.tick();
         keymap.handle_input(input::Event::Press { keymap_index: 1 });
         assert!(!keymap.test_is_pending());
-        assert_eq!(INPUT_QUEUE_TICK_DELAY, keymap.test_input_queue_delay());
+        assert!(keymap.test_input_queue_delay());
         // Session log may have prepended Press(1); queue non-empty is ok.
         let queue_after_resolve = keymap.test_input_queue_len();
 

--- a/src/keymap/input_event_queue.rs
+++ b/src/keymap/input_event_queue.rs
@@ -7,10 +7,14 @@ use crate::input;
 /// Backed by a [`heapless::Deque`] so events can be prepended
 ///  when a pending key state needs to replay buffered input
 ///  without draining and rebuilding the queue.
+///
+/// After an event is processed, [`set_delay`] marks the queue so the next
+///  event waits until [`tick_delay`] (called from `Keymap::tick`).
 #[derive(Debug)]
 pub(crate) struct InputEventQueue<const N: usize> {
     events: heapless::Deque<input::Event, N>,
-    delay_counter: u8,
+    /// When true, the next event must wait for a tick before processing.
+    delay: bool,
 }
 
 #[allow(dead_code)]
@@ -18,13 +22,13 @@ impl<const N: usize> InputEventQueue<N> {
     pub const fn new() -> Self {
         Self {
             events: heapless::Deque::new(),
-            delay_counter: 0,
+            delay: false,
         }
     }
 
     pub fn clear(&mut self) {
         self.events.clear();
-        self.delay_counter = 0;
+        self.delay = false;
     }
 
     pub fn is_full(&self) -> bool {
@@ -39,18 +43,19 @@ impl<const N: usize> InputEventQueue<N> {
         self.events.len()
     }
 
-    pub fn set_delay_counter(&mut self, delay_counter: u8) {
-        self.delay_counter = delay_counter;
+    /// Arms the one-tick pacing gate so the next event waits for [`tick_delay`].
+    pub fn set_delay(&mut self) {
+        self.delay = true;
     }
 
-    pub fn delay_counter(&self) -> u8 {
-        self.delay_counter
+    /// Returns whether the queue is currently waiting for a tick before processing.
+    pub fn delay(&self) -> bool {
+        self.delay
     }
 
+    /// Clears the pacing gate (one tick of delay has elapsed).
     pub fn tick_delay(&mut self) {
-        if self.delay_counter > 0 {
-            self.delay_counter -= 1;
-        }
+        self.delay = false;
     }
 
     pub fn push_back(&mut self, event: input::Event) -> Result<(), input::Event> {
@@ -107,7 +112,7 @@ impl<const N: usize> InputEventQueue<N> {
     }
 
     pub fn ready_to_process(&self) -> bool {
-        !self.is_empty() && self.delay_counter == 0
+        !self.is_empty() && !self.delay
     }
 
     pub fn pop_front_if_ready(&mut self) -> Option<input::Event> {
@@ -124,7 +129,6 @@ use crate::key;
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
-    use super::super::INPUT_QUEUE_TICK_DELAY;
     use super::*;
 
     const CAPACITY: usize = 4;
@@ -135,7 +139,7 @@ mod tests {
 
         queue.push_back(input::Event::press(0)).unwrap();
         assert_eq!(queue.pop_front_if_ready(), Some(input::Event::press(0)));
-        queue.set_delay_counter(INPUT_QUEUE_TICK_DELAY);
+        queue.set_delay();
 
         queue.push_back(input::Event::release(0)).unwrap();
         assert_eq!(queue.pop_front_if_ready(), None);
@@ -169,7 +173,7 @@ mod tests {
         queue.append_all(&mut other);
         assert_eq!(queue.len(), 3);
         assert_eq!(queue.pop_front_if_ready(), Some(input::Event::press(0)));
-        queue.set_delay_counter(0);
+        // No delay set: remaining events are ready immediately.
         assert_eq!(queue.pop_front_if_ready(), Some(input::Event::release(0)));
         assert_eq!(queue.pop_front_if_ready(), Some(input::Event::press(1)));
     }

--- a/src/keymap/observed_eb_keymap.rs
+++ b/src/keymap/observed_eb_keymap.rs
@@ -44,10 +44,9 @@ impl<
 
         distinct_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-        for _ in 0..keymap::INPUT_QUEUE_TICK_DELAY {
-            keymap.tick();
-            distinct_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-        }
+        // Clear input-queue pacing so a follow-up handle_input can process next.
+        keymap.tick();
+        distinct_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
         next_ev
     }

--- a/src/keymap/observed_keymap.rs
+++ b/src/keymap/observed_keymap.rs
@@ -43,10 +43,9 @@ impl<
         keymap.handle_input(ev);
         distinct_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
 
-        for _ in 0..keymap::INPUT_QUEUE_TICK_DELAY {
-            keymap.tick();
-            distinct_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
-        }
+        // Clear input-queue pacing so a follow-up handle_input can process next.
+        keymap.tick();
+        distinct_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
     }
 
     /// Proxies [keymap::Keymap::tick], updating reports appropriately.

--- a/tests/rust/tap_hold/hold_on_interrupt_tap.rs
+++ b/tests/rust/tap_hold/hold_on_interrupt_tap.rs
@@ -80,8 +80,8 @@ fn interrupting_tap_resolves_hold() {
 #[test]
 fn rolling_nested_tap_th_tap_th_tap_kbd() {
     // Observed buggy behaviour with,
-    //  (in the case where the releases occur quickly enough,
-    //   quicker than the keymap's INPUT_QUEUE_TICK_DELAY):
+    //  (in the case where the releases occur quickly enough
+    //   that they land while the input-queue pacing gate is still armed):
     // - Press TH(A)
     // - Press TH(B)
     // - Press C
@@ -134,8 +134,8 @@ fn rolling_nested_tap_th_tap_th_tap_kbd() {
 #[test]
 fn rolling_nested_tap_th_tap_th_tap_th() {
     // Observed buggy behaviour with,
-    //  (in the case where the releases occur quickly enough,
-    //   quicker than the keymap's INPUT_QUEUE_TICK_DELAY):
+    //  (in the case where the releases occur quickly enough
+    //   that they land while the input-queue pacing gate is still armed):
     // - Press TH(A)
     // - Press TH(B)
     // - Press TH(C)


### PR DESCRIPTION
## Summary

- Replace the input-queue `u8` delay counter with a `bool`, since `INPUT_QUEUE_TICK_DELAY` was always `1` and only ever armed or cleared.
- Expose `set_delay()` / `tick_delay()` / `delay()` instead of `set_delay_counter(n)`.
- Drop `INPUT_QUEUE_TICK_DELAY` and the `for _ in 0..1` loops in ObservedKeymap wrappers in favour of a single `tick()`.

Behaviour is unchanged: after processing an input, the next queued event waits until the next `tick()`.

## Test plan

- [x] `cargo test --lib keymap::`
- [x] `cargo test --test rust-integration hold_on_interrupt`
- [x] pre-commit (clippy, rustfmt, no_std check)
- [ ] CI green on the PR