### PR TITLE
rust: prefer KeyEvents::event / schedule_event over bare Immediate

### DIFF
--- a/smart-keymap-core/src/key.rs
+++ b/smart-keymap-core/src/key.rs
@@ -46,17 +46,32 @@ impl<E: Copy + Debug> KeyEvents<E> {
         KeyEvents(None.into_iter().collect())
     }
 
-    /// Constructs a [KeyEvents] with an immediate [Event].
+    /// Constructs a [KeyEvents] with one same-turn [Event].
+    ///
+    /// Prefer this for effects that should run in the current turn
+    ///  (via the event scheduler's pending queue).
+    /// For delayed effects, use [`Self::schedule_event`] or
+    ///  [`Self::scheduled_event`] with [`ScheduledEvent::after`].
+    ///
+    /// This is **not** the physical input delay line
+    ///  (`InputEventQueue` one-per-tick pacing).
     pub fn event(event: Event<E>) -> Self {
         KeyEvents(Some(ScheduledEvent::immediate(event)).into_iter().collect())
     }
 
-    /// Constructs a [KeyEvents] with an [Event] scheduled after a delay.
+    /// Constructs a [KeyEvents] from a single [ScheduledEvent]
+    ///  (typically [`ScheduledEvent::after`]).
     pub fn scheduled_event(sch_event: ScheduledEvent<E>) -> Self {
         KeyEvents(Some(sch_event).into_iter().collect())
     }
 
-    /// Adds an event with the schedule to the [KeyEvents].
+    /// Appends a same-turn [Event] (see [`Self::event`]).
+    pub fn add_event(&mut self, event: Event<E>) {
+        let _ = self.0.push(ScheduledEvent::immediate(event));
+    }
+
+    /// Appends an [Event] scheduled after `delay` ticks/ms units
+    ///  (promoted on `Keymap::tick`, not same-turn).
     pub fn schedule_event(&mut self, delay: u16, event: Event<E>) {
         let _ = self.0.push(ScheduledEvent::after(delay, event));
     }
@@ -66,11 +81,6 @@ impl<E: Copy + Debug> KeyEvents<E> {
         other.0.into_iter().for_each(|ev| {
             let _ = self.0.push(ev);
         });
-    }
-
-    /// Adds an event from to the [KeyEvents].
-    pub fn add_event(&mut self, ev: ScheduledEvent<E>) {
-        let _ = self.0.push(ev);
     }
 
     /// Maps over the KeyEvents.
@@ -818,28 +828,36 @@ impl<T> From<input::Event> for Event<T> {
     }
 }
 
-/// Schedule for a [ScheduledEvent].
-#[allow(unused)]
+/// When the event scheduler should deliver a [ScheduledEvent].
+///
+/// Orthogonal to physical input pacing (`InputEventQueue`):
+/// - [`Schedule::Immediate`] — enqueue for same-turn drain
+///   (`EventScheduler` pending queue → `handle_pending_events`).
+/// - [`Schedule::After`] — wait until `Keymap::tick` advances time;
+///   **not** the same as Immediate even when delay is `0`
+///   (still waits for a tick boundary).
+///
+/// Prefer constructing via [`KeyEvents::event`] / [`KeyEvents::schedule_event`]
+///  rather than building these variants by hand.
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
 pub enum Schedule {
-    /// Immediately.
+    /// Same-turn: pending queue, drained before returning to the caller.
     Immediate,
-    /// After a given number of `tick`s.
+    /// After the given number of `tick` units (ms when `ms_per_tick` is 1).
     After(u16),
 }
 
