### PR TITLE
ncl: key_system: emit init size consts from family init_params

### DIFF
--- a/ncl/key_system/families.ncl
+++ b/ncl/key_system/families.ncl
@@ -69,6 +69,11 @@
 
         ref_ty | default = "%{module}::Ref",
         event_ty | default = "%{module}::Event",
+
+        # Size / const-generic params for `pub mod init` (always emitted).
+        # Each: `{ const_name, doc, value = fun ctx => usize }` where
+        # `ctx = { json_keymap, key_codegen_values, smart_key }`.
+        init_params | default = [],
       },
 
       # Family registry as a record keyed by snake_case name
@@ -108,6 +113,21 @@
           >"%,
             expr = "%{module}::Context::from_config(config.automation)",
           },
+          init_params = [
+            {
+              const_name = "AUTOMATION_INSTRUCTION_COUNT",
+              doc = "Number of instructions used by the [crate::key::automation] implementation.",
+              value = fun { json_keymap, .. } =>
+                if std.record.has_field "automation" json_keymap.config then
+                  let automation_cfg = json_keymap.config.automation in
+                  if std.record.has_field "instructions" automation_cfg then
+                    std.array.length automation_cfg.instructions
+                  else
+                    0
+                else
+                  0,
+            },
+          ],
         },
         callback = {
           module = "smart_keymap::key::callback",
@@ -228,6 +248,39 @@
           >"%,
             expr = "%{module}::Context::from_config(config.chorded)",
           },
+          init_params =
+            let chords_from = fun { json_keymap, .. } =>
+              ((json_keymap.config & { chorded | default = {} }).chorded & { chords | default = [] }).chords
+            in
+            [
+              {
+                const_name = "CHORDED_MAX_CHORD_SIZE",
+                doc = "The maximum number of keys in a chord.",
+                value = fun ctx =>
+                  chords_from ctx
+                  |> std.array.map std.array.length
+                  |> std.array.fold_left std.number.max 0,
+              },
+              {
+                const_name = "CHORDED_MAX_CHORDS",
+                doc = "The maximum number of chords.",
+                value = fun ctx => chords_from ctx |> std.array.length,
+              },
+              {
+                const_name = "CHORDED_MAX_OVERLAPPING_CHORD_SIZE",
+                doc = "The maximum number of overlapping chords for a chorded key.",
+                value = fun ctx =>
+                  chords_from ctx
+                  |> std.array.map (fun [i, ..] => std.to_string i)
+                  |> std.array.fold_left
+                    (fun r i =>
+                      std.record.update i (1 + (std.record.get_or i 0 r)) r
+                    )
+                    {}
+                  |> std.record.values
+                  |> std.array.fold_left std.number.max 0,
+              },
+            ],
         },
         consumer = {
           module = "smart_keymap::key::consumer",
@@ -321,6 +374,31 @@
             expr = "%{module}::Context::from_config(config.layered)",
           },
           event_ty = "%{module}::LayerEvent",
+          init_params = [
+            {
+              const_name = "LAYERED_LAYER_COUNT",
+              doc = "Number of layers supported by the [smart_keymap::key::layered] implementation.",
+              value = fun { key_codegen_values, smart_key, .. } =>
+                # Longest layered array across every key tree (not only the first layered key).
+                key_codegen_values
+                |> std.array.fold_left
+                  (fun acc cv =>
+                    smart_key.traverse
+                      (fun acc cv =>
+                        cv
+                        |> match {
+                          { nested = { layered, .. }, .. } =>
+                            let len = std.array.length layered in
+                            if len > acc then len else acc,
+                          _ => acc,
+                        }
+                      )
+                      acc
+                      cv
+                  )
+                  0,
+            },
+          ],
         },
         mouse = {
           module = "smart_keymap::key::mouse",
@@ -396,6 +474,29 @@
             ty = "%{module}::Context",
             expr = "%{module}::Context::from_config(config.tap_dance)",
           },
