### PR TITLE
rust: factor out composite_full_vec mod

### DIFF
--- a/src/bin/sizes.rs
+++ b/src/bin/sizes.rs
@@ -19,12 +19,10 @@ fn main() {
     let sizes_data = StructSizes {
         input_event: mem::size_of::<input::Event>(),
         key_keyboardmodifiers: mem::size_of::<key::KeyboardModifiers>(),
-        key_composite_context: mem::size_of::<key::composite_full_vec::key_system::Context>(),
-        key_composite_event: mem::size_of::<key::composite_full_vec::key_system::Event>(),
-        key_composite_pendingkeystate: mem::size_of::<
-            key::composite_full_vec::key_system::PendingKeyState,
-        >(),
-        key_composite_keystate: mem::size_of::<key::composite_full_vec::key_system::KeyState>(),
+        key_composite_context: mem::size_of::<key::key_system::Context>(),
+        key_composite_event: mem::size_of::<key::key_system::Event>(),
+        key_composite_pendingkeystate: mem::size_of::<key::key_system::PendingKeyState>(),
+        key_composite_keystate: mem::size_of::<key::key_system::KeyState>(),
         keymap_keymap: mem::size_of::<smart_keymap::init::Keymap>(),
     };
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -29,15 +29,8 @@ pub mod tap_dance;
 /// Tap-Hold keys.
 pub mod tap_hold;
 
-/// Generated full composite shell with `Vec` key-data storage (cucumber / runtime serde).
-///
-/// Produced by `build.rs` when `feature = "std"` (not checked in).
-/// Source of truth: `ncl/composite-key-system.ncl` (full profile + vec data → `key_system`).
-/// Types live at [`composite_full_vec::key_system`].
 #[cfg(feature = "std")]
-pub mod composite_full_vec {
-    include!(concat!(env!("OUT_DIR"), "/composite_full_vec.rs"));
-}
+include!(concat!(env!("OUT_DIR"), "/composite_full_vec.rs"));
 
 /// The maximum number of key events that are emitted by [crate::key::System] implementations.
 pub const MAX_KEY_EVENTS: usize = 4;

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -955,15 +955,15 @@ mod tests {
     fn tap_hold_interrupt_keymap(
         interrupt_response: crate::key::tap_hold::InterruptResponse,
     ) -> crate::keymap::Keymap<
-        [crate::key::composite_full_vec::key_system::Ref; 2],
-        crate::key::composite_full_vec::key_system::Ref,
-        crate::key::composite_full_vec::key_system::Context,
-        crate::key::composite_full_vec::key_system::Event,
-        crate::key::composite_full_vec::key_system::PendingKeyState,
-        crate::key::composite_full_vec::key_system::KeyState,
-        crate::key::composite_full_vec::key_system::System,
+        [crate::key::key_system::Ref; 2],
+        crate::key::key_system::Ref,
+        crate::key::key_system::Context,
+        crate::key::key_system::Event,
+        crate::key::key_system::PendingKeyState,
+        crate::key::key_system::KeyState,
+        crate::key::key_system::System,
     > {
-        use crate::key::composite_full_vec::key_system;
+        use crate::key::key_system;
 
         let mut config = key_system::Config::new();
         config.tap_hold.interrupt_response = interrupt_response;
@@ -996,7 +996,7 @@ mod tests {
     macro_rules! simple_keyboard_keymap {
         () => {{
             use crate as smart_keymap;
-            use smart_keymap::key::composite_full_vec::key_system;
+            use smart_keymap::key::key_system;
 
             use key_system::Context;
             use key_system::Ref;
@@ -1023,10 +1023,10 @@ mod tests {
         }};
     }
 
-    fn tap_hold_timeout_event() -> key::Event<crate::key::composite_full_vec::key_system::Event> {
+    fn tap_hold_timeout_event() -> key::Event<crate::key::key_system::Event> {
         key::Event::Key {
             keymap_index: 0,
-            key_event: crate::key::composite_full_vec::key_system::Event::TapHold(
+            key_event: crate::key::key_system::Event::TapHold(
                 crate::key::tap_hold::Event::TapHoldTimeout,
             ),
         }
@@ -1508,7 +1508,7 @@ mod tests {
         // Assemble
         let mut keymap = {
             use crate as smart_keymap;
-            use smart_keymap::key::composite_full_vec::key_system;
+            use smart_keymap::key::key_system;
 
             use key_system::Context;
             use key_system::Ref;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //!
 //! Per-keymap aggregation is produced by Nickel codegen
 //!  as `init::key_system` (custom keymap / `keymap!`),
-//!  or as `key::composite_full_vec` for std/cucumber.
+//!  or as `key::key_system` for std/cucumber.
 //! Without a custom keymap,
 //!  [init] provides a trivial keyboard-only shell
 //!  so [`new_keymap`] still type-checks.

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -14,8 +14,8 @@ use smart_keymap_nickel_helper::{
     NickelError,
 };
 
-// Full composite shell from Nickel emit (Vec storage), not hand-written key::composite.
-use smart_keymap::key::composite_full_vec::key_system::{
+// Full composite key system from Nickel codegen (Vec storage).
+use smart_keymap::key::key_system::{
     Config, Context, Event, KeyState, PendingKeyState, Ref, System,
 };
 


### PR DESCRIPTION
- Cucumber & "sizes" bin use the codegen'd "composite key system, with Vec data storage". (May be this should be a separate crate? It's not a useful module for the keyboard firmware).
- In any case, `key::composite_full_vec::key_system` is an unwieldy name. It mixes that: it's the "composite" key, ('smart key' is really implemented as 'smart key system'), an that the 'init' module uses this the codegen output as "key system". -- I think the simplest way to reconcile these is just: although it's a "composite"/"aggregate" key (system), it can be considered *the* key system for std use cases like cucumber/sizes.