### PR TITLE
init: keyboard-only default shell without key::composite

### DIFF
--- a/src/key/composite.rs
+++ b/src/key/composite.rs
@@ -2,12 +2,14 @@
 //!  implementations (array-backed).
 //!
 //! **Who uses what:**
-//! - **This module** — non-custom default [`crate::init`] (array `System`).
+//! - **This module** — residual unit tests / `sizes` bin (array `System`).
 //! - **Cucumber / runtime serde** — generated vec-backed shell at
 //!    `crate::key::composite_full_vec` (`feature = "std"`; `build.rs`).
 //! - **`keymap!` and firmware custom keymaps** — Nickel-generated **trimmed**
 //!    per-keymap `key_system` (`ncl/composite-key-system.ncl`), only the
 //!    families that map uses (e.g. keyboard + tap-hold + layered).
+//! - **Default (non-custom) [`crate::init`]** — keyboard-only mini shell in
+//!    `src/lib.rs`, not this module.
 //!
 //! Generated shells are intentionally human-readable and mirror the structure
 //!  here: `Ref` / `Event` / `PendingKeyState` / `KeyState`, `Config` /
@@ -16,7 +18,7 @@
 //! When adding a new key family:
 //! 1. implement `key::foo` and Nickel `smart_keys/foo/`,
 //! 2. register it in `ncl/composite-key-system.ncl` (codegen source of truth),
-//! 3. update this hand-written shell if default `init` still depends on it.
+//! 3. update this hand-written shell if residual tests still depend on it.
 
 use core::fmt::Debug;
 use core::marker::PhantomData;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,12 @@
 //! The heart of the library is the [key] module,
 //! and its [key::System] trait.
 //!
-//! Implementors are then aggregated by [key::composite],
-//! which is used by the [keymap] module.
+//! Per-keymap aggregation is produced by Nickel codegen
+//!  as `init::key_system` (custom keymap / `keymap!`),
+//!  or as `key::composite_full_vec` for std/cucumber.
+//! Without a custom keymap,
+//!  [init] provides a trivial keyboard-only shell
+//!  so [`new_keymap`] still type-checks.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -63,16 +67,14 @@ pub mod split;
 pub mod slice;
 
 /// Types and initial data used for constructing a [keymap::Keymap].