+          init_params = [
+            {
+              const_name = "TAP_DANCE_MAX_DEFINITIONS",
+              doc = "The tap-dance definitions.",
+              value = fun { key_codegen_values, smart_key, .. } =>
+                key_codegen_values
+                |> std.array.map (fun cv =>
+                  smart_key.traverse
+                    (fun acc cv =>
+                      cv
+                      |> match {
+                        { nested = { definitions }, .. } =>
+                          let len = std.array.length definitions in
+                          if len > acc then len else acc,
+                        _ => acc,
+                      }
+                    )
+                    0
+                    cv
+                )
+                |> std.array.fold_left (fun x y => if x > y then x else y) 0,
+            },
+          ],
         },
         tap_hold = {
           module = "smart_keymap::key::tap_hold",

--- a/ncl/key_system/keymap-codegen.ncl
+++ b/ncl/key_system/keymap-codegen.ncl
@@ -12,6 +12,7 @@
 #   - `composite.config.Json` / `composite.config.rust_expr`
 #   - `composite.system.rust_expr`
 #   - `composite.system.init_consts_rust_stmts` (fn of key_data)
+#   - `composite.system.init_size_consts_rust_stmts` (fn of ctx; always-emit)
 #   - `composite.system.rust_mod` (generated `pub mod key_system { … }`)
 #
 # Profile:
@@ -769,6 +770,7 @@ pub mod key_system {
 "%,
 
       # Key-data length consts for init (e.g. `const KEYBOARD: usize = N;`).
+      # Profile-trimmed to active `systems`.
       init_consts_rust_stmts = fun key_data =>
         systems
         |> std.array.fold_left
@@ -790,6 +792,17 @@ pub mod key_system {
           )
           []
         |> std.string.join "\n",
+
+      # Size / const-generic params for init (e.g. `LAYERED_LAYER_COUNT`).
+      # Always emitted from the full family registry (v1 policy; not profile-trimmed).
+      # `ctx = { json_keymap, key_codegen_values, smart_key }`.
+      init_size_consts_rust_stmts = fun ctx =>
+        family_list
+        |> std.array.flat_map (fun f => f.init_params)
+        |> std.array.map (fun p =>
+          "    /// %{p.doc}\n    pub const %{p.const_name}: usize = %{std.to_string (p.value ctx)};"
+        )
+        |> std.string.join "\n\n",
     },
 
     # Public artefacts assembled from active fragments.
@@ -809,6 +822,7 @@ pub mod key_system {
       rust_expr = fragments.system_rust_expr,
       rust_mod = fragments.rust_mod,
       init_consts_rust_stmts = fragments.init_consts_rust_stmts,
+      init_size_consts_rust_stmts = fragments.init_size_consts_rust_stmts,
     },
   },
 

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -265,78 +265,16 @@
     | doc "Record of rust expressions generated from keymap.json"
     =
       let keymap_len = std.array.length json_keymap.keys in
-      let num_automation_instructions =
-        if std.record.has_field "automation" json_keymap.config then
-          let automation_cfg = json_keymap.config.automation in
-          if std.record.has_field "instructions" automation_cfg then
-            std.array.length automation_cfg.instructions
-          else
-            0
-        else
-          0
-      in
-      let max_tap_dance_definitions =
-        # For each of the keys,
-        #  compute max length of any tap dance definitions.
-        let max_td_defs =
-          std.array.map
-            (fun cv =>
-              smart_key.traverse
-                (fun acc cv =>
-                  cv
-                  |> match {
-                    { nested = { definitions }, .. } =>
-                      let len = std.array.length definitions in
-                      if len > acc then len else acc,
-                    _ => acc,
-                  }
-                )
-                0
-                cv
-            )
-            key_codegen_values
-        in
-        # Compute the max over all
-        std.array.reduce_left (fun x y => if x > y then x else y) max_td_defs
-      in
-      let num_layers =
-        # Longest layered array across every key tree (not only the first layered key).
-        key_codegen_values
-        |> std.array.fold_left
-          (fun acc cv =>
-            smart_key.traverse
-              (fun acc cv =>
-                cv
-                |> match {
-                  { nested = { layered, .. }, .. } =>
-                    let len = std.array.length layered in
-                    if len > acc then len else acc,
-                  _ => acc,
-                }
-              )
-              acc
-              cv
-          )
-          0
-      in
-      let chords = ((json_keymap.config & { chorded | default = {} }).chorded & { chords | default = [] }).chords in
-      let chord_count = chords |> std.array.length in
-      let max_chord_size = chords |> std.array.map std.array.length |> std.array.fold_left std.number.max 0 in
-      let max_overlapping_chord_size =
-        chords
-        |> std.array.map (fun [i, ..] => std.to_string i)
-        |> std.array.fold_left
-          (fun r i =>
-            std.record.update i (1 + (std.record.get_or i 0 r)) r
-          )
-          {}
-        |> std.record.values
-        |> std.array.fold_left std.number.max 0
-      in
       let { key_data, key_refs } = key_data_and_refs in
       let key_refs_expr = "[%{key_refs |> std.array.map (fun { rust_expr, .. } => rust_expr) |> std.string.join ", "}]" in
       let config = composite.config.rust_expr in
       let context = "key_system::Context::from_config(%{config})" in
