### PR TITLE
keymap: reset Context from config on init

### DIFF
--- a/ncl/key_system/keymap-codegen.ncl
+++ b/ncl/key_system/keymap-codegen.ncl
@@ -449,6 +449,14 @@ if let Ok(e) = event.try_into_key_event() {
         )
         |> join,
 
+      # Reset each family context (from_config / clear runtime state).
+      context_reset_stmts =
+        (
+          ["self.keymap_context = smart_keymap::keymap::KeymapContext::new();"]
+          @ (systems |> std.array.map (fun f => "self.%{f.field}.reset();"))
+        )
+        |> join,
+
       set_keymap_context_updates =
         systems
         |> std.array.filter family_updates_keymap_context
@@ -704,6 +712,10 @@ pub mod key_system {
             let mut pke = key::KeyEvents::no_events();
 %{context_handle_event}
             pke
+        }
+
+        fn reset(&mut self) {
+%{context_reset_stmts}
         }
     }
 

--- a/smart-keymap-core/src/key.rs
+++ b/smart-keymap-core/src/key.rs
@@ -258,6 +258,12 @@ pub trait Context: Clone + Copy {
 
     /// Used to update the [Context]'s state.
     fn handle_event(&mut self, event: Event<Self::Event>) -> KeyEvents<Self::Event>;
+
+    /// Restore runtime state from this context's keymap config.
+    ///
+    /// Config data (timeouts, chords, …) is preserved; ephemeral state
+    /// (active layers, sticky mods, queues, …) is cleared.
+    fn reset(&mut self);
 }
 
 /// Bool flags for each of the modifier keys (left ctrl, etc.).

--- a/smart-keymap-core/src/key/automation.rs
+++ b/smart-keymap-core/src/key/automation.rs
@@ -244,6 +244,11 @@ impl<const INSTRUCTION_COUNT: usize> Context<INSTRUCTION_COUNT> {
         }
     }
 
