### PR TITLE
ncl: keymap-level named_layers rows

### DIFF
--- a/features/keymap/ncl/named_layers.feature
+++ b/features/keymap/ncl/named_layers.feature
@@ -1,0 +1,66 @@
+Feature: Named Layers
+
+  Named layers are like `layers`, but whole overlay rows are declared by
+   name rather than by numeric index.
+
+  Use keymap-level `named_layers` for Fn-style full rows, and refer to
+   those names from `layer_mod` (e.g. `K.layer_mod.hold "fn"`). Names
+   are lowered to dense numbered slots after any numbered `layers`
+   (alphabetical order among names).
+
+  Per-key `{ named_layers = { … } }` still works and wins when the same
+   name is set both at keymap scope and on a key.
+
+  Background:
+
+    Here, a keymap.ncl file with 2 keys: a hold layer-mod named `"fn"`,
+     and a base `A` that becomes `B` on the `fn` named layer.
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        layers = [
+          [
+            K.layer_mod.hold "fn",
+            K.A,
+          ],
+        ],
+        named_layers = {
+          fn = [
+            K.TTTT,
+            K.B,
+          ],
+        },
+      }
+      """
+
+  Example: named layers act as the base when no layer is active
+
+    If no named layers are active, the key will be the key
+     on the base layer.
+
+    When the keymap registers the following input
+      """
+      [
+        press (K.A),
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { key_codes = [K.A] }
+      """
+
+  Example: named layers act as active layer when its named layer modifier is held
+
+    When the keymap registers the following input
+      """
+      [
+        press (K.layer_mod.hold "fn"),
+        press (K.B),
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { key_codes = [K.B] }
+      """

--- a/features/scripts/generate-doc.sh
+++ b/features/scripts/generate-doc.sh
@@ -49,6 +49,7 @@ keymap_ncl_features=(
     "chords-config-required_idle_time"
     "layer_string"
     "layers"
+    "named_layers"
 )
 
 KEY_FIELDS_MD="${NCL_DIR}/key-docs.md"

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -9,6 +9,7 @@
 #
 # - Authored inputs (keymap.ncl surface)
 #   - `keys` / `layers`   KeymapLayer: string tokens or Array Key
+#   - `named_layers`      Record name → KeymapLayer (full rows by name; optional)
 #   - `chords`            [{ indices, key }, …]
 #   - `config`            optional per-feature config
 #   - `custom_keys`       extends token vocabulary for string layers
@@ -21,7 +22,8 @@
 # - Intermediate key arrays (same length; each pass rewrites slots)
 #   - `layers_of_keys`     layers normalized to Array Key     (passes/fold-layers.ncl)
 #   - `layered_keys`       multi-layer authoring folded       (passes/fold-layers.ncl)
-#                           (per-key `named_layers` still allowed)
+#                           KM `named_layers` rows zipped into per-key `named_layers`
+#                           (per-key `named_layers` still allowed; per-key wins on conflict)
 #   - `chorded_keys`       global `chords` attached           (passes/attach-chords.ncl)
 #   - `automation_transform`                                  (passes/automation.ncl)
 #       { automation_instructions, keys }
@@ -150,6 +152,15 @@
     | Array KeymapLayer
     | doc "The layers of the keymap that gets rendered to JSON"
     = [keys],
+
+  # Full named layer rows at keymap scope (name → layer of same width as base).
+  # Zipped into per-key `named_layers` in fold-layers, then lowered with the
+  # usual named-layer pass. Coexists with numbered `layers` (named after numbered).
+  named_layers
+    | default
+    | { _ | KeymapLayer }
+    | doc "Named layers: whole rows keyed by name (same width as the base layer)."
+    = {},
 
   chords
     | Array Chord

--- a/ncl/passes/fold-layers.ncl
+++ b/ncl/passes/fold-layers.ncl
@@ -1,15 +1,22 @@
 # Pass: fold multi-layer authoring → per-key base & { layered }
 #
 # Inputs (from driver merge):
-#   layers, layer_as_array_of_keys, keymap_ncl, validators
+#   layers, named_layers, layer_as_array_of_keys, keymap_ncl, validators
 #
 # Outputs:
 #   layers_of_keys, layered_keys, LayeredKeyElement
+#
+# Numbered `layers` fold first (base + overlay arrays → `{ layered = [...] }`).
+# KM-level `named_layers` (name → full row) then zip into per-key `named_layers`
+# records; later prepare_keys_named_layers lowers those to dense arrays.
 {
   layers,
   layer_as_array_of_keys,
   keymap_ncl,
   validators,
+
+  # Keymap-level named layer rows (optional; default empty).
+  named_layers | default = {},
 
   layered_key_element_validator = fun k =>
     k
@@ -23,28 +30,66 @@
 
   layers_of_keys = layers |> std.array.map layer_as_array_of_keys,
 
+  # Zip each KM-level named layer row into per-key `named_layers`.
+  # Per-key entries for the same name win (right merge). Row width must match
+  # the base key count. Empty `km_named` is a no-op.
+  inject_km_named_layers = fun km_named keys =>
+    std.record.fields km_named
+    |> std.array.fold_left
+      (fun keys name =>
+        let row = layer_as_array_of_keys (std.record.get name km_named) in
+        let keys_len = std.array.length keys in
+        let row_len = std.array.length row in
+        if row_len != keys_len then
+          std.fail_with "named_layers.%{name}: expected %{keys_len} keys, got %{row_len}"
+        else
+          std.array.map_with_index
+            (fun i k =>
+              let cell = std.array.at i row in
+              let existing =
+                k
+                |> match {
+                  { named_layers = nl, .. } => nl,
+                  _ => {},
+                }
+              in
+              # Per-key entry for the same name wins; otherwise take the KM cell.
+              let named =
+                if std.record.has_field name existing then
+                  existing
+                else
+                  existing & { "%{name}" = cell }
+              in
+              k & { named_layers = named }
+            )
+            keys
+      )
+      keys,
+
+  layered_keys_from_numbered_layers =
+    if std.array.length layers == 0 then
+      std.fail_with "keys or layers must be provided"
+    else if std.array.length layers <= 1 then
+      std.array.at 0 layers |> layer_as_array_of_keys
+    else
+      let base_keys = std.array.first layers_of_keys in
+      let overlay_layers = std.array.drop_first layers_of_keys in
+      std.array.generate
+        (fun idx =>
+          let base_key = std.array.at idx base_keys in
+          let layered_ = std.array.map (std.array.at idx) overlay_layers in
+          let no_layered = std.array.all (fun x => x == null) layered_ in
+          if no_layered then
+            base_key
+          else
+            base_key & { layered = layered_ }
+        )
+        (std.array.length base_keys),
+
   layered_keys
     | Array LayeredKeyElement
-    | doc "Constructs array of key::layered::LayeredKey values from layers."
-    =
-      if std.array.length layers == 0 then
-        std.fail_with "keys or layers must be provided"
-      else if std.array.length layers <= 1 then
-        std.array.at 0 layers |> layer_as_array_of_keys
-      else
-        let base_keys = std.array.first layers_of_keys in
-        let layered_keys = std.array.drop_first layers_of_keys in
-        std.array.generate
-          (fun idx =>
-            let base_key = std.array.at idx base_keys in
-            let layered_ = std.array.map (std.array.at idx) layered_keys in
-            let no_layered = std.array.all (fun x => x == null) layered_ in
-            if no_layered then
-              base_key
-            else
-              base_key & { layered = layered_ }
-          )
-          (std.array.length base_keys),
+    | doc "Constructs array of key::layered::LayeredKey values from layers (+ optional named_layers)."
+    = inject_km_named_layers named_layers layered_keys_from_numbered_layers,
 
   checks.check_layered_key_element =
     let K = import "keys.ncl" in
@@ -76,4 +121,77 @@
       expected = [ null ],
     },
   },
+
+  checks.check_inject_km_named_layers =
+    let K = import "keys.ncl" in
+    {
+      check_inject_simple = {
+        actual =
+          inject_km_named_layers
+            { fn = [ null, K.B] }
+            [K.layer_mod.hold "fn", K.A],
+        expected = [
+          { layer_modifier = { hold = "fn" }, named_layers = { fn = null } },
+          K.A & { named_layers = { fn = K.B } },
+        ],
+      },
+
+      check_inject_empty_is_noop = {
+        actual = inject_km_named_layers {} [K.A, K.B],
+        expected = [K.A, K.B],
+      },
+
+      # Per-key named_layers wins over KM-level for the same name.
+      check_per_key_wins_on_name_conflict = {
+        actual =
+          inject_km_named_layers
+            { fn = [K.B, K.C] }
+            [
+              K.A & { named_layers = { fn = K.D } },
+              K.E,
+            ],
+        expected = [
+          K.A & { named_layers = { fn = K.D } },
+          K.E & { named_layers = { fn = K.C } },
+        ],
+      },
+
+      # KM-level merges with other per-key named layer names.
+      check_merge_other_named_names = {
+        actual =
+          inject_km_named_layers
+            { fn = [K.B] }
+            [K.A & { named_layers = { nav = K.C } }],
+        expected = [
+          K.A & { named_layers = { fn = K.B, nav = K.C } },
+        ],
+      },
+
+      # Multiple named rows (alphabetical order is for later lowering, not inject).
+      check_inject_multiple_names = {
+        actual =
+          inject_km_named_layers
+            {
+              nav = [ null, K.Left],
+              fn = [ null, K.F1],
+            }
+            [K.A, K.B],
+        expected = [
+          K.A & { named_layers = { fn = null, nav = null } },
+          K.B & { named_layers = { fn = K.F1, nav = K.Left } },
+        ],
+      },
+
+      # String KeymapLayer rows (via layer_as_array_of_keys).
+      check_inject_string_row = {
+        actual =
+          inject_km_named_layers
+            { fn = " TTTT B " }
+            [K.A, K.C],
+        expected = [
+          K.A & { named_layers = { fn = null } },
+          K.C & { named_layers = { fn = K.B } },
+        ],
+      },
+    },
 }


### PR DESCRIPTION
## Summary

- Add keymap-level `named_layers` (name → full `KeymapLayer` row), parallel to numbered `layers` but keyed by name.
- Fold pass zips each named row into per-key `named_layers`; existing prepare/lower path turns them into dense arrays and resolves `layer_mod` name strings.
- Per-key `named_layers` for the same name wins over the keymap row; row width must match the base layer.
- Cucumber feature documents the Fn-style authoring pattern (`K.layer_mod.hold "fn"` + `named_layers.fn = [...]`).

## Test plan

- [x] `nickel eval --import-path=ncl --field=evaluated_checks checks.ncl chording.ncl keymap-ncl-to-json.ncl keymap-codegen.ncl`
- [x] `cargo test --test cucumber-keymap --features std -- --input 'features/keymap/ncl/named_layers.feature'`
- [x] Manual `nickel export` of array and string named rows, numbered+named coexistence, and width-mismatch error