### PR TITLE
macros: split trybuild UI pass and compile-fail tests

### DIFF
--- a/smart-keymap-macros/tests/tests.rs
+++ b/smart-keymap-macros/tests/tests.rs
@@ -1,6 +1,11 @@
 #[test]
-fn tests() {
+fn ui_pass() {
     let t = trybuild::TestCases::new();
     t.pass("tests/ui/01-pass.rs");
+}
+
+#[test]
+fn ui_compile_fail() {
+    let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/02-fail-nickel-error.rs");
 }

--- a/smart-keymap-macros/tests/ui/02-fail-nickel-error.stderr
+++ b/smart-keymap-macros/tests/ui/02-fail-nickel-error.stderr
@@ -14,9 +14,9 @@ error: proc macro panicked
    = help: message: Nickel evaluation failed:
            error: contract broken by the value of `layers`
                   Value is not a valid keymap key
-               ┌─ $WORKSPACE/ncl/keymap-ncl-to-json.ncl:155:13
+               ┌─ $WORKSPACE/ncl/keymap-ncl-to-json.ncl:156:13
                │
-           155 │     | Array KeymapLayer
+           156 │     | Array KeymapLayer
                │             ----------- expected array element type
                │
                ┌─ <stdin>:4:17


### PR DESCRIPTION
Keep functional expansion and error diagnostics as separate tests so failures report which category broke.