### PR TITLE
Feat/layer mod tap toggle

### DIFF
--- a/features/keymap/key/layer_modifier-tap_toggle.feature
+++ b/features/keymap/key/layer_modifier-tap_toggle.feature
@@ -1,0 +1,88 @@
+Feature: Layer Modifier: Tap Toggle
+
+  The `K.layer_mod.tap_toggle` key combines momentary and toggle layer
+  access (QMK `TT` with `TAPPING_TOGGLE = 1`):
+
+  - holding the key (interrupted by another key) activates the layer while
+    held, like `K.layer_mod.hold`;
+  - tapping the key toggles whether the layer is active, like
+    `K.layer_mod.toggle`.
+
+  For examples of this feature in other smart keyboard firmware, see e.g.:
+
+  - [QMK's TT(layer)](https://docs.qmk.fm/feature_layers#switching-and-toggling-layers),
+
+  Background:
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        layers = [
+          [
+            K.layer_mod.tap_toggle 1,
+            K.A,
+          ],
+          [
+            K.TTTT,
+            K.B,
+          ],
+        ],
+      }
+      """
+
+  Example: holding the tap-toggle key activates the layer
+    When the keymap registers the following input
+      """
+      [
+        press (K.layer_mod.tap_toggle 1),
+        press (K.B),
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { key_codes = [K.B] }
+      """
+
+  Example: releasing a held tap-toggle key deactivates the layer
+    When the keymap registers the following input
+      """
+      [
+        press (K.layer_mod.tap_toggle 1),
+        press_keymap_index 1,
+        release_keymap_index 1,
+        release (K.layer_mod.tap_toggle 1),
+        press (K.A),
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { key_codes = [K.A] }
+      """
+
+  Example: tapping the tap-toggle key toggles the layer on
+    When the keymap registers the following input
+      """
+      [
+        tap (K.layer_mod.tap_toggle 1),
+        press (K.B),
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { key_codes = [K.B] }
+      """
+
+  Example: tapping the tap-toggle key a second time toggles the layer off
+    When the keymap registers the following input
+      """
+      [
+        tap (K.layer_mod.tap_toggle 1),
+        tap (K.layer_mod.tap_toggle 1),
+        press (K.A),
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { key_codes = [K.A] }
+      """

--- a/features/scripts/generate-doc.sh
+++ b/features/scripts/generate-doc.sh
@@ -31,6 +31,7 @@ keymap_key_features=(
     "layer_modifier-sticky-config-timeout"
     "semantic_os_desktop"
     "layer_modifier-toggle"
+    "layer_modifier-tap_toggle"
     "mouse"
     "sticky_modifiers"
     "sticky_modifiers-config-release_on_next_press"

--- a/ncl/layered-key.ncl
+++ b/ncl/layered-key.ncl
@@ -93,125 +93,165 @@
     else
       false,
 
+  # Helpers for layer_mod simulation on the inputs path.
+  # Broad outer arms + has_field (not nested `{ layer_modifier = { … } }` multi-arms):
+  # extra dedicated Press/Tap/Release nested patterns hang Nickel match compilation.
+  apply_hold_press = fun hold layer_state =>
+    let { active_layers = al, ..without_active_layers } = layer_state in
+    let ll =
+      if std.record.has_field "locked_layers" without_active_layers then without_active_layers.locked_layers else []
+    in
+    let other_fields =
+      if std.record.has_field "locked_layers" without_active_layers then
+        std.record.remove "locked_layers" without_active_layers
+      else
+        without_active_layers
+    in
+    if layer_flag_at ll hold then
+      {
+        active_layers = deactivate_layer al hold,
+        locked_layers = set_layer false ll hold,
+      }
+      & other_fields
+    else
+      { active_layers = activate_layer al hold, locked_layers = ll } & other_fields,
+
+  apply_hold_release = fun hold layer_state =>
+    let { active_layers = al, ..without_active_layers } = layer_state in
+    let ll =
+      if std.record.has_field "locked_layers" without_active_layers then without_active_layers.locked_layers else []
+    in
+    let other_fields =
+      if std.record.has_field "locked_layers" without_active_layers then
+        std.record.remove "locked_layers" without_active_layers
+      else
+        without_active_layers
+    in
+    if layer_flag_at ll hold then
+      { active_layers = al, locked_layers = ll } & other_fields
+    else
+      { active_layers = deactivate_layer al hold, locked_layers = ll } & other_fields,
+
+  apply_lock_invert = fun lm layer_state =>
+    let { active_layers = al, ..without_active_layers } = layer_state in
+    let ll =
+      if std.record.has_field "locked_layers" without_active_layers then
+        without_active_layers.locked_layers
+      else
+        []
+    in
+    let other_fields =
+      if std.record.has_field "locked_layers" without_active_layers then
+        std.record.remove "locked_layers" without_active_layers
+      else
+        without_active_layers
+    in
+    # true = highest active layer; number = specific layer index.
+    let layer =
+      if lm.lock == true then
+        highest_active_layer al
+      else
+        lm.lock
+    in
+    if layer == null then
+      { active_layers = al, locked_layers = ll } & other_fields
+    else if layer_flag_at ll layer then
+      {
+        active_layers = deactivate_layer al layer,
+        locked_layers = set_layer false ll layer,
+      }
+      & other_fields
+    else
+      {
+        active_layers = activate_layer al layer,
+        locked_layers = set_layer true ll layer,
+      }
+      & other_fields,
+
+  # Tap of hold: net press+release — unlock if locked, else no-op.
+  apply_hold_tap = fun hold layer_state =>
+    let { active_layers = al, ..without_active_layers } = layer_state in
+    let ll =
+      if std.record.has_field "locked_layers" without_active_layers then
+        without_active_layers.locked_layers
+      else
+        []
+    in
+    let other_fields =
+      if std.record.has_field "locked_layers" without_active_layers then
+        std.record.remove "locked_layers" without_active_layers
+      else
+        without_active_layers
+    in
+    if layer_flag_at ll hold then
+      {
+        active_layers = deactivate_layer al hold,
+        locked_layers = set_layer false ll hold,
+      }
+      & other_fields
+    else
+      { active_layers = al, locked_layers = ll } & other_fields,
+
+  apply_set_active_layers_mod = fun lm layer_state =>
+    let { active_layers = prior_active_layers, ..layer_state } = layer_state in
+    let new_active_layers =
+      if std.record.has_field "affected_layers" lm then
+        apply_set_active_layers_masked lm.set_active_layers_to lm.affected_layers prior_active_layers
+      else
+        apply_set_active_layers lm.set_active_layers_to prior_active_layers
+    in
+    { active_layers = new_active_layers } & layer_state,
+
   # `..` keeps the pattern open so locked_layers (and future fields) are accepted.
   update_layer_state_for_input = fun input layer_state @ { default_layer, active_layers, .. } =>
     input
     |> match {
-      'Press { layer_modifier = { hold }, .. } =>
-        let { active_layers = al, ..without_active_layers } = layer_state in
-        let ll =
-          if std.record.has_field "locked_layers" without_active_layers then without_active_layers.locked_layers else []
-        in
-        let other_fields =
-          if std.record.has_field "locked_layers" without_active_layers then
-            std.record.remove "locked_layers" without_active_layers
-          else
-            without_active_layers
-        in
-        if layer_flag_at ll hold then
-          {
-            active_layers = deactivate_layer al hold,
-            locked_layers = set_layer false ll hold,
-          }
-          & other_fields
-        else
-          { active_layers = activate_layer al hold, locked_layers = ll } & other_fields,
-      'Release { layer_modifier = { hold }, .. } =>
-        let { active_layers = al, ..without_active_layers } = layer_state in
-        let ll =
-          if std.record.has_field "locked_layers" without_active_layers then without_active_layers.locked_layers else []
-        in
-        let other_fields =
-          if std.record.has_field "locked_layers" without_active_layers then
-            std.record.remove "locked_layers" without_active_layers
-          else
-            without_active_layers
-        in
-        if layer_flag_at ll hold then
-          { active_layers = al, locked_layers = ll } & other_fields
-        else
-          { active_layers = deactivate_layer al hold, locked_layers = ll } & other_fields,
-      'Press { layer_modifier = { toggle }, .. } or
-      'Tap { layer_modifier = { toggle }, .. } =>
-        let { active_layers = al, ..layer_state } = layer_state in
-        { active_layers = toggle_layer al toggle } & layer_state,
-      # Note: lock (and Tap-hold) are handled inside this arm — extra dedicated Press/Tap
-      # or-patterns make Nickel's match compilation hang/time out.
-      # Press/Release hold are matched above; Tap hold falls through here.
-      'Press { layer_modifier = lm, .. } or
-      'Tap { layer_modifier = lm, .. } =>
-        if std.record.has_field "lock" lm then
-          let { active_layers = al, ..without_active_layers } = layer_state in
-          let ll =
-            if std.record.has_field "locked_layers" without_active_layers then
-              without_active_layers.locked_layers
-            else
-              []
-          in
-          let other_fields =
-            if std.record.has_field "locked_layers" without_active_layers then
-              std.record.remove "locked_layers" without_active_layers
-            else
-              without_active_layers
-          in
-          # true = highest active layer; number = specific layer index.
-          let layer =
-            if lm.lock == true then
-              highest_active_layer al
-            else
-              lm.lock
-          in
-          if layer == null then
-            { active_layers = al, locked_layers = ll } & other_fields
-          else if layer_flag_at ll layer then
-            {
-              active_layers = deactivate_layer al layer,
-              locked_layers = set_layer false ll layer,
-            }
-            & other_fields
-          else
-            {
-              active_layers = activate_layer al layer,
-              locked_layers = set_layer true ll layer,
-            }
-            & other_fields
-        else if std.record.has_field "hold" lm then
-          # Tap hold only (Press/Release matched above). Net press+release: unlock if locked, else no-op.
-          let { active_layers = al, ..without_active_layers } = layer_state in
-          let ll =
-            if std.record.has_field "locked_layers" without_active_layers then
-              without_active_layers.locked_layers
-            else
-              []
-          in
-          let other_fields =
-            if std.record.has_field "locked_layers" without_active_layers then
-              std.record.remove "locked_layers" without_active_layers
-            else
-              without_active_layers
-          in
-          if layer_flag_at ll lm.hold then
-            {
-              active_layers = deactivate_layer al lm.hold,
-              locked_layers = set_layer false ll lm.hold,
-            }
-            & other_fields
-          else
-            { active_layers = al, locked_layers = ll } & other_fields
+      # One broad arm per input kind + has_field on `lm` (match-tax).
+      'Press { layer_modifier = lm, .. } =>
+        if std.record.has_field "hold" lm then
+          apply_hold_press lm.hold layer_state
+        else if std.record.has_field "tap_toggle" lm then
+          # Hold path: activate like MO while pressed.
+          let { active_layers = al, ..layer_state } = layer_state in
+          { active_layers = activate_layer al lm.tap_toggle } & layer_state
+        else if std.record.has_field "toggle" lm then
+          let { active_layers = al, ..layer_state } = layer_state in
+          { active_layers = toggle_layer al lm.toggle } & layer_state
+        else if std.record.has_field "lock" lm then
+          apply_lock_invert lm layer_state
         else if std.record.has_field "set_active_layers_to" lm then
-          let { active_layers = prior_active_layers, ..layer_state } = layer_state in
-          let new_active_layers =
-            if std.record.has_field "affected_layers" lm then
-              apply_set_active_layers_masked lm.set_active_layers_to lm.affected_layers prior_active_layers
-            else
-              apply_set_active_layers lm.set_active_layers_to prior_active_layers
-          in
-          { active_layers = new_active_layers } & layer_state
+          apply_set_active_layers_mod lm layer_state
         else
           layer_state,
-      'Release { layer_modifier = { default_ }, .. } =>
-        let { default_layer, ..layer_state } = layer_state in
-        { default_layer = default_ } & layer_state,
+      'Release { layer_modifier = lm, .. } =>
+        if std.record.has_field "hold" lm then
+          apply_hold_release lm.hold layer_state
+        else if std.record.has_field "tap_toggle" lm then
+          # Hold-release path: deactivate like MO.
+          # (NCL sim does not track interruption; pure taps use 'Tap below.)
+          let { active_layers = al, ..layer_state } = layer_state in
+          { active_layers = deactivate_layer al lm.tap_toggle } & layer_state
+        else if std.record.has_field "default_" lm then
+          let { default_layer, ..layer_state } = layer_state in
+          { default_layer = lm.default_ } & layer_state
+        else
+          layer_state,
+      'Tap { layer_modifier = lm, .. } =>
+        if std.record.has_field "toggle" lm then
+          let { active_layers = al, ..layer_state } = layer_state in
+          { active_layers = toggle_layer al lm.toggle } & layer_state
+        else if std.record.has_field "tap_toggle" lm then
+          # Net toggle (press+release without interruption).
+          let { active_layers = al, ..layer_state } = layer_state in
+          { active_layers = toggle_layer al lm.tap_toggle } & layer_state
+        else if std.record.has_field "lock" lm then
+          apply_lock_invert lm layer_state
+        else if std.record.has_field "hold" lm then
+          apply_hold_tap lm.hold layer_state
+        else if std.record.has_field "set_active_layers_to" lm then
+          apply_set_active_layers_mod lm layer_state
+        else
+          layer_state,
       _ => layer_state,
     },
 

--- a/ncl/passes/named-layers.ncl
+++ b/ncl/passes/named-layers.ncl
@@ -271,6 +271,8 @@
             { layer_modifier = { sticky = resolve_layer_index name_to_idx s } },
           { toggle = t } =>
             { layer_modifier = { toggle = resolve_layer_index name_to_idx t } },
+          { tap_toggle = t } =>
+            { layer_modifier = { tap_toggle = resolve_layer_index name_to_idx t } },
           # true = highest active (no named-layer resolution); number/string = specific layer.
           { lock = true } =>
             { layer_modifier = { lock = true } },

--- a/ncl/smart_keys/layered/key-extensions.ncl
+++ b/ncl/smart_keys/layered/key-extensions.ncl
@@ -13,6 +13,11 @@
         {
           layer_modifier = { toggle = layer_num }
         },
+      # Hold = momentary layer; tap = toggle layer.
+      tap_toggle = fun layer_num =>
+        {
+          layer_modifier = { tap_toggle = layer_num }
+        },
       sticky = fun layer_num =>
         {
           layer_modifier = { sticky = layer_num }

--- a/ncl/smart_keys/layered/keymap-codegen.ncl
+++ b/ncl/smart_keys/layered/keymap-codegen.ncl
@@ -74,6 +74,9 @@
     check_json_is_toggle =
       let json = { Toggle = 1 } in
       smart_keymap.layered.modifier_key.is_json json,
+    check_json_is_tap_toggle =
+      let json = { TapToggle = 1 } in
+      smart_keymap.layered.modifier_key.is_json json,
     check_json_is_lock =
       let json = { Lock = "HighestActive" } in
       smart_keymap.layered.modifier_key.is_json json,
@@ -93,13 +96,13 @@
         key_type = "%{module}::ModifierKey",
 
         # c.f. doc_de_layered.md.
-        # JSON serialization of key::layered::ModifierKey has variants: Default(layer), Hold([layer, kb_mods]), SetActiveLayers({ layers, mask? }), Lock("HighestActive"|{ Layer }).
+        # JSON serialization of key::layered::ModifierKey has variants: Default(layer), Hold([layer, kb_mods]), SetActiveLayers({ layers, mask? }), TapToggle(layer), Lock("HighestActive"|{ Layer }).
         json_validator =
           validators.record.validator {
             fields_validator =
               validators.all_of [
-                validators.record.has_any_field_of ["Default", "Hold", "Sticky", "SetActiveLayers", "Toggle", "Lock"],
-                validators.record.has_only_fields ["Default", "Hold", "Sticky", "SetActiveLayers", "Toggle", "Lock"],
+                validators.record.has_any_field_of ["Default", "Hold", "Sticky", "SetActiveLayers", "Toggle", "TapToggle", "Lock"],
+                validators.record.has_only_fields ["Default", "Hold", "Sticky", "SetActiveLayers", "Toggle", "TapToggle", "Lock"],
               ],
             field_validators =
               let modifier_bitset_validator =
@@ -127,6 +130,7 @@
                     _ => 'Error { message = "expected Hold to be [layer_index, kb_mods]" },
                   },
                 Toggle = validators.is_number,
+                TapToggle = validators.is_number,
                 Sticky = validators.is_number,
                 # LayerLockTarget: "HighestActive" | { Layer = layer_index } (1-based).
                 Lock = fun lock =>
@@ -184,6 +188,14 @@
                 include key_type,
                 variant = "Toggle",
                 rust_expr = "%{module}::ModifierKey::toggle(%{std.to_string layer_index})",
+              },
+            { TapToggle = layer_index } =>
+              {
+                include json,
+                include module,
+                include key_type,
+                variant = "TapToggle",
+                rust_expr = "%{module}::ModifierKey::tap_toggle(%{std.to_string layer_index})",
               },
             { Sticky = layer_index } =>
               {

--- a/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
@@ -26,6 +26,16 @@
         expected = { Toggle = 1 },
       },
 
+      keymap_example_tap_toggle = {
+        actual = K.layer_mod.tap_toggle 1,
+        expected = { layer_modifier.tap_toggle = 1 },
+      },
+
+      check_json_value_tap_toggle = {
+        actual = K.layer_mod.tap_toggle 1 |> keymap_ncl.key.to_json_value,
+        expected = { TapToggle = 1 },
+      },
+
       keymap_example_lock = {
         actual = K.layer_mod.lock,
         expected = { layer_modifier.lock = true },
@@ -188,6 +198,11 @@
                   'Ok
                 else
                   validators.all_of [validators.is_number, validators.is_greater_than 0] toggle,
+              { tap_toggle } =>
+                if std.is_string tap_toggle then
+                  'Ok
+                else
+                  validators.all_of [validators.is_number, validators.is_greater_than 0] tap_toggle,
               { lock } =>
                 # true = highest active; named layer string ok; numeric layer index must be > 0.
                 if std.is_bool lock then
@@ -207,12 +222,12 @@
               { set_active_layers_to } => layer_indices_array set_active_layers_to,
               _ =>
                 'Error {
-                  message = "expected { layer_modifier = { default_ } }, { hold }, { sticky }, { toggle }, { lock }, { set_active_layers_to }, or { set_active_layers_to, affected_layers }",
+                  message = "expected { layer_modifier = { default_ } }, { hold }, { sticky }, { toggle }, { tap_toggle }, { lock }, { set_active_layers_to }, or { set_active_layers_to, affected_layers }",
                 },
             },
           _ =>
             'Error {
-              message = "expected { layer_modifier = { default_ } }, { hold }, { sticky }, { toggle }, { lock }, { set_active_layers_to }, or { set_active_layers_to, affected_layers }",
+              message = "expected { layer_modifier = { default_ } }, { hold }, { sticky }, { toggle }, { tap_toggle }, { lock }, { set_active_layers_to }, or { set_active_layers_to, affected_layers }",
             },
         },
 
@@ -246,6 +261,8 @@
                 { Toggle = toggle_layer },
               { sticky = sticky_layer } =>
                 { Sticky = sticky_layer },
+              { tap_toggle = tap_toggle_layer } =>
+                { TapToggle = tap_toggle_layer },
               { lock = true } =>
                 { Lock = "HighestActive" },
               { lock = lock_layer } =>
@@ -262,12 +279,12 @@
                 { SetActiveLayers = modifier_bitset },
               _ =>
                 'Error {
-                  message = "expected { layer_modifier = { default_ } }, { hold }, { sticky }, { toggle }, { lock }, { set_active_layers_to }, or { set_active_layers_to, affected_layers }",
+                  message = "expected { layer_modifier = { default_ } }, { hold }, { sticky }, { toggle }, { tap_toggle }, { lock }, { set_active_layers_to }, or { set_active_layers_to, affected_layers }",
                 },
             },
           _ =>
             'Error {
-              message = "expected { layer_modifier = { default_ } }, { hold }, { sticky }, { toggle }, { lock }, { set_active_layers_to }, or { set_active_layers_to, affected_layers }",
+              message = "expected { layer_modifier = { default_ } }, { hold }, { sticky }, { toggle }, { tap_toggle }, { lock }, { set_active_layers_to }, or { set_active_layers_to, affected_layers }",
             },
         },
 

--- a/smart-keymap-core/src/key/layered.rs
+++ b/smart-keymap-core/src/key/layered.rs
@@ -178,6 +178,17 @@ pub enum ModifierKey {
     /// Acts the same as `Hold` variant if interrupted.
     /// If tapped, then the layer is activated for the next key tap.
     Sticky(LayerIndex),
+    /// Tap-toggle layer modifier.
+    ///
+    /// - **Hold** (interrupted by another key, or released after hold use):
+    ///   acts as [`ModifierKey::Hold`] — layer on while pressed.
+    /// - **Tap** (released without interruption): toggles the layer.
+    ///
+    /// On press the layer is always activated so nested keys resolve on the
+    /// target layer immediately. On release, the layer is left active only when
+    /// the press was a tap that turned the layer *on*, or a hold of a layer
+    /// that was already active before the press (i.e. already toggled on).
+    TapToggle(LayerIndex),
     /// Sets the set of active layers to the given layers when the key is pressed.
     SetActiveLayers(ModifierBitset),
     /// Sets the default layer.
@@ -215,6 +226,14 @@ impl ModifierKey {
     /// Create a new [ModifierKey] that toggles the given layer.
     pub const fn toggle(layer: LayerIndex) -> Self {
         ModifierKey::Toggle(layer)
+    }
+
+    /// Create a new [ModifierKey] that holds the layer while pressed, or toggles it when tapped.
+    ///
+    /// Hold-vs-tap is decided by interruption (another key pressed while this
+    /// key is held), same as sticky. A single uninterrupted tap toggles the layer.
+    pub const fn tap_toggle(layer: LayerIndex) -> Self {
+        ModifierKey::TapToggle(layer)
     }
 
     /// Create a new [ModifierKey] that sets the active layers to the given slice of layers when pressed.
@@ -276,7 +295,13 @@ impl ModifierKey {
     /// Create a new [input::PressedKey] and [key::ScheduledEvent] for the given keymap index.
     ///
     /// Pressing a [ModifierKey::Hold] emits a [LayerEvent::Activated] event.
-    pub fn new_pressed_key(&self) -> (ModifierKeyState, Option<LayerEvent>) {
+    ///
+    /// `context` is used by [ModifierKey::TapToggle] to record whether the layer
+    /// was already active before this press (needed for correct release).
+    pub fn new_pressed_key<const LAYER_COUNT: usize, const CONDITIONAL_LAYER_COUNT: usize>(
+        &self,
+        context: &Context<LAYER_COUNT, CONDITIONAL_LAYER_COUNT>,
+    ) -> (ModifierKeyState, Option<LayerEvent>) {
         match self {
             ModifierKey::Hold(layer, _) => {
                 (ModifierKeyState::new(), Some(LayerEvent::Activated(*layer)))
@@ -288,6 +313,16 @@ impl ModifierKey {
                 ModifierKeyState::sticky(),
                 Some(LayerEvent::StickyActivated(*layer)),
             ),
+            ModifierKey::TapToggle(layer) => {
+                let was_active = context
+                    .layer_state()
+                    .get(*layer as usize - 1)
+                    .is_some_and(|a| a.is_active());
+                (
+                    ModifierKeyState::tap_toggle(was_active),
+                    Some(LayerEvent::Activated(*layer)),
+                )
+            }
             ModifierKey::SetActiveLayers(modifier_bitset) => (
                 ModifierKeyState::new(),
                 Some(LayerEvent::Set(*modifier_bitset)),
@@ -994,19 +1029,28 @@ pub enum LayerEvent {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PendingKeyState;
 
-/// Whether the pressed Sticky modifier key is "sticky" or "regular".
+/// Whether the pressed Sticky / TapToggle modifier key is still "pending tap" or "held".
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum Behavior {
-    /// Key state is "sticky". (Will activate sticky modifier when released).
+    /// Key state is "sticky" / pending tap. (Not interrupted by another key.)
+    ///
+    /// For sticky: activates sticky layer on release.
+    /// For tap-toggle: release toggles relative to pre-press layer state.
     Sticky,
-    /// Key state is "regular". (No sticky modifiers activated when released).
+    /// Key state is "regular" / hold. (Interrupted by another key, or non-tap key.)
+    ///
+    /// For sticky: deactivates layer on release (hold behavior).
+    /// For tap-toggle: deactivates layer on release unless it was already active.
     Regular,
 }
 
 /// [crate::key::KeyState] of [ModifierKey].
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ModifierKeyState {
-    behavior: Behavior,
+    /// Hold-vs-tap (sticky / tap-toggle pending) classification.
+    pub behavior: Behavior,
+    /// For [ModifierKey::TapToggle]: whether the layer was active before press.
+    pub was_active: bool,
 }
 
 impl Default for ModifierKeyState {
@@ -1020,6 +1064,7 @@ impl ModifierKeyState {
     pub fn new() -> Self {
         Self {
             behavior: Behavior::Regular,
+            was_active: false,
         }
     }
 
@@ -1027,6 +1072,18 @@ impl ModifierKeyState {
     pub fn sticky() -> Self {
         Self {
             behavior: Behavior::Sticky,
+            was_active: false,
+        }
+    }
+
+    /// Constructs a tap-toggle ModifierKeyState.
+    ///
+    /// Starts as pending-tap ([Behavior::Sticky]); interruption converts to hold.
+    /// `was_active` is whether the target layer was already active when pressed.
+    pub fn tap_toggle(was_active: bool) -> Self {
+        Self {
+            behavior: Behavior::Sticky,
+            was_active,
         }
     }
 
@@ -1068,6 +1125,30 @@ impl ModifierKeyState {
                         // Sticky key tapped (released without interruption):
                         // layer stays sticky; arm optional timeout via context.
                         Behavior::Sticky => Some(LayerEvent::StickyReleased),
+                    }
+                }
+                _ => None,
+            },
+            ModifierKey::TapToggle(layer) => match event {
+                key::Event::Input(input::Event::Press { keymap_index: _ }) => {
+                    // Another key pressed while TT is held → hold (MO) path.
+                    if self.behavior == Behavior::Sticky {
+                        self.behavior = Behavior::Regular;
+                    }
+                    None
+                }
+                key::Event::Input(input::Event::Release { keymap_index: ki })
+                    if keymap_index == ki =>
+                {
+                    // End state:
+                    // - hold → restore pre-press activity (deactivate only if was inactive)
+                    // - tap  → invert pre-press activity (deactivate only if was active)
+                    // i.e. deactivate iff (is_hold XOR was_active).
+                    let is_hold = self.behavior == Behavior::Regular;
+                    if is_hold != self.was_active {
+                        Some(LayerEvent::Deactivated(*layer))
+                    } else {
+                        None
                     }
                 }
                 _ => None,
@@ -1149,7 +1230,7 @@ impl<
         match key_ref {
             Ref::Modifier(mod_key_index) => {
                 let key = self.modifier_keys[mod_key_index as usize];
-                let (m_ks, maybe_lmod_ev) = key.new_pressed_key();
+                let (m_ks, maybe_lmod_ev) = key.new_pressed_key(context);
                 let pks = key::PressedKeyResult::Resolved(m_ks);
                 let pke = match maybe_lmod_ev {
                     Some(lmod_ev) => {
@@ -1287,8 +1368,9 @@ mod tests {
     fn test_pressing_hold_modifier_key_emits_event_activate_layer() {
         let layer = 1;
         let key = ModifierKey::hold(layer);
+        let context = Context::default();
 
-        let (_pressed_key, layer_event) = key.new_pressed_key();
+        let (_pressed_key, layer_event) = key.new_pressed_key(&context);
 
         assert_eq!(Some(LayerEvent::Activated(layer)), layer_event);
     }
@@ -1298,8 +1380,9 @@ mod tests {
         // Assemble: press a Hold layer modifier key
         let layer = 1;
         let key = ModifierKey::hold(layer);
+        let context = Context::default();
         let keymap_index = 9; // arbitrary
-        let (mut pressed_key_state, _) = key.new_pressed_key();
+        let (mut pressed_key_state, _) = key.new_pressed_key(&context);
 
         // Act: the modifier key handles "release key" input event
         let actual_events = pressed_key_state
@@ -1326,8 +1409,9 @@ mod tests {
         // Assemble: press a Hold layer modifier key
         let layer = 1;
         let key = ModifierKey::hold(layer);
+        let context = Context::default();
         let keymap_index = 9; // arbitrary
-        let (mut pressed_key_state, _) = key.new_pressed_key();
+        let (mut pressed_key_state, _) = key.new_pressed_key(&context);
 
         // Act: the modifier key handles "release key" input event for a different key
         let different_keymap_index = keymap_index + 1;
@@ -1613,9 +1697,10 @@ mod tests {
         // Assemble
         let layer = 1;
         let key = ModifierKey::Toggle(layer);
+        let context = Context::default();
 
         // Act
-        let (_pressed_key, layer_event) = key.new_pressed_key();
+        let (_pressed_key, layer_event) = key.new_pressed_key(&context);
 
         // Assert
         assert_eq!(Some(LayerEvent::Toggled(layer)), layer_event);
@@ -1625,9 +1710,10 @@ mod tests {
     fn test_pressing_lock_key_emits_lock_invert_highest() {
         // Assemble
         let key = ModifierKey::lock();
+        let context = Context::default();
 
         // Act
-        let (_pressed_key, layer_event) = key.new_pressed_key();
+        let (_pressed_key, layer_event) = key.new_pressed_key(&context);
 
         // Assert
         assert_eq!(
@@ -1640,15 +1726,130 @@ mod tests {
     fn test_pressing_lock_layer_key_emits_lock_invert_layer() {
         // Assemble
         let key = ModifierKey::lock_layer(2);
+        let context = Context::default();
 
         // Act
-        let (_pressed_key, layer_event) = key.new_pressed_key();
+        let (_pressed_key, layer_event) = key.new_pressed_key(&context);
 
         // Assert
         assert_eq!(
             Some(LayerEvent::LockInvert(LayerLockTarget::Layer(2))),
             layer_event
         );
+    }
+
+    #[test]
+    fn test_pressing_tap_toggle_emits_activated_and_records_was_inactive() {
+        let layer = 1;
+        let key = ModifierKey::tap_toggle(layer);
+        let context = Context::default();
+
+        let (state, layer_event) = key.new_pressed_key(&context);
+
+        assert_eq!(Some(LayerEvent::Activated(layer)), layer_event);
+        assert!(!state.was_active);
+        assert_eq!(Behavior::Sticky, state.behavior);
+    }
+
+    #[test]
+    fn test_pressing_tap_toggle_records_was_active() {
+        let layer = 1;
+        let key = ModifierKey::tap_toggle(layer);
+        let mut context = Context::default();
+        context.handle_layer_event(LayerEvent::Activated(layer));
+
+        let (state, layer_event) = key.new_pressed_key(&context);
+
+        assert_eq!(Some(LayerEvent::Activated(layer)), layer_event);
+        assert!(state.was_active);
+    }
+
+    #[test]
+    fn test_tap_toggle_tap_release_when_inactive_leaves_layer_on() {
+        // Press when inactive + tap release → layer stays active (toggled on).
+        let layer = 1;
+        let key = ModifierKey::tap_toggle(layer);
+        let context = Context::default();
+        let keymap_index = 0;
+        let (mut state, _) = key.new_pressed_key(&context);
+
+        let ev = state.handle_event(
+            keymap_index,
+            key::Event::Input(input::Event::Release { keymap_index }),
+            &key,
+        );
+
+        assert_eq!(None, ev);
+    }
+
+    #[test]
+    fn test_tap_toggle_tap_release_when_active_deactivates() {
+        // Press when already active + tap release → toggle off.
+        let layer = 1;
+        let key = ModifierKey::tap_toggle(layer);
+        let mut context = Context::default();
+        context.handle_layer_event(LayerEvent::Activated(layer));
+        let keymap_index = 0;
+        let (mut state, _) = key.new_pressed_key(&context);
+
+        let ev = state.handle_event(
+            keymap_index,
+            key::Event::Input(input::Event::Release { keymap_index }),
+            &key,
+        );
+
+        assert_eq!(Some(LayerEvent::Deactivated(layer)), ev);
+    }
+
+    #[test]
+    fn test_tap_toggle_hold_release_when_inactive_deactivates() {
+        // Press when inactive + interrupt + release → MO off.
+        let layer = 1;
+        let key = ModifierKey::tap_toggle(layer);
+        let context = Context::default();
+        let keymap_index = 0;
+        let (mut state, _) = key.new_pressed_key(&context);
+
+        // Interrupt with another key
+        let _ = state.handle_event(
+            keymap_index,
+            key::Event::Input(input::Event::Press { keymap_index: 1 }),
+            &key,
+        );
+        assert_eq!(Behavior::Regular, state.behavior);
+
+        let ev = state.handle_event(
+            keymap_index,
+            key::Event::Input(input::Event::Release { keymap_index }),
+            &key,
+        );
+
+        assert_eq!(Some(LayerEvent::Deactivated(layer)), ev);
+    }
+
+    #[test]
+    fn test_tap_toggle_hold_release_when_active_leaves_layer_on() {
+        // Press when already toggled on + interrupt + release → stay on.
+        let layer = 1;
+        let key = ModifierKey::tap_toggle(layer);
+        let mut context = Context::default();
+        context.handle_layer_event(LayerEvent::Activated(layer));
+        let keymap_index = 0;
+        let (mut state, _) = key.new_pressed_key(&context);
+
+        let _ = state.handle_event(
+            keymap_index,
+            key::Event::Input(input::Event::Press { keymap_index: 1 }),
+            &key,
+        );
+
+        let ev = state.handle_event(
+            keymap_index,
+            key::Event::Input(input::Event::Release { keymap_index }),
+            &key,
+        );
+
+        assert_eq!(None, ev);
     }
 
     #[test]

--- a/tests/rust/layered/tap_toggle.rs
+++ b/tests/rust/layered/tap_toggle.rs
@@ -1,13 +1,3 @@
-mod conditional;
-mod lock;
-mod modified_hold;
-mod set_active_layers;
-mod sticky;
-mod sticky_timeout;
-mod tap_hold;
-mod tap_toggle;
-mod toggle;
-
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;
 
@@ -15,45 +5,21 @@ use crate::hid_keycodes::*;
 use smart_keymap_macros::keymap;
 
 #[test]
-fn press_base_key_when_no_layers_active() {
+fn hold_tap_toggle_activates_layer_while_pressed() {
     // Assemble
     let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
                 layers = [
-                    [K.layer_mod.hold 1, K.A],
+                    [K.layer_mod.tap_toggle 1, K.A],
                     [K.TTTT, K.B],
                 ],
             }
         "#
     ));
 
-    // Act
-    keymap.handle_input(input::Event::Press { keymap_index: 1 });
-
-    // Assert
-    let expected_report: [u8; 8] = [0, 0, KC_A, 0, 0, 0, 0, 0];
-    let actual_report = keymap.boot_keyboard_report();
-    assert_eq!(expected_report, actual_report,);
-}
-
-#[test]
-fn press_active_layer_when_layer_mod_held() {
-    // Assemble
-    let mut keymap = ObservedKeymap::new(keymap!(
-        r#"
-            let K = import "keys.ncl" in
-            {
-                layers = [
-                    [K.layer_mod.hold 1, K.A],
-                    [K.TTTT, K.B],
-                ],
-            }
-        "#
-    ));
-
-    // Act
+    // Act: hold TT and press the other key (interrupt → hold path)
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
 
@@ -64,78 +30,114 @@ fn press_active_layer_when_layer_mod_held() {
 }
 
 #[test]
-fn press_retained_when_layer_mod_released() {
+fn hold_tap_toggle_deactivates_layer_on_release() {
     // Assemble
     let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
                 layers = [
-                    [K.layer_mod.hold 1, K.A],
+                    [K.layer_mod.tap_toggle 1, K.A],
                     [K.TTTT, K.B],
                 ],
             }
         "#
     ));
 
-    // Act
+    // Act: hold TT, interrupt with layer key, release both, then press base key
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
 
-    // Assert
+    // Assert: back on base layer
+    let expected_report: [u8; 8] = [0, 0, KC_A, 0, 0, 0, 0, 0];
+    let actual_report = keymap.boot_keyboard_report();
+    assert_eq!(expected_report, actual_report);
+}
+
+#[test]
+fn tap_tap_toggle_activates_layer() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                layers = [
+                    [K.layer_mod.tap_toggle 1, K.A],
+                    [K.TTTT, K.B],
+                ],
+            }
+        "#
+    ));
+
+    // Act: tap TT (no interrupt), then press the other key
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+
+    // Assert: layer stays toggled on
     let expected_report: [u8; 8] = [0, 0, KC_B, 0, 0, 0, 0, 0];
     let actual_report = keymap.boot_keyboard_report();
     assert_eq!(expected_report, actual_report);
 }
 
 #[test]
-fn uses_base_when_pressed_after_layer_mod_released() {
+fn tap_tap_toggle_twice_deactivates_layer() {
     // Assemble
     let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
                 layers = [
-                    [K.layer_mod.hold 1, K.A],
+                    [K.layer_mod.tap_toggle 1, K.A],
                     [K.TTTT, K.B],
                 ],
             }
         "#
     ));
 
-    // Act
+    // Act: tap TT twice, then press the other key
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
     keymap.handle_input(input::Event::Press { keymap_index: 0 });
     keymap.handle_input(input::Event::Release { keymap_index: 0 });
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
 
-    // Assert
+    // Assert: layer toggled off
     let expected_report: [u8; 8] = [0, 0, KC_A, 0, 0, 0, 0, 0];
     let actual_report = keymap.boot_keyboard_report();
     assert_eq!(expected_report, actual_report);
 }
 
 #[test]
-fn init_resets_active_layers() {
-    // Assemble: hold layer 1
+fn hold_of_toggled_on_layer_stays_active_after_release() {
+    // Assemble
     let mut keymap = ObservedKeymap::new(keymap!(
         r#"
             let K = import "keys.ncl" in
             {
                 layers = [
-                    [K.layer_mod.hold 1, K.A],
+                    [K.layer_mod.tap_toggle 1, K.A],
                     [K.TTTT, K.B],
                 ],
             }
         "#
     ));
-    keymap.handle_input(input::Event::Press { keymap_index: 0 });
 
-    // Act: reset, then press the letter key without re-holding the mod
-    keymap.init();
+    // Act: tap to toggle layer on, then hold TT with interrupt, release TT, press key
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    // Layer is on. Hold TT and interrupt with another key, then release TT.
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
     keymap.handle_input(input::Event::Press { keymap_index: 1 });
 
-    // Assert: layer state was cleared — base key, not layer 1
-    let expected_report: [u8; 8] = [0, 0, KC_A, 0, 0, 0, 0, 0];
-    assert_eq!(expected_report, keymap.boot_keyboard_report());
+    // Assert: still on toggled layer
+    let expected_report: [u8; 8] = [0, 0, KC_B, 0, 0, 0, 0, 0];
+    let actual_report = keymap.boot_keyboard_report();
+    assert_eq!(expected_report, actual_report);
 }


### PR DESCRIPTION
### Summary
Adds a tap-toggle layer modifier: hold behaves like a momentary layer switch, and a single uninterrupted tap toggles the layer on or off. Hold-versus-tap is decided by interruption (another key pressed while the modifier is held), the same pattern as sticky layer mods. On press the layer activates immediately so keys resolve on the target layer right away; release restores or inverts activity based on the pre-press state and whether the press was a hold or a tap.

### Changes
- Core: new tap-toggle modifier variant and release semantics, with unit tests
- Nickel: authoring helper, validation, JSON/codegen, named-layer resolution, and layered-key simulation for input index lookup
- Tests: Rust integration coverage for hold and tap paths (including hold while already toggled on)
- Cucumber feature scenarios documenting the behaviour (QMK TT comparison lives only there)

### Test plan
- [ ] Layered core unit tests
- [ ] Rust integration tests for tap-toggle
- [ ] Cucumber scenarios for the tap-toggle feature
- [ ] Nickel checks for layered/layer-modifier codegen
- [ ] `cargo doc -p smart-keymap-core --no-deps` with warnings denied