### PR TITLE
ncl: make families a name-keyed record with deferred defaults

### DIFF
--- a/ncl/composite-key-system.ncl
+++ b/ncl/composite-key-system.ncl
@@ -63,15 +63,29 @@
         x == 'Array || x == 'Vec
       ),
 
-    # Shared defaults for a key family. Merge: `{ name = "…", … } & default_family`.
+    # Shared defaults for a key family.
+    # Applied at use sites: `{ name = family_name } & families.<name> & default_family`.
     # Lazy fields see `name` / `variant` / `module` from the merged record (like Nickel `| default`).
-    # Required from the left-hand record: name, variant, system_ty.array, context_ty, context_expr.
-    # Const-generic / array lengths use `{ crate::init::… }` in type position (rustc needs braces on paths).
+    # Required from the left-hand / partial: system_ty.array, context_ty, context_expr
+    # (and `name` from the resolver). Const-generic / array lengths use
+    # `{ crate::init::… }` in type position (rustc needs braces on paths).
     #
     # Data-carrying families also set `system_ty.vec` (Vec storage); singletons share `system_ty.array`.
+    camel_case_from_snake_case = fun s =>
+      s
+      |> std.string.split "_"
+      |> std.array.map (fun part =>
+        let chars = std.string.characters part in
+        let head = std.array.first chars in
+        let tail = std.array.drop_first chars in
+        "%{std.string.uppercase head}%{std.string.join "" tail}"
+      )
+      |> std.string.join "",
+
     default_family = {
       name,
-      variant,
+      # e.g. tap_hold → TapHold
+      variant | default = camel_case_from_snake_case name,
       system_ty.array,
       context_ty,
       context_expr,
@@ -102,83 +116,76 @@
       # Lazy until forced — do not confuse with system_expr above.
     },
 
