### PR TITLE
Feature/layer lock

### DIFF
--- a/features/keymap/key/layer_modifier-lock.feature
+++ b/features/keymap/key/layer_modifier-lock.feature
@@ -1,0 +1,178 @@
+Feature: Layer Modifier: Lock
+
+  The `K.layer_mod.lock` key locks the highest currently active layer so it stays
+  on after the momentary (hold) layer modifier is released.
+
+  The `K.layer_mod.lock_layer` key locks or unlocks a specific layer (activates
+  the layer when locking; deactivates when unlocking).
+
+  For examples of this feature in other smart keyboard firmware, see e.g.:
+
+  - [QMK's Layer Lock](https://docs.qmk.fm/features/layer_lock),
+
+  - [Miryoku's CURR / OPP layer lock](https://github.com/manna-harbour/miryoku/tree/master/docs/reference)
+
+  Example: locking a held layer keeps it active after hold is released
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        layers = [
+          [
+            K.layer_mod.hold 1,
+            K.layer_mod.lock,
+            K.A,
+          ],
+          [
+            K.TTTT,
+            K.TTTT,
+            K.B,
+          ],
+        ],
+      }
+      """
+    When the keymap registers the following input
+      """
+      [
+        press (K.layer_mod.hold 1),
+        tap (K.layer_mod.lock),
+        release (K.layer_mod.hold 1),
+        press (K.B),
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { key_codes = [K.B] }
+      """
+
+  Example: tapping lock again unlocks and deactivates the layer
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        layers = [
+          [
+            K.layer_mod.hold 1,
+            K.layer_mod.lock,
+            K.A,
+          ],
+          [
+            K.TTTT,
+            K.TTTT,
+            K.B,
+          ],
+        ],
+      }
+      """
+    When the keymap registers the following input
+      """
+      [
+        press (K.layer_mod.hold 1),
+        tap (K.layer_mod.lock),
+        release (K.layer_mod.hold 1),
+        tap (K.layer_mod.lock),
+        press (K.A),
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { key_codes = [K.A] }
+      """
+
+  Example: pressing hold again while locked unlocks the layer
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        layers = [
+          [
+            K.layer_mod.hold 1,
+            K.layer_mod.lock,
+            K.A,
+          ],
+          [
+            K.TTTT,
+            K.TTTT,
+            K.B,
+          ],
+        ],
+      }
+      """
+    When the keymap registers the following input
+      """
+      [
+        press (K.layer_mod.hold 1),
+        tap (K.layer_mod.lock),
+        release (K.layer_mod.hold 1),
+        tap (K.layer_mod.hold 1),
+        press (K.A),
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { key_codes = [K.A] }
+      """
+
+  Example: lock_layer activates an inactive layer
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        layers = [
+          [
+            K.layer_mod.lock_layer 1,
+            K.A,
+          ],
+          [
+            K.TTTT,
+            K.B,
+          ],
+        ],
+      }
+      """
+    When the keymap registers the following input
+      """
+      [
+        tap (K.layer_mod.lock_layer 1),
+        press (K.B),
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { key_codes = [K.B] }
+      """
+
+  Example: lock_layer a second time deactivates the layer
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        layers = [
+          [
+            K.layer_mod.lock_layer 1,
+            K.A,
+          ],
+          [
+            K.TTTT,
+            K.B,
+          ],
+        ],
+      }
+      """
+    When the keymap registers the following input
+      """
+      [
+        tap (K.layer_mod.lock_layer 1),
+        tap (K.layer_mod.lock_layer 1),
+        press (K.A),
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { key_codes = [K.A] }
+      """

--- a/ncl/inputs-to-json.ncl
+++ b/ncl/inputs-to-json.ncl
@@ -91,7 +91,12 @@
       let initial_active_layers =
         std.array.generate (std.function.const false) max_layered_length
       in
-      { default_layer = 0, active_layers = initial_active_layers }
+      {
+        default_layer = 0,
+        active_layers = initial_active_layers,
+        # Parallel flags for locked layers.
+        locked_layers = initial_active_layers,
+      }
     in
     let { json_value, .. } =
       std.array.fold_left

--- a/ncl/layered-key.ncl
+++ b/ncl/layered-key.ncl
@@ -68,19 +68,120 @@
     },
   },
 
+  # Highest active layer index (1-based), or null if none.
+  highest_active_layer = fun active_layers =>
+    std.array.fold_left
+      (fun acc is_active =>
+        let { idx, found } = acc in
+        if is_active then
+          { idx = idx + 1, found = idx + 1 }
+        else
+          { idx = idx + 1, found = found }
+      )
+      { idx = 0, found = null }
+      active_layers
+    |> (fun { found, .. } => found),
+
+  # True if flags[layer_idx - 1] is set. Invalid / out-of-range indices are false.
+  layer_flag_at = fun flags layer_idx =>
+    let idx = layer_idx - 1 in
+    if idx >= 0 && idx < std.array.length flags then
+      std.array.at idx flags
+    else
+      false,
+
   update_layer_state_for_input = fun input layer_state @ { default_layer, active_layers } =>
     input
     |> match {
       'Press { layer_modifier = { hold }, .. } =>
-        let { active_layers = al, ..layer_state } = layer_state in
-        { active_layers = activate_layer al hold } & layer_state,
+        let { active_layers = al, ..without_active_layers } = layer_state in
+        let ll =
+          if std.record.has_field "locked_layers" without_active_layers then without_active_layers.locked_layers else []
+        in
+        let other_fields =
+          if std.record.has_field "locked_layers" without_active_layers then
+            std.record.remove "locked_layers" without_active_layers
+          else
+            without_active_layers
+        in
+        if layer_flag_at ll hold then
+          {
+            active_layers = deactivate_layer al hold,
+            locked_layers = set_layer false ll hold,
+          }
+          & other_fields
+        else
+          { active_layers = activate_layer al hold, locked_layers = ll } & other_fields,
       'Release { layer_modifier = { hold }, .. } =>
-        let { active_layers = al, ..layer_state } = layer_state in
-        { active_layers = deactivate_layer al hold } & layer_state,
+        let { active_layers = al, ..without_active_layers } = layer_state in
+        let ll =
+          if std.record.has_field "locked_layers" without_active_layers then without_active_layers.locked_layers else []
+        in
+        let other_fields =
+          if std.record.has_field "locked_layers" without_active_layers then
+            std.record.remove "locked_layers" without_active_layers
+          else
+            without_active_layers
+        in
+        if layer_flag_at ll hold then
+          { active_layers = al, locked_layers = ll } & other_fields
+        else
+          { active_layers = deactivate_layer al hold, locked_layers = ll } & other_fields,
       'Press { layer_modifier = { toggle }, .. } or
       'Tap { layer_modifier = { toggle }, .. } =>
         let { active_layers = al, ..layer_state } = layer_state in
         { active_layers = toggle_layer al toggle } & layer_state,
+      'Press { layer_modifier = { lock = true }, .. } or
+      'Tap { layer_modifier = { lock = true }, .. } =>
+        let { active_layers = al, ..without_active_layers } = layer_state in
+        let ll =
+          if std.record.has_field "locked_layers" without_active_layers then without_active_layers.locked_layers else []
+        in
+        let other_fields =
+          if std.record.has_field "locked_layers" without_active_layers then
+            std.record.remove "locked_layers" without_active_layers
+          else
+            without_active_layers
+        in
+        let layer = highest_active_layer al in
+        if layer == null then
+          { active_layers = al, locked_layers = ll } & other_fields
+        else if layer_flag_at ll layer then
+          {
+            active_layers = deactivate_layer al layer,
+            locked_layers = set_layer false ll layer,
+          }
+          & other_fields
+        else
+          {
+            active_layers = activate_layer al layer,
+            locked_layers = set_layer true ll layer,
+          }
+          & other_fields,
+      'Press { layer_modifier = { lock = lock_layer }, .. } or
+      'Tap { layer_modifier = { lock = lock_layer }, .. } =>
+        let { active_layers = al, ..without_active_layers } = layer_state in
+        let ll =
+          if std.record.has_field "locked_layers" without_active_layers then without_active_layers.locked_layers else []
+        in
+        let other_fields =
+          if std.record.has_field "locked_layers" without_active_layers then
+            std.record.remove "locked_layers" without_active_layers
+          else
+            without_active_layers
+        in
+        if layer_flag_at ll lock_layer then
+          {
+            active_layers = deactivate_layer al lock_layer,
+            locked_layers = set_layer false ll lock_layer,
+          }
+          & other_fields
+        else
+          {
+            active_layers = activate_layer al lock_layer,
+            locked_layers = set_layer true ll lock_layer,
+          }
+          & other_fields,
       'Press { layer_modifier = lm, .. } or
       'Tap { layer_modifier = lm, .. } =>
         if std.record.has_field "set_active_layers_to" lm then

--- a/ncl/passes/named-layers.ncl
+++ b/ncl/passes/named-layers.ncl
@@ -261,6 +261,11 @@
         { layer_modifier = { sticky = resolve_layer_index name_to_idx s } },
       { layer_modifier = { toggle = t } } =>
         { layer_modifier = { toggle = resolve_layer_index name_to_idx t } },
+      # true = highest active (no named-layer resolution); number/string = specific layer.
+      { layer_modifier = { lock = true } } =>
+        { layer_modifier = { lock = true } },
+      { layer_modifier = { lock = lock_layer } } =>
+        { layer_modifier = { lock = resolve_layer_index name_to_idx lock_layer } },
       { layer_modifier = { set_active_layers_to = active, affected_layers = mask } } =>
         {
           layer_modifier = {

--- a/ncl/smart_keys/layered/key-extensions.ncl
+++ b/ncl/smart_keys/layered/key-extensions.ncl
@@ -17,6 +17,13 @@
         {
           layer_modifier = { sticky = layer_num }
         },
+      # Lock highest currently active layer.
+      lock = { layer_modifier = { lock = true } },
+      # Lock/unlock a specific layer.
+      lock_layer = fun layer_num =>
+        {
+          layer_modifier = { lock = layer_num }
+        },
       set_active_layers_to = fun active_layers =>
         {
           layer_modifier = { set_active_layers_to = active_layers }

--- a/ncl/smart_keys/layered/keymap-codegen.ncl
+++ b/ncl/smart_keys/layered/keymap-codegen.ncl
@@ -74,6 +74,12 @@
     check_json_is_toggle =
       let json = { Toggle = 1 } in
       smart_keymap.layered.modifier_key.is_json json,
+    check_json_is_lock =
+      let json = { Lock = "HighestActive" } in
+      smart_keymap.layered.modifier_key.is_json json,
+    check_json_is_lock_layer =
+      let json = { Lock = { Layer = 2 } } in
+      smart_keymap.layered.modifier_key.is_json json,
   },
 
   smart_keymap.layered
@@ -87,13 +93,13 @@
         key_type = "%{module}::ModifierKey",
 
         # c.f. doc_de_layered.md.
-        # JSON serialization of key::layered::ModifierKey has variants: Default(layer), Hold([layer, kb_mods]), SetActiveLayers({ layers, mask? }).
+        # JSON serialization of key::layered::ModifierKey has variants: Default(layer), Hold([layer, kb_mods]), SetActiveLayers({ layers, mask? }), Lock("HighestActive"|{ Layer }).
         json_validator =
           validators.record.validator {
             fields_validator =
               validators.all_of [
-                validators.record.has_any_field_of ["Default", "Hold", "Sticky", "SetActiveLayers", "Toggle"],
-                validators.record.has_only_fields ["Default", "Hold", "Sticky", "SetActiveLayers", "Toggle"],
+                validators.record.has_any_field_of ["Default", "Hold", "Sticky", "SetActiveLayers", "Toggle", "Lock"],
+                validators.record.has_only_fields ["Default", "Hold", "Sticky", "SetActiveLayers", "Toggle", "Lock"],
               ],
             field_validators =
               let modifier_bitset_validator =
@@ -122,6 +128,23 @@
                   },
                 Toggle = validators.is_number,
                 Sticky = validators.is_number,
+                # LayerLockTarget: "HighestActive" | { Layer = layer_index } (1-based).
+                Lock = fun lock =>
+                  lock
+                  |> match {
+                    "HighestActive" => 'Ok,
+                    { Layer = layer_index } =>
+                      validators.all_of
+                        [
+                          validators.is_number,
+                          validators.is_greater_than 0,
+                        ]
+                        layer_index,
+                    _ =>
+                      'Error {
+                        message = "expected Lock to be \"HighestActive\" or { Layer = layer_index > 0 }",
+                      },
+                  },
                 SetActiveLayers = modifier_bitset_validator,
               },
           },
@@ -169,6 +192,22 @@
                 include key_type,
                 variant = "Sticky",
                 rust_expr = "%{module}::ModifierKey::sticky(%{std.to_string layer_index})",
+              },
+            { Lock = "HighestActive" } =>
+              {
+                include json,
+                include module,
+                include key_type,
+                variant = "Lock",
+                rust_expr = "%{module}::ModifierKey::lock()",
+              },
+            { Lock = { Layer = layer_index } } =>
+              {
+                include json,
+                include module,
+                include key_type,
+                variant = "Lock",
+                rust_expr = "%{module}::ModifierKey::lock_layer(%{std.to_string layer_index})",
               },
             { SetActiveLayers = { layers = active_layers_bitset } } =>
               {

--- a/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
@@ -25,6 +25,26 @@
         actual = K.layer_mod.toggle 1 |> keymap_ncl.key.to_json_value,
         expected = { Toggle = 1 },
       },
+
+      keymap_example_lock = {
+        actual = K.layer_mod.lock,
+        expected = { layer_modifier.lock = true },
+      },
+
+      check_json_value_lock = {
+        actual = K.layer_mod.lock |> keymap_ncl.key.to_json_value,
+        expected = { Lock = "HighestActive" },
+      },
+
+      keymap_example_lock_layer = {
+        actual = K.layer_mod.lock_layer 2,
+        expected = { layer_modifier.lock = 2 },
+      },
+
+      check_json_value_lock_layer = {
+        actual = K.layer_mod.lock_layer 2 |> keymap_ncl.key.to_json_value,
+        expected = { Lock = { Layer = 2 } },
+      },
       check_json_value_set_active_layers_amongst = {
         actual =
           K.layer_mod.set_active_layers_amongst {
@@ -155,6 +175,14 @@
               'Ok
             else
               validators.all_of [validators.is_number, validators.is_greater_than 0] toggle,
+          { layer_modifier = { lock } } =>
+            # true = highest active; named layer string ok; numeric layer index must be > 0.
+            if std.is_bool lock then
+              if lock then 'Ok else 'Error { message = "layer_modifier.lock must be true or a layer index" }
+            else if std.is_string lock then
+              'Ok
+            else
+              validators.all_of [validators.is_number, validators.is_greater_than 0] lock,
           { layer_modifier = { set_active_layers_to } } => layer_indices_array set_active_layers_to,
           { layer_modifier = { set_active_layers_to, affected_layers } } =>
             validators.all_ok [
@@ -163,7 +191,7 @@
             ],
           _ =>
             'Error {
-              message = "expected { layer_modifier = { default_ } }, { hold }, { sticky }, { toggle }, { set_active_layers_to }, or { set_active_layers_to, affected_layers }",
+              message = "expected { layer_modifier = { default_ } }, { hold }, { sticky }, { toggle }, { lock }, { set_active_layers_to }, or { set_active_layers_to, affected_layers }",
             },
         },
 
@@ -185,6 +213,10 @@
             { Toggle = toggle_layer },
           { layer_modifier = { sticky = sticky_layer } } =>
             { Sticky = sticky_layer },
+          { layer_modifier = { lock = true } } =>
+            { Lock = "HighestActive" },
+          { layer_modifier = { lock = lock_layer } } =>
+            { Lock = { Layer = lock_layer } },
           { layer_modifier = { set_active_layers_to = active_layers } } =>
             let modifier_bitset = { layers = layer_indices_to_bitset active_layers } in
             { SetActiveLayers = modifier_bitset },
@@ -197,7 +229,7 @@
             { SetActiveLayers = modifier_bitset },
           _ =>
             'Error {
-              message = "expected { layer_modifier = { default_ } }, { hold }, { sticky }, { toggle }, { set_active_layers_to }, or { set_active_layers_to, affected_layers }",
+              message = "expected { layer_modifier = { default_ } }, { hold }, { sticky }, { toggle }, { lock }, { set_active_layers_to }, or { set_active_layers_to, affected_layers }",
             },
         },
 

--- a/smart-keymap-core/src/key/layered.rs
+++ b/smart-keymap-core/src/key/layered.rs
@@ -10,6 +10,11 @@ use crate::key::KeyboardModifiers;
 use crate::slice::Slice;
 
 /// The type used for layer index.
+///
+/// Layer modifiers and layer events use **1-based** indices (`1` = first non-base
+/// layer). Index `0` is reserved (base / always active). Call sites must only
+/// pass indices in range for the keymap's layer count; out-of-range values are
+/// a construction bug and are checked with [`debug_assert`] in debug builds.
 pub type LayerIndex = u32;
 
 /// Fixed-capacity bitset of layers for modifier / conditional-layer state.
@@ -54,6 +59,15 @@ impl LayerBitset {
     pub const fn insert(self, index: usize) -> Self {
         if index < Self::BITS {
             Self(self.0 | (1u32 << index))
+        } else {
+            self
+        }
+    }
+
+    /// Returns a copy with bit `index` cleared, if `index` is in range.
+    pub const fn remove(self, index: usize) -> Self {
+        if index < Self::BITS {
+            Self(self.0 & !(1u32 << index))
         } else {
             self
         }
@@ -141,6 +155,15 @@ pub enum Ref {
     Layered(u8),
 }
 
+/// Target of a layer-lock action.
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub enum LayerLockTarget {
+    /// Highest currently active layer.
+    HighestActive,
+    /// A specific layer.
+    Layer(LayerIndex),
+}
+
 /// Modifier layer key affects what layers are active.
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq)]
 pub enum ModifierKey {
@@ -157,6 +180,14 @@ pub enum ModifierKey {
     SetActiveLayers(ModifierBitset),
     /// Sets the default layer.
     Default(LayerIndex),
+    /// Layer lock key.
+    ///
+    /// Inverts lock on the [LayerLockTarget]: if unlocked, lock and activate; if locked,
+    /// unlock and deactivate.
+    ///
+    /// While a layer is locked, releasing a [`ModifierKey::Hold`] that activated it leaves the
+    /// layer active. Pressing that [`ModifierKey::Hold`] again unlocks and turns the layer off.
+    Lock(LayerLockTarget),
 }
 
 impl ModifierKey {
@@ -229,6 +260,16 @@ impl ModifierKey {
         ModifierKey::Default(layer)
     }
 
+    /// Create a [ModifierKey::Lock] that targets the highest currently active layer.
+    pub const fn lock() -> Self {
+        ModifierKey::Lock(LayerLockTarget::HighestActive)
+    }
+
+    /// Create a [ModifierKey::Lock] that targets a specific layer.
+    pub const fn lock_layer(layer: LayerIndex) -> Self {
+        ModifierKey::Lock(LayerLockTarget::Layer(layer))
+    }
+
     /// Create a new [input::PressedKey] and [key::ScheduledEvent] for the given keymap index.
     ///
     /// Pressing a [ModifierKey::Hold] emits a [LayerEvent::Activated] event.
@@ -251,6 +292,10 @@ impl ModifierKey {
             ModifierKey::Default(layer) => (
                 ModifierKeyState::new(),
                 Some(LayerEvent::SetDefault(*layer)),
+            ),
+            ModifierKey::Lock(target) => (
+                ModifierKeyState::new(),
+                Some(LayerEvent::LockInvert(*target)),
             ),
         }
     }
@@ -301,10 +346,12 @@ pub trait LayerState: Copy + Debug {
 impl<const L: usize> LayerState for [Activity; L] {
     fn activate(&mut self, layer_index: LayerIndex, style: ActivationStyle) {
         let layer_index: usize = layer_index as usize;
+        // 1-based layer indices; keymap construction / NCL validation must ensure range.
         debug_assert!(
-            layer_index <= L,
-            "layer must be less than array length of {}",
-            L
+            (1..=L).contains(&layer_index),
+            "layer must be in 1..={} (got {})",
+            L,
+            layer_index
         );
         self[layer_index - 1] = Activity::Active(style);
     }
@@ -312,9 +359,10 @@ impl<const L: usize> LayerState for [Activity; L] {
     fn deactivate(&mut self, layer_index: LayerIndex) {
         let layer_index: usize = layer_index as usize;
         debug_assert!(
-            layer_index <= L,
-            "layer must be less than array length of {}",
-            L
+            (1..=L).contains(&layer_index),
+            "layer must be in 1..={} (got {})",
+            L,
+            layer_index
         );
         self[layer_index - 1] = Activity::Inactive;
     }
@@ -439,6 +487,10 @@ pub struct Context<const LAYER_COUNT: usize, const CONDITIONAL_LAYER_COUNT: usiz
     config: Config<CONDITIONAL_LAYER_COUNT>,
     default_layer: Option<LayerIndex>,
     active_layers: [Activity; LAYER_COUNT],
+    /// Bitset of locked layers (bit `i` = layer `i` is locked).
+    ///
+    /// Locked layers stay active when a [ModifierKey::Hold] for that layer is released.
+    locked_layers: LayerBitset,
     // Keymap index which was pressed while a layer was sticky.
     pressed_keymap_index: Option<u16>,
     // Invalidates pending sticky-timeout events when advanced.
@@ -458,6 +510,7 @@ impl<const LAYER_COUNT: usize, const CONDITIONAL_LAYER_COUNT: usize> Debug
                     active_layers: &self.active_layers,
                 },
             )
+            .field("locked_layers", &self.locked_layers)
             .field("pressed_keymap_index", &self.pressed_keymap_index)
             .field("sticky_timeout_id", &self.sticky_timeout_id)
             .finish()
@@ -478,6 +531,7 @@ impl<const LAYER_COUNT: usize, const CONDITIONAL_LAYER_COUNT: usize>
             config,
             default_layer: None,
             active_layers: [Activity::Inactive; LAYER_COUNT],
+            locked_layers: LayerBitset::EMPTY,
             pressed_keymap_index: None,
             sticky_timeout_id: 0,
         }
@@ -494,8 +548,56 @@ impl<const LAYER_COUNT: usize, const CONDITIONAL_LAYER_COUNT: usize>
 
     fn deactivate_sticky_layer(&mut self, layer: LayerIndex) {
         self.active_layers.deactivate(layer);
+        self.clear_layer_lock(layer);
         self.pressed_keymap_index = None;
         self.invalidate_sticky_timeouts();
+        self.apply_conditional_layers();
+    }
+
+    /// Returns true if `layer` is currently locked.
+    pub fn is_layer_locked(&self, layer: LayerIndex) -> bool {
+        self.locked_layers.contains(layer as usize)
+    }
+
+    fn set_layer_lock(&mut self, layer: LayerIndex) {
+        self.locked_layers = self.locked_layers.insert(layer as usize);
+    }
+
+    fn clear_layer_lock(&mut self, layer: LayerIndex) {
+        self.locked_layers = self.locked_layers.remove(layer as usize);
+    }
+
+    /// Highest active layer index, if any (1-based layers only).
+    fn highest_active_layer(&self) -> Option<LayerIndex> {
+        self.active_layers.active_layers().next()
+    }
+
+    /// Invert lock on `layer`.
+    ///
+    /// If unlocked: lock and turn the layer on.
+    /// If locked: unlock and turn the layer off.
+    ///
+    /// `layer` must be a valid 1-based index (`1..=LAYER_COUNT`); debug builds assert this
+    /// via [LayerState::activate] / [LayerState::deactivate].
+    fn lock_invert(&mut self, layer: LayerIndex) {
+        if self.is_layer_locked(layer) {
+            self.clear_layer_lock(layer);
+            self.active_layers.deactivate(layer);
+            if self.sticky_layer() == Some(layer) {
+                self.pressed_keymap_index = None;
+                self.invalidate_sticky_timeouts();
+            }
+        } else {
+            self.set_layer_lock(layer);
+            self.active_layers.activate(layer, ActivationStyle::Regular);
+            // Lock supersedes sticky wait on this layer.
+            if self.sticky_layer() == Some(layer) {
+                self.pressed_keymap_index = None;
+                self.invalidate_sticky_timeouts();
+            } else {
+                self.invalidate_sticky_timeouts();
+            }
+        }
         self.apply_conditional_layers();
     }
 
@@ -525,6 +627,9 @@ impl<const LAYER_COUNT: usize, const CONDITIONAL_LAYER_COUNT: usize>
                 self.active_layers
                     .activate(rule.then_layer, ActivationStyle::Regular);
                 true
+            } else if self.is_layer_locked(rule.then_layer) {
+                // Locked layers stay active even when conditional if-layers drop.
+                changed
             } else {
                 self.active_layers.deactivate(rule.then_layer);
                 true
@@ -576,17 +681,28 @@ impl<const LAYER_COUNT: usize, const CONDITIONAL_LAYER_COUNT: usize>
     fn handle_layer_event(&mut self, event: LayerEvent) -> key::KeyEvents<LayerEvent> {
         match event {
             LayerEvent::Activated(layer) => {
-                self.active_layers.activate(layer, ActivationStyle::Regular);
+                if self.is_layer_locked(layer) {
+                    // Hold pressed while layer is locked: unlock and turn off.
+                    self.clear_layer_lock(layer);
+                    self.active_layers.deactivate(layer);
+                } else {
+                    self.active_layers.activate(layer, ActivationStyle::Regular);
+                }
                 // Sticky cancelled / converted to hold — drop any sticky timeout.
                 self.invalidate_sticky_timeouts();
                 self.apply_conditional_layers();
                 key::KeyEvents::no_events()
             }
             LayerEvent::Deactivated(layer) => {
-                self.active_layers.deactivate(layer);
-                self.invalidate_sticky_timeouts();
-                self.apply_conditional_layers();
-                key::KeyEvents::no_events()
+                if self.is_layer_locked(layer) {
+                    // Locked layers stay on when the Hold that activated them is released.
+                    key::KeyEvents::no_events()
+                } else {
+                    self.active_layers.deactivate(layer);
+                    self.invalidate_sticky_timeouts();
+                    self.apply_conditional_layers();
+                    key::KeyEvents::no_events()
+                }
             }
             LayerEvent::StickyActivated(layer) => {
                 self.active_layers.activate(layer, ActivationStyle::Sticky);
@@ -627,6 +743,7 @@ impl<const LAYER_COUNT: usize, const CONDITIONAL_LAYER_COUNT: usize>
             LayerEvent::Toggled(layer) => {
                 if self.active_layers[layer as usize - 1].is_active() {
                     self.active_layers.deactivate(layer);
+                    self.clear_layer_lock(layer);
                 } else {
                     self.active_layers.activate(layer, ActivationStyle::Regular);
                 }
@@ -644,6 +761,7 @@ impl<const LAYER_COUNT: usize, const CONDITIONAL_LAYER_COUNT: usize>
                                 .activate(li as LayerIndex, ActivationStyle::Regular);
                         } else {
                             self.active_layers.deactivate(li as LayerIndex);
+                            self.clear_layer_lock(li as LayerIndex);
                         }
                     }
                 }
@@ -656,6 +774,16 @@ impl<const LAYER_COUNT: usize, const CONDITIONAL_LAYER_COUNT: usize>
             }
             LayerEvent::SetDefault(layer) => {
                 self.default_layer = Some(layer);
+                key::KeyEvents::no_events()
+            }
+            LayerEvent::LockInvert(target) => {
+                let layer = match target {
+                    LayerLockTarget::HighestActive => self.highest_active_layer(),
+                    LayerLockTarget::Layer(layer) => Some(layer),
+                };
+                if let Some(layer) = layer {
+                    self.lock_invert(layer);
+                }
                 key::KeyEvents::no_events()
             }
         }
@@ -833,11 +961,11 @@ impl<R: Copy + Debug + PartialEq, const LAYER_COUNT: usize> LayeredKey<R, LAYER_
 /// Events from [ModifierKey] which affect [Context].
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum LayerEvent {
-    /// Activates the given layer.
+    /// Activates the given layer (1-based; see [LayerIndex]).
     Activated(LayerIndex),
-    /// Deactivates the given layer.
+    /// Deactivates the given layer (1-based; see [LayerIndex]).
     Deactivated(LayerIndex),
-    /// Toggles the given layer.
+    /// Toggles the given layer (1-based; see [LayerIndex]).
     Toggled(LayerIndex),
     /// Activates the given layer as sticky (on sticky-mod press).
     StickyActivated(LayerIndex),
@@ -851,6 +979,10 @@ pub enum LayerEvent {
     Set(ModifierBitset),
     /// Changes the default layer.
     SetDefault(LayerIndex),
+    /// Invert lock on the given [LayerLockTarget].
+    ///
+    /// See [ModifierKey::Lock].
+    LockInvert(LayerLockTarget),
 }
 
 /// Struct for layer system pending key state. (No pending state).
@@ -946,6 +1078,7 @@ impl ModifierKeyState {
                 }
                 _ => None,
             },
+            ModifierKey::Lock(_) => None,
         }
     }
 }
@@ -1118,6 +1251,7 @@ mod tests {
         assert_eq!(31, MAX_BITSET_LAYER);
         assert!(LayerBitset::EMPTY.insert(31).contains(31));
         assert!(!LayerBitset::EMPTY.insert(32).contains(32));
+        assert!(!LayerBitset::ALL.remove(31).contains(31));
         assert!(LayerBitset::ALL.is_superset_of(LayerBitset::from_bits(0b1010)));
     }
 
@@ -1271,6 +1405,25 @@ mod tests {
 
         // Assert
         assert_eq!(Activity::Inactive, context.active_layers[2]);
+    }
+
+    #[test]
+    fn test_locked_conditional_layer_stays_active_when_if_layers_release() {
+        // Assemble: lower+raise → adjust; lock adjust while both if-layers held
+        let mut context = tri_layer_context();
+        context.handle_layer_event(LayerEvent::Activated(1));
+        context.handle_layer_event(LayerEvent::Activated(2));
+        assert!(context.active_layers[2].is_active());
+        context.handle_layer_event(LayerEvent::LockInvert(LayerLockTarget::Layer(3)));
+        assert!(context.is_layer_locked(3));
+
+        // Act: release if-layers (would normally turn adjust off)
+        context.handle_layer_event(LayerEvent::Deactivated(1));
+        context.handle_layer_event(LayerEvent::Deactivated(2));
+
+        // Assert: lock keeps adjust on
+        assert!(context.is_layer_locked(3));
+        assert!(context.active_layers[2].is_active());
     }
 
     #[test]
@@ -1461,5 +1614,125 @@ mod tests {
 
         // Assert
         assert_eq!(Some(LayerEvent::Toggled(layer)), layer_event);
+    }
+
+    #[test]
+    fn test_pressing_lock_key_emits_lock_invert_highest() {
+        // Assemble
+        let key = ModifierKey::lock();
+
+        // Act
+        let (_pressed_key, layer_event) = key.new_pressed_key();
+
+        // Assert
+        assert_eq!(
+            Some(LayerEvent::LockInvert(LayerLockTarget::HighestActive)),
+            layer_event
+        );
+    }
+
+    #[test]
+    fn test_pressing_lock_layer_key_emits_lock_invert_layer() {
+        // Assemble
+        let key = ModifierKey::lock_layer(2);
+
+        // Act
+        let (_pressed_key, layer_event) = key.new_pressed_key();
+
+        // Assert
+        assert_eq!(
+            Some(LayerEvent::LockInvert(LayerLockTarget::Layer(2))),
+            layer_event
+        );
+    }
+
+    #[test]
+    fn test_lock_highest_keeps_layer_after_hold_release() {
+        // Assemble: hold activates layer 1, then lock highest
+        let mut context = Context::default();
+        context.handle_layer_event(LayerEvent::Activated(1));
+        context.handle_layer_event(LayerEvent::LockInvert(LayerLockTarget::HighestActive));
+        assert!(context.is_layer_locked(1));
+        assert!(context.active_layers[0].is_active());
+
+        // Act: hold release (would normally deactivate)
+        context.handle_layer_event(LayerEvent::Deactivated(1));
+
+        // Assert: still active and locked
+        assert!(context.is_layer_locked(1));
+        assert!(context.active_layers[0].is_active());
+    }
+
+    #[test]
+    fn test_lock_again_unlocks_and_deactivates() {
+        // Assemble: lock highest after hold, then release hold
+        let mut context = Context::default();
+        context.handle_layer_event(LayerEvent::Activated(1));
+        context.handle_layer_event(LayerEvent::LockInvert(LayerLockTarget::HighestActive));
+        context.handle_layer_event(LayerEvent::Deactivated(1));
+        assert!(context.is_layer_locked(1));
+        assert!(context.active_layers[0].is_active());
+
+        // Act: lock again (unlock)
+        context.handle_layer_event(LayerEvent::LockInvert(LayerLockTarget::HighestActive));
+
+        // Assert
+        assert!(!context.is_layer_locked(1));
+        assert!(!context.active_layers[0].is_active());
+    }
+
+    #[test]
+    fn test_hold_press_while_locked_unlocks() {
+        // Assemble: lock layer, then release hold so only lock keeps it active
+        let mut context = Context::default();
+        context.handle_layer_event(LayerEvent::Activated(1));
+        context.handle_layer_event(LayerEvent::LockInvert(LayerLockTarget::HighestActive));
+        context.handle_layer_event(LayerEvent::Deactivated(1));
+        assert!(context.is_layer_locked(1));
+        assert!(context.active_layers[0].is_active());
+
+        // Act: press hold again while locked
+        context.handle_layer_event(LayerEvent::Activated(1));
+
+        // Assert
+        assert!(!context.is_layer_locked(1));
+        assert!(!context.active_layers[0].is_active());
+    }
+
+    #[test]
+    fn test_lock_specific_layer_activates_when_inactive() {
+        // Assemble
+        let mut context = Context::default();
+
+        // Act
+        context.handle_layer_event(LayerEvent::LockInvert(LayerLockTarget::Layer(2)));
+
+        // Assert
+        assert!(context.is_layer_locked(2));
+        assert!(context.active_layers[1].is_active());
+    }
+
+    #[test]
+    fn test_lock_no_active_layer_is_noop() {
+        // Assemble
+        let mut context = Context::default();
+
+        // Act
+        context.handle_layer_event(LayerEvent::LockInvert(LayerLockTarget::HighestActive));
+
+        // Assert
+        assert_eq!(LayerBitset::EMPTY, context.locked_layers);
+        assert!(!context.active_layers.iter().any(|a| a.is_active()));
+    }
+
+    #[test]
+    fn deserialize_lock_json() {
+        // Assemble / Act
+        let highest: ModifierKey = serde_json::from_str(r#"{"Lock":"HighestActive"}"#).unwrap();
+        let layer: ModifierKey = serde_json::from_str(r#"{"Lock":{"Layer":3}}"#).unwrap();
+
+        // Assert
+        assert_eq!(ModifierKey::Lock(LayerLockTarget::HighestActive), highest);
+        assert_eq!(ModifierKey::Lock(LayerLockTarget::Layer(3)), layer);
     }
 }

--- a/tests/rust/layered/lock.rs
+++ b/tests/rust/layered/lock.rs
@@ -1,12 +1,3 @@
-mod conditional;
-mod lock;
-mod modified_hold;
-mod set_active_layers;
-mod sticky;
-mod sticky_timeout;
-mod tap_hold;
-mod toggle;
-
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 
@@ -14,38 +5,102 @@ use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
-fn press_base_key_when_no_layers_active() {
+fn lock_keeps_layer_after_hold_released() {
     // Assemble
     let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
                 layers = [
-                    [K.layer_mod.hold 1, K.A],
-                    [K.TTTT, K.B],
+                    [K.layer_mod.hold 1, K.layer_mod.lock, K.A],
+                    [K.TTTT, K.TTTT, K.B],
                 ],
             }
         "#
     ));
 
-    // Act
+    // Act: hold layer, lock, release hold, press letter
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 2 });
 
     // Assert
-    let expected_report: [u8; 8] = [0, 0, KC_A, 0, 0, 0, 0, 0];
+    let expected_report: [u8; 8] = [0, 0, KC_B, 0, 0, 0, 0, 0];
     let actual_report = keymap.boot_keyboard_report();
-    assert_eq!(expected_report, actual_report,);
+    assert_eq!(expected_report, actual_report);
 }
 
 #[test]
-fn press_active_layer_when_layer_mod_held() {
+fn lock_again_unlocks_layer() {
     // Assemble
     let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
                 layers = [
-                    [K.layer_mod.hold 1, K.A],
+                    [K.layer_mod.hold 1, K.layer_mod.lock, K.A],
+                    [K.TTTT, K.TTTT, K.B],
+                ],
+            }
+        "#
+    ));
+
+    // Act: lock layer, unlock with lock again, press letter
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+    keymap.handle_input(input::Event::Press { keymap_index: 2 });
+
+    // Assert
+    let expected_report: [u8; 8] = [0, 0, KC_A, 0, 0, 0, 0, 0];
+    let actual_report = keymap.boot_keyboard_report();
+    assert_eq!(expected_report, actual_report);
+}
+
+#[test]
+fn hold_while_locked_unlocks() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                layers = [
+                    [K.layer_mod.hold 1, K.layer_mod.lock, K.A],
+                    [K.TTTT, K.TTTT, K.B],
+                ],
+            }
+        "#
+    ));
+
+    // Act: lock, then tap hold again to unlock
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 2 });
+
+    // Assert
+    let expected_report: [u8; 8] = [0, 0, KC_A, 0, 0, 0, 0, 0];
+    let actual_report = keymap.boot_keyboard_report();
+    assert_eq!(expected_report, actual_report);
+}
+
+#[test]
+fn lock_layer_activates_specific_layer() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                layers = [
+                    [K.layer_mod.lock_layer 1, K.A],
                     [K.TTTT, K.B],
                 ],
             }
@@ -54,6 +109,7 @@ fn press_active_layer_when_layer_mod_held() {
 
     // Act
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
 
     // Assert
@@ -63,40 +119,14 @@ fn press_active_layer_when_layer_mod_held() {
 }
 
 #[test]
-fn press_retained_when_layer_mod_released() {
+fn lock_layer_twice_deactivates() {
     // Assemble
     let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
                 layers = [
-                    [K.layer_mod.hold 1, K.A],
-                    [K.TTTT, K.B],
-                ],
-            }
-        "#
-    ));
-
-    // Act
-    keymap.handle_input(input::Event::Press { keymap_index: 0 });
-    keymap.handle_input(input::Event::Press { keymap_index: 1 });
-    keymap.handle_input(input::Event::Release { keymap_index: 0 });
-
-    // Assert
-    let expected_report: [u8; 8] = [0, 0, KC_B, 0, 0, 0, 0, 0];
-    let actual_report = keymap.boot_keyboard_report();
-    assert_eq!(expected_report, actual_report);
-}
-
-#[test]
-fn uses_base_when_pressed_after_layer_mod_released() {
-    // Assemble
-    let mut keymap = ObservedKeymap::new(keymap!(
-        r#"
-            let K = import "keys.ncl" in
-            {
-                layers = [
-                    [K.layer_mod.hold 1, K.A],
+                    [K.layer_mod.lock_layer 1, K.A],
                     [K.TTTT, K.B],
                 ],
             }
@@ -106,35 +136,12 @@ fn uses_base_when_pressed_after_layer_mod_released() {
     // Act
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
 
     // Assert
     let expected_report: [u8; 8] = [0, 0, KC_A, 0, 0, 0, 0, 0];
     let actual_report = keymap.boot_keyboard_report();
     assert_eq!(expected_report, actual_report);
-}
-
-#[test]
-fn init_resets_active_layers() {
-    // Assemble: hold layer 1
-    let mut keymap = ObservedKeymap::new(keymap!(
-        r#"
-            let K = import "keys.ncl" in
-            {
-                layers = [
-                    [K.layer_mod.hold 1, K.A],
-                    [K.TTTT, K.B],
-                ],
-            }
-        "#
-    ));
-    keymap.handle_input(input::Event::Press { keymap_index: 0 });
-
-    // Act: reset, then press the letter key without re-holding the mod
-    keymap.init();
-    keymap.handle_input(input::Event::Press { keymap_index: 1 });
-
-    // Assert: layer state was cleared — base key, not layer 1
-    let expected_report: [u8; 8] = [0, 0, KC_A, 0, 0, 0, 0, 0];
-    assert_eq!(expected_report, keymap.boot_keyboard_report());
 }


### PR DESCRIPTION
## Summary

- Add `ModifierKey::Lock` with `LayerLockTarget` (`HighestActive` | `Layer`) so a layer can stay active after a hold modifier is released, and can be unlocked by locking again or pressing the hold again.
- Wire Nickel authoring (`K.layer_mod.lock` / `lock_layer`), named-layer resolution, inputs simulation, JSON, and Rust codegen for the new lock variants.
- Cover behaviour with core unit tests, rust integration tests, and cucumber scenarios.

## Test plan

- [ ] `cargo test -p smart-keymap-core --lib key::layered`
- [ ] `cargo test --test layered` (or the project’s usual rust integration path for layered/lock)
- [ ] Run cucumber feature `features/keymap/key/layer_modifier-lock.feature` if part of the default cucumber suite
- [ ] Smoke a keymap that uses `K.layer_mod.lock` after hold and `K.layer_mod.lock_layer N`

