### PR TITLE
nickel-helper: bound nickel subprocesses with configurable timeout

### DIFF
--- a/smart-keymap-full-system-std/build.rs
+++ b/smart-keymap-full-system-std/build.rs
@@ -3,7 +3,9 @@ use std::fs;
 use std::io::Write;
 use std::path::Path;
 
-use smart_keymap_nickel_helper::{nickel_composite_full_vec_rs, rustfmt, NickelError};
+use smart_keymap_nickel_helper::{
+    nickel_composite_full_vec_rs, rustfmt, NickelError, NICKEL_TIMEOUT_ENV,
+};
 
 fn main() {
     // Workspace root is the parent of this package.
@@ -23,6 +25,7 @@ fn main() {
     );
     // Family modules can affect the registry merge / types referenced by emit.
     println!("cargo:rerun-if-changed={}/smart_keys", ncl_import_path);
+    println!("cargo:rerun-if-env-changed={NICKEL_TIMEOUT_ENV}");
 
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("composite_full_vec.rs");
@@ -40,6 +43,12 @@ fn main() {
         }
         Err(NickelError::EvalError(e)) => {
             panic!("Nickel evaluation failed while emitting composite_full_vec:\n{e}");
+        }
+        Err(NickelError::Timeout { timeout_secs }) => {
+            panic!(
+                "Nickel evaluation timed out after {timeout_secs}s while emitting composite_full_vec \
+                 (set {NICKEL_TIMEOUT_ENV}=0 to disable, or raise the limit)"
+            );
         }
     }
 }

--- a/smart-keymap-macros/src/lib.rs
+++ b/smart-keymap-macros/src/lib.rs
@@ -30,5 +30,11 @@ pub fn keymap(input: TokenStream) -> TokenStream {
         Err(NickelError::NickelNotFound) => {
             panic!("`nickel` executable not found in PATH");
         }
+        Err(NickelError::Timeout { timeout_secs }) => {
+            panic!(
+                "Nickel evaluation timed out after {}s (set SMART_KEYMAP_NICKEL_TIMEOUT_SECS=0 to disable, or raise the limit)",
+                timeout_secs
+            );
+        }
     }
 }

--- a/smart-keymap-nickel-helper/src/lib.rs
+++ b/smart-keymap-nickel-helper/src/lib.rs
@@ -1,10 +1,23 @@
 use std::collections::HashMap;
 use std::env;
 use std::fs;
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Output, Stdio};
 use std::sync::{Mutex, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// Environment variable controlling Nickel wall-clock timeout (seconds).
+///
+/// - unset → default ([`DEFAULT_NICKEL_TIMEOUT_SECS`])
+/// - `0` → no timeout
+/// - positive integer → timeout in seconds
+/// - unparsable → default
+pub const NICKEL_TIMEOUT_ENV: &str = "SMART_KEYMAP_NICKEL_TIMEOUT_SECS";
+
+/// Default Nickel subprocess timeout when [`NICKEL_TIMEOUT_ENV`] is unset.
+pub const DEFAULT_NICKEL_TIMEOUT_SECS: u64 = 60;
 
 /// Identifies a cached Nickel JSON export (keymap, inputs, or HID report).
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
@@ -97,13 +110,147 @@ pub struct CodegenInputs<'a> {
 }
 
 /// Likely reasons why running `nickel` may fail.
+#[derive(Debug)]
 pub enum NickelError {
     NickelNotFound,
     EvalError(String),
+    /// Nickel did not finish within the configured wall-clock limit.
+    Timeout {
+        timeout_secs: u64,
+    },
 }
 
 /// Result of Nickel evaluation.
 pub type NickelResult = Result<String, NickelError>;