+    /// Re-construct from context's [Config], clearing the execution queue.
+    pub fn reset(&mut self) {
+        *self = Self::from_config(self.config);
+    }
+
     /// Enqueues a new execution onto the execution queue.
     pub fn enqueue(&mut self, new_execution: Execution) -> usize {
         // Ignore empty executions.
@@ -289,6 +294,10 @@ impl<const INSTRUCTION_COUNT: usize> Context<INSTRUCTION_COUNT> {
 
 impl<const INSTRUCTION_COUNT: usize> key::Context for Context<INSTRUCTION_COUNT> {
     type Event = Event;
+
+    fn reset(&mut self) {
+        Context::reset(self);
+    }
 
     fn handle_event(&mut self, event: key::Event<Self::Event>) -> key::KeyEvents<Self::Event> {
         match event {

--- a/smart-keymap-core/src/key/callback.rs
+++ b/smart-keymap-core/src/key/callback.rs
@@ -30,6 +30,11 @@ impl Key {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Context;
 
+impl Context {
+    /// No runtime state to clear.
+    pub fn reset(&mut self) {}
+}
+
 /// The event type for keymap callback keys. (No events).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Event;

--- a/smart-keymap-core/src/key/caps_word.rs
+++ b/smart-keymap-core/src/key/caps_word.rs
@@ -29,6 +29,11 @@ impl Context {
         Context { is_active: false }
     }
 
+    /// Clear caps-word active state.
+    pub fn reset(&mut self) {
+        *self = Self::new();
+    }
+
     /// Updates the context with the given event.
     fn handle_event(&mut self, event: key::Event<Event>) -> key::KeyEvents<Event> {
         match event {
@@ -102,6 +107,10 @@ impl key::Context for Context {
 
     fn handle_event(&mut self, event: key::Event<Self::Event>) -> key::KeyEvents<Self::Event> {
         self.handle_event(event)
+    }
+
+    fn reset(&mut self) {
+        Context::reset(self);
     }
 }
 

--- a/smart-keymap-core/src/key/chorded.rs
+++ b/smart-keymap-core/src/key/chorded.rs
@@ -232,6 +232,11 @@ impl<const MAX_CHORDS: usize, const MAX_CHORD_SIZE: usize, const MAX_PRESSED_IND
         }
     }
 
+    /// Re-construct from context's [Config], clearing pressed/chord runtime state.
+    pub fn reset(&mut self) {
+        *self = Self::from_config(self.config);
+    }
+
     /// Updates the context with the given keymap context.
     pub fn update_keymap_context(
         &mut self,
@@ -442,6 +447,10 @@ impl<const MAX_CHORDS: usize, const MAX_CHORD_SIZE: usize, const MAX_PRESSED_IND
     fn handle_event(&mut self, event: key::Event<Self::Event>) -> key::KeyEvents<Self::Event> {
         self.handle_event(event);
         key::KeyEvents::no_events()
+    }
+
+    fn reset(&mut self) {
+        Context::reset(self);
     }
 }
 

--- a/smart-keymap-core/src/key/consumer.rs
+++ b/smart-keymap-core/src/key/consumer.rs
@@ -15,6 +15,11 @@ pub enum Ref {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Context;
 
+impl Context {
+    /// No runtime state to clear.
+    pub fn reset(&mut self) {}
+}
+
 /// The event type for consumer keys. (No events).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Event;

--- a/smart-keymap-core/src/key/custom.rs
+++ b/smart-keymap-core/src/key/custom.rs
@@ -13,6 +13,11 @@ pub struct Ref(pub u8);
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Context;
 
+impl Context {
+    /// No runtime state to clear.
+    pub fn reset(&mut self) {}
+}
+
 /// The event type for keymap callback keys. (No events).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Event;

--- a/smart-keymap-core/src/key/keyboard.rs
+++ b/smart-keymap-core/src/key/keyboard.rs
@@ -55,12 +55,21 @@ impl core::fmt::Debug for Key {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Context;
 
+impl Context {
+    /// No runtime state to clear.
+    pub fn reset(&mut self) {}
+}
+
 impl key::Context for Context {
     type Event = Event;
 
     /// Used to update the [Context]'s state.
     fn handle_event(&mut self, _event: key::Event<Self::Event>) -> key::KeyEvents<Self::Event> {
         key::KeyEvents::no_events()
+    }
+
+    fn reset(&mut self) {
+        Context::reset(self);
     }
 }
 

--- a/smart-keymap-core/src/key/layered.rs
+++ b/smart-keymap-core/src/key/layered.rs
@@ -338,6 +338,11 @@ impl<const LAYER_COUNT: usize> Context<LAYER_COUNT> {
         }
     }
 
+    /// Re-construct from context's [Config], clearing active layers and sticky state.
+    pub fn reset(&mut self) {
+        *self = Self::from_config(self.config);
+    }
+
     fn invalidate_sticky_timeouts(&mut self) {
         self.sticky_timeout_id = self.sticky_timeout_id.wrapping_add(1);
     }
@@ -489,6 +494,10 @@ impl<const LAYER_COUNT: usize> key::Context for Context<LAYER_COUNT> {
 
     fn handle_event(&mut self, event: key::Event<Self::Event>) -> key::KeyEvents<Self::Event> {
         self.handle_event(event)
+    }
+
+    fn reset(&mut self) {
+        Context::reset(self);
     }
 }
 

--- a/smart-keymap-core/src/key/mouse.rs
+++ b/smart-keymap-core/src/key/mouse.rs
@@ -31,6 +31,11 @@ pub enum Ref {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Context;
 
+impl Context {
+    /// No runtime state to clear.
+    pub fn reset(&mut self) {}
+}
+
 /// The event type for mouse keys. (No events).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Event;

--- a/smart-keymap-core/src/key/sticky.rs
+++ b/smart-keymap-core/src/key/sticky.rs
@@ -141,6 +141,11 @@ impl Context {
         }
     }
 
+    /// Re-construct from context's [Config], clearing active sticky modifiers.
+    pub fn reset(&mut self) {
+        *self = Self::from_config(self.config);
+    }
+
     /// Updates the context with the given event.
     fn handle_event(&mut self, event: key::Event<Event>) -> key::KeyEvents<Event> {
         // Cases:
@@ -284,6 +289,10 @@ impl key::Context for Context {
 
     fn handle_event(&mut self, event: key::Event<Self::Event>) -> key::KeyEvents<Self::Event> {
         self.handle_event(event)
+    }
+
+    fn reset(&mut self) {
+        Context::reset(self);
     }
 }
 

--- a/smart-keymap-core/src/key/tap_dance.rs
+++ b/smart-keymap-core/src/key/tap_dance.rs
@@ -104,6 +104,11 @@ impl Context {
     pub const fn from_config(config: Config) -> Context {
         Context { config }
     }
+
+    /// Re-construct from context's [Config] (no other runtime state).
+    pub fn reset(&mut self) {
+        *self = Self::from_config(self.config);
+    }
 }
 
 /// Resolution of a tap-dance key. (Index of the tap-dance definition).

--- a/smart-keymap-core/src/key/tap_hold.rs
+++ b/smart-keymap-core/src/key/tap_hold.rs
@@ -124,6 +124,11 @@ impl Context {
         }
     }
 
+    /// Re-construct from context's [Config], clearing idle-time tracking.
+    pub fn reset(&mut self) {
+        *self = Self::from_config(self.config);
+    }
+
     /// Updates the context with the given keymap context.
     pub fn update_keymap_context(
         &mut self,

--- a/smart-keymap-core/src/keymap.rs
+++ b/smart-keymap-core/src/keymap.rs
@@ -282,7 +282,12 @@ impl<
     }
 
     /// Initializes or resets the keyboard to an initial state.
+    ///
+    /// Resets [key::Context] from each family's config (clearing active layers and
+    /// other runtime state while keeping that keymap's config), and clears pressed
+    /// keys, pending work, and HID report state.
     pub fn init(&mut self) {
+        self.context.reset();
         self.pressed_inputs.clear();
         self.event_scheduler.init();
         self.hid_reporter.init();

--- a/smart-keymap-core/src/keymap/observed_keymap.rs
+++ b/smart-keymap-core/src/keymap/observed_keymap.rs
@@ -33,6 +33,12 @@ impl<
         }
     }
 
+    /// Proxies [keymap::Keymap::init] and clears observed reports.
+    pub fn init(&mut self) {
+        self.keymap.init();
+        self.distinct_reports = keymap::DistinctReports::new();
+    }
+
     /// Proxies [keymap::Keymap::handle_input], `tick`'ing the keymap appropriately.
     pub fn handle_input(&mut self, ev: input::Event) {
         let ObservedKeymap {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,11 @@ pub mod init {
             ) -> key::KeyEvents<Self::Event> {
                 key::KeyEvents::no_events()
             }
+
+            fn reset(&mut self) {
+                self.keymap_context = smart_keymap::keymap::KeymapContext::new();
+                self.keyboard.reset();
+            }
         }
 
         impl keymap::SetKeymapContext for Context {

--- a/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
+++ b/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
@@ -105,6 +105,13 @@ pub mod init {
                 }
                 pke
             }
+
+            fn reset(&mut self) {
+                self.keymap_context = smart_keymap::keymap::KeymapContext::new();
+                self.keyboard.reset();
+                self.layered.reset();
+                self.tap_hold.reset();
+            }
         }
 
         impl keymap::SetKeymapContext for Context {

--- a/tests/ncl/keymap-1key-abbrev-ent/expected.rs
+++ b/tests/ncl/keymap-1key-abbrev-ent/expected.rs
@@ -84,6 +84,11 @@ pub mod init {
 
                 pke
             }
+
+            fn reset(&mut self) {
+                self.keymap_context = smart_keymap::keymap::KeymapContext::new();
+                self.keyboard.reset();
+            }
         }
 
         impl keymap::SetKeymapContext for Context {

--- a/tests/ncl/keymap-1key-automation/expected.rs
+++ b/tests/ncl/keymap-1key-automation/expected.rs
@@ -95,6 +95,11 @@ pub mod init {
                 }
                 pke
             }
+
+            fn reset(&mut self) {
+                self.keymap_context = smart_keymap::keymap::KeymapContext::new();
+                self.automation.reset();
+            }
         }
 
         impl keymap::SetKeymapContext for Context {

--- a/tests/ncl/keymap-1key-callback-custom/expected.rs
+++ b/tests/ncl/keymap-1key-callback-custom/expected.rs
@@ -84,6 +84,11 @@ pub mod init {
 
                 pke
             }
+
+            fn reset(&mut self) {
+                self.keymap_context = smart_keymap::keymap::KeymapContext::new();
+                self.callback.reset();
+            }
         }
 
         impl keymap::SetKeymapContext for Context {

--- a/tests/ncl/keymap-1key-custom/expected.rs
+++ b/tests/ncl/keymap-1key-custom/expected.rs
@@ -82,6 +82,11 @@ pub mod init {
 
                 pke
             }
+
+            fn reset(&mut self) {
+                self.keymap_context = smart_keymap::keymap::KeymapContext::new();
+                self.custom.reset();
+            }
         }
 
         impl keymap::SetKeymapContext for Context {

--- a/tests/ncl/keymap-1key-simple/expected.rs
+++ b/tests/ncl/keymap-1key-simple/expected.rs
@@ -84,6 +84,11 @@ pub mod init {
 
                 pke
             }
+
+            fn reset(&mut self) {
+                self.keymap_context = smart_keymap::keymap::KeymapContext::new();
+                self.keyboard.reset();
+            }
         }
 
         impl keymap::SetKeymapContext for Context {

--- a/tests/ncl/keymap-1key-tap_dance/expected.rs
+++ b/tests/ncl/keymap-1key-tap_dance/expected.rs
@@ -94,6 +94,12 @@ pub mod init {
 
                 pke
             }
+
+            fn reset(&mut self) {
+                self.keymap_context = smart_keymap::keymap::KeymapContext::new();
+                self.keyboard.reset();
+                self.tap_dance.reset();
+            }
         }
 
         impl keymap::SetKeymapContext for Context {

--- a/tests/ncl/keymap-1key-tap_hold/expected.rs
+++ b/tests/ncl/keymap-1key-tap_hold/expected.rs
@@ -94,6 +94,12 @@ pub mod init {
 
                 pke
             }
+
+            fn reset(&mut self) {
+                self.keymap_context = smart_keymap::keymap::KeymapContext::new();
+                self.keyboard.reset();
+                self.tap_hold.reset();
+            }
         }
 
         impl keymap::SetKeymapContext for Context {

--- a/tests/ncl/keymap-2key-2layer-composite/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-composite/expected.rs
@@ -105,6 +105,13 @@ pub mod init {
                 }
                 pke
             }
+
+            fn reset(&mut self) {
+                self.keymap_context = smart_keymap::keymap::KeymapContext::new();
+                self.keyboard.reset();
+                self.layered.reset();
+                self.tap_hold.reset();
+            }
         }
 
         impl keymap::SetKeymapContext for Context {

--- a/tests/ncl/keymap-2key-2layer-named-layer_string/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-named-layer_string/expected.rs
@@ -97,6 +97,12 @@ pub mod init {
                 }
                 pke
             }
+
+            fn reset(&mut self) {
+                self.keymap_context = smart_keymap::keymap::KeymapContext::new();
+                self.keyboard.reset();
+                self.layered.reset();
+            }
         }
 
         impl keymap::SetKeymapContext for Context {

--- a/tests/ncl/keymap-2key-2layer-named/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-named/expected.rs
@@ -97,6 +97,12 @@ pub mod init {
                 }
                 pke
             }
+
+            fn reset(&mut self) {
+                self.keymap_context = smart_keymap::keymap::KeymapContext::new();
+                self.keyboard.reset();
+                self.layered.reset();
+            }
         }
 
         impl keymap::SetKeymapContext for Context {

--- a/tests/ncl/keymap-2key-2layer-simple/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-simple/expected.rs
@@ -97,6 +97,12 @@ pub mod init {
                 }
                 pke
             }
+
+            fn reset(&mut self) {
+                self.keymap_context = smart_keymap::keymap::KeymapContext::new();
+                self.keyboard.reset();
+                self.layered.reset();
+            }
         }
 
         impl keymap::SetKeymapContext for Context {

--- a/tests/ncl/keymap-2key-chorded-named-th-lmod/expected.rs
+++ b/tests/ncl/keymap-2key-chorded-named-th-lmod/expected.rs
@@ -126,6 +126,14 @@ pub mod init {
                 }
                 pke
             }
+
+            fn reset(&mut self) {
+                self.keymap_context = smart_keymap::keymap::KeymapContext::new();
+                self.chorded.reset();
+                self.keyboard.reset();
+                self.layered.reset();
+                self.tap_hold.reset();
+            }
         }
 
         impl keymap::SetKeymapContext for Context {

--- a/tests/ncl/keymap-2key-chorded/expected.rs
+++ b/tests/ncl/keymap-2key-chorded/expected.rs
@@ -106,6 +106,12 @@ pub mod init {
                 }
                 pke
             }
