### PR TITLE
keymap: re-feed nested pending session inputs in FIFO order

### DIFF
--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -454,7 +454,8 @@ impl<
                     key::PressedKeyResult::Pending(pks) => {
                         *pending_key_state = pks;
 
-                        // Pending key transitioned to another pending state: replay session log.
+                        // Nested pending: re-queue session-log inputs chronologically
+                        //  so the new pending state re-observes them as they occurred.
                         pending::dispatch_replayed_events(
                             pending::KeyResolution::Pending,
                             queued_events,

--- a/src/keymap/input_event_queue.rs
+++ b/src/keymap/input_event_queue.rs
@@ -93,21 +93,23 @@ impl<const N: usize> InputEventQueue<N> {
         }
     }
 
-    /// Replays input events from a pending key's buffer ahead of any already-queued events.
+    /// Replays input events from a pending key's session log ahead of any already-queued events.
     ///
-    /// Events are popped LIFO from `pending_events` and appended to the front of the queue,
-    ///  preserving the historical behaviour of the pending-state re-queue path.
+    /// Session-log inputs are re-queued in **chronological (FIFO) order** so a nested
+    ///  pending key re-observes prior inputs as they occurred.
+    /// Non-input events are dropped. `pending_events` is cleared.
     pub fn prepend_pending_input_events<Ev: Debug, const M: usize>(
         &mut self,
         pending_events: &mut heapless::Vec<key::Event<Ev>, M>,
     ) {
         let mut pending_inputs = heapless::Vec::<input::Event, M>::new();
-        while let Some(event) = pending_events.pop() {
+        for event in pending_events.iter() {
             if let key::Event::Input(input_event) = event {
                 // If the temporary buffer is full, drop the current pending input.
-                let _ = pending_inputs.push(input_event);
+                let _ = pending_inputs.push(*input_event);
             }
         }
+        pending_events.clear();
         self.prepend(&pending_inputs);
     }
 
@@ -190,7 +192,7 @@ mod tests {
     }
 
     #[test]
-    fn prepend_pending_input_events_replays_lifo_then_restores_tail() {
+    fn prepend_pending_input_events_replays_fifo_then_restores_tail() {
         let mut queue = InputEventQueue::<CAPACITY>::new();
         queue.push_back(input::Event::press(9)).unwrap();
 
@@ -203,10 +205,12 @@ mod tests {
 
         queue.prepend_pending_input_events(&mut pending_events);
 
-        assert_eq!(queue.pop_front_if_ready(), Some(input::Event::release(0)));
+        // Chronological inputs (key events dropped), then original tail.
         assert_eq!(queue.pop_front_if_ready(), Some(input::Event::press(0)));
+        assert_eq!(queue.pop_front_if_ready(), Some(input::Event::release(0)));
         assert_eq!(queue.pop_front_if_ready(), Some(input::Event::press(9)));
         assert!(queue.is_empty());
+        assert!(pending_events.is_empty());
     }
 
     #[test]

--- a/src/keymap/pending.rs
+++ b/src/keymap/pending.rs
@@ -66,8 +66,8 @@ pub(crate) enum KeyResolution {
     /// **Example:**
     ///  A layered key resolves the outer layer
     ///   but the inner key is still pending.
-    ///  All session-log inputs are prepended LIFO ahead of the delay line
-    ///   so pacing continues correctly for the new pending state.
+    ///  All session-log inputs are re-queued in chronological order ahead of the
+    ///  delay line so the new pending state re-observes them as they occurred.
     Pending,
 }
 
@@ -220,17 +220,15 @@ mod tests {
         );
     }
 
-    /// Nested-pending policy: LIFO over input events only
+    /// Nested-pending policy: chronological (FIFO) over input events only
     ///  (key events dropped),
     ///  prepended before any existing delay-line tail.
     ///
     /// Motivating smart keys: **chorded → passthrough pending**
     ///  (e.g. chorded over tap-hold) and other pending→pending
     ///  transitions (layered outer resolving into an inner pending key).
-    ///  LIFO vs FIFO is not yet covered by `rust-integration` HID reports;
-    ///  this unit test pins the historical re-queue policy.
     #[test]
-    fn nested_pending_replay_prepends_inputs_lifo_before_delay_line_tail() {
+    fn nested_pending_replay_prepends_inputs_fifo_before_delay_line_tail() {
         // Assemble -- log: Press(0), KeyEvent, Release(0), Press(1);
         //  delay-line tail: Press(9).
         let mut queued: heapless::Vec<key::Event<()>, 8> = heapless::Vec::new();
@@ -252,10 +250,10 @@ mod tests {
             &mut event_scheduler,
         );
 
-        // Assert -- LIFO inputs, then original tail; no key-event scheduling.
+        // Assert -- chronological inputs, then original tail; no key-event scheduling.
         assert_eq!(
             input_queue.pop_front_if_ready(),
-            Some(input::Event::press(1))
+            Some(input::Event::press(0))
         );
         assert_eq!(
             input_queue.pop_front_if_ready(),
@@ -263,13 +261,14 @@ mod tests {
         );
         assert_eq!(
             input_queue.pop_front_if_ready(),
-            Some(input::Event::press(0))
+            Some(input::Event::press(1))
         );
         assert_eq!(
             input_queue.pop_front_if_ready(),
             Some(input::Event::press(9))
         );
         assert!(input_queue.is_empty());
+        assert!(queued.is_empty());
         assert!(event_scheduler.next_event_time().is_none());
     }
 }


### PR DESCRIPTION
## Summary

- Nested pending re-queue used `Vec::pop`, which reversed session-log inputs (LIFO).
- Re-queue in chronological (FIFO) order so the new pending key re-observes prior inputs as they occurred.
- Unit tests pin FIFO; integration suite was already insensitive to LIFO vs FIFO.

Small independent fix; split out so it can land without the larger pending-local ingest pacing change.

## Test plan

- [x] `cargo test -p smart-keymap --lib`
- [x] `cargo test -p smart-keymap --test rust-integration`
- [ ] CI green