-/// Schedules a given `T` with [Event], for some [Schedule].
+/// An [Event] with a [Schedule] for the keymap event scheduler.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ScheduledEvent<T> {
-    /// Whether to handle the event immediately, or after some delay.
+    /// When to deliver the event (same-turn vs after delay).
     pub schedule: Schedule,
     /// The event.
     pub event: Event<T>,
 }
 
 impl<T: Copy> ScheduledEvent<T> {
-    /// Constructs a [ScheduledEvent] with [Schedule::Immediate].
-    #[allow(unused)]
+    /// Same-turn [ScheduledEvent]; prefer [`KeyEvents::event`] at call sites.
     pub fn immediate(event: Event<T>) -> Self {
         ScheduledEvent {
             schedule: Schedule::Immediate,
@@ -847,7 +865,7 @@ impl<T: Copy> ScheduledEvent<T> {
         }
     }
 
-    /// Constructs a [ScheduledEvent] with [Schedule::After].
+    /// Delayed [ScheduledEvent]; also available as [`KeyEvents::schedule_event`].
     pub fn after(delay: u16, event: Event<T>) -> Self {
         ScheduledEvent {
             schedule: Schedule::After(delay),

--- a/smart-keymap-core/src/key/automation.rs
+++ b/smart-keymap-core/src/key/automation.rs
@@ -278,13 +278,13 @@ impl<const INSTRUCTION_COUNT: usize> Context<INSTRUCTION_COUNT> {
 
             // If there's more to execute, schedule it to execute.
             if !self.execution_queue[0].is_empty() {
-                pke.add_event(key::ScheduledEvent::after(
+                pke.schedule_event(
                     self.config.instruction_duration,
                     key::Event::Key {
                         keymap_index,
                         key_event: Event::NextInstruction,
                     },
-                ));
+                );
             }
         }
 
@@ -363,52 +363,40 @@ pub fn key_events_for<const INSTRUCTION_COUNT: usize>(
 
     match instruction {
         Instruction::NoOp => {
-            let sch_ev = key::ScheduledEvent::after(config.instruction_duration, next_key_ev);
-            key::KeyEvents::scheduled_event(sch_ev)
+            let mut pke = key::KeyEvents::no_events();
+            pke.schedule_event(config.instruction_duration, next_key_ev);
+            pke
         }
         Instruction::Press(key_output) => {
-            let sch_ev =
-                key::ScheduledEvent::immediate(key::Event::Input(input::Event::VirtualKeyPress {
-                    key_output,
-                }));
-
-            let mut pke = key::KeyEvents::scheduled_event(sch_ev);
-            let sch_ev = key::ScheduledEvent::after(config.instruction_duration, next_key_ev);
-            pke.add_event(sch_ev);
-
+            let mut pke = key::KeyEvents::event(key::Event::Input(input::Event::VirtualKeyPress {
+                key_output,
+            }));
+            pke.schedule_event(config.instruction_duration, next_key_ev);
             pke
         }
         Instruction::Release(key_output) => {
-            let sch_ev = key::ScheduledEvent::immediate(key::Event::Input(
-                input::Event::VirtualKeyRelease { key_output },
-            ));
-
-            let mut pke = key::KeyEvents::scheduled_event(sch_ev);
-            let sch_ev = key::ScheduledEvent::after(config.instruction_duration, next_key_ev);
-            pke.add_event(sch_ev);
-
+            let mut pke =
+                key::KeyEvents::event(key::Event::Input(input::Event::VirtualKeyRelease {
+                    key_output,
+                }));
+            pke.schedule_event(config.instruction_duration, next_key_ev);
             pke
         }
         Instruction::Tap(key_output) => {
-            let sch_press_ev =
-                key::ScheduledEvent::immediate(key::Event::Input(input::Event::VirtualKeyPress {
-                    key_output,
-                }));
-            let sch_release_ev = key::ScheduledEvent::after(
+            let mut pke = key::KeyEvents::event(key::Event::Input(input::Event::VirtualKeyPress {
+                key_output,
+            }));
+            pke.schedule_event(
                 config.instruction_duration,
                 key::Event::Input(input::Event::VirtualKeyRelease { key_output }),
             );
-
-            let mut pke = key::KeyEvents::scheduled_event(sch_press_ev);
-            pke.add_event(sch_release_ev);
-            let sch_ev = key::ScheduledEvent::after(config.instruction_duration, next_key_ev);
-            pke.add_event(sch_ev);
-
+            pke.schedule_event(config.instruction_duration, next_key_ev);
             pke
         }
         Instruction::Wait(ticks) => {
-            let sch_ev = key::ScheduledEvent::after(ticks, next_key_ev);
-            key::KeyEvents::scheduled_event(sch_ev)
+            let mut pke = key::KeyEvents::no_events();
+            pke.schedule_event(ticks, next_key_ev);
+            pke
         }
     }
 }

--- a/smart-keymap-core/src/key/chorded.rs
+++ b/smart-keymap-core/src/key/chorded.rs
@@ -609,15 +609,11 @@ impl<
             };
 
             let ch_r_ev = Event::ChordResolved(ch_state);
-            let sch_ev =
-                key::ScheduledEvent::immediate(key::Event::key_event(keymap_index, ch_r_ev));
+            let pke = key::KeyEvents::event(key::Event::key_event(keymap_index, ch_r_ev));
 
             if let Some(new_key_ref) = maybe_new_key_ref {
-                let pke = key::KeyEvents::scheduled_event(sch_ev);
-
                 (Some(key::NewPressedKey::key(new_key_ref)), pke)
             } else {
-                let pke = key::KeyEvents::scheduled_event(sch_ev);
                 (Some(key::NewPressedKey::no_op()), pke)
             }
         } else {
@@ -724,9 +720,7 @@ impl<
         let ch_state = pending_state.handle_event(keymap_index, event);
         if let Some(ChordResolution::Passthrough) = ch_state {
             let ch_r_ev = Event::ChordResolved(ChordResolution::Passthrough);
-            let sch_ev =
-                key::ScheduledEvent::immediate(key::Event::key_event(keymap_index, ch_r_ev));
-            let pke = key::KeyEvents::scheduled_event(sch_ev);
+            let pke = key::KeyEvents::event(key::Event::key_event(keymap_index, ch_r_ev));
 
             (Some(key::NewPressedKey::key(self.passthrough)), pke)
         } else if let Some(ChordResolution::Chord(resolved_chord_id)) = ch_state {

--- a/smart-keymap-core/src/key/sticky.rs
+++ b/smart-keymap-core/src/key/sticky.rs
@@ -244,7 +244,7 @@ impl Context {
                         let vk_ev = key::Event::Input(input::Event::VirtualKeyRelease {
                             key_output: sticky_key_output,
                         });
-                        pke.add_event(key::ScheduledEvent::immediate(vk_ev));
+                        pke.add_event(vk_ev);
                     });
 
                 self.active_modifier_count = 0;
@@ -271,7 +271,7 @@ impl Context {
                         let vk_ev = key::Event::Input(input::Event::VirtualKeyRelease {
                             key_output: sticky_key_output,
                         });
-                        pke.add_event(key::ScheduledEvent::immediate(vk_ev));
+                        pke.add_event(vk_ev);
                     });
 
                 self.active_modifier_count = 0;
@@ -395,7 +395,7 @@ impl KeyState {
                             });
 
                             let mut pke = key::KeyEvents::event(k_ev);
-                            pke.add_event(key::ScheduledEvent::immediate(vk_ev));
+                            pke.add_event(vk_ev);
                             pke
                         }
                     }