+
+            fn reset(&mut self) {
+                self.keymap_context = smart_keymap::keymap::KeymapContext::new();
+                self.chorded.reset();
+                self.keyboard.reset();
+            }
         }
 
         impl keymap::SetKeymapContext for Context {

--- a/tests/ncl/keymap-34key-seniply/expected.rs
+++ b/tests/ncl/keymap-34key-seniply/expected.rs
@@ -108,6 +108,13 @@ pub mod init {
                 }
                 pke
             }
+
+            fn reset(&mut self) {
+                self.keymap_context = smart_keymap::keymap::KeymapContext::new();
+                self.keyboard.reset();
+                self.layered.reset();
+                self.sticky.reset();
+            }
         }
 
         impl keymap::SetKeymapContext for Context {

--- a/tests/ncl/keymap-48key-basic/expected.rs
+++ b/tests/ncl/keymap-48key-basic/expected.rs
@@ -102,6 +102,13 @@ pub mod init {
                 }
                 pke
             }
+
+            fn reset(&mut self) {
+                self.keymap_context = smart_keymap::keymap::KeymapContext::new();
+                self.callback.reset();
+                self.keyboard.reset();
+                self.layered.reset();
+            }
         }
 
         impl keymap::SetKeymapContext for Context {

--- a/tests/ncl/keymap-48key-rgoulter/expected.rs
+++ b/tests/ncl/keymap-48key-rgoulter/expected.rs
@@ -158,6 +158,19 @@ pub mod init {
                 }
                 pke
             }
