### PR TITLE
ncl: size_consts takes key_data directly

### DIFF
--- a/ncl/composite-key-system.ncl
+++ b/ncl/composite-key-system.ncl
@@ -1041,7 +1041,9 @@ pub mod key_system {
 "%
     in
 
-    let size_consts = fun data_len_rust_expr_for_field =>
+    # Key-data length consts for init (e.g. `const KEYBOARD: usize = N;`).
+    # Takes key_data directly; missing fields default to empty arrays (len 0).
+    let size_consts = fun key_data =>
       systems
       |> std.array.fold_left
         (fun acc f =>
@@ -1049,7 +1051,9 @@ pub mod key_system {
           @ (
             f.data_lengths
             |> std.array.map (fun { const_name, data_field } =>
-              "    const %{const_name}: usize = %{data_len_rust_expr_for_field data_field};"
+              let data = (key_data & { "%{data_field}" | default = [] })."%{data_field}" in
+              let len = data |> std.array.length |> std.to_string in
+              "    const %{const_name}: usize = %{len};"
             )
           )
         )

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -380,10 +380,6 @@
         |> std.array.fold_left std.number.max 0
       in
       let { key_data, key_refs } = key_data_and_refs in
-      let data_len_rust_expr_for_field = fun field_name =>
-        let data = (key_data & { "%{field_name}" | default = [] })."%{field_name}" in
-        data |> std.array.length |> std.to_string
-      in
       let key_refs_expr = "[%{key_refs |> std.array.map (fun { rust_expr, .. } => rust_expr) |> std.string.join ", "}]" in
       let config = composite.emit.config_rust_expr in
       let context = "key_system::Context::from_config(%{config})" in
@@ -412,7 +408,7 @@ pub mod init {
     /// The tap-dance definitions.
     pub const TAP_DANCE_MAX_DEFINITIONS: usize = %{max_tap_dance_definitions |> std.to_string};
 
-%{composite.emit.size_consts data_len_rust_expr_for_field}
+%{composite.emit.size_consts key_data}
 
 %{composite.emit.module_src}
 


### PR DESCRIPTION
## Summary

- `composite.emit.size_consts` now takes `key_data` directly instead of a `field_name -> len` callback. Keymap-codegen drops the intermediate helper.

## Test plan

- [x] `make test-ncl-checks`
- [x] Regenerated `tests/ncl/keymap-4key-simple/keymap.rs` matches existing snapshot
- [ ] CI green