### PR TITLE
ncl: make families.ncl a mergeable composite fragment

### DIFF
--- a/ncl/key_system/families.ncl
+++ b/ncl/key_system/families.ncl
@@ -1,9 +1,13 @@
 # Family registry for the composite key_system shell.
 #
-# Only dependency: smart_keymap (for row exprs).
-fun smart_keymap =>
-  {
-    camel_case_from_snake_case = fun s =>
+# Mergeable fragment:
+#  needs `smart_keymap` (for row exprs);
+#  contributes `composite.default_family` and `composite.families`.
+{
+  smart_keymap,
+
+  composite =
+    let camel_case_from_snake_case = fun s =>
       s
       |> std.string.split "_"
       |> std.array.map (fun part =>
@@ -12,334 +16,336 @@ fun smart_keymap =>
         let tail = std.array.drop_first chars in
         "%{std.string.uppercase head}%{std.string.join "" tail}"
       )
-      |> std.string.join "",
+      |> std.string.join ""
+    in
+    {
+      # Shared defaults for a key family.
+      # Applied at use sites: `{ name = family_name } & families.<name> & default_family`.
+      # Lazy fields see `name` / `variant` / `module` from the merged record (like Nickel `| default`).
+      # Required from the left-hand / partial:
+      #  system_ty.array, context_ty, context_expr (and `name` from the resolver).
+      #
+      # Data-carrying families also set `system_ty.vec` (Vec storage);
+      #  singletons share `system_ty.array`.
+      default_family = {
+        name,
+        # e.g. "tap_hold" → "TapHold"
+        variant | default = camel_case_from_snake_case name,
+        system_ty.array,
+        context_ty,
+        context_expr,
 
-    # Shared defaults for a key family.
-    # Applied at use sites: `{ name = family_name } & families.<name> & default_family`.
-    # Lazy fields see `name` / `variant` / `module` from the merged record (like Nickel `| default`).
-    # Required from the left-hand / partial:
-    #  system_ty.array, context_ty, context_expr (and `name` from the resolver).
-    #
-    # Data-carrying families also set `system_ty.vec` (Vec storage);
-    #  singletons share `system_ty.array`.
-    default_family = {
-      name,
-      # e.g. "tap_hold" → "TapHold"
-      variant | default = camel_case_from_snake_case name,
-      system_ty.array,
-      context_ty,
-      context_expr,
+        module | default = "smart_keymap::key::%{name}",
+        field | default = name,
+        has_config | default = false,
+        config_path | default = name,
+        has_pending_dispatch | default = false,
+        has_state_update | default = false,
+        has_key_output | default = false,
+        handles_context_events | default = false,
+        updates_keymap_context | default = false,
+        key_state_variant | default = variant,
+        has_key_data | default = false,
+        data_lengths | default = [],
+        # Default: same as array system type (singletons / non-data).
+        system_ty.vec | default = system_ty.array,
 
-      module | default = "smart_keymap::key::%{name}",
-      field | default = name,
-      has_config | default = false,
-      config_path | default = name,
-      has_pending_dispatch | default = false,
-      has_state_update | default = false,
-      has_key_output | default = false,
-      handles_context_events | default = false,
-      updates_keymap_context | default = false,
-      key_state_variant | default = variant,
-      has_key_data | default = false,
-      data_lengths | default = [],
-      # Default: same as array system type (singletons / non-data).
-      system_ty.vec | default = system_ty.array,
+        ref_ty | default = "%{module}::Ref",
+        event_ty | default = "%{module}::Event",
+        pending_ty | default = "%{module}::PendingKeyState",
+        key_state_ty | default = "%{module}::KeyState",
+        config_ty | default = "%{module}::Config",
+        # Singleton System::new() in struct init body (not key_data system.rust_expr).
+        system_expr | default = "%{module}::System::new()",
+        # Optional: set on families with has_config / has_key_data (join to smart_keymap.*).
+        # Lazy until forced — do not confuse with system_expr above.
+      },
 
-      ref_ty | default = "%{module}::Ref",
-      event_ty | default = "%{module}::Event",
-      pending_ty | default = "%{module}::PendingKeyState",
-      key_state_ty | default = "%{module}::KeyState",
-      config_ty | default = "%{module}::Config",
-      # Singleton System::new() in struct init body (not key_data system.rust_expr).
-      system_expr | default = "%{module}::System::new()",
-      # Optional: set on families with has_config / has_key_data (join to smart_keymap.*).
-      # Lazy until forced — do not confuse with system_expr above.
+      # Family registry as a record keyed by snake_case name
+      #  (stable alphabetical order via std.record.fields).
+      # Partials only — merge `default_family` when resolving.
+      # Local `module` lets keep `%{module}` type strings without baking defaults here.
+      families = {
+        automation =
+          let module = "smart_keymap::key::automation" in
+          {
+            has_config = true,
+            has_state_update = true,
+            handles_context_events = true,
+            has_key_data = true,
+            data_lengths = [{ const_name = "AUTOMATION", data_field = "automation" }],
+            system_ty.array = m%"%{module}::System<
+            Ref,
+            [%{module}::Key; crate::init::AUTOMATION],
+            { crate::init::AUTOMATION_INSTRUCTION_COUNT }
+          >"%,
+            system_ty.vec = m%"%{module}::System<
+            Ref,
+            Vec<%{module}::Key>,
+            { crate::init::AUTOMATION_INSTRUCTION_COUNT }
+          >"%,
+            context_ty = m%"%{module}::Context<
+            { crate::init::AUTOMATION_INSTRUCTION_COUNT }
+          >"%,
+            context_expr = "%{module}::Context::from_config(config.automation)",
+            config_ty = m%"%{module}::Config<
+            { crate::init::AUTOMATION_INSTRUCTION_COUNT }
+          >"%,
+            config_rust_expr = smart_keymap.automation.config.rust_expr,
+            system_rust_expr = smart_keymap.automation.system.rust_expr,
+          },
+        callback =
+          let module = "smart_keymap::key::callback" in
+          {
+            has_key_data = true,
+            data_lengths = [{ const_name = "CALLBACK", data_field = "callback" }],
+            system_ty.array = m%"%{module}::System<
+            Ref,
+            [%{module}::Key; crate::init::CALLBACK]
+          >"%,
+            system_ty.vec = m%"%{module}::System<
+            Ref,
+            Vec<%{module}::Key>
+          >"%,
+            context_ty = "%{module}::Context",
+            context_expr = "%{module}::Context",
+            system_rust_expr = smart_keymap.callback.system.rust_expr,
+          },
+        caps_word =
+          let module = "smart_keymap::key::caps_word" in
+          {
+            handles_context_events = true,
+            system_ty.array = "%{module}::System<Ref>",
+            context_ty = "%{module}::Context",
+            context_expr = "%{module}::Context::new()",
+          },
+        chorded =
+          let module = "smart_keymap::key::chorded" in
+          {
+            has_config = true,
+            has_pending_dispatch = true,
+            handles_context_events = true,
+            updates_keymap_context = true,
+            has_key_data = true,
+            data_lengths = [
+              { const_name = "CHORDED", data_field = "chorded" },
+              { const_name = "CHORDED_AUXILIARY", data_field = "chorded_auxiliary" },
+            ],
+            system_ty.array = m%"%{module}::System<
+            Ref,
+            [
+              %{module}::Key<
+                Ref,
+                { crate::init::CHORDED_MAX_CHORDS },
+                { crate::init::CHORDED_MAX_CHORD_SIZE },
+                { crate::init::CHORDED_MAX_OVERLAPPING_CHORD_SIZE },
+                CHORDED_MAX_PRESSED_INDICES
+              >;
+              crate::init::CHORDED
+            ],
+            [
+              %{module}::AuxiliaryKey<
+                Ref,
+                { crate::init::CHORDED_MAX_CHORDS },
+                { crate::init::CHORDED_MAX_CHORD_SIZE },
+                CHORDED_MAX_PRESSED_INDICES
+              >;
+              crate::init::CHORDED_AUXILIARY
+            ],
+            { crate::init::CHORDED_MAX_CHORDS },
+            { crate::init::CHORDED_MAX_CHORD_SIZE },
+            { crate::init::CHORDED_MAX_OVERLAPPING_CHORD_SIZE },
+            CHORDED_MAX_PRESSED_INDICES
+          >"%,
+            system_ty.vec = m%"%{module}::System<
+            Ref,
+            Vec<
+              %{module}::Key<
+                Ref,
+                { crate::init::CHORDED_MAX_CHORDS },
+                { crate::init::CHORDED_MAX_CHORD_SIZE },
+                { crate::init::CHORDED_MAX_OVERLAPPING_CHORD_SIZE },
+                CHORDED_MAX_PRESSED_INDICES
+              >
+            >,
+            Vec<
+              %{module}::AuxiliaryKey<
+                Ref,
+                { crate::init::CHORDED_MAX_CHORDS },
+                { crate::init::CHORDED_MAX_CHORD_SIZE },
+                CHORDED_MAX_PRESSED_INDICES
+              >
+            >,
+            { crate::init::CHORDED_MAX_CHORDS },
+            { crate::init::CHORDED_MAX_CHORD_SIZE },
+            { crate::init::CHORDED_MAX_OVERLAPPING_CHORD_SIZE },
+            CHORDED_MAX_PRESSED_INDICES
+          >"%,
+            context_ty = m%"%{module}::Context<
+            { crate::init::CHORDED_MAX_CHORDS },
+            { crate::init::CHORDED_MAX_CHORD_SIZE },
+            CHORDED_MAX_PRESSED_INDICES
+          >"%,
+            context_expr = "%{module}::Context::from_config(config.chorded)",
+            pending_ty = m%"%{module}::PendingKeyState<
+            { crate::init::CHORDED_MAX_CHORDS },
+            { crate::init::CHORDED_MAX_CHORD_SIZE },
+            CHORDED_MAX_PRESSED_INDICES
+          >"%,
+            config_ty = m%"%{module}::Config<
+            { crate::init::CHORDED_MAX_CHORDS },
+            { crate::init::CHORDED_MAX_CHORD_SIZE }
+          >"%,
+            config_rust_expr = smart_keymap.chorded.config.rust_expr,
+            system_rust_expr = smart_keymap.chorded.system.rust_expr,
+          },
+        consumer =
+          let module = "smart_keymap::key::consumer" in
+          {
+            has_state_update = true,
+            has_key_output = true,
+            system_ty.array = "%{module}::System<Ref>",
+            context_ty = "%{module}::Context",
+            context_expr = "%{module}::Context",
+          },
+        custom =
+          let module = "smart_keymap::key::custom" in
+          {
+            has_key_output = true,
+            system_ty.array = "%{module}::System<Ref>",
+            context_ty = "%{module}::Context",
+            context_expr = "%{module}::Context",
+          },
+        keyboard =
+          let module = "smart_keymap::key::keyboard" in
+          {
+            has_state_update = true,
+            has_key_output = true,
+            has_key_data = true,
+            data_lengths = [{ const_name = "KEYBOARD", data_field = "keyboard" }],
+            system_ty.array = m%"%{module}::System<
+            Ref,
+            [%{module}::Key; crate::init::KEYBOARD]
+          >"%,
+            system_ty.vec = m%"%{module}::System<
+            Ref,
+            Vec<%{module}::Key>
+          >"%,
+            context_ty = "%{module}::Context",
+            context_expr = "%{module}::Context",
+            system_rust_expr = smart_keymap.keyboard.system.rust_expr,
+          },
+        layered =
+          let module = "smart_keymap::key::layered" in
+          {
+            has_config = true,
+            has_state_update = true,
+            has_key_output = true,
+            handles_context_events = true,
+            has_key_data = true,
+            key_state_variant = "LayerModifier",
+            data_lengths = [
+              { const_name = "LAYERED", data_field = "layered" },
+              { const_name = "LAYER_MODIFIERS", data_field = "layer_modifiers" },
+            ],
+            system_ty.array = m%"%{module}::System<
+            Ref,
+            [%{module}::ModifierKey; crate::init::LAYER_MODIFIERS],
+            [
+              %{module}::LayeredKey<Ref, { crate::init::LAYERED_LAYER_COUNT }>;
+              crate::init::LAYERED
+            ],
+            { crate::init::LAYERED_LAYER_COUNT }
+          >"%,
+            system_ty.vec = m%"%{module}::System<
+            Ref,
+            Vec<%{module}::ModifierKey>,
+            Vec<%{module}::LayeredKey<Ref, { crate::init::LAYERED_LAYER_COUNT }>>,
+            { crate::init::LAYERED_LAYER_COUNT }
+          >"%,
+            context_ty = "%{module}::Context<{ crate::init::LAYERED_LAYER_COUNT }>",
+            context_expr = "%{module}::Context::from_config(config.layered)",
+            event_ty = "%{module}::LayerEvent",
+            key_state_ty = "%{module}::ModifierKeyState",
+            config_rust_expr = smart_keymap.layered.config.rust_expr,
+            system_rust_expr = smart_keymap.layered.system.rust_expr,
+          },
+        mouse =
+          let module = "smart_keymap::key::mouse" in
+          {
+            has_key_output = true,
+            system_ty.array = "%{module}::System<Ref>",
+            context_ty = "%{module}::Context",
+            context_expr = "%{module}::Context",
+          },
+        sticky =
+          let module = "smart_keymap::key::sticky" in
+          {
+            has_config = true,
+            has_state_update = true,
+            has_key_output = true,
+            handles_context_events = true,
+            has_key_data = true,
+            data_lengths = [{ const_name = "STICKY", data_field = "sticky" }],
+            system_ty.array = m%"%{module}::System<
+            Ref,
+            [%{module}::Key; crate::init::STICKY]
+          >"%,
+            system_ty.vec = m%"%{module}::System<
+            Ref,
+            Vec<%{module}::Key>
+          >"%,
+            context_ty = "%{module}::Context",
+            context_expr = "%{module}::Context::from_config(config.sticky)",
+            config_rust_expr = smart_keymap.sticky.config.rust_expr,
+            system_rust_expr = smart_keymap.sticky.system.rust_expr,
+          },
+        tap_dance =
+          let module = "smart_keymap::key::tap_dance" in
+          {
+            has_config = true,
+            has_pending_dispatch = true,
+            has_key_data = true,
+            data_lengths = [{ const_name = "TAP_DANCE", data_field = "tap_dance" }],
+            system_ty.array = m%"%{module}::System<
+            Ref,
+            [
+              %{module}::Key<Ref, { crate::init::TAP_DANCE_MAX_DEFINITIONS }>;
+              crate::init::TAP_DANCE
+            ],
+            { crate::init::TAP_DANCE_MAX_DEFINITIONS }
+          >"%,
+            system_ty.vec = m%"%{module}::System<
+            Ref,
+            Vec<%{module}::Key<Ref, { crate::init::TAP_DANCE_MAX_DEFINITIONS }>>,
+            { crate::init::TAP_DANCE_MAX_DEFINITIONS }
+          >"%,
+            context_ty = "%{module}::Context",
+            context_expr = "%{module}::Context::from_config(config.tap_dance)",
+            config_rust_expr = smart_keymap.tap_dance.config.rust_expr,
+            system_rust_expr = smart_keymap.tap_dance.system.rust_expr,
+          },
+        tap_hold =
+          let module = "smart_keymap::key::tap_hold" in
+          {
+            has_config = true,
+            has_pending_dispatch = true,
+            updates_keymap_context = true,
+            has_key_data = true,
+            data_lengths = [{ const_name = "TAP_HOLD", data_field = "tap_hold" }],
+            system_ty.array = m%"%{module}::System<
+            Ref,
+            [%{module}::Key<Ref>; crate::init::TAP_HOLD]
+          >"%,
+            system_ty.vec = m%"%{module}::System<
+            Ref,
+            Vec<%{module}::Key<Ref>>
+          >"%,
+            context_ty = "%{module}::Context",
+            context_expr = "%{module}::Context::from_config(config.tap_hold)",
+            config_rust_expr = smart_keymap.tap_hold.config.rust_expr,
+            system_rust_expr = smart_keymap.tap_hold.system.rust_expr,
+          },
+      },
     },
-
-    # Family registry as a record keyed by snake_case name
-    #  (stable alphabetical order via std.record.fields).
-    # Partials only — merge `default_family` when resolving.
-    # Local `module` lets keep `%{module}` type strings without baking defaults here.
-    families = {
-      automation =
-        let module = "smart_keymap::key::automation" in
-        {
-          has_config = true,
-          has_state_update = true,
-          handles_context_events = true,
-          has_key_data = true,
-          data_lengths = [{ const_name = "AUTOMATION", data_field = "automation" }],
-          system_ty.array = m%"%{module}::System<
-          Ref,
-          [%{module}::Key; crate::init::AUTOMATION],
-          { crate::init::AUTOMATION_INSTRUCTION_COUNT }
-        >"%,
-          system_ty.vec = m%"%{module}::System<
-          Ref,
-          Vec<%{module}::Key>,
-          { crate::init::AUTOMATION_INSTRUCTION_COUNT }
-        >"%,
-          context_ty = m%"%{module}::Context<
-          { crate::init::AUTOMATION_INSTRUCTION_COUNT }
-        >"%,
-          context_expr = "%{module}::Context::from_config(config.automation)",
-          config_ty = m%"%{module}::Config<
-          { crate::init::AUTOMATION_INSTRUCTION_COUNT }
-        >"%,
-          config_rust_expr = smart_keymap.automation.config.rust_expr,
-          system_rust_expr = smart_keymap.automation.system.rust_expr,
-        },
-      callback =
-        let module = "smart_keymap::key::callback" in
-        {
-          has_key_data = true,
-          data_lengths = [{ const_name = "CALLBACK", data_field = "callback" }],
-          system_ty.array = m%"%{module}::System<
-          Ref,
-          [%{module}::Key; crate::init::CALLBACK]
-        >"%,
-          system_ty.vec = m%"%{module}::System<
-          Ref,
-          Vec<%{module}::Key>
-        >"%,
-          context_ty = "%{module}::Context",
-          context_expr = "%{module}::Context",
-          system_rust_expr = smart_keymap.callback.system.rust_expr,
-        },
-      caps_word =
-        let module = "smart_keymap::key::caps_word" in
-        {
-          handles_context_events = true,
-          system_ty.array = "%{module}::System<Ref>",
-          context_ty = "%{module}::Context",
-          context_expr = "%{module}::Context::new()",
-        },
-      chorded =
-        let module = "smart_keymap::key::chorded" in
-        {
-          has_config = true,
-          has_pending_dispatch = true,
-          handles_context_events = true,
-          updates_keymap_context = true,
-          has_key_data = true,
-          data_lengths = [
-            { const_name = "CHORDED", data_field = "chorded" },
-            { const_name = "CHORDED_AUXILIARY", data_field = "chorded_auxiliary" },
-          ],
-          system_ty.array = m%"%{module}::System<
-          Ref,
-          [
-            %{module}::Key<
-              Ref,
-              { crate::init::CHORDED_MAX_CHORDS },
-              { crate::init::CHORDED_MAX_CHORD_SIZE },
-              { crate::init::CHORDED_MAX_OVERLAPPING_CHORD_SIZE },
-              CHORDED_MAX_PRESSED_INDICES
-            >;
-            crate::init::CHORDED
-          ],
-          [
-            %{module}::AuxiliaryKey<
-              Ref,
-              { crate::init::CHORDED_MAX_CHORDS },
-              { crate::init::CHORDED_MAX_CHORD_SIZE },
-              CHORDED_MAX_PRESSED_INDICES
-            >;
-            crate::init::CHORDED_AUXILIARY
-          ],
-          { crate::init::CHORDED_MAX_CHORDS },
-          { crate::init::CHORDED_MAX_CHORD_SIZE },
-          { crate::init::CHORDED_MAX_OVERLAPPING_CHORD_SIZE },
-          CHORDED_MAX_PRESSED_INDICES
-        >"%,
-          system_ty.vec = m%"%{module}::System<
-          Ref,
-          Vec<
-            %{module}::Key<
-              Ref,
-              { crate::init::CHORDED_MAX_CHORDS },
-              { crate::init::CHORDED_MAX_CHORD_SIZE },
-              { crate::init::CHORDED_MAX_OVERLAPPING_CHORD_SIZE },
-              CHORDED_MAX_PRESSED_INDICES
-            >
-          >,
-          Vec<
-            %{module}::AuxiliaryKey<
-              Ref,
-              { crate::init::CHORDED_MAX_CHORDS },
-              { crate::init::CHORDED_MAX_CHORD_SIZE },
-              CHORDED_MAX_PRESSED_INDICES
-            >
-          >,
-          { crate::init::CHORDED_MAX_CHORDS },
-          { crate::init::CHORDED_MAX_CHORD_SIZE },
-          { crate::init::CHORDED_MAX_OVERLAPPING_CHORD_SIZE },
-          CHORDED_MAX_PRESSED_INDICES
-        >"%,
-          context_ty = m%"%{module}::Context<
-          { crate::init::CHORDED_MAX_CHORDS },
-          { crate::init::CHORDED_MAX_CHORD_SIZE },
-          CHORDED_MAX_PRESSED_INDICES
-        >"%,
-          context_expr = "%{module}::Context::from_config(config.chorded)",
-          pending_ty = m%"%{module}::PendingKeyState<
-          { crate::init::CHORDED_MAX_CHORDS },
-          { crate::init::CHORDED_MAX_CHORD_SIZE },
-          CHORDED_MAX_PRESSED_INDICES
-        >"%,
-          config_ty = m%"%{module}::Config<
-          { crate::init::CHORDED_MAX_CHORDS },
-          { crate::init::CHORDED_MAX_CHORD_SIZE }
-        >"%,
-          config_rust_expr = smart_keymap.chorded.config.rust_expr,
-          system_rust_expr = smart_keymap.chorded.system.rust_expr,
-        },
-      consumer =
-        let module = "smart_keymap::key::consumer" in
-        {
-          has_state_update = true,
-          has_key_output = true,
-          system_ty.array = "%{module}::System<Ref>",
-          context_ty = "%{module}::Context",
-          context_expr = "%{module}::Context",
-        },
-      custom =
-        let module = "smart_keymap::key::custom" in
-        {
-          has_key_output = true,
-          system_ty.array = "%{module}::System<Ref>",
-          context_ty = "%{module}::Context",
-          context_expr = "%{module}::Context",
-        },
-      keyboard =
-        let module = "smart_keymap::key::keyboard" in
-        {
-          has_state_update = true,
-          has_key_output = true,
-          has_key_data = true,
-          data_lengths = [{ const_name = "KEYBOARD", data_field = "keyboard" }],
-          system_ty.array = m%"%{module}::System<
-          Ref,
-          [%{module}::Key; crate::init::KEYBOARD]
-        >"%,
-          system_ty.vec = m%"%{module}::System<
-          Ref,
-          Vec<%{module}::Key>
-        >"%,
-          context_ty = "%{module}::Context",
-          context_expr = "%{module}::Context",
-          system_rust_expr = smart_keymap.keyboard.system.rust_expr,
-        },
-      layered =
-        let module = "smart_keymap::key::layered" in
-        {
-          has_config = true,
-          has_state_update = true,
-          has_key_output = true,
-          handles_context_events = true,
-          has_key_data = true,
-          key_state_variant = "LayerModifier",
-          data_lengths = [
-            { const_name = "LAYERED", data_field = "layered" },
-            { const_name = "LAYER_MODIFIERS", data_field = "layer_modifiers" },
-          ],
-          system_ty.array = m%"%{module}::System<
-          Ref,
-          [%{module}::ModifierKey; crate::init::LAYER_MODIFIERS],
-          [
-            %{module}::LayeredKey<Ref, { crate::init::LAYERED_LAYER_COUNT }>;
-            crate::init::LAYERED
-          ],
-          { crate::init::LAYERED_LAYER_COUNT }
-        >"%,
-          system_ty.vec = m%"%{module}::System<
-          Ref,
-          Vec<%{module}::ModifierKey>,
-          Vec<%{module}::LayeredKey<Ref, { crate::init::LAYERED_LAYER_COUNT }>>,
-          { crate::init::LAYERED_LAYER_COUNT }
-        >"%,
-          context_ty = "%{module}::Context<{ crate::init::LAYERED_LAYER_COUNT }>",
-          context_expr = "%{module}::Context::from_config(config.layered)",
-          event_ty = "%{module}::LayerEvent",
-          key_state_ty = "%{module}::ModifierKeyState",
-          config_rust_expr = smart_keymap.layered.config.rust_expr,
-          system_rust_expr = smart_keymap.layered.system.rust_expr,
-        },
-      mouse =
-        let module = "smart_keymap::key::mouse" in
-        {
-          has_key_output = true,
-          system_ty.array = "%{module}::System<Ref>",
-          context_ty = "%{module}::Context",
-          context_expr = "%{module}::Context",
-        },
-      sticky =
-        let module = "smart_keymap::key::sticky" in
-        {
-          has_config = true,
-          has_state_update = true,
-          has_key_output = true,
-          handles_context_events = true,
-          has_key_data = true,
-          data_lengths = [{ const_name = "STICKY", data_field = "sticky" }],
-          system_ty.array = m%"%{module}::System<
-          Ref,
-          [%{module}::Key; crate::init::STICKY]
-        >"%,
-          system_ty.vec = m%"%{module}::System<
-          Ref,
-          Vec<%{module}::Key>
-        >"%,
-          context_ty = "%{module}::Context",
-          context_expr = "%{module}::Context::from_config(config.sticky)",
-          config_rust_expr = smart_keymap.sticky.config.rust_expr,
-          system_rust_expr = smart_keymap.sticky.system.rust_expr,
-        },
-      tap_dance =
-        let module = "smart_keymap::key::tap_dance" in
-        {
-          has_config = true,
-          has_pending_dispatch = true,
-          has_key_data = true,
-          data_lengths = [{ const_name = "TAP_DANCE", data_field = "tap_dance" }],
-          system_ty.array = m%"%{module}::System<
-          Ref,
-          [
-            %{module}::Key<Ref, { crate::init::TAP_DANCE_MAX_DEFINITIONS }>;
-            crate::init::TAP_DANCE
-          ],
-          { crate::init::TAP_DANCE_MAX_DEFINITIONS }
-        >"%,
-          system_ty.vec = m%"%{module}::System<
-          Ref,
-          Vec<%{module}::Key<Ref, { crate::init::TAP_DANCE_MAX_DEFINITIONS }>>,
-          { crate::init::TAP_DANCE_MAX_DEFINITIONS }
-        >"%,
-          context_ty = "%{module}::Context",
-          context_expr = "%{module}::Context::from_config(config.tap_dance)",
-          config_rust_expr = smart_keymap.tap_dance.config.rust_expr,
-          system_rust_expr = smart_keymap.tap_dance.system.rust_expr,
-        },
-      tap_hold =
-        let module = "smart_keymap::key::tap_hold" in
-        {
-          has_config = true,
-          has_pending_dispatch = true,
-          updates_keymap_context = true,
-          has_key_data = true,
-          data_lengths = [{ const_name = "TAP_HOLD", data_field = "tap_hold" }],
-          system_ty.array = m%"%{module}::System<
-          Ref,
-          [%{module}::Key<Ref>; crate::init::TAP_HOLD]
-        >"%,
-          system_ty.vec = m%"%{module}::System<
-          Ref,
-          Vec<%{module}::Key<Ref>>
-        >"%,
-          context_ty = "%{module}::Context",
-          context_expr = "%{module}::Context::from_config(config.tap_hold)",
-          config_rust_expr = smart_keymap.tap_hold.config.rust_expr,
-          system_rust_expr = smart_keymap.tap_hold.system.rust_expr,
-        },
-    },
-  }
+}

--- a/ncl/key_system/keymap-codegen.ncl
+++ b/ncl/key_system/keymap-codegen.ncl
@@ -1,6 +1,7 @@
 # Composite profile selection + key_system module generation.
 #
-# Family table: families.ncl (static-ish rows + smart_keymap expr joins).
+# Family table: families.ncl (merged fragment; static-ish rows + smart_keymap
+# expr joins under composite.default_family / composite.families).
 #
 # Selection is by merge composition:
 # - `composite.profile` — which families (default: keymap-stripped).
@@ -19,6 +20,9 @@
 # Data storage (`composite.data`):
 # - `'Array` — concrete `System` with `[Key; N]` (firmware trimmed default).
 # - `'Vec`   — concrete `System` with `Vec<Key>` (cucumber / runtime serde).
+#
+# Registry fields come from merging families.ncl; refer via composite.* paths
+# (short names are not shared across merge operands).
 {
   key_codegen_values,
 
@@ -26,206 +30,201 @@
 
   smart_keymap,
 
-  composite =
-    let sm_km = smart_keymap in
-    let registry = (import "key_system/families.ncl") sm_km in
-    {
-      camel_case_from_snake_case = registry.camel_case_from_snake_case,
-      default_family = registry.default_family,
-      families = registry.families,
+  composite = {
+    # Resolve a registry partial into a full family record (defaults applied here).
+    family = fun family_name =>
+      { name = family_name }
+      & composite.families."%{family_name}"
+      & composite.default_family,
 
-      # Resolve a registry partial into a full family record (defaults applied here).
-      family = fun family_name =>
-        { name = family_name } & families."%{family_name}" & default_family,
+    # Resolved families in registry order (alphabetical field order).
+    family_list =
+      composite.families
+      |> std.record.fields
+      |> std.array.map family,
 
-      # Resolved families in registry order (alphabetical field order).
-      family_list =
-        families
-        |> std.record.fields
-        |> std.array.map family,
-
-      Family = {
-        name | String,
-        module | String,
-        variant | String,
-        field | String,
-        has_key_data | Bool,
-        has_config | Bool,
-        config_path | String,
-        has_pending_dispatch | Bool,
-        has_state_update | Bool,
-        has_key_output | Bool,
-        handles_context_events | Bool,
-        updates_keymap_context | Bool,
-        key_state_variant | String,
-        ref_ty | String,
-        event_ty | String,
-        pending_ty | String,
-        key_state_ty | String,
-        config_ty | String,
-        system_ty = {
-          array | String,
-          vec | String,
-        },
-        context_ty | String,
-        context_expr | String,
-        # Singleton System::new() in struct init body.
-        system_expr | String,
-        # From smart_keymap.*.config / .system
-        config_rust_expr | String | optional,
-        # Required when has_key_data
-        system_rust_expr | String | optional,
-        data_lengths | Array { const_name | String, data_field | String },
+    Family = {
+      name | String,
+      module | String,
+      variant | String,
+      field | String,
+      has_key_data | Bool,
+      has_config | Bool,
+      config_path | String,
+      has_pending_dispatch | Bool,
+      has_state_update | Bool,
+      has_key_output | Bool,
+      handles_context_events | Bool,
+      updates_keymap_context | Bool,
+      key_state_variant | String,
+      ref_ty | String,
+      event_ty | String,
+      pending_ty | String,
+      key_state_ty | String,
+      config_ty | String,
+      system_ty = {
+        array | String,
+        vec | String,
       },
+      context_ty | String,
+      context_expr | String,
+      # Singleton System::new() in struct init body.
+      system_expr | String,
+      # From smart_keymap.*.config / .system
+      config_rust_expr | String | optional,
+      # Required when has_key_data
+      system_rust_expr | String | optional,
+      data_lengths | Array { const_name | String, data_field | String },
+    },
 
-      Profile = {
-        systems | Array Dyn,
-        ref_variants | Array String,
-        pending_variants | Array String,
-        state_update_variants | Array String,
-        key_output_variants | Array String,
-        context_event_variants | Array String,
-        config_fields | Array String,
-        used_modules | Array String,
-      },
+    Profile = {
+      systems | Array Dyn,
+      ref_variants | Array String,
+      pending_variants | Array String,
+      state_update_variants | Array String,
+      key_output_variants | Array String,
+      context_event_variants | Array String,
+      config_fields | Array String,
+      used_modules | Array String,
+    },
 
-      used_modules_from = fun codegen_values =>
-        codegen_values
-        |> std.array.fold_left
-          (fun acc cv =>
-            smart_key.traverse
-              (fun acc cv =>
-                if std.record.has_field "module" cv then
-                  if std.array.elem cv.module acc then
-                    acc
-                  else
-                    acc @ [cv.module]
-                else
+    used_modules_from = fun codegen_values =>
+      codegen_values
+      |> std.array.fold_left
+        (fun acc cv =>
+          smart_key.traverse
+            (fun acc cv =>
+              if std.record.has_field "module" cv then
+                if std.array.elem cv.module acc then
                   acc
-              )
-              acc
-              cv
-          )
-          [],
+                else
+                  acc @ [cv.module]
+              else
+                acc
+            )
+            acc
+            cv
+        )
+        [],
 
-      profile_from_modules = fun used_modules =>
-        let systems =
-          family_list
-          |> std.array.filter (fun f => std.array.elem f.module used_modules)
-        in
-        {
-          include systems,
-          ref_variants = systems |> std.array.map (fun f => f.variant),
-          pending_variants =
-            systems
-            |> std.array.filter (fun f => f.has_pending_dispatch)
-            |> std.array.map (fun f => f.variant),
-          state_update_variants =
-            systems
-            |> std.array.filter (fun f => f.has_state_update)
-            |> std.array.map (fun f => f.variant),
-          key_output_variants =
-            systems
-            |> std.array.filter (fun f => f.has_key_output)
-            |> std.array.map (fun f => f.variant),
-          context_event_variants =
-            systems
-            |> std.array.filter (fun f => f.handles_context_events)
-            |> std.array.map (fun f => f.variant),
-          config_fields =
-            systems
-            |> std.array.filter (fun f => f.has_config)
-            |> std.array.map (fun f => f.config_path),
-          include used_modules,
-        } | Profile,
-
-      profile_from_keys = fun keys =>
-        keys
-        |> std.array.map smart_key.codegen_values
-        |> used_modules_from
-        |> profile_from_modules,
-
-      # All families in registry order
-      # (Used by: cucumber / universal shell target).
-      full_profile =
+    profile_from_modules = fun used_modules =>
+      let systems =
         family_list
-        |> std.array.map (fun f => f.module)
-        |> profile_from_modules,
+        |> std.array.filter (fun f => std.array.elem f.module used_modules)
+      in
+      {
+        include systems,
+        ref_variants = systems |> std.array.map (fun f => f.variant),
+        pending_variants =
+          systems
+          |> std.array.filter (fun f => f.has_pending_dispatch)
+          |> std.array.map (fun f => f.variant),
+        state_update_variants =
+          systems
+          |> std.array.filter (fun f => f.has_state_update)
+          |> std.array.map (fun f => f.variant),
+        key_output_variants =
+          systems
+          |> std.array.filter (fun f => f.has_key_output)
+          |> std.array.map (fun f => f.variant),
+        context_event_variants =
+          systems
+          |> std.array.filter (fun f => f.handles_context_events)
+          |> std.array.map (fun f => f.variant),
+        config_fields =
+          systems
+          |> std.array.filter (fun f => f.has_config)
+          |> std.array.map (fun f => f.config_path),
+        include used_modules,
+      } | Profile,
 
-      # Families used by the current keymap
-      # (Used by: firmware-trimmed shell).
-      keymap_profile =
-        key_codegen_values
-        |> used_modules_from
-        |> profile_from_modules,
+    profile_from_keys = fun keys =>
+      keys
+      |> std.array.map smart_key.codegen_values
+      |> used_modules_from
+      |> profile_from_modules,
 
-      Storage =
-        std.contract.from_predicate (fun x =>
-          x == 'Array || x == 'Vec
-        ),
+    # All families in registry order
+    # (Used by: cucumber / universal shell target).
+    full_profile =
+      family_list
+      |> std.array.map (fun f => f.module)
+      |> profile_from_modules,
 
-      # Active profile for composite artefacts. Default = keymap-stripped.
-      profile | default = keymap_profile,
+    # Families used by the current keymap
+    # (Used by: firmware-trimmed shell).
+    keymap_profile =
+      key_codegen_values
+      |> used_modules_from
+      |> profile_from_modules,
 
-      # Key-data storage for composite artefacts. Default = Array (firmware).
-      data | Storage | default = 'Array,
+    Storage =
+      std.contract.from_predicate (fun x =>
+        x == 'Array || x == 'Vec
+      ),
 
-      # Merge this record to select the full registry profile.
-      with_full_profile = {
-        profile = full_profile,
+    # Active profile for composite artefacts. Default = keymap-stripped.
+    profile | default = keymap_profile,
+
+    # Key-data storage for composite artefacts. Default = Array (firmware).
+    data | Storage | default = 'Array,
+
+    # Merge this record to select the full registry profile.
+    with_full_profile = {
+      profile = full_profile,
+    },
+
+    # Merge this record to select Vec key-data storage.
+    with_vec_data = {
+      data | Storage = 'Vec,
+    },
+
+    # --- composite fragments (config / system codegen) -------------------------
+    # Named fragments over active profile + data.
+
+    system_ty_for = fun storage f =>
+      storage
+      |> match {
+        'Array => f.system_ty.array,
+        'Vec => f.system_ty.vec,
       },
 
-      # Merge this record to select Vec key-data storage.
-      with_vec_data = {
-        data | Storage = 'Vec,
-      },
+    # Module-shaped codegen fragments for the active profile + data.
+    fragments = {
+      systems = profile.systems,
+      is_full =
+        std.array.length systems == std.record.length composite.families,
+      is_vec = data == 'Vec,
 
-      # --- composite fragments (config / system codegen) -------------------------
-      # Named fragments over active profile + data.
+      join = fun xs => std.string.join "\n" xs,
 
-      system_ty_for = fun storage f =>
-        storage
-        |> match {
-          'Array => f.system_ty.array,
-          'Vec => f.system_ty.vec,
-        },
+      config_systems = systems |> std.array.filter (fun f => f.has_config),
+      data_array_systems = systems |> std.array.filter (fun f => f.has_key_data),
+      singleton_systems =
+        systems |> std.array.filter (fun f => f.has_key_data == false),
+      has_chorded = std.array.any (fun f => f.name == "chorded") systems,
 
-      # Module-shaped codegen fragments for the active profile + data.
-      fragments = {
-        systems = profile.systems,
-        is_full =
-          std.array.length systems == std.record.length families,
-        is_vec = data == 'Vec,
+      sty = fun f => system_ty_for data f,
 
-        join = fun xs => std.string.join "\n" xs,
+      enum_variants = fun ty_of =>
+        systems
+        |> std.array.map (fun f => "/// [%{f.module}] variant.\n%{f.variant}(%{ty_of f}),")
+        |> join,
 
-        config_systems = systems |> std.array.filter (fun f => f.has_config),
-        data_array_systems = systems |> std.array.filter (fun f => f.has_key_data),
-        singleton_systems =
-          systems |> std.array.filter (fun f => f.has_key_data == false),
-        has_chorded = std.array.any (fun f => f.name == "chorded") systems,
-
-        sty = fun f => system_ty_for data f,
-
-        enum_variants = fun ty_of =>
-          systems
-          |> std.array.map (fun f => "/// [%{f.module}] variant.\n%{f.variant}(%{ty_of f}),")
-          |> join,
-
-        from_impls = fun aggregate ty_of =>
-          systems
-          |> std.array.map (fun f =>
-            m%"
+      from_impls = fun aggregate ty_of =>
+        systems
+        |> std.array.map (fun f =>
+          m%"
 impl From<%{ty_of f}> for %{aggregate} {
       fn from(v: %{ty_of f}) -> Self { %{aggregate}::%{f.variant}(v) }
 }"%
-          )
-          |> join,
+        )
+        |> join,
 
-        try_from_impls = fun aggregate ty_of =>
-          systems
-          |> std.array.map (fun f =>
-            m%"
+      try_from_impls = fun aggregate ty_of =>
+        systems
+        |> std.array.map (fun f =>
+          m%"
 #[allow(unreachable_patterns)]
 impl TryFrom<%{aggregate}> for %{ty_of f} {
       type Error = smart_keymap::key::EventError;
@@ -236,15 +235,15 @@ impl TryFrom<%{aggregate}> for %{ty_of f} {
           }
       }
 }"%
-          )
-          |> join,
+        )
+        |> join,
 
-        # Vec-backed shells deserialize sparse key_data/config (cucumber).
-        config_field_attrs = if is_vec then "\n    #[serde(default)]" else "",
+      # Vec-backed shells deserialize sparse key_data/config (cucumber).
+      config_field_attrs = if is_vec then "\n    #[serde(default)]" else "",
 
-        config_struct =
-          if config_systems == [] then
-            m%"
+      config_struct =
+        if config_systems == [] then
+          m%"
 /// Aggregate config (no configurable families in this keymap).
 #[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct Config {}
@@ -255,20 +254,20 @@ impl Config {
       /// Constructs a new [Config] with defaults.
       pub const fn new() -> Self { Self {} }
 }"%
-          else
-            let fields =
-              config_systems
-              |> std.array.map (fun f =>
-                "/// Config for [%{f.module}].%{config_field_attrs}\n    pub %{f.config_path}: %{f.config_ty},"
-              )
-              |> join
-            in
-            let new_fields =
-              config_systems
-              |> std.array.map (fun f => "%{f.config_path}: %{f.module}::Config::new(),")
-              |> join
-            in
-            m%"
+        else
+          let fields =
+            config_systems
+            |> std.array.map (fun f =>
+              "/// Config for [%{f.module}].%{config_field_attrs}\n    pub %{f.config_path}: %{f.config_ty},"
+            )
+            |> join
+          in
+          let new_fields =
+            config_systems
+            |> std.array.map (fun f => "%{f.config_path}: %{f.module}::Config::new(),")
+            |> join
+          in
+          m%"
 /// Aggregate config for families used by this keymap.
 #[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct Config {
@@ -286,76 +285,76 @@ impl Config {
       }
 }"%,
 
-        context_fields =
-          (
-            ["keymap_context: smart_keymap::keymap::KeymapContext,"]
-            @ (systems |> std.array.map (fun f => "%{f.field}: %{f.context_ty},"))
-          )
-          |> join,
+      context_fields =
+        (
+          ["keymap_context: smart_keymap::keymap::KeymapContext,"]
+          @ (systems |> std.array.map (fun f => "%{f.field}: %{f.context_ty},"))
+        )
+        |> join,
 
-        context_from_config_fields =
-          (
-            ["keymap_context: smart_keymap::keymap::KeymapContext::new(),"]
-            @ (systems |> std.array.map (fun f => "%{f.field}: %{f.context_expr},"))
-          )
-          |> join,
+      context_from_config_fields =
+        (
+          ["keymap_context: smart_keymap::keymap::KeymapContext::new(),"]
+          @ (systems |> std.array.map (fun f => "%{f.field}: %{f.context_expr},"))
+        )
+        |> join,
 
-        context_handle_event =
-          systems
-          |> std.array.filter (fun f => f.handles_context_events)
-          |> std.array.map (fun f =>
-            m%"
+      context_handle_event =
+        systems
+        |> std.array.filter (fun f => f.handles_context_events)
+        |> std.array.map (fun f =>
+          m%"
 if let Ok(e) = event.try_into_key_event() {
       pke.extend(self.%{f.field}.handle_event(e).into_events());
 }"%
-          )
-          |> join,
+        )
+        |> join,
 
-        set_keymap_context_updates =
-          systems
-          |> std.array.filter (fun f => f.updates_keymap_context)
-          |> std.array.map (fun f => "self.%{f.field}.update_keymap_context(&context);")
-          |> join,
+      set_keymap_context_updates =
+        systems
+        |> std.array.filter (fun f => f.updates_keymap_context)
+        |> std.array.map (fun f => "self.%{f.field}.update_keymap_context(&context);")
+        |> join,
 
-        system_fields =
-          systems
-          |> std.array.map (fun f => "%{f.field}: %{sty f},")
-          |> join,
+      system_fields =
+        systems
+        |> std.array.map (fun f => "%{f.field}: %{sty f},")
+        |> join,
 
-        system_new_params =
-          data_array_systems
-          |> std.array.map (fun f => "%{f.field}: %{sty f},")
-          |> join,
+      system_new_params =
+        data_array_systems
+        |> std.array.map (fun f => "%{f.field}: %{sty f},")
+        |> join,
 
-        system_new_body =
-          (
-            (data_array_systems |> std.array.map (fun f => "%{f.field},"))
-            @ (singleton_systems |> std.array.map (fun f => "%{f.field}: %{f.system_expr},"))
-          )
-          |> join,
+      system_new_body =
+        (
+          (data_array_systems |> std.array.map (fun f => "%{f.field},"))
+          @ (singleton_systems |> std.array.map (fun f => "%{f.field}: %{f.system_expr},"))
+        )
+        |> join,
 
-        new_pressed_key_arms =
-          systems
-          |> std.array.map (fun f =>
-            m%"
+      new_pressed_key_arms =
+        systems
+        |> std.array.map (fun f =>
+          m%"
 Ref::%{f.variant}(key_ref) => {
       let (pkr, pke) = self.%{f.field}.new_pressed_key(keymap_index, &context.%{f.field}, key_ref);
       (pkr.into_result(), pke.into_events())
 }"%
-          )
-          |> join,
+        )
+        |> join,
 
-        update_pending_arms =
-          let pending_systems =
-            systems |> std.array.filter (fun f => f.has_pending_dispatch)
-          in
-          if pending_systems == [] then
-            "_ => panic!(\"no pending key systems in this key_system\"),"
-          else
-            (
-              pending_systems
-              |> std.array.map (fun f =>
-                m%"
+      update_pending_arms =
+        let pending_systems =
+          systems |> std.array.filter (fun f => f.has_pending_dispatch)
+        in
+        if pending_systems == [] then
+          "_ => panic!(\"no pending key systems in this key_system\"),"
+        else
+          (
+            pending_systems
+            |> std.array.map (fun f =>
+              m%"
 (Ref::%{f.variant}(key_ref), PendingKeyState::%{f.variant}(pending_state)) => {
       if let Ok(event) = event.try_into_key_event() {
           let (maybe_npk, pke) = self.%{f.field}.update_pending_state(
@@ -366,19 +365,19 @@ Ref::%{f.variant}(key_ref) => {
           (None, smart_keymap::key::KeyEvents::no_events())
       }
 }"%
-              )
-              |> join
             )
-            ++ "\n(_, _) => panic!(\"mismatched key_ref and pending_state variants\"),",
+            |> join
+          )
+          ++ "\n(_, _) => panic!(\"mismatched key_ref and pending_state variants\"),",
 
-        update_state_arms =
-          let state_systems =
-            systems |> std.array.filter (fun f => f.has_state_update)
-          in
-          (
-            state_systems
-            |> std.array.map (fun f =>
-              m%"
+      update_state_arms =
+        let state_systems =
+          systems |> std.array.filter (fun f => f.has_state_update)
+        in
+        (
+          state_systems
+          |> std.array.map (fun f =>
+            m%"
 (Ref::%{f.variant}(key_ref), KeyState::%{f.key_state_variant}(key_state)) => {
       if let Ok(event) = event.try_into_key_event() {
           self.%{f.field}
@@ -388,49 +387,49 @@ Ref::%{f.variant}(key_ref) => {
           smart_keymap::key::KeyEvents::no_events()
       }
 }"%
-            )
-            |> join
           )
-          ++ "\n(_, _) => smart_keymap::key::KeyEvents::no_events(),",
+          |> join
+        )
+        ++ "\n(_, _) => smart_keymap::key::KeyEvents::no_events(),",
 
-        key_output_arms =
-          let out_systems =
-            systems |> std.array.filter (fun f => f.has_key_output)
-          in
-          (
-            out_systems
-            |> std.array.map (fun f =>
-              "(Ref::%{f.variant}(r), KeyState::%{f.key_state_variant}(ks)) => self.%{f.field}.key_output(r, ks),"
-            )
-            |> join
-          )
-          ++ "\n(_, _) => None,",
-
-        key_state_from_family =
-          systems
+      key_output_arms =
+        let out_systems =
+          systems |> std.array.filter (fun f => f.has_key_output)
+        in
+        (
+          out_systems
           |> std.array.map (fun f =>
-            m%"
+            "(Ref::%{f.variant}(r), KeyState::%{f.key_state_variant}(ks)) => self.%{f.field}.key_output(r, ks),"
+          )
+          |> join
+        )
+        ++ "\n(_, _) => None,",
+
+      key_state_from_family =
+        systems
+        |> std.array.map (fun f =>
+          m%"
 impl From<%{f.key_state_ty}> for KeyState {
       fn from(ks: %{f.key_state_ty}) -> Self { KeyState::%{f.key_state_variant}(ks) }
 }"%
-          )
-          |> join,
+        )
+        |> join,
 
-        pending_from_family =
-          systems
-          |> std.array.map (fun f =>
-            m%"
+      pending_from_family =
+        systems
+        |> std.array.map (fun f =>
+          m%"
 impl From<%{f.pending_ty}> for PendingKeyState {
       fn from(pks: %{f.pending_ty}) -> Self { PendingKeyState::%{f.variant}(pks) }
 }"%
-          )
-          |> join,
+        )
+        |> join,
 
-        pending_mut_try_from =
-          systems
-          |> std.array.filter (fun f => f.has_pending_dispatch)
-          |> std.array.map (fun f =>
-            m%"
+      pending_mut_try_from =
+        systems
+        |> std.array.filter (fun f => f.has_pending_dispatch)
+        |> std.array.map (fun f =>
+          m%"
 #[allow(unreachable_patterns)]
 impl<'pks> TryFrom<&'pks mut PendingKeyState> for &'pks mut %{f.pending_ty} {
       type Error = ();
@@ -441,72 +440,72 @@ impl<'pks> TryFrom<&'pks mut PendingKeyState> for &'pks mut %{f.pending_ty} {
           }
       }
 }"%
-          )
-          |> join,
+        )
+        |> join,
 
-        config_rust_expr =
-          if config_systems == [] then
-            "key_system::Config::new()"
-          else
-            let fields =
-              config_systems
-              |> std.array.map (fun f =>
-                "%{f.config_path}: %{f.config_rust_expr},"
-              )
-              |> join
-            in
-            m%"key_system::Config {
+      config_rust_expr =
+        if config_systems == [] then
+          "key_system::Config::new()"
+        else
+          let fields =
+            config_systems
+            |> std.array.map (fun f =>
+              "%{f.config_path}: %{f.config_rust_expr},"
+            )
+            |> join
+          in
+          m%"key_system::Config {
 %{fields}
 }"%,
 
-        system_rust_expr =
-          if data_array_systems == [] then
-            "key_system::System::new()"
-          else
-            let args =
-              data_array_systems
-              |> std.array.map (fun f => "%{f.system_rust_expr},")
-              |> join
-            in
-            m%"key_system::System::new(
+      system_rust_expr =
+        if data_array_systems == [] then
+          "key_system::System::new()"
+        else
+          let args =
+            data_array_systems
+            |> std.array.map (fun f => "%{f.system_rust_expr},")
+            |> join
+          in
+          m%"key_system::System::new(
 %{args}
 )"%,
 
-        chorded_pressed_indices_const =
-          if has_chorded then
-            "const CHORDED_MAX_PRESSED_INDICES: usize = crate::init::CHORDED_MAX_CHORD_SIZE * 2;\n"
-          else
-            "",
+      chorded_pressed_indices_const =
+        if has_chorded then
+          "const CHORDED_MAX_PRESSED_INDICES: usize = crate::init::CHORDED_MAX_CHORD_SIZE * 2;\n"
+        else
+          "",
 
-        key_state_variants =
-          systems
-          |> std.array.map (fun f =>
-            "/// [%{f.module}] key state.\n%{f.key_state_variant}(%{f.key_state_ty}),"
-          )
-          |> join,
+      key_state_variants =
+        systems
+        |> std.array.map (fun f =>
+          "/// [%{f.module}] key state.\n%{f.key_state_variant}(%{f.key_state_ty}),"
+        )
+        |> join,
 
-        module_doc =
-          data
-          |> match {
-            'Array =>
-              if is_full then
-                "Full composite key system (generated; all registry families)."
-              else
-                "Per-keymap composite key system (generated; only families used by this keymap).",
-            'Vec =>
-              if is_full then
-                "Full composite key system (generated; all registry families; vec-backed key data)."
-              else
-                "Per-keymap composite key system (generated; only families used by this keymap; vec-backed key data).",
-          },
+      module_doc =
+        data
+        |> match {
+          'Array =>
+            if is_full then
+              "Full composite key system (generated; all registry families)."
+            else
+              "Per-keymap composite key system (generated; only families used by this keymap).",
+          'Vec =>
+            if is_full then
+              "Full composite key system (generated; all registry families; vec-backed key data)."
+            else
+              "Per-keymap composite key system (generated; only families used by this keymap; vec-backed key data).",
+        },
 
-        system_derives =
-          if is_vec then
-            "#[derive(Debug, Clone, PartialEq)]"
-          else
-            "#[derive(Debug, Clone, Copy, PartialEq)]",
+      system_derives =
+        if is_vec then
+          "#[derive(Debug, Clone, PartialEq)]"
+        else
+          "#[derive(Debug, Clone, Copy, PartialEq)]",
 
-        rust_mod = m%"
+      rust_mod = m%"
 /// %{module_doc}
 pub mod key_system {
       use crate as smart_keymap;
@@ -679,33 +678,33 @@ pub mod key_system {
 }
 "%,
 
-        # Key-data length consts for init (e.g. `const KEYBOARD: usize = N;`).
-        init_consts_rust_stmts = fun key_data =>
-          systems
-          |> std.array.fold_left
-            (fun acc f =>
-              acc
-              @ (
-                f.data_lengths
-                |> std.array.map (fun { const_name, data_field } =>
-                  let data = (key_data & { "%{data_field}" | default = [] })."%{data_field}" in
-                  let len = data |> std.array.length |> std.to_string in
-                  "    const %{const_name}: usize = %{len};"
-                )
+      # Key-data length consts for init (e.g. `const KEYBOARD: usize = N;`).
+      init_consts_rust_stmts = fun key_data =>
+        systems
+        |> std.array.fold_left
+          (fun acc f =>
+            acc
+            @ (
+              f.data_lengths
+              |> std.array.map (fun { const_name, data_field } =>
+                let data = (key_data & { "%{data_field}" | default = [] })."%{data_field}" in
+                let len = data |> std.array.length |> std.to_string in
+                "    const %{const_name}: usize = %{len};"
               )
             )
-            []
-          |> std.string.join "\n",
-      },
-
-      # Public artefacts assembled from active fragments.
-      config.rust_expr = fragments.config_rust_expr,
-      system = {
-        rust_expr = fragments.system_rust_expr,
-        rust_mod = fragments.rust_mod,
-        init_consts_rust_stmts = fragments.init_consts_rust_stmts,
-      },
+          )
+          []
+        |> std.string.join "\n",
     },
+
+    # Public artefacts assembled from active fragments.
+    config.rust_expr = fragments.config_rust_expr,
+    system = {
+      rust_expr = fragments.system_rust_expr,
+      rust_mod = fragments.rust_mod,
+      init_consts_rust_stmts = fragments.init_consts_rust_stmts,
+    },
+  },
 
   checks.composite_profile = {
     check_1key_simple_keyboard_only =

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -10,6 +10,7 @@
 & (import "smart_keys/sticky/keymap-codegen.ncl")
 & (import "smart_keys/tap_dance/keymap-codegen.ncl")
 & (import "smart_keys/tap_hold/keymap-codegen.ncl")
+& (import "key_system/families.ncl")
 & (import "key_system/keymap-codegen.ncl")
 & {
   KeymapJson


### PR DESCRIPTION
Replace `fun smart_keymap => { families, … }` with a record that takes `smart_keymap` and contributes `composite.default_family` / `composite.families`, matching the smart_keys/* merge style.

Wire it via `& (import "key_system/families.ncl")` and refer to registry fields through `composite.*` paths (short names do not cross merge).