### PR TITLE
Fix/bound tick until no scheduled events

### DIFF
--- a/smart-keymap-core/src/keymap/observed_eb_keymap.rs
+++ b/smart-keymap-core/src/keymap/observed_eb_keymap.rs
@@ -9,6 +9,12 @@ use keymap::Keymap;
 use keymap::ReportHints;
 use keymap::SetKeymapContext;
 
+/// Upper bound on ticks when draining scheduled events in tests.
+///
+/// Prevents integration tests from hanging indefinitely if a key keeps
+/// rescheduling work (e.g. an automation / string-macro loop).
+pub const MAX_TICKS_UNTIL_NO_SCHEDULED_EVENTS: usize = 10_000;
+
 /// Wrapper around a [crate::keymap::Keymap] that also tracks distinct HID reports.
 #[derive(Debug)]
 pub struct ObservedKeymap<I: Index<usize, Output = R>, R, Ctx, Ev: Debug, PKS, KS, S> {
@@ -79,16 +85,30 @@ impl<
     }
 
     /// Ticks the keymap until there are no scheduled events, updating reports appropriately.
+    ///
+    /// Panics if the keymap still has scheduled events after
+    /// `MAX_TICKS_UNTIL_NO_SCHEDULED_EVENTS` ticks (likely an infinite
+    /// reschedule loop).
     pub fn tick_until_no_scheduled_events(&mut self) {
         let ObservedKeymap {
             keymap,
             distinct_reports,
         } = self;
 
-        while keymap.has_scheduled_events() {
+        for _ in 0..MAX_TICKS_UNTIL_NO_SCHEDULED_EVENTS {
+            if !keymap.has_scheduled_events() {
+                return;
+            }
             keymap.tick();
             distinct_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
         }
+        if !keymap.has_scheduled_events() {
+            return;
+        }
+        panic!(
+            "keymap did not become idle after {} ticks; possible infinite scheduled-event loop",
+            MAX_TICKS_UNTIL_NO_SCHEDULED_EVENTS
+        );
     }
 
     /// Proxies [keymap::Keymap::requires_polling].

--- a/smart-keymap-core/src/keymap/observed_keymap.rs
+++ b/smart-keymap-core/src/keymap/observed_keymap.rs
@@ -9,6 +9,12 @@ use keymap::Keymap;
 use keymap::ReportHints;
 use keymap::SetKeymapContext;
 
+/// Upper bound on ticks when draining scheduled events in tests.
+///
+/// Prevents integration tests from hanging indefinitely if a key keeps
+/// rescheduling work (e.g. an automation / string-macro loop).
+pub const MAX_TICKS_UNTIL_NO_SCHEDULED_EVENTS: usize = 10_000;
+
 /// Wrapper around a [crate::keymap::Keymap] that also tracks distinct HID reports.
 #[derive(Debug)]
 pub struct ObservedKeymap<I: Index<usize, Output = R>, R, Ctx, Ev: Debug, PKS, KS, S> {
@@ -79,15 +85,29 @@ impl<
     }
 
     /// Ticks the keymap until there are no scheduled events, updating reports appropriately.
+    ///
+    /// Panics if the keymap still has scheduled events after
+    /// `MAX_TICKS_UNTIL_NO_SCHEDULED_EVENTS` ticks (likely an infinite
+    /// reschedule loop).
     pub fn tick_until_no_scheduled_events(&mut self) {
         let ObservedKeymap {
             keymap,
             distinct_reports,
         } = self;
 
-        while keymap.has_scheduled_events() {
+        for _ in 0..MAX_TICKS_UNTIL_NO_SCHEDULED_EVENTS {
+            if !keymap.has_scheduled_events() {
+                return;
+            }
             keymap.tick();
             distinct_reports.update(keymap.report_output().as_hid_boot_keyboard_report());
         }
+        if !keymap.has_scheduled_events() {
+            return;
+        }
+        panic!(
+            "keymap did not become idle after {} ticks; possible infinite scheduled-event loop",
+            MAX_TICKS_UNTIL_NO_SCHEDULED_EVENTS
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Bound `ObservedKeymap::tick_until_no_scheduled_events` (both input- and event-based wrappers) to 10_000 ticks, panicking with a clear message if the keymap never becomes idle.
- Run the cucumber-keymap CI job with `--nocapture` so scenario progress and panics show up in job logs.

## Context

Cucumber jobs were hanging (and eventually getting SIGTERM from the runner) while draining scheduled events—likely an unbounded reschedule loop in a scenario such as string macros. A step `timeout-minutes: 15` does not help much if the runner is shut down first or if the hang is hard to attribute in captured output.

This turns a multi-minute hang into a fast, deterministic test failure across cucumber and rust integration tests that share the helper.