-    # Stable match-arm / field order for generated code.
-    # Each entry: `{ name = "…", module = "smart_keymap::key::%{name}", … } & default_family`.
-    # `module` is on the left so `system_ty.*` / constructors can use `%{module}` recursively.
-    families = [
-      {
-        name = "automation",
-        module = "smart_keymap::key::%{name}",
-        variant = "Automation",
-        has_config = true,
-        has_state_update = true,
-        handles_context_events = true,
-        has_key_data = true,
-        data_lengths = [{ const_name = "AUTOMATION", data_field = "automation" }],
-        system_ty.array = m%"%{module}::System<
+    # Family registry as a record keyed by snake_case name (stable alphabetical order
+    # via std.record.fields). Partials only — merge `default_family` when resolving.
+    # Local `module` lets keep `%{module}` type strings without baking defaults here.
+    families = {
+      automation =
+        let module = "smart_keymap::key::automation" in
+        {
+          has_config = true,
+          has_state_update = true,
+          handles_context_events = true,
+          has_key_data = true,
+          data_lengths = [{ const_name = "AUTOMATION", data_field = "automation" }],
+          system_ty.array = m%"%{module}::System<
           Ref,
           [%{module}::Key; { crate::init::AUTOMATION }],
           { crate::init::AUTOMATION_INSTRUCTION_COUNT }
         >"%,
-        system_ty.vec = m%"%{module}::System<
+          system_ty.vec = m%"%{module}::System<
           Ref,
           Vec<%{module}::Key>,
           { crate::init::AUTOMATION_INSTRUCTION_COUNT }
         >"%,
-        context_ty = m%"%{module}::Context<
+          context_ty = m%"%{module}::Context<
           { crate::init::AUTOMATION_INSTRUCTION_COUNT }
         >"%,
-        context_expr = "%{module}::Context::from_config(config.automation)",
-        config_ty = m%"%{module}::Config<
+          context_expr = "%{module}::Context::from_config(config.automation)",
+          config_ty = m%"%{module}::Config<
           { crate::init::AUTOMATION_INSTRUCTION_COUNT }
         >"%,
-        config_rust_expr = smart_keymap.automation.config.rust_expr,
-        system_rust_expr = smart_keymap.automation.system.rust_expr,
-      }
-      & default_family,
-      {
-        name = "callback",
-        module = "smart_keymap::key::%{name}",
-        variant = "Callback",
-        has_key_data = true,
-        data_lengths = [{ const_name = "CALLBACK", data_field = "callback" }],
-        system_ty.array = m%"%{module}::System<
+          config_rust_expr = smart_keymap.automation.config.rust_expr,
+          system_rust_expr = smart_keymap.automation.system.rust_expr,
+        },
+      callback =
+        let module = "smart_keymap::key::callback" in
+        {
+          has_key_data = true,
+          data_lengths = [{ const_name = "CALLBACK", data_field = "callback" }],
+          system_ty.array = m%"%{module}::System<
           Ref,
           [%{module}::Key; { crate::init::CALLBACK }]
         >"%,
-        system_ty.vec = m%"%{module}::System<
+          system_ty.vec = m%"%{module}::System<
           Ref,
           Vec<%{module}::Key>
         >"%,
-        context_ty = "%{module}::Context",
-        context_expr = "%{module}::Context",
-        system_rust_expr = smart_keymap.callback.system.rust_expr,
-      }
-      & default_family,
-      {
-        name = "caps_word",
-        module = "smart_keymap::key::%{name}",
-        variant = "CapsWord",
-        handles_context_events = true,
-        system_ty.array = "%{module}::System<Ref>",
-        context_ty = "%{module}::Context",
-        context_expr = "%{module}::Context::new()",
-      }
-      & default_family,
-      {
-        name = "chorded",
-        module = "smart_keymap::key::%{name}",
-        variant = "Chorded",
-        has_config = true,
-        has_pending_dispatch = true,
-        handles_context_events = true,
-        updates_keymap_context = true,
-        has_key_data = true,
-        data_lengths = [
-          { const_name = "CHORDED", data_field = "chorded" },
-          { const_name = "CHORDED_AUXILIARY", data_field = "chorded_auxiliary" },
-        ],
-        system_ty.array = m%"%{module}::System<
+          context_ty = "%{module}::Context",
+          context_expr = "%{module}::Context",
+          system_rust_expr = smart_keymap.callback.system.rust_expr,
+        },
+      caps_word =
+        let module = "smart_keymap::key::caps_word" in
+        {
+          handles_context_events = true,
+          system_ty.array = "%{module}::System<Ref>",
+          context_ty = "%{module}::Context",
+          context_expr = "%{module}::Context::new()",
+        },
+      chorded =
+        let module = "smart_keymap::key::chorded" in
+        {
+          has_config = true,
+          has_pending_dispatch = true,
+          handles_context_events = true,
+          updates_keymap_context = true,
+          has_key_data = true,
+          data_lengths = [
+            { const_name = "CHORDED", data_field = "chorded" },
+            { const_name = "CHORDED_AUXILIARY", data_field = "chorded_auxiliary" },
+          ],
+          system_ty.array = m%"%{module}::System<
           Ref,
           [
             %{module}::Key<
@@ -204,7 +211,7 @@
           { crate::init::CHORDED_MAX_OVERLAPPING_CHORD_SIZE },
           CHORDED_MAX_PRESSED_INDICES
         >"%,
-        system_ty.vec = m%"%{module}::System<
+          system_ty.vec = m%"%{module}::System<
           Ref,
           Vec<
             %{module}::Key<
@@ -228,82 +235,74 @@
           { crate::init::CHORDED_MAX_OVERLAPPING_CHORD_SIZE },
           CHORDED_MAX_PRESSED_INDICES
         >"%,
-        context_ty = m%"%{module}::Context<
+          context_ty = m%"%{module}::Context<
           { crate::init::CHORDED_MAX_CHORDS },
           { crate::init::CHORDED_MAX_CHORD_SIZE },
           CHORDED_MAX_PRESSED_INDICES
         >"%,
-        context_expr = "%{module}::Context::from_config(config.chorded)",
-        pending_ty = m%"%{module}::PendingKeyState<
+          context_expr = "%{module}::Context::from_config(config.chorded)",
+          pending_ty = m%"%{module}::PendingKeyState<
           { crate::init::CHORDED_MAX_CHORDS },
           { crate::init::CHORDED_MAX_CHORD_SIZE },
           CHORDED_MAX_PRESSED_INDICES
         >"%,
-        config_ty = m%"%{module}::Config<
+          config_ty = m%"%{module}::Config<
           { crate::init::CHORDED_MAX_CHORDS },
           { crate::init::CHORDED_MAX_CHORD_SIZE }
         >"%,
-        config_rust_expr = smart_keymap.chorded.config.rust_expr,
-        system_rust_expr = smart_keymap.chorded.system.rust_expr,
-      }
-      & default_family,
-      {
-        name = "consumer",
-        module = "smart_keymap::key::%{name}",
-        variant = "Consumer",
-        has_state_update = true,
-        has_key_output = true,
-        system_ty.array = "%{module}::System<Ref>",
-        context_ty = "%{module}::Context",
-        context_expr = "%{module}::Context",
-      }
-      & default_family,
-      {
-        name = "custom",
-        module = "smart_keymap::key::%{name}",
-        variant = "Custom",
-        has_key_output = true,
-        system_ty.array = "%{module}::System<Ref>",
-        context_ty = "%{module}::Context",
-        context_expr = "%{module}::Context",
-      }
-      & default_family,
-      {
-        name = "keyboard",
-        module = "smart_keymap::key::%{name}",
-        variant = "Keyboard",
-        has_state_update = true,
-        has_key_output = true,
-        has_key_data = true,
-        data_lengths = [{ const_name = "KEYBOARD", data_field = "keyboard" }],
-        system_ty.array = m%"%{module}::System<
+          config_rust_expr = smart_keymap.chorded.config.rust_expr,
+          system_rust_expr = smart_keymap.chorded.system.rust_expr,
+        },
+      consumer =
+        let module = "smart_keymap::key::consumer" in
+        {
+          has_state_update = true,
+          has_key_output = true,
+          system_ty.array = "%{module}::System<Ref>",
+          context_ty = "%{module}::Context",
+          context_expr = "%{module}::Context",
+        },
+      custom =
+        let module = "smart_keymap::key::custom" in
+        {
+          has_key_output = true,
+          system_ty.array = "%{module}::System<Ref>",
+          context_ty = "%{module}::Context",
+          context_expr = "%{module}::Context",
+        },
+      keyboard =
+        let module = "smart_keymap::key::keyboard" in
+        {
+          has_state_update = true,
+          has_key_output = true,
+          has_key_data = true,
+          data_lengths = [{ const_name = "KEYBOARD", data_field = "keyboard" }],
+          system_ty.array = m%"%{module}::System<
           Ref,
           [%{module}::Key; { crate::init::KEYBOARD }]
         >"%,
-        system_ty.vec = m%"%{module}::System<
+          system_ty.vec = m%"%{module}::System<
           Ref,
           Vec<%{module}::Key>
         >"%,
-        context_ty = "%{module}::Context",
-        context_expr = "%{module}::Context",
-        system_rust_expr = smart_keymap.keyboard.system.rust_expr,
-      }
-      & default_family,
-      {
-        name = "layered",
-        module = "smart_keymap::key::%{name}",
-        variant = "Layered",
-        has_config = true,
-        has_state_update = true,
-        has_key_output = true,
-        handles_context_events = true,
-        has_key_data = true,
-        key_state_variant = "LayerModifier",
-        data_lengths = [
-          { const_name = "LAYERED", data_field = "layered" },
-          { const_name = "LAYER_MODIFIERS", data_field = "layer_modifiers" },
-        ],
-        system_ty.array = m%"%{module}::System<
+          context_ty = "%{module}::Context",
+          context_expr = "%{module}::Context",
+          system_rust_expr = smart_keymap.keyboard.system.rust_expr,
+        },
+      layered =
+        let module = "smart_keymap::key::layered" in
+        {
+          has_config = true,
+          has_state_update = true,
+          has_key_output = true,
+          handles_context_events = true,
+          has_key_data = true,
+          key_state_variant = "LayerModifier",
+          data_lengths = [
+            { const_name = "LAYERED", data_field = "layered" },
+            { const_name = "LAYER_MODIFIERS", data_field = "layer_modifiers" },
+          ],
+          system_ty.array = m%"%{module}::System<
           Ref,
           [%{module}::ModifierKey; { crate::init::LAYER_MODIFIERS }],
           [
@@ -312,63 +311,57 @@
           ],
           { crate::init::LAYERED_LAYER_COUNT }
         >"%,
-        system_ty.vec = m%"%{module}::System<
+          system_ty.vec = m%"%{module}::System<
           Ref,
           Vec<%{module}::ModifierKey>,
           Vec<%{module}::LayeredKey<Ref, { crate::init::LAYERED_LAYER_COUNT }>>,
           { crate::init::LAYERED_LAYER_COUNT }
         >"%,
-        context_ty = "%{module}::Context<{ crate::init::LAYERED_LAYER_COUNT }>",
-        context_expr = "%{module}::Context::from_config(config.layered)",
-        event_ty = "%{module}::LayerEvent",
-        key_state_ty = "%{module}::ModifierKeyState",
-        config_rust_expr = smart_keymap.layered.config.rust_expr,
-        system_rust_expr = smart_keymap.layered.system.rust_expr,
-      }
-      & default_family,
-      {
-        name = "mouse",
-        module = "smart_keymap::key::%{name}",
-        variant = "Mouse",
-        has_key_output = true,
-        system_ty.array = "%{module}::System<Ref>",
-        context_ty = "%{module}::Context",
-        context_expr = "%{module}::Context",
-      }
-      & default_family,
-      {
-        name = "sticky",
-        module = "smart_keymap::key::%{name}",
-        variant = "Sticky",
-        has_config = true,
-        has_state_update = true,
-        has_key_output = true,
-        handles_context_events = true,
-        has_key_data = true,
-        data_lengths = [{ const_name = "STICKY", data_field = "sticky" }],
-        system_ty.array = m%"%{module}::System<
+          context_ty = "%{module}::Context<{ crate::init::LAYERED_LAYER_COUNT }>",
+          context_expr = "%{module}::Context::from_config(config.layered)",
+          event_ty = "%{module}::LayerEvent",
+          key_state_ty = "%{module}::ModifierKeyState",
+          config_rust_expr = smart_keymap.layered.config.rust_expr,
+          system_rust_expr = smart_keymap.layered.system.rust_expr,
+        },
+      mouse =
+        let module = "smart_keymap::key::mouse" in
+        {
+          has_key_output = true,
+          system_ty.array = "%{module}::System<Ref>",
+          context_ty = "%{module}::Context",
+          context_expr = "%{module}::Context",
+        },
+      sticky =
+        let module = "smart_keymap::key::sticky" in
+        {
+          has_config = true,
+          has_state_update = true,
+          has_key_output = true,
+          handles_context_events = true,
+          has_key_data = true,
+          data_lengths = [{ const_name = "STICKY", data_field = "sticky" }],
+          system_ty.array = m%"%{module}::System<
           Ref,
           [%{module}::Key; { crate::init::STICKY }]
         >"%,
-        system_ty.vec = m%"%{module}::System<
+          system_ty.vec = m%"%{module}::System<
           Ref,
           Vec<%{module}::Key>
         >"%,
-        context_ty = "%{module}::Context",
-        context_expr = "%{module}::Context::from_config(config.sticky)",
-        config_rust_expr = smart_keymap.sticky.config.rust_expr,
-        system_rust_expr = smart_keymap.sticky.system.rust_expr,
-      }
-      & default_family,
-      {
-        name = "tap_dance",
-        module = "smart_keymap::key::%{name}",
-        variant = "TapDance",
-        has_config = true,
-        has_pending_dispatch = true,
-        has_key_data = true,
-        data_lengths = [{ const_name = "TAP_DANCE", data_field = "tap_dance" }],
-        system_ty.array = m%"%{module}::System<
+          context_ty = "%{module}::Context",
+          context_expr = "%{module}::Context::from_config(config.sticky)",
+          config_rust_expr = smart_keymap.sticky.config.rust_expr,
+          system_rust_expr = smart_keymap.sticky.system.rust_expr,
+        },
+      tap_dance =
+        let module = "smart_keymap::key::tap_dance" in
+        {
+          has_config = true,
+          has_pending_dispatch = true,
+          has_key_data = true,
+          data_lengths = [{ const_name = "TAP_DANCE", data_field = "tap_dance" }],
+          system_ty.array = m%"%{module}::System<
           Ref,
           [
             %{module}::Key<Ref, { crate::init::TAP_DANCE_MAX_DEFINITIONS }>;
@@ -376,41 +369,48 @@
           ],
           { crate::init::TAP_DANCE_MAX_DEFINITIONS }
         >"%,
-        system_ty.vec = m%"%{module}::System<
+          system_ty.vec = m%"%{module}::System<
           Ref,
           Vec<%{module}::Key<Ref, { crate::init::TAP_DANCE_MAX_DEFINITIONS }>>,
           { crate::init::TAP_DANCE_MAX_DEFINITIONS }
         >"%,
-        context_ty = "%{module}::Context",
-        context_expr = "%{module}::Context::from_config(config.tap_dance)",
-        config_rust_expr = smart_keymap.tap_dance.config.rust_expr,
-        system_rust_expr = smart_keymap.tap_dance.system.rust_expr,
-      }
-      & default_family,
-      {
-        name = "tap_hold",
-        module = "smart_keymap::key::%{name}",
-        variant = "TapHold",
-        has_config = true,
-        has_pending_dispatch = true,
-        updates_keymap_context = true,
-        has_key_data = true,
-        data_lengths = [{ const_name = "TAP_HOLD", data_field = "tap_hold" }],
-        system_ty.array = m%"%{module}::System<
+          context_ty = "%{module}::Context",
+          context_expr = "%{module}::Context::from_config(config.tap_dance)",
+          config_rust_expr = smart_keymap.tap_dance.config.rust_expr,
+          system_rust_expr = smart_keymap.tap_dance.system.rust_expr,
+        },
+      tap_hold =
+        let module = "smart_keymap::key::tap_hold" in
+        {
+          has_config = true,
+          has_pending_dispatch = true,
+          updates_keymap_context = true,
+          has_key_data = true,
+          data_lengths = [{ const_name = "TAP_HOLD", data_field = "tap_hold" }],
+          system_ty.array = m%"%{module}::System<
           Ref,
           [%{module}::Key<Ref>; { crate::init::TAP_HOLD }]
         >"%,
-        system_ty.vec = m%"%{module}::System<
+          system_ty.vec = m%"%{module}::System<
           Ref,
           Vec<%{module}::Key<Ref>>
         >"%,
-        context_ty = "%{module}::Context",
-        context_expr = "%{module}::Context::from_config(config.tap_hold)",
-        config_rust_expr = smart_keymap.tap_hold.config.rust_expr,
-        system_rust_expr = smart_keymap.tap_hold.system.rust_expr,
-      }
-      & default_family,
-    ],
+          context_ty = "%{module}::Context",
+          context_expr = "%{module}::Context::from_config(config.tap_hold)",
+          config_rust_expr = smart_keymap.tap_hold.config.rust_expr,
+          system_rust_expr = smart_keymap.tap_hold.system.rust_expr,
+        },
+    },
+
+    # Resolve a registry partial into a full family record (defaults applied here).
+    family = fun family_name =>
+      { name = family_name } & families."%{family_name}" & default_family,
+
+    # Resolved families in registry order (alphabetical field order).
+    family_list =
+      families
+      |> std.record.fields
+      |> std.array.map family,
 
     Family = {
       name | String,
@@ -478,7 +478,7 @@
 
     profile_from_modules = fun used_modules =>
       let systems =
-        families
+        family_list
         |> std.array.filter (fun f => std.array.elem f.module used_modules)
       in
       {
@@ -515,7 +515,7 @@
 
     # All families in registry order (cucumber / universal shell target).
     full_profile =
-      families
+      family_list
       |> std.array.map (fun f => f.module)
       |> profile_from_modules,
 
@@ -561,7 +561,7 @@
     fragments = {
       systems = profile.systems,
       is_full =
-        std.array.length systems == std.array.length families,
+        std.array.length systems == std.record.length families,
       is_vec = data == 'Vec,
 
       join = fun xs => std.string.join "\n" xs,
@@ -1148,7 +1148,7 @@ pub mod key_system {
       {
         check_family_count = {
           actual = std.array.length profile.systems,
-          expected = std.array.length composite.families,
+          expected = std.record.length composite.families,
         },
         check_ref_variants = {
           actual = profile.ref_variants,


### PR DESCRIPTION
## Summary

Clean up the family registry in `composite-key-system.ncl`:

1. **Record registry** — `families` is `{ automation = {…}, … }` keyed by snake_case name (order via `std.record.fields`, same alphabetical order as before).
2. **Default variant** — `variant | default = camel_case_from_snake_case name` (e.g. `tap_hold` → `TapHold`); only `layered` still overrides `key_state_variant`.
3. **Deferred defaults** — registry entries are partials; `default_family` is applied at resolve time via `family` / `family_list`, not at each definition.

Partials use a local `let module = "smart_keymap::key::…"` so `%{module}` type strings stay short without baking `name`/`module`/`variant` into every entry.

Stacked on #636.

## Test plan

- [x] `ncl/scripts/run-ncl-checks.sh`
- [x] Spot-check `family "keyboard"` / full_profile ref variants
- [x] CI green