+///
+/// Without `SMART_KEYMAP_CUSTOM_KEYMAP`, this is a **keyboard-only** dummy map
+/// (letter `A`) plus generous size constants used by composite shells /
+/// cucumber. With a custom keymap, build codegen replaces this module.
 /// cbindgen:ignore
 #[cfg(not(custom_keymap))]
 pub mod init {
     use crate as smart_keymap;
-
-    use smart_keymap::key::composite;
-    use smart_keymap::key::keyboard;
-    use smart_keymap::keymap;
-
-    use composite as key_system;
 
     /// Number of instructions used by the [crate::key::automation] implementation.
     pub const AUTOMATION_INSTRUCTION_COUNT: usize = 1024;
@@ -92,40 +94,247 @@ pub mod init {
     /// The tap-dance definitions.
     pub const TAP_DANCE_MAX_DEFINITIONS: usize = 3;
 
-    pub use key_system::Ref;
+    /// Trivial composite shell: keyboard family only (matches codegen shape).
+    pub mod key_system {
+        use crate as smart_keymap;
+        use smart_keymap::key;
+        use smart_keymap::keymap;
+
+        /// Aggregate key reference.
+        #[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq)]
+        pub enum Ref {
+            /// [smart_keymap::key::keyboard] variant.
+            Keyboard(smart_keymap::key::keyboard::Ref),
+        }
+
+        /// Aggregate config (no configurable families in this default map).
+        #[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq)]
+        pub struct Config {}
+
+        impl Default for Config {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
+        impl Config {
+            /// Constructs a new [Config] with defaults.
+            pub const fn new() -> Self {
+                Self {}
+            }
+        }
+
+        /// Aggregate context.
+        #[derive(Debug, Clone, Copy)]
+        pub struct Context {
+            keymap_context: smart_keymap::keymap::KeymapContext,
+            keyboard: smart_keymap::key::keyboard::Context,
+        }
+
+        impl Context {
+            /// Constructs a [Context] from the given [Config].
+            pub const fn from_config(config: Config) -> Self {
+                let _ = &config;
+                Self {
+                    keymap_context: smart_keymap::keymap::KeymapContext::new(),
+                    keyboard: smart_keymap::key::keyboard::Context,
+                }
+            }
+        }
+
+        impl Default for Context {
+            fn default() -> Self {
+                Self::from_config(Config::new())
+            }
+        }
+
+        impl key::Context for Context {
+            type Event = Event;
+
+            fn handle_event(
+                &mut self,
+                _event: key::Event<Self::Event>,
+            ) -> key::KeyEvents<Self::Event> {
+                key::KeyEvents::no_events()
+            }
+        }
+
+        impl keymap::SetKeymapContext for Context {
+            fn set_keymap_context(&mut self, context: keymap::KeymapContext) {
+                self.keymap_context = context;
+            }
+        }
+
+        /// Aggregate event.
+        #[derive(Debug, Clone, Copy, PartialEq)]
+        pub enum Event {
+            /// [smart_keymap::key::keyboard] variant.
+            Keyboard(smart_keymap::key::keyboard::Event),
+        }
+
+        impl From<smart_keymap::key::keyboard::Event> for Event {
+            fn from(v: smart_keymap::key::keyboard::Event) -> Self {
+                Event::Keyboard(v)
+            }
+        }
+
+        impl TryFrom<Event> for smart_keymap::key::keyboard::Event {
+            type Error = smart_keymap::key::EventError;
+
+            fn try_from(v: Event) -> Result<Self, Self::Error> {
+                match v {
+                    Event::Keyboard(v) => Ok(v),
+                }
+            }
+        }
+
+        /// Aggregate pending key state.
+        #[derive(Debug, Clone, PartialEq)]
+        #[allow(clippy::large_enum_variant)]
+        pub enum PendingKeyState {
+            /// [smart_keymap::key::keyboard] variant.
+            Keyboard(smart_keymap::key::keyboard::PendingKeyState),
+        }
+
+        impl From<smart_keymap::key::keyboard::PendingKeyState> for PendingKeyState {
+            fn from(pks: smart_keymap::key::keyboard::PendingKeyState) -> Self {
+                PendingKeyState::Keyboard(pks)
+            }
+        }
+
+        /// Aggregate key state.
+        #[derive(Debug, Clone, Copy, PartialEq)]
+        pub enum KeyState {
+            /// No-op key state (e.g. auxiliary chorded keys).
+            NoOp,
+            /// [smart_keymap::key::keyboard] key state.
+            Keyboard(smart_keymap::key::keyboard::KeyState),
+        }
+
+        impl From<key::NoOpKeyState> for KeyState {
+            fn from(_: key::NoOpKeyState) -> Self {
+                KeyState::NoOp
+            }
+        }
+
+        impl From<smart_keymap::key::keyboard::KeyState> for KeyState {
+            fn from(ks: smart_keymap::key::keyboard::KeyState) -> Self {
+                KeyState::Keyboard(ks)
+            }
+        }
+
+        /// Aggregate [key::System] for the default keyboard-only map.
+        #[derive(Debug, Clone, Copy, PartialEq)]
+        pub struct System {
+            keyboard:
+                smart_keymap::key::keyboard::System<Ref, [smart_keymap::key::keyboard::Key; 0]>,
+        }
+
+        impl System {
+            /// Constructs the system from the keyboard subsystem.
+            pub const fn new(
+                keyboard: smart_keymap::key::keyboard::System<
+                    Ref,
+                    [smart_keymap::key::keyboard::Key; 0],
+                >,
+            ) -> Self {
+                Self { keyboard }
+            }
+        }
+
+        impl key::System<Ref> for System {
+            type Ref = Ref;
+            type Context = Context;
+            type Event = Event;
+            type PendingKeyState = PendingKeyState;
+            type KeyState = KeyState;
+
+            fn new_pressed_key(
+                &self,
+                keymap_index: u16,
+                context: &Self::Context,
+                key_ref: Ref,
+            ) -> (
+                key::PressedKeyResult<Ref, Self::PendingKeyState, Self::KeyState>,
+                key::KeyEvents<Self::Event>,
+            ) {
+                match key_ref {
+                    Ref::Keyboard(key_ref) => {
+                        let (pkr, pke) =
+                            self.keyboard
+                                .new_pressed_key(keymap_index, &context.keyboard, key_ref);
+                        (pkr.into_result(), pke.into_events())
+                    }
+                }
+            }
+
+            fn update_pending_state(
+                &self,
+                pending_state: &mut Self::PendingKeyState,
+                keymap_index: u16,
+                context: &Self::Context,
+                key_ref: Ref,
+                event: key::Event<Self::Event>,
+            ) -> (Option<key::NewPressedKey<Ref>>, key::KeyEvents<Self::Event>) {
+                let _ = (pending_state, keymap_index, context, key_ref, event);
+                panic!("no pending key systems in this key_system")
+            }
+
+            fn update_state(
+                &self,
+                key_state: &mut Self::KeyState,
+                key_ref: &Self::Ref,
+                context: &Self::Context,
+                keymap_index: u16,
+                event: key::Event<Self::Event>,
+            ) -> key::KeyEvents<Self::Event> {
+                match (key_ref, key_state) {
+                    (Ref::Keyboard(key_ref), KeyState::Keyboard(key_state)) => {
+                        if let Ok(event) = event.try_into_key_event() {
+                            self.keyboard
+                                .update_state(
+                                    key_state,
+                                    key_ref,
+                                    &context.keyboard,
+                                    keymap_index,
+                                    event,
+                                )
+                                .into_events()
+                        } else {
+                            key::KeyEvents::no_events()
+                        }
+                    }
+                    (_, _) => key::KeyEvents::no_events(),
+                }
+            }
+
+            fn key_output(
+                &self,
+                key_ref: &Self::Ref,
+                key_state: &Self::KeyState,
+            ) -> Option<key::KeyOutput> {
+                match (key_ref, key_state) {
+                    (Ref::Keyboard(r), KeyState::Keyboard(ks)) => self.keyboard.key_output(r, ks),
+                    (_, _) => None,
+                }
+            }
+        }
+    }
 
     pub use key_system::Context;
-
     pub use key_system::Event;
-
-    pub use key_system::PendingKeyState;
-
     pub use key_system::KeyState;
-
-    /// Max number of data entries for each system.
-    pub const DATA_LEN: usize = 0;
-
-    /// Alias for the System type
-    pub type System = key_system::System<
-        key_system::KeyArrays<
-            DATA_LEN,
-            DATA_LEN,
-            DATA_LEN,
-            DATA_LEN,
-            DATA_LEN,
-            DATA_LEN,
-            DATA_LEN,
-            DATA_LEN,
-            DATA_LEN,
-            DATA_LEN,
-        >,
-    >;
+    pub use key_system::PendingKeyState;
+    pub use key_system::Ref;
+    pub use key_system::System;
 
     /// The number of keys in the keymap.
     pub const KEY_COUNT: usize = 1;
 
-    /// A tuples KeysN value with keys. Without a custom keymap, just the letter 'A'.
-    pub const KEY_REFS: [Ref; KEY_COUNT] = [Ref::Keyboard(keyboard::Ref::KeyCode(0x04))];
+    /// Without a custom keymap, just the letter 'A'.
+    pub const KEY_REFS: [Ref; KEY_COUNT] = [Ref::Keyboard(
+        smart_keymap::key::keyboard::Ref::KeyCode(0x04),
+    )];
 
     /// Config used to construct initial context.
     pub const CONFIG: key_system::Config = key_system::Config::new();
@@ -133,21 +342,20 @@ pub mod init {
     /// Initial [Context] value.
     pub const CONTEXT: Context = key_system::Context::from_config(CONFIG);
 
-    /// Initial [Context] value.
-    pub const SYSTEM: System = System::array_based(
-        smart_keymap::key::automation::System::new([]),
-        smart_keymap::key::callback::System::new([]),
-        smart_keymap::key::chorded::System::new([], []),
-        smart_keymap::key::keyboard::System::new([]),
-        smart_keymap::key::layered::System::new([], []),
-        smart_keymap::key::sticky::System::new([]),
-        smart_keymap::key::tap_dance::System::new([]),
-        smart_keymap::key::tap_hold::System::new([]),
-    );
+    /// Initial [System] value.
+    pub const SYSTEM: System =
+        key_system::System::new(smart_keymap::key::keyboard::System::new([]));
 
-    /// Alias for the [keymap::Keymap] type.
-    pub type Keymap =
-        keymap::Keymap<[Ref; KEY_COUNT], Ref, Context, Event, PendingKeyState, KeyState, System>;
+    /// Alias for the [crate::keymap::Keymap] type.
+    pub type Keymap = smart_keymap::keymap::Keymap<
+        [Ref; KEY_COUNT],
+        Ref,
+        Context,
+        Event,
+        PendingKeyState,
+        KeyState,
+        System,
+    >;
 }
 
 #[cfg(custom_keymap)]
@@ -155,7 +363,7 @@ include!(concat!(env!("OUT_DIR"), "/keymap.rs"));
 
 pub use init::{Keymap, CONTEXT, KEY_REFS, SYSTEM};
 
-/// Constructs a new keymap;
+/// Constructs a new keymap.
 pub const fn new_keymap() -> Keymap {
     Keymap::new(KEY_REFS, CONTEXT, SYSTEM)
 }


### PR DESCRIPTION
## Summary

- Replace default (non-custom) `init`’s dependency on hand-written `key::composite` with a **keyboard-only** mini `key_system` (same shape as trimmed codegen, dummy letter `A`).
- Keep generous size constants on `init` so cucumber / residual composite consumers still compile.
- Doc updates only in `key::composite` (default init is no longer a consumer).

This is the small-blast-radius step from the composite codegen sketch: free default `init` from the full shell without forcing custom keymap everywhere or changing firmware/keyberon.

## Test plan

- [x] `cargo check` (std + `--no-default-features`)
- [x] `cargo check -p keyberon-smart-keyboard --no-default-features`
- [x] `cargo test --lib`
- [x] `cargo test --test rust-integration`
- [x] `cargo run --bin sizes` (default `init::Keymap` is now tiny; full composite type sizes still reported)