+
+            fn reset(&mut self) {
+                self.keymap_context = smart_keymap::keymap::KeymapContext::new();
+                self.callback.reset();
+                self.chorded.reset();
+                self.consumer.reset();
+                self.keyboard.reset();
+                self.layered.reset();
+                self.mouse.reset();
+                self.sticky.reset();
+                self.tap_dance.reset();
+                self.tap_hold.reset();
+            }
         }
 
         impl keymap::SetKeymapContext for Context {

--- a/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
@@ -94,6 +94,12 @@ pub mod init {
 
                 pke
             }
+
+            fn reset(&mut self) {
+                self.keymap_context = smart_keymap::keymap::KeymapContext::new();
+                self.keyboard.reset();
+                self.tap_hold.reset();
+            }
         }
 
         impl keymap::SetKeymapContext for Context {

--- a/tests/ncl/keymap-60key-dvorak-simple/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple/expected.rs
@@ -84,6 +84,11 @@ pub mod init {
 
                 pke
             }
+
+            fn reset(&mut self) {
+                self.keymap_context = smart_keymap::keymap::KeymapContext::new();
+                self.keyboard.reset();
+            }
         }
 
         impl keymap::SetKeymapContext for Context {

--- a/tests/rust/layered.rs
+++ b/tests/rust/layered.rs
@@ -111,3 +111,28 @@ fn uses_base_when_pressed_after_layer_mod_released() {
     let actual_report = keymap.boot_keyboard_report();
     assert_eq!(expected_report, actual_report);
 }
+
+#[test]
+fn init_resets_active_layers() {
+    // Assemble: hold layer 1
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                layers = [
+                    [K.layer_mod.hold 1, K.A],
+                    [K.TTTT, K.B],
+                ],
+            }
+        "#
+    ));
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+
+    // Act: reset, then press the letter key without re-holding the mod
+    keymap.init();
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+
+    // Assert: layer state was cleared — base key, not layer 1
+    let expected_report: [u8; 8] = [0, 0, KC_A, 0, 0, 0, 0, 0];
+    assert_eq!(expected_report, keymap.boot_keyboard_report());
+}


### PR DESCRIPTION
## Summary

- `Keymap::init` / `keymap_init` previously cleared pressed keys and queues but left `key::Context` alone, so active layers (and other runtime context state) leaked across re-inits (e.g. Ceedling cases).
- Add `Context::reset` to rebuild each family context from its **stored keymap config** (not empty `Config::new()`), clearing ephemeral state while keeping timeouts, chords, etc.
- Call `reset` from `Keymap::init` and `ObservedKeymap::init`; emit aggregate `reset` in key_system codegen.
- Integration test: hold a layer mod, `init`, press letter → base key (not the held layer).

## Test plan

- [x] `cargo test -p smart-keymap-core --lib`
- [x] `cargo test -p smart-keymap --test rust-integration init_resets_active_layers`
- [x] ncl snapshot regen for `reset` in generated `key_system`