+      let init_size_ctx = {
+        include json_keymap,
+        include key_codegen_values,
+        include smart_key,
+      }
+      in
       # Firmware / custom-keymap module: included as `crate::init` with
       # `use crate as smart_keymap` and `crate::init::…` size paths.
       let keymap_module_src = m%"
@@ -344,23 +282,7 @@
 pub mod init {
     use crate as smart_keymap;
 
-    /// Number of instructions used by the [crate::key::automation] implementation.
-    pub const AUTOMATION_INSTRUCTION_COUNT: usize = %{std.to_string num_automation_instructions};
-
-    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYERED_LAYER_COUNT: usize = %{std.to_string num_layers};
-
-    /// The maximum number of keys in a chord.
-    pub const CHORDED_MAX_CHORD_SIZE: usize = %{max_chord_size |> std.to_string};
-
-    /// The maximum number of chords.
-    pub const CHORDED_MAX_CHORDS: usize = %{chord_count |> std.to_string};
-
-    /// The maximum number of overlapping chords for a chorded key.
-    pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = %{max_overlapping_chord_size |> std.to_string};
-
-    /// The tap-dance definitions.
-    pub const TAP_DANCE_MAX_DEFINITIONS: usize = %{max_tap_dance_definitions |> std.to_string};
+%{composite.system.init_size_consts_rust_stmts init_size_ctx}
 
 %{composite.system.init_consts_rust_stmts key_data}
 

--- a/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
+++ b/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
@@ -5,9 +5,6 @@ pub mod init {
     /// Number of instructions used by the [crate::key::automation] implementation.
     pub const AUTOMATION_INSTRUCTION_COUNT: usize = 0;
 
-    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYERED_LAYER_COUNT: usize = 1;
-
     /// The maximum number of keys in a chord.
     pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
@@ -16,6 +13,9 @@ pub mod init {
 
     /// The maximum number of overlapping chords for a chorded key.
     pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+
+    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
+    pub const LAYERED_LAYER_COUNT: usize = 1;
 
     /// The tap-dance definitions.
     pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;

--- a/tests/ncl/keymap-1key-abbrev-ent/expected.rs
+++ b/tests/ncl/keymap-1key-abbrev-ent/expected.rs
@@ -5,9 +5,6 @@ pub mod init {
     /// Number of instructions used by the [crate::key::automation] implementation.
     pub const AUTOMATION_INSTRUCTION_COUNT: usize = 0;
 
-    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYERED_LAYER_COUNT: usize = 0;
-
     /// The maximum number of keys in a chord.
     pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
@@ -16,6 +13,9 @@ pub mod init {
 
     /// The maximum number of overlapping chords for a chorded key.
     pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+
+    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
+    pub const LAYERED_LAYER_COUNT: usize = 0;
 
     /// The tap-dance definitions.
     pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;

--- a/tests/ncl/keymap-1key-automation/expected.rs
+++ b/tests/ncl/keymap-1key-automation/expected.rs
@@ -5,9 +5,6 @@ pub mod init {
     /// Number of instructions used by the [crate::key::automation] implementation.
     pub const AUTOMATION_INSTRUCTION_COUNT: usize = 1;
 
-    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYERED_LAYER_COUNT: usize = 0;
-
     /// The maximum number of keys in a chord.
     pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
@@ -16,6 +13,9 @@ pub mod init {
 
     /// The maximum number of overlapping chords for a chorded key.
     pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+
+    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
+    pub const LAYERED_LAYER_COUNT: usize = 0;
 
     /// The tap-dance definitions.
     pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;

--- a/tests/ncl/keymap-1key-callback-custom/expected.rs
+++ b/tests/ncl/keymap-1key-callback-custom/expected.rs
@@ -5,9 +5,6 @@ pub mod init {
     /// Number of instructions used by the [crate::key::automation] implementation.
     pub const AUTOMATION_INSTRUCTION_COUNT: usize = 0;
 
-    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYERED_LAYER_COUNT: usize = 0;
-
     /// The maximum number of keys in a chord.
     pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
@@ -16,6 +13,9 @@ pub mod init {
 
     /// The maximum number of overlapping chords for a chorded key.
     pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+
+    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
+    pub const LAYERED_LAYER_COUNT: usize = 0;
 
     /// The tap-dance definitions.
     pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;

--- a/tests/ncl/keymap-1key-custom/expected.rs
+++ b/tests/ncl/keymap-1key-custom/expected.rs
@@ -5,9 +5,6 @@ pub mod init {
     /// Number of instructions used by the [crate::key::automation] implementation.
     pub const AUTOMATION_INSTRUCTION_COUNT: usize = 0;
 
-    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYERED_LAYER_COUNT: usize = 0;
-
     /// The maximum number of keys in a chord.
     pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
@@ -16,6 +13,9 @@ pub mod init {
 
     /// The maximum number of overlapping chords for a chorded key.
     pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+
+    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
+    pub const LAYERED_LAYER_COUNT: usize = 0;
 
     /// The tap-dance definitions.
     pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;

--- a/tests/ncl/keymap-1key-simple/expected.rs
+++ b/tests/ncl/keymap-1key-simple/expected.rs
@@ -5,9 +5,6 @@ pub mod init {
     /// Number of instructions used by the [crate::key::automation] implementation.
     pub const AUTOMATION_INSTRUCTION_COUNT: usize = 0;
 
-    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYERED_LAYER_COUNT: usize = 0;
-
     /// The maximum number of keys in a chord.
     pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
@@ -16,6 +13,9 @@ pub mod init {
 
     /// The maximum number of overlapping chords for a chorded key.
     pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+
+    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
+    pub const LAYERED_LAYER_COUNT: usize = 0;
 
     /// The tap-dance definitions.
     pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;

--- a/tests/ncl/keymap-1key-tap_dance/expected.rs
+++ b/tests/ncl/keymap-1key-tap_dance/expected.rs
@@ -5,9 +5,6 @@ pub mod init {
     /// Number of instructions used by the [crate::key::automation] implementation.
     pub const AUTOMATION_INSTRUCTION_COUNT: usize = 0;
 
-    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYERED_LAYER_COUNT: usize = 0;
-
     /// The maximum number of keys in a chord.
     pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
@@ -16,6 +13,9 @@ pub mod init {
 
     /// The maximum number of overlapping chords for a chorded key.
     pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+
+    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
+    pub const LAYERED_LAYER_COUNT: usize = 0;
 
     /// The tap-dance definitions.
     pub const TAP_DANCE_MAX_DEFINITIONS: usize = 3;

--- a/tests/ncl/keymap-1key-tap_hold/expected.rs
+++ b/tests/ncl/keymap-1key-tap_hold/expected.rs
@@ -5,9 +5,6 @@ pub mod init {
     /// Number of instructions used by the [crate::key::automation] implementation.
     pub const AUTOMATION_INSTRUCTION_COUNT: usize = 0;
 
-    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYERED_LAYER_COUNT: usize = 0;
-
     /// The maximum number of keys in a chord.
     pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
@@ -16,6 +13,9 @@ pub mod init {
 
     /// The maximum number of overlapping chords for a chorded key.
     pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+
+    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
+    pub const LAYERED_LAYER_COUNT: usize = 0;
 
     /// The tap-dance definitions.
     pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;

--- a/tests/ncl/keymap-2key-2layer-composite/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-composite/expected.rs
@@ -5,9 +5,6 @@ pub mod init {
     /// Number of instructions used by the [crate::key::automation] implementation.
     pub const AUTOMATION_INSTRUCTION_COUNT: usize = 0;
 
-    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYERED_LAYER_COUNT: usize = 1;
-
     /// The maximum number of keys in a chord.
     pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
@@ -16,6 +13,9 @@ pub mod init {
 
     /// The maximum number of overlapping chords for a chorded key.
     pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+
+    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
+    pub const LAYERED_LAYER_COUNT: usize = 1;
 
     /// The tap-dance definitions.
     pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;

--- a/tests/ncl/keymap-2key-2layer-named-layer_string/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-named-layer_string/expected.rs
@@ -5,9 +5,6 @@ pub mod init {
     /// Number of instructions used by the [crate::key::automation] implementation.
     pub const AUTOMATION_INSTRUCTION_COUNT: usize = 0;
 
-    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYERED_LAYER_COUNT: usize = 1;
-
     /// The maximum number of keys in a chord.
     pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
@@ -16,6 +13,9 @@ pub mod init {
 
     /// The maximum number of overlapping chords for a chorded key.
     pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+
+    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
+    pub const LAYERED_LAYER_COUNT: usize = 1;
 
     /// The tap-dance definitions.
     pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;

--- a/tests/ncl/keymap-2key-2layer-named/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-named/expected.rs
@@ -5,9 +5,6 @@ pub mod init {
     /// Number of instructions used by the [crate::key::automation] implementation.
     pub const AUTOMATION_INSTRUCTION_COUNT: usize = 0;
 
-    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYERED_LAYER_COUNT: usize = 1;
-
     /// The maximum number of keys in a chord.
     pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
@@ -16,6 +13,9 @@ pub mod init {
 
     /// The maximum number of overlapping chords for a chorded key.
     pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+
+    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
+    pub const LAYERED_LAYER_COUNT: usize = 1;
 
     /// The tap-dance definitions.
     pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;

--- a/tests/ncl/keymap-2key-2layer-simple/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-simple/expected.rs
@@ -5,9 +5,6 @@ pub mod init {
     /// Number of instructions used by the [crate::key::automation] implementation.
     pub const AUTOMATION_INSTRUCTION_COUNT: usize = 0;
 
-    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYERED_LAYER_COUNT: usize = 1;
-
     /// The maximum number of keys in a chord.
     pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
@@ -16,6 +13,9 @@ pub mod init {
 
     /// The maximum number of overlapping chords for a chorded key.
     pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+
+    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
+    pub const LAYERED_LAYER_COUNT: usize = 1;
 
     /// The tap-dance definitions.
     pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;

--- a/tests/ncl/keymap-2key-chorded-named-th-lmod/expected.rs
+++ b/tests/ncl/keymap-2key-chorded-named-th-lmod/expected.rs
@@ -5,9 +5,6 @@ pub mod init {
     /// Number of instructions used by the [crate::key::automation] implementation.
     pub const AUTOMATION_INSTRUCTION_COUNT: usize = 0;
 
-    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYERED_LAYER_COUNT: usize = 1;
-
     /// The maximum number of keys in a chord.
     pub const CHORDED_MAX_CHORD_SIZE: usize = 2;
 
@@ -16,6 +13,9 @@ pub mod init {
 
     /// The maximum number of overlapping chords for a chorded key.
     pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 1;
+
+    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
+    pub const LAYERED_LAYER_COUNT: usize = 1;
 
     /// The tap-dance definitions.
     pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;

--- a/tests/ncl/keymap-2key-chorded/expected.rs
+++ b/tests/ncl/keymap-2key-chorded/expected.rs
@@ -5,9 +5,6 @@ pub mod init {
     /// Number of instructions used by the [crate::key::automation] implementation.
     pub const AUTOMATION_INSTRUCTION_COUNT: usize = 0;
 
-    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYERED_LAYER_COUNT: usize = 0;
-
     /// The maximum number of keys in a chord.
     pub const CHORDED_MAX_CHORD_SIZE: usize = 2;
 
@@ -16,6 +13,9 @@ pub mod init {
 
     /// The maximum number of overlapping chords for a chorded key.
     pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 1;
+
+    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
+    pub const LAYERED_LAYER_COUNT: usize = 0;
 
     /// The tap-dance definitions.
     pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;

--- a/tests/ncl/keymap-34key-seniply/expected.rs
+++ b/tests/ncl/keymap-34key-seniply/expected.rs
@@ -5,9 +5,6 @@ pub mod init {
     /// Number of instructions used by the [crate::key::automation] implementation.
     pub const AUTOMATION_INSTRUCTION_COUNT: usize = 0;
 
-    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYERED_LAYER_COUNT: usize = 5;
-
     /// The maximum number of keys in a chord.
     pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
@@ -16,6 +13,9 @@ pub mod init {
 
     /// The maximum number of overlapping chords for a chorded key.
     pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+
+    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
+    pub const LAYERED_LAYER_COUNT: usize = 5;
 
     /// The tap-dance definitions.
     pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;

--- a/tests/ncl/keymap-48key-basic/expected.rs
+++ b/tests/ncl/keymap-48key-basic/expected.rs
@@ -5,9 +5,6 @@ pub mod init {
     /// Number of instructions used by the [crate::key::automation] implementation.
     pub const AUTOMATION_INSTRUCTION_COUNT: usize = 0;
 
-    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYERED_LAYER_COUNT: usize = 3;
-
     /// The maximum number of keys in a chord.
     pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
@@ -16,6 +13,9 @@ pub mod init {
 
     /// The maximum number of overlapping chords for a chorded key.
     pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+
+    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
+    pub const LAYERED_LAYER_COUNT: usize = 3;
 
     /// The tap-dance definitions.
     pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;

--- a/tests/ncl/keymap-48key-rgoulter/expected.rs
+++ b/tests/ncl/keymap-48key-rgoulter/expected.rs
@@ -5,9 +5,6 @@ pub mod init {
     /// Number of instructions used by the [crate::key::automation] implementation.
     pub const AUTOMATION_INSTRUCTION_COUNT: usize = 0;
 
-    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYERED_LAYER_COUNT: usize = 9;
-
     /// The maximum number of keys in a chord.
     pub const CHORDED_MAX_CHORD_SIZE: usize = 2;
 
@@ -16,6 +13,9 @@ pub mod init {
 
     /// The maximum number of overlapping chords for a chorded key.
     pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 1;
+
+    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
+    pub const LAYERED_LAYER_COUNT: usize = 9;
 
     /// The tap-dance definitions.
     pub const TAP_DANCE_MAX_DEFINITIONS: usize = 2;

--- a/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
@@ -5,9 +5,6 @@ pub mod init {
     /// Number of instructions used by the [crate::key::automation] implementation.
     pub const AUTOMATION_INSTRUCTION_COUNT: usize = 0;
 
-    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYERED_LAYER_COUNT: usize = 0;
-
     /// The maximum number of keys in a chord.
     pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
@@ -16,6 +13,9 @@ pub mod init {
 
     /// The maximum number of overlapping chords for a chorded key.
     pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+
+    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
+    pub const LAYERED_LAYER_COUNT: usize = 0;
 
     /// The tap-dance definitions.
     pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;

--- a/tests/ncl/keymap-60key-dvorak-simple/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple/expected.rs
@@ -5,9 +5,6 @@ pub mod init {
     /// Number of instructions used by the [crate::key::automation] implementation.
     pub const AUTOMATION_INSTRUCTION_COUNT: usize = 0;
 
-    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
-    pub const LAYERED_LAYER_COUNT: usize = 0;
-
     /// The maximum number of keys in a chord.
     pub const CHORDED_MAX_CHORD_SIZE: usize = 0;
 
@@ -16,6 +13,9 @@ pub mod init {
 
     /// The maximum number of overlapping chords for a chorded key.
     pub const CHORDED_MAX_OVERLAPPING_CHORD_SIZE: usize = 0;
+
+    /// Number of layers supported by the [smart_keymap::key::layered] implementation.
+    pub const LAYERED_LAYER_COUNT: usize = 0;
 
     /// The tap-dance definitions.
     pub const TAP_DANCE_MAX_DEFINITIONS: usize = 0;


### PR DESCRIPTION
## Summary

- Declare `init_params` (`const_name`, `doc`, `value`) on automation / chorded / layered / tap_dance families
- Emit size consts via `composite.system.init_size_consts_rust_stmts` (always-emit, full family registry)
- Drop open-coded size walks from top-level `keymap-codegen` `rust_expressions`; assemble from a small ctx only

Follows the same “knowledge on family / aggregate” pattern as `ref.wrap` and `data_lengths` (PR #645). Value computation also lives on family rows.

## Snapshot note

Size const *order* is now registry-alphabetical (`automation` → `chorded` → `layered` → `tap_dance`). Values are unchanged.

## Test plan

- [x] `nickel eval` unit checks (`ncl/scripts/run-ncl-checks.sh` path)
- [x] All `tests/ncl` expected.rs snapshots refreshed and re-diffed
- [ ] CI on PR