+
+/// Wall-clock timeout for Nickel subprocesses.
+///
+/// Controlled by [`NICKEL_TIMEOUT_ENV`] (`SMART_KEYMAP_NICKEL_TIMEOUT_SECS`):
+/// unset → [`DEFAULT_NICKEL_TIMEOUT_SECS`]; `0` → no timeout; positive → seconds.
+pub fn nickel_timeout() -> Option<Duration> {
+    match env::var(NICKEL_TIMEOUT_ENV) {
+        Ok(raw) => {
+            let raw = raw.trim();
+            if raw.is_empty() {
+                return Some(Duration::from_secs(DEFAULT_NICKEL_TIMEOUT_SECS));
+            }
+            match raw.parse::<u64>() {
+                Ok(0) => None,
+                Ok(secs) => Some(Duration::from_secs(secs)),
+                Err(_) => Some(Duration::from_secs(DEFAULT_NICKEL_TIMEOUT_SECS)),
+            }
+        }
+        Err(_) => Some(Duration::from_secs(DEFAULT_NICKEL_TIMEOUT_SECS)),
+    }
+}
+
+/// Wait for a child, optionally killing it after `timeout`.
+///
+/// Stdout/stderr are drained on background threads so a full pipe buffer cannot
+/// deadlock the wait.
+fn wait_with_optional_timeout(
+    mut child: Child,
+    timeout: Option<Duration>,
+) -> Result<Output, NickelError> {
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+
+    let stdout_handle = thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(mut reader) = stdout {
+            let _ = reader.read_to_end(&mut buf);
+        }
+        buf
+    });
+    let stderr_handle = thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(mut reader) = stderr {
+            let _ = reader.read_to_end(&mut buf);
+        }
+        buf
+    });
+
+    let status = match timeout {
+        None => child
+            .wait()
+            .unwrap_or_else(|e| panic!("Failed to wait on nickel: {:?}", e)),
+        Some(limit) => {
+            let start = Instant::now();
+            loop {
+                match child.try_wait() {
+                    Ok(Some(status)) => break status,
+                    Ok(None) => {
+                        if start.elapsed() >= limit {
+                            let _ = child.kill();
+                            let _ = child.wait();
+                            let _ = stdout_handle.join();
+                            let _ = stderr_handle.join();
+                            return Err(NickelError::Timeout {
+                                timeout_secs: limit.as_secs().max(1),
+                            });
+                        }
+                        thread::sleep(Duration::from_millis(20));
+                    }
+                    Err(e) => panic!("Failed to wait on nickel: {:?}", e),
+                }
+            }
+        }
+    };
+
+    let stdout = stdout_handle
+        .join()
+        .unwrap_or_else(|_| panic!("nickel stdout reader panicked"));
+    let stderr = stderr_handle
+        .join()
+        .unwrap_or_else(|_| panic!("nickel stderr reader panicked"));
+
+    Ok(Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
+/// Spawn `nickel` with the given args and optional stdin, applying the configured timeout.
+fn run_nickel(args: &[&str], stdin_bytes: Option<&[u8]>) -> NickelResult {
+    let mut command = Command::new("nickel");
+    command
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    if stdin_bytes.is_some() {
+        command.stdin(Stdio::piped());
+    } else {
+        command.stdin(Stdio::null());
+    }
+
+    let mut child = command.spawn().map_err(|e| match e.kind() {
+        io::ErrorKind::NotFound => NickelError::NickelNotFound,
+        _ => panic!("Failed to spawn nickel: {:?}", e),
+    })?;
+
+    if let Some(bytes) = stdin_bytes {
+        let mut child_stdin = child
+            .stdin
+            .take()
+            .unwrap_or_else(|| panic!("nickel stdin not piped"));
+        child_stdin
+            .write_all(bytes)
+            .unwrap_or_else(|e| panic!("Failed to write to nickel stdin: {:?}", e));
+        // Drop stdin so Nickel sees EOF.
+    }
+
+    let output = wait_with_optional_timeout(child, nickel_timeout())?;
+
+    if output.status.success() {
+        String::from_utf8(output.stdout).map_err(|e| panic!("Failed to decode UTF-8: {:?}", e))
+    } else {
+        let nickel_error_message = String::from_utf8(output.stderr)
+            .unwrap_or_else(|e| panic!("Failed to decode UTF-8: {:?}", e));
+        Err(NickelError::EvalError(nickel_error_message))
+    }
+}
 
 /// Evaluates the Nickel expr for a keymap, returning the keymap.rs contents.
 pub fn nickel_keymap_rs_for_keymap_path(
@@ -112,94 +259,37 @@ pub fn nickel_keymap_rs_for_keymap_path(
         input_path,
     }: NickelEvalInputs,
 ) -> NickelResult {
-    let spawn_nickel_result = Command::new("nickel")
-        .args([
+    let import_path_arg = format!("--import-path={}", ncl_import_path);
+    run_nickel(
+        &[
             "export",
             "--format=raw",
-            format!("--import-path={}", ncl_import_path).as_ref(),
+            import_path_arg.as_str(),
             "--field=keymap_rs",
             "keymap-codegen.ncl",
             "keymap-ncl-to-json.ncl",
             input_path.to_str().unwrap(),
-        ])
-        .stdin(Stdio::null())
-        .stderr(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()
-        .map_err(|e| match e.kind() {
-            io::ErrorKind::NotFound => Err(NickelError::NickelNotFound),
-            _ => panic!("Failed to spawn nickel: {:?}", e),
-        });
-
-    match spawn_nickel_result {
-        Ok(nickel_command) => match nickel_command.wait_with_output() {
-            Ok(output) => {
-                if output.status.success() {
-                    String::from_utf8(output.stdout)
-                        .map_err(|e| panic!("Failed to decode UTF-8: {:?}", e))
-                } else {
-                    let nickel_error_message = String::from_utf8(output.stderr)
-                        .unwrap_or_else(|e| panic!("Failed to decode UTF-8: {:?}", e));
-                    Err(NickelError::EvalError(nickel_error_message))
-                }
-            }
-            Err(io_e) => {
-                panic!("Unhandled IO error: {:?}", io_e)
-            }
-        },
-        Err(e) => Err(e?),
-    }
+        ],
+        None,
+    )
 }
 
 /// Evaluates the Nickel expr for a keymap, returning the keymap expression.
 pub fn nickel_keymap_expr_for_keymap_ncl(ncl_import_path: &str, keymap_ncl: &str) -> NickelResult {
-    let spawn_nickel_result = Command::new("nickel")
-        .args([
+    let import_path_arg = format!("--import-path={}", ncl_import_path);
+    let stdin = format!(
+        r#"(import "keymap-codegen.ncl") & (import "keymap-ncl-to-json.ncl") & ({})"#,
+        keymap_ncl
+    );
+    run_nickel(
+        &[
             "export",
             "--format=raw",
-            &format!("--import-path={}", ncl_import_path),
+            import_path_arg.as_str(),
             "--field=rust_expressions.keymap",
-        ])
-        .stdin(Stdio::piped())
-        .stderr(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()
-        .map_err(|e| match e.kind() {
-            io::ErrorKind::NotFound => Err(NickelError::NickelNotFound),
-            _ => panic!("Failed to spawn nickel: {:?}", e),
-        });
-
-    match spawn_nickel_result {
-        Ok(mut nickel_command) => {
-            let child_stdin = nickel_command.stdin.as_mut().unwrap();
-            child_stdin
-                .write_all(
-                    format!(
-                        r#"(import "keymap-codegen.ncl") & (import "keymap-ncl-to-json.ncl") & ({})"#,
-                        keymap_ncl
-                    )
-                    .as_bytes(),
-                )
-                .unwrap_or_else(|e| panic!("Failed to write to stdin: {:?}", e));
-
-            match nickel_command.wait_with_output() {
-                Ok(output) => {
-                    if output.status.success() {
-                        String::from_utf8(output.stdout)
-                            .map_err(|e| panic!("Failed to decode UTF-8: {:?}", e))
-                    } else {
-                        let nickel_error_message = String::from_utf8(output.stderr)
-                            .unwrap_or_else(|e| panic!("Failed to decode UTF-8: {:?}", e));
-                        Err(NickelError::EvalError(nickel_error_message))
-                    }
-                }
-                Err(io_e) => {
-                    panic!("Unhandled IO error: {:?}", io_e)
-                }
-            }
-        }
-        Err(e) => Err(e?),
-    }
+        ],
+        Some(stdin.as_bytes()),
+    )
 }
 
 /// Evaluates the Nickel expr for a board, returning the board.rs contents.
@@ -209,42 +299,18 @@ pub fn nickel_board_rs_for_board_path(
         input_path,
     }: NickelEvalInputs,
 ) -> NickelResult {
-    let spawn_nickel_result = Command::new("nickel")
-        .args([
+    let import_path_arg = format!("--import-path={}", ncl_import_path);
+    run_nickel(
+        &[
             "export",
             "--format=raw",
-            format!("--import-path={}", ncl_import_path).as_ref(),
+            import_path_arg.as_str(),
             "--field=board_rs",
             "codegen.ncl",
             input_path.to_str().unwrap(),
-        ])
-        .stdin(Stdio::null())
-        .stderr(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()
-        .map_err(|e| match e.kind() {
-            io::ErrorKind::NotFound => Err(NickelError::NickelNotFound),
-            _ => panic!("Failed to spawn nickel: {:?}", e),
-        });
-
-    match spawn_nickel_result {
-        Ok(nickel_command) => match nickel_command.wait_with_output() {
-            Ok(output) => {
-                if output.status.success() {
-                    String::from_utf8(output.stdout)
-                        .map_err(|e| panic!("Failed to decode UTF-8: {:?}", e))
-                } else {
-                    let nickel_error_message = String::from_utf8(output.stderr)
-                        .unwrap_or_else(|e| panic!("Failed to decode UTF-8: {:?}", e));
-                    Err(NickelError::EvalError(nickel_error_message))
-                }
-            }
-            Err(io_e) => {
-                panic!("Unhandled IO error: {:?}", io_e)
-            }
-        },
-        Err(e) => Err(e?),
-    }
+        ],
+        None,
+    )
 }
 
 /// Tries running the given source through `rustfmt`.
@@ -290,50 +356,19 @@ pub fn nickel_json_value_for_keymap(ncl_import_path: String, keymap_ncl: &str) -
 }
 
 fn nickel_json_value_for_keymap_uncached(ncl_import_path: &str, keymap_ncl: &str) -> NickelResult {
-    let spawn_nickel_result = Command::new("nickel")
-        .args([
+    let import_path_arg = format!("--import-path={ncl_import_path}");
+    let stdin = format!(
+        r#"(import "keymap-codegen.ncl") & (import "keymap-ncl-to-json.ncl") & ({keymap_ncl})"#
+    );
+    run_nickel(
+        &[
             "export",
             "--format=json",
-            format!("--import-path={ncl_import_path}").as_ref(),
+            import_path_arg.as_str(),
             "--field=json_deserializable_keymap",
-        ])
-        .stdin(Stdio::piped())
-        .stderr(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()
-        .map_err(|e| match e.kind() {
-            io::ErrorKind::NotFound => Err(NickelError::NickelNotFound),
-            _ => panic!("Failed to spawn nickel: {:?}", e),
-        });
-
-    match spawn_nickel_result {
-        Ok(mut nickel_command) => {
-            let child_stdin = nickel_command.stdin.as_mut().unwrap();
-            child_stdin
-                .write_all(
-                    format!(r#"(import "keymap-codegen.ncl") & (import "keymap-ncl-to-json.ncl") & ({keymap_ncl})"#)
-                        .as_bytes(),
-                )
-                .unwrap_or_else(|e| panic!("Failed to write to stdin: {:?}", e));
-
-            match nickel_command.wait_with_output() {
-                Ok(output) => {
-                    if output.status.success() {
-                        String::from_utf8(output.stdout)
-                            .map_err(|e| panic!("Failed to decode UTF-8: {:?}", e))
-                    } else {
-                        let nickel_error_message = String::from_utf8(output.stderr)
-                            .unwrap_or_else(|e| panic!("Failed to decode UTF-8: {:?}", e));
-                        Err(NickelError::EvalError(nickel_error_message))
-                    }
-                }
-                Err(io_e) => {
-                    panic!("Unhandled IO error: {:?}", io_e)
-                }
-            }
-        }
-        Err(e) => Err(e?),
-    }
+        ],
+        Some(stdin.as_bytes()),
+    )
 }
 
 /// Evaluates the Nickel expr for inputs, with a given keymap ncl, returning the json serialization.
@@ -359,29 +394,9 @@ fn nickel_json_value_for_inputs_uncached(
     keymap_ncl: &str,
     inputs_ncl: &str,
 ) -> NickelResult {
-    let spawn_nickel_result = Command::new("nickel")
-        .args([
-            "export",
-            "--format=json",
-            format!("--import-path={ncl_import_path}").as_ref(),
-            "--field=inputs_as_json_value_input_events",
-        ])
-        .stdin(Stdio::piped())
-        .stderr(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()
-        .map_err(|e| match e.kind() {
-            io::ErrorKind::NotFound => Err(NickelError::NickelNotFound),
-            _ => panic!("Failed to spawn nickel: {:?}", e),
-        });
-
-    match spawn_nickel_result {
-        Ok(mut nickel_command) => {
-            let child_stdin = nickel_command.stdin.as_mut().unwrap();
-            child_stdin
-                .write_all(
-                    format!(
-                        r#"
+    let import_path_arg = format!("--import-path={ncl_import_path}");
+    let stdin = format!(
+        r#"
                            (import "keymap-codegen.ncl")
                            & (import "keymap-ncl-to-json.ncl")
                            & (import "inputs-to-json.ncl")
@@ -402,36 +417,23 @@ fn nickel_json_value_for_inputs_uncached(
                                     {inputs_ncl},
                               }})
                         "#,
-                    )
-                    .as_bytes(),
-                )
-                .unwrap_or_else(|e| panic!("Failed to write to stdin: {:?}", e));
-
-            match nickel_command.wait_with_output() {
-                Ok(output) => {
-                    if output.status.success() {
-                        String::from_utf8(output.stdout)
-                            .map_err(|e| panic!("Failed to decode UTF-8: {:?}", e))
-                    } else {
-                        let nickel_error_message = String::from_utf8(output.stderr)
-                            .unwrap_or_else(|e| panic!("Failed to decode UTF-8: {:?}", e));
-                        Err(NickelError::EvalError(nickel_error_message))
-                    }
-                }
-                Err(io_e) => {
-                    panic!("Unhandled IO error: {:?}", io_e)
-                }
-            }
-        }
-        Err(e) => Err(e?),
-    }
+    );
+    run_nickel(
+        &[
+            "export",
+            "--format=json",
+            import_path_arg.as_str(),
+            "--field=inputs_as_json_value_input_events",
+        ],
+        Some(stdin.as_bytes()),
+    )
 }
 
 /// Evaluates the Nickel expr for an HID, returning the json serialization.
 pub fn nickel_to_json_for_hid_report(
     ncl_import_path: String,
     hid_report_ncl: &str,
-) -> io::Result<String> {
+) -> NickelResult {
     let cache_key = NickelJsonExport::hid_report(&ncl_import_path, hid_report_ncl);
     if let Some(json) = eval_cache::get(&cache_key) {
         return Ok(json);
@@ -445,35 +447,26 @@ pub fn nickel_to_json_for_hid_report(
 fn nickel_to_json_for_hid_report_uncached(
     ncl_import_path: &str,
     hid_report_ncl: &str,
-) -> io::Result<String> {
-    let mut nickel_command = Command::new("nickel")
-        .args([
-            "export",
-            "--format=json",
-            format!("--import-path={ncl_import_path}").as_ref(),
-            "--field=as_bytes",
-        ])
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()?;
-
-    let child_stdin = nickel_command.stdin.as_mut().unwrap();
-    child_stdin.write_all(
-        format!(
-            r#"
+) -> NickelResult {
+    let import_path_arg = format!("--import-path={ncl_import_path}");
+    let stdin = format!(
+        r#"
                 (import "hid-report.ncl")
                 & (
                     let K = import "hid-usage-keyboard.ncl" in
                     {hid_report_ncl}
                 )
             "#,
-        )
-        .as_bytes(),
-    )?;
-
-    let output = nickel_command.wait_with_output()?;
-
-    String::from_utf8(output.stdout).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    );
+    run_nickel(
+        &[
+            "export",
+            "--format=json",
+            import_path_arg.as_str(),
+            "--field=as_bytes",
+        ],
+        Some(stdin.as_bytes()),
+    )
 }
 
 /// Emits the full-profile composite `key_system` module with Vec storage.
@@ -486,53 +479,22 @@ fn nickel_to_json_for_hid_report_uncached(
 /// that defines size consts (referenced as `super::…`), and resolve engine
 /// paths via the `smart_keymap` crate name.
 pub fn nickel_composite_full_vec_rs(ncl_import_path: &str) -> NickelResult {
-    let spawn_nickel_result = Command::new("nickel")
-        .args([
+    let import_path_arg = format!("--import-path={ncl_import_path}");
+    run_nickel(
+        &[
             "export",
             "--format=raw",
-            format!("--import-path={ncl_import_path}").as_ref(),
+            import_path_arg.as_str(),
             "--field=composite.system.rust_mod",
-        ])
-        .stdin(Stdio::piped())
-        .stderr(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()
-        .map_err(|e| match e.kind() {
-            io::ErrorKind::NotFound => Err(NickelError::NickelNotFound),
-            _ => panic!("Failed to spawn nickel: {:?}", e),
-        });
-
-    match spawn_nickel_result {
-        Ok(mut nickel_command) => {
-            let child_stdin = nickel_command.stdin.as_mut().unwrap();
-            child_stdin
-                .write_all(
-                    br#"
+        ],
+        Some(
+            br#"
   (import "keymap-codegen.ncl")
   & { composite, composite.profile = 'FullProfile }
   & { composite.data = 'Vec }
 "#,
-                )
-                .unwrap();
-
-            match nickel_command.wait_with_output() {
-                Ok(output) => {
-                    if output.status.success() {
-                        String::from_utf8(output.stdout)
-                            .map_err(|e| panic!("Failed to decode UTF-8: {:?}", e))
-                    } else {
-                        let nickel_error_message = String::from_utf8(output.stderr)
-                            .unwrap_or_else(|e| panic!("Failed to decode UTF-8: {:?}", e));
-                        Err(NickelError::EvalError(nickel_error_message))
-                    }
-                }
-                Err(io_e) => {
-                    panic!("Unhandled IO error: {:?}", io_e)
-                }
-            }
-        }
-        Err(e) => Err(e?),
-    }
+        ),
+    )
 }
 
 /// Generates the code for the given module.
@@ -546,6 +508,7 @@ pub fn codegen_rust_module(
     }: CodegenInputs,
 ) {
     println!("cargo:rerun-if-env-changed={}", env_var);
+    println!("cargo:rerun-if-env-changed={}", NICKEL_TIMEOUT_ENV);
     println!("cargo::rustc-check-cfg=cfg({})", cfg_name);
     if let Some(custom_module_path) = env::var(env_var).ok().filter(|s| !s.is_empty()) {
         let out_dir = env::var("OUT_DIR").unwrap();
@@ -577,6 +540,12 @@ pub fn codegen_rust_module(
                 Err(NickelError::EvalError(e)) => {
                     panic!("Nickel evaluation failed: {}", e);
                 }
+                Err(NickelError::Timeout { timeout_secs }) => {
+                    panic!(
+                        "Nickel evaluation timed out after {}s (set {}=0 to disable, or raise the limit)",
+                        timeout_secs, NICKEL_TIMEOUT_ENV
+                    );
+                }
             }
         } else {
             panic!("Unsupported {}: {}", env_var, custom_module_path);
@@ -586,7 +555,12 @@ pub fn codegen_rust_module(
 
 #[cfg(test)]
 mod tests {
-    use super::{clear_nickel_eval_cache, eval_cache, NickelJsonExport};
+    use super::{
+        clear_nickel_eval_cache, eval_cache, nickel_timeout, wait_with_optional_timeout,
+        NickelError, NickelJsonExport, DEFAULT_NICKEL_TIMEOUT_SECS, NICKEL_TIMEOUT_ENV,
+    };
+    use std::process::{Command, Stdio};
+    use std::time::{Duration, Instant};
 
     #[test]
     fn nickel_json_export_distinguishes_eval_kinds() {
@@ -604,5 +578,65 @@ mod tests {
         eval_cache::insert(key, "value".into());
         clear_nickel_eval_cache();
         assert!(eval_cache::get(&NickelJsonExport::keymap("/ncl", "{ keys = [] }")).is_none());
+    }
+
+    #[test]
+    fn nickel_timeout_env_parsing() {
+        // Serialize env mutations: cargo runs lib tests in parallel by default.
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = ENV_LOCK.lock().unwrap();
+
+        let prev = std::env::var_os(NICKEL_TIMEOUT_ENV);
+
+        std::env::remove_var(NICKEL_TIMEOUT_ENV);
+        assert_eq!(
+            nickel_timeout(),
+            Some(Duration::from_secs(DEFAULT_NICKEL_TIMEOUT_SECS))
+        );
+
+        std::env::set_var(NICKEL_TIMEOUT_ENV, "0");
+        assert_eq!(nickel_timeout(), None);
+
+        std::env::set_var(NICKEL_TIMEOUT_ENV, "12");
+        assert_eq!(nickel_timeout(), Some(Duration::from_secs(12)));
+
+        std::env::set_var(NICKEL_TIMEOUT_ENV, "not-a-number");
+        assert_eq!(
+            nickel_timeout(),
+            Some(Duration::from_secs(DEFAULT_NICKEL_TIMEOUT_SECS))
+        );
+
+        match prev {
+            Some(v) => std::env::set_var(NICKEL_TIMEOUT_ENV, v),
+            None => std::env::remove_var(NICKEL_TIMEOUT_ENV),
+        }
+    }
+
+    #[test]
+    fn wait_timeout_kills_long_running_child() {
+        let child = Command::new("sleep")
+            .arg("30")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn sleep");
+
+        let start = Instant::now();
+        let err = wait_with_optional_timeout(child, Some(Duration::from_millis(200)))
+            .expect_err("expected timeout");
+        let elapsed = start.elapsed();
+
+        match err {
+            NickelError::Timeout { timeout_secs } => {
+                // Sub-second limits report at least 1s in the error.
+                assert_eq!(timeout_secs, 1);
+            }
+            other => panic!("unexpected error: {:?}", other),
+        }
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "kill path should return promptly, elapsed {:?}",
+            elapsed
+        );
     }
 }

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -226,6 +226,10 @@ fn load_keymap(keymap_ncl: &str) -> Keymap {
                 "\n\nerror evaluating step's doc string nickel:\n\n{}",
                 nickel_error_message
             ),
+            NickelError::Timeout { timeout_secs } => panic!(
+                "\n\nNickel evaluation timed out after {}s (set SMART_KEYMAP_NICKEL_TIMEOUT_SECS=0 to disable, or raise the limit)\n",
+                timeout_secs
+            ),
         },
     }
 }
@@ -287,6 +291,10 @@ fn inputs_from_ncl(keymap_ncl: &str, inputs_ncl: &str) -> Vec<Input> {
             NickelError::EvalError(nickel_error_message) => panic!(
                 "\n\nerror evaluating step's doc string nickel:\n\n{}",
                 nickel_error_message
+            ),
+            NickelError::Timeout { timeout_secs } => panic!(
+                "\n\nNickel evaluation timed out after {}s (set SMART_KEYMAP_NICKEL_TIMEOUT_SECS=0 to disable, or raise the limit)\n",
+                timeout_secs
             ),
         },
     }


### PR DESCRIPTION
Prevent hanging cargo/cucumber runs when nickel eval loops unbounded. Default 60s wall-clock limit via SMART_KEYMAP_NICKEL_TIMEOUT_SECS (0 disables).