--- a/smart-keymap-core/src/keymap/event_scheduler.rs
+++ b/smart-keymap-core/src/keymap/event_scheduler.rs
@@ -1,3 +1,15 @@
+//! Keymap event scheduler: same-turn pending queue vs time-based delays.
+//!
+//! Smart keys emit [`key::ScheduledEvent`]s. Delivery is **orthogonal** to
+//!  physical input pacing (`InputEventQueue` one-input-per-tick delay line):
+//!
+//! - [`key::Schedule::Immediate`] → `pending_events`, drained in the same turn
+//!   via `Keymap::handle_pending_events`. Prefer constructing these with
+//!   [`key::KeyEvents::event`].
+//! - [`key::Schedule::After`] → `scheduled_events` timed list, promoted on
+//!   [`EventScheduler::tick`]. Prefer [`key::KeyEvents::schedule_event`].
+//!   Delay `0` still waits for a tick boundary (not the same as Immediate).
+
 use core::cmp::PartialEq;
 use core::fmt::Debug;
 use core::marker::Copy;


### PR DESCRIPTION
## Summary

- Standardize smart-key event emission: same-turn work uses `KeyEvents::event` / `add_event`, delays use `schedule_event`, instead of spelling `ScheduledEvent::immediate` by hand.
- Document that `Schedule::Immediate` is orthogonal to the physical input delay line, and that `After(0)` is not Immediate.
- Update chorded, sticky, and automation call sites accordingly.

## Test plan

- [x] `cargo test -p smart-keymap-core`
- [x] `cargo test -p smart-keymap-full-system-std` (cucumber + keymap delay-line tests)