### PR TITLE
Feat/tap hold polish

### DIFF
--- a/features/keymap/key/tap_hold-config-quick_tap.feature
+++ b/features/keymap/key/tap_hold-config-quick_tap.feature
@@ -1,0 +1,64 @@
+Feature: TapHold Key (configure quick_tap_ms)
+
+  The `quick_tap_ms` config (ZMK `quick-tap-ms`) means that
+   re-pressing a tap-hold key within the window of its previous press
+   immediately resolves as tap.
+
+  This is useful for hold-to-repeat on the tap behaviour
+   (e.g. backspace) without waiting for the hold timeout.
+
+  For examples of this key in other smart keyboard firmware, see e.g.:
+
+  - [ZMK's hold-tap, quick-tap-ms](https://zmk.dev/docs/keymaps/behaviors/hold-tap#quick-tap-ms)
+
+  Background:
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        config.tap_hold.quick_tap_ms = 175,
+        config.tap_hold.timeout = 200,
+        keys = [
+          K.A & K.hold K.LeftCtrl,
+        ]
+      }
+      """
+
+  Example: re-press within quick_tap_ms forces tap even when held
+
+    When the keymap registers the following input
+      """
+      [
+        tap (K.A & K.hold K.LeftCtrl),
+        wait 50,
+        press (K.A & K.hold K.LeftCtrl),
+        wait 250,
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        tap (K.A),
+        press (K.A),
+      ]
+      """
+
+  Example: re-press after quick_tap_ms allows hold
+
+    When the keymap registers the following input
+      """
+      [
+        tap (K.A & K.hold K.LeftCtrl),
+        wait 200,
+        press (K.A & K.hold K.LeftCtrl),
+        wait 250,
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        tap (K.A),
+        press (K.LeftCtrl),
+      ]
+      """

--- a/features/keymap/key/tap_hold-config-retro_tap.feature
+++ b/features/keymap/key/tap_hold-config-retro_tap.feature
@@ -1,0 +1,60 @@
+Feature: TapHold Key (configure retro_tap)
+
+  The `retro_tap` config (ZMK `retro-tap`) means that
+   timeout alone never resolves a tap-hold as hold.
+   Hold activates only when another key interrupts;
+   releasing alone always yields tap.
+
+  For examples of this key in other smart keyboard firmware, see e.g.:
+
+  - [ZMK's hold-tap, retro-tap](https://zmk.dev/docs/keymaps/behaviors/hold-tap#retro-tap)
+
+  Background:
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        config.tap_hold.retro_tap = true,
+        config.tap_hold.timeout = 200,
+        config.tap_hold.interrupt_response = "HoldOnKeyPress",
+        keys = [
+          K.A & K.hold K.LeftCtrl,
+          K.B,
+        ]
+      }
+      """
+
+  Example: long hold alone resolves as tap
+
+    When the keymap registers the following input
+      """
+      [
+        press (K.A & K.hold K.LeftCtrl),
+        wait 250,
+        release (K.A & K.hold K.LeftCtrl),
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        tap (K.A),
+      ]
+      """
+
+  Example: interrupting press still resolves as hold
+
+    When the keymap registers the following input
+      """
+      [
+        press (K.A & K.hold K.LeftCtrl),
+        press (K.B),
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        press (K.LeftCtrl),
+        press (K.B),
+      ]
+      """

--- a/features/keymap/key/tap_hold-hold_trigger_positions.feature
+++ b/features/keymap/key/tap_hold-hold_trigger_positions.feature
@@ -1,0 +1,67 @@
+Feature: TapHold Key (hold_trigger_key_positions / opposite-hand)
+
+  When a tap-hold key sets `hold_trigger_key_positions`,
+   only those keymap indices may resolve an interrupt as hold.
+   Interrupts from other positions are ignored for the hold decision
+   (ZMK positional hold-tap / opposite-hand HRM polish).
+
+  Timeout and self-release behaviour are unchanged.
+
+  For examples of this key in other smart keyboard firmware, see e.g.:
+
+  - [ZMK's hold-tap, hold-trigger-key-positions](https://zmk.dev/docs/keymaps/behaviors/hold-tap#positional-hold-tap-and-hold-trigger-key-positions)
+
+  Background:
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        config.tap_hold.interrupt_response = "HoldOnKeyPress",
+        config.tap_hold.timeout = 200,
+        keys = [
+          K.A & K.hold K.LeftCtrl & { hold_trigger_key_positions = [2] },
+          K.B,
+          K.C,
+        ]
+      }
+      """
+
+  Example: allowed interrupt position resolves as hold
+
+    When the keymap registers the following input
+      """
+      [
+        press (K.A & K.hold K.LeftCtrl & { hold_trigger_key_positions = [2] }),
+        press (K.C),
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        press (K.LeftCtrl),
+        press (K.C),
+      ]
+      """
+
+  Example: non-trigger interrupt does not force hold
+
+    Interrupting with a non-trigger key (press & release), then releasing
+     the tap-hold, resolves as tap rather than hold.
+
+    When the keymap registers the following input
+      """
+      [
+        press (K.A & K.hold K.LeftCtrl & { hold_trigger_key_positions = [2] }),
+        tap (K.B),
+        release (K.A & K.hold K.LeftCtrl & { hold_trigger_key_positions = [2] }),
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        press (K.A),
+        tap (K.B),
+        release (K.A),
+      ]
+      """

--- a/features/scripts/generate-doc.sh
+++ b/features/scripts/generate-doc.sh
@@ -39,9 +39,12 @@ keymap_key_features=(
     "tap_hold-config-interrupt-ignore"
     "tap_hold-config-interrupt-presses"
     "tap_hold-config-interrupt-tap"
+    "tap_hold-config-quick_tap"
     "tap_hold-config-required_idle_time"
+    "tap_hold-config-retro_tap"
     "tap_hold-config-timeout"
     "tap_hold-config-timeout-none"
+    "tap_hold-hold_trigger_positions"
 )
 
 keymap_ncl_features=(

--- a/ncl/smart_keys/tap_hold/keymap-codegen.ncl
+++ b/ncl/smart_keys/tap_hold/keymap-codegen.ncl
@@ -59,34 +59,59 @@
         key_type = "%{module}::Key",
 
         # c.f. doc_de_tap_hold.md.
-        # JSON serialization of key::tap_hold::Key is { tap: key, hold: key }
+        # JSON: { tap, hold, hold_trigger_key_positions? }
         json_validator =
           validators.record.validator {
-            fields_validator = validators.record.has_exact_fields ["tap", "hold"],
+            fields_validator =
+              validators.all_of [
+                validators.record.has_all_fields ["tap", "hold"],
+                validators.record.has_only_fields [
+                  "tap",
+                  "hold",
+                  "hold_trigger_key_positions",
+                ],
+              ],
             field_validators = {
               tap = smart_key.json_validator,
               hold = smart_key.json_validator,
+              hold_trigger_key_positions =
+                validators.array.validator validators.is_number,
             },
           },
 
         is_json = fun json => 'Ok == json_validator json,
 
-        codegen_values = fun json @ { hold, tap } =>
+        codegen_values = fun json @ { hold, tap, ..rest } =>
           let hold_cv = hold |> smart_key.codegen_values in
           let tap_cv = tap |> smart_key.codegen_values in
+          let hold_triggers =
+            if std.record.has_field "hold_trigger_key_positions" rest then
+              rest.hold_trigger_key_positions
+            else
+              null
+          in
 
           {
             nested = {
               tap = tap_cv,
               hold = hold_cv,
             },
+            hold_trigger_key_positions = hold_triggers,
             include json,
             include module,
             include key_type,
             rust_expr =
               let hold_expr = nested.hold.rust_expr in
               let tap_expr = nested.tap.rust_expr in
-              "%{module}::Key::new(%{tap_expr}, %{hold_expr})",
+              if hold_triggers == null then
+                "%{module}::Key::new(%{tap_expr}, %{hold_expr})"
+              else
+                let idxs =
+                  hold_triggers
+                  |> std.array.map (fun i => "%{std.to_string i}")
+                  |> std.string.join ", "
+                in
+                "%{module}::Key::with_hold_triggers(%{tap_expr}, %{hold_expr}, %{module}::KeyPositionMask::from_indices(&[%{idxs}]))",
           },
 
         map_nested = fun f cv @ { nested, ..rest } =>
@@ -105,22 +130,46 @@
           let acc = smart_key.traverse f acc cv.nested.tap in
           smart_key.traverse f acc cv.nested.hold,
 
-        data_and_ref = fun key_data cv @ { nested = { tap = tap_cv, hold = hold_cv }, .. } =>
+        data_and_ref = fun key_data cv @ {
+          nested = { tap = tap_cv, hold = hold_cv },
+          hold_trigger_key_positions = hold_triggers,
+          ..
+        } =>
           let { key_data, ref = tap_ref } = smart_key.data_and_ref key_data tap_cv in
           let tap_ref = tap_ref |> composite.ref.wrap in
           let { key_data, ref = hold_ref } = smart_key.data_and_ref key_data hold_cv in
           let hold_ref = hold_ref |> composite.ref.wrap in
           let { tap_hold = tap_hold_, ..other_data } = key_data & { tap_hold | default = [] } in
           let new_index = std.array.length tap_hold_ in
+          let hold_triggers_rust =
+            if hold_triggers == null then
+              "None"
+            else
+              let idxs =
+                hold_triggers
+                |> std.array.map (fun i => "%{std.to_string i}")
+                |> std.string.join ", "
+              in
+              "Some(%{module}::KeyPositionMask::from_indices(&[%{idxs}]))"
+          in
+          let triggers_json =
+            if hold_triggers == null then
+              {}
+            else
+              { hold_trigger_key_positions = hold_triggers }
+          in
           let new_key = {
-            json = {
-              tap = tap_ref.json,
-              hold = hold_ref.json,
-            },
+            json =
+              {
+                tap = tap_ref.json,
+                hold = hold_ref.json,
+              }
+              & triggers_json,
             rust_expr = m%"
             %{module}::Key {
               tap: %{tap_ref.rust_expr},
               hold: %{hold_ref.rust_expr},
+              hold_trigger_positions: %{hold_triggers_rust},
             }
           "%,
           }
@@ -147,6 +196,8 @@
             ),
           interrupt_response | optional | TapHoldInterruptResponseJson,
           required_idle_time | optional | Number,
+          quick_tap_ms | optional | Number,
+          retro_tap | optional | Bool,
         },
 
         expr =
@@ -176,6 +227,22 @@
               if std.record.has_field "required_idle_time" c then
                 {
                   required_idle_time = "Some(%{std.to_string c.required_idle_time})",
+                }
+              else
+                {}
+            )
+            & (
+              if std.record.has_field "quick_tap_ms" c then
+                {
+                  quick_tap_ms = "Some(%{std.to_string c.quick_tap_ms})",
+                }
+              else
+                {}
+            )
+            & (
+              if std.record.has_field "retro_tap" c then
+                {
+                  retro_tap = if c.retro_tap then "true" else "false",
                 }
               else
                 {}

--- a/ncl/smart_keys/tap_hold/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/tap_hold/keymap-ncl-to-json.ncl
@@ -52,30 +52,65 @@
           ),
         interrupt_response | optional | TapHoldInterruptResponse,
         required_idle_time | optional | Number,
+        quick_tap_ms | optional | Number,
+        retro_tap | optional | Bool,
       },
 
       Key = std.contract.from_validator key_validator,
 
+      # Strip optional positional-hold metadata before validating the tap key.
+      strip_hold_meta = fun r =>
+        if std.record.has_field "hold_trigger_key_positions" r then
+          std.record.remove "hold_trigger_key_positions" r
+        else
+          r,
+
       key_validator = fun k =>
         k
         |> match {
-          { hold = hold_key, ..tap_key } =>
+          { hold = hold_key, ..rest } =>
+            let tap_key = strip_hold_meta rest in
+            let positions_ok =
+              if std.record.has_field "hold_trigger_key_positions" rest then
+                if std.is_array rest.hold_trigger_key_positions then
+                  'Ok
+                else
+                  'Error { message = "hold_trigger_key_positions must be an array" }
+              else
+                'Ok
+            in
             validators.all_ok [
               keymap_ncl.key.key_validator hold_key,
               keymap_ncl.key.key_validator tap_key,
+              positions_ok,
             ],
           _ => 'Error { message = "expected { hold = Key, ..tap_key }" },
         },
 
       is_key = fun k => 'Ok == key_validator k,
 
-      to_json_value = fun { hold = hold_key, ..tap_key } =>
+      to_json_value = fun { hold = hold_key, ..rest } =>
+        let hold_triggers =
+          if std.record.has_field "hold_trigger_key_positions" rest then
+            { hold_trigger_key_positions = rest.hold_trigger_key_positions }
+          else
+            {}
+        in
+        let tap_key = strip_hold_meta rest in
         {
           hold = keymap_ncl.key.to_json_value hold_key,
           tap = keymap_ncl.key.to_json_value tap_key,
-        },
+        }
+        & hold_triggers,
 
-      map_accum = fun f acc k @ { hold = hold_key, ..tap_key } =>
+      map_accum = fun f acc { hold = hold_key, ..rest } =>
+        let hold_triggers =
+          if std.record.has_field "hold_trigger_key_positions" rest then
+            { hold_trigger_key_positions = rest.hold_trigger_key_positions }
+          else
+            {}
+        in
+        let tap_key = strip_hold_meta rest in
         let { acc, k = tap_key } = f acc tap_key in
         let { acc, k = hold_key } = f acc hold_key in
         {
@@ -84,6 +119,7 @@
             {
               hold = hold_key,
             }
+            & hold_triggers
             & tap_key,
         },
     },

--- a/smart-keymap-core/src/key/tap_hold.rs
+++ b/smart-keymap-core/src/key/tap_hold.rs
@@ -11,6 +11,88 @@ use crate::keymap;
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct Ref(pub u8);
 
+/// Bitmask of keymap indices (0..128) used for positional hold triggers.
+///
+/// Empty mask means "no restriction" only when wrapped in [`Option::None`] on
+/// [Key]; a `Some(empty)` mask matches no positions.
+///
+/// JSON accepts an array of keymap indices (e.g. `[2, 3, 18]`), matching the
+/// Nickel authoring surface `hold_trigger_key_positions`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct KeyPositionMask {
+    /// Bits for keymap indices 0..63.
+    pub lo: u64,
+    /// Bits for keymap indices 64..127.
+    pub hi: u64,
+}
+
+impl<'de> Deserialize<'de> for KeyPositionMask {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = KeyPositionMask;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.write_str("an array of keymap indices")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let mut mask = KeyPositionMask::EMPTY;
+                while let Some(idx) = seq.next_element::<u16>()? {
+                    mask = mask.with(idx);
+                }
+                Ok(mask)
+            }
+        }
+
+        deserializer.deserialize_seq(Visitor)
+    }
+}
+
+impl KeyPositionMask {
+    /// Empty mask (matches no indices).
+    pub const EMPTY: Self = Self { lo: 0, hi: 0 };
+
+    /// Whether `keymap_index` is set in the mask.
+    pub const fn contains(self, keymap_index: u16) -> bool {
+        if keymap_index < 64 {
+            (self.lo & (1u64 << keymap_index)) != 0
+        } else if keymap_index < 128 {
+            (self.hi & (1u64 << (keymap_index - 64))) != 0
+        } else {
+            false
+        }
+    }
+
+    /// Returns a copy with `keymap_index` set (indices ≥ 128 are ignored).
+    pub const fn with(mut self, keymap_index: u16) -> Self {
+        if keymap_index < 64 {
+            self.lo |= 1u64 << keymap_index;
+        } else if keymap_index < 128 {
+            self.hi |= 1u64 << (keymap_index - 64);
+        }
+        self
+    }
+
+    /// Build a mask from a list of keymap indices.
+    pub const fn from_indices(indices: &[u16]) -> Self {
+        let mut mask = Self::EMPTY;
+        let mut i = 0;
+        while i < indices.len() {
+            mask = mask.with(indices[i]);
+            i += 1;
+        }
+        mask
+    }
+}
+
 /// A key with tap-hold functionality.
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct Key<R> {
@@ -18,12 +100,47 @@ pub struct Key<R> {
     pub tap: R,
     /// The 'hold' key.
     pub hold: R,
+    /// When set, only these keymap indices may resolve an interrupt as hold
+    /// (ZMK `hold-trigger-key-positions` / opposite-hand HRM polish).
+    ///
+    /// `None` means any other key may trigger hold (default).
+    ///
+    /// JSON field name matches the Nickel authoring surface
+    ///  (`hold_trigger_key_positions`).
+    #[serde(default, rename = "hold_trigger_key_positions")]
+    pub hold_trigger_positions: Option<KeyPositionMask>,
 }
 
 impl<R> Key<R> {
-    /// Constructs a new tap-hold key.
+    /// Constructs a new tap-hold key (no positional hold restriction).
     pub const fn new(tap: R, hold: R) -> Key<R> {
-        Key { tap, hold }
+        Key {
+            tap,
+            hold,
+            hold_trigger_positions: None,
+        }
+    }
+
+    /// Constructs a tap-hold key that only resolves as hold when interrupted
+    /// by a key whose keymap index is in `hold_trigger_positions`.
+    pub const fn with_hold_triggers(
+        tap: R,
+        hold: R,
+        hold_trigger_positions: KeyPositionMask,
+    ) -> Key<R> {
+        Key {
+            tap,
+            hold,
+            hold_trigger_positions: Some(hold_trigger_positions),
+        }
+    }
+
+    /// Whether `other_keymap_index` is allowed to resolve this key as hold.
+    pub const fn allows_hold_trigger(&self, other_keymap_index: u16) -> bool {
+        match self.hold_trigger_positions {
+            None => true,
+            Some(mask) => mask.contains(other_keymap_index),
+        }
     }
 }
 
@@ -33,6 +150,7 @@ impl<R: Default> Default for Key<R> {
         Key {
             tap: R::default(),
             hold: R::default(),
+            hold_trigger_positions: None,
         }
     }
 }
@@ -71,6 +189,22 @@ pub struct Config {
     /// This reduces disruption from unexpected hold resolutions
     ///  when typing quickly.
     pub required_idle_time: Option<u16>,
+
+    /// If a tap-hold key is pressed again within this many milliseconds of its
+    /// previous press (ZMK `quick-tap-ms`), immediately resolve as tap.
+    ///
+    /// Useful for hold-to-repeat on the tap letter (e.g. backspace) without
+    /// waiting for the hold timeout. `None` disables (default).
+    #[serde(default)]
+    pub quick_tap_ms: Option<u16>,
+
+    /// When true, timeout alone never resolves as hold (ZMK `retro-tap`).
+    ///
+    /// Hold activates only when another key interrupts (per
+    /// [InterruptResponse]); releasing the key alone always yields tap,
+    /// even after the timeout has elapsed.
+    #[serde(default)]
+    pub retro_tap: bool,
 }
 
 /// The default timeout.
@@ -92,6 +226,8 @@ pub const DEFAULT_CONFIG: Config = Config {
     timeout: Some(DEFAULT_TIMEOUT),
     interrupt_response: DEFAULT_INTERRUPT_RESPONSE,
     required_idle_time: None,
+    quick_tap_ms: None,
+    retro_tap: false,
 };
 
 impl Config {
@@ -113,6 +249,9 @@ impl Default for Config {
 pub struct Context {
     config: Config,
     idle_time_ms: u32,
+    time_ms: u32,
+    recent_presses: [(u16, u32); keymap::MAX_RECENT_PRESSES],
+    recent_press_count: u8,
 }
 
 impl Context {
@@ -121,6 +260,9 @@ impl Context {
         Context {
             config,
             idle_time_ms: 0,
+            time_ms: 0,
+            recent_presses: [(0, 0); keymap::MAX_RECENT_PRESSES],
+            recent_press_count: 0,
         }
     }
 
@@ -132,9 +274,37 @@ impl Context {
     /// Updates the context with the given keymap context.
     pub fn update_keymap_context(
         &mut self,
-        keymap::KeymapContext { idle_time_ms, .. }: &keymap::KeymapContext,
+        keymap::KeymapContext {
+            idle_time_ms,
+            time_ms,
+            recent_presses,
+            recent_press_count,
+            ..
+        }: &keymap::KeymapContext,
     ) {
         self.idle_time_ms = *idle_time_ms;
+        self.time_ms = *time_ms;
+        self.recent_presses = *recent_presses;
+        self.recent_press_count = *recent_press_count;
+    }
+
+    fn last_press_time_ms(&self, keymap_index: u16) -> Option<u32> {
+        self.recent_presses[..self.recent_press_count as usize]
+            .iter()
+            .rev()
+            .find(|(ki, _)| *ki == keymap_index)
+            .map(|(_, t)| *t)
+    }
+
+    /// Whether a re-press of `keymap_index` falls within `quick_tap_ms`.
+    fn is_quick_tap(&self, keymap_index: u16) -> bool {
+        let Some(quick_tap_ms) = self.config.quick_tap_ms else {
+            return false;
+        };
+        let Some(last_t) = self.last_press_time_ms(keymap_index) else {
+            return false;
+        };
+        self.time_ms.saturating_sub(last_t) < quick_tap_ms as u32
     }
 }
 
@@ -174,15 +344,22 @@ impl PendingKeyState {
     fn hold_resolution(
         &self,
         interrupt_response: InterruptResponse,
+        retro_tap: bool,
         keymap_index: u16,
         event: key::Event<Event>,
+        allows_hold_trigger: impl Fn(u16) -> bool,
     ) -> Option<TapHoldState> {
         match interrupt_response {
             InterruptResponse::HoldOnKeyPress => {
                 match event {
-                    key::Event::Input(input::Event::Press { .. }) => {
-                        // TapHold: any interruption resolves pending TapHold as Hold.
-                        Some(TapHoldState::Hold)
+                    key::Event::Input(input::Event::Press { keymap_index: ki }) => {
+                        // TapHold: interruption resolves as Hold when positional
+                        //  filter (if any) allows the interrupting key.
+                        if allows_hold_trigger(ki) {
+                            Some(TapHoldState::Hold)
+                        } else {
+                            None
+                        }
                     }
                     key::Event::Input(input::Event::Release { keymap_index: ki }) => {
                         if keymap_index == ki {
@@ -196,8 +373,12 @@ impl PendingKeyState {
                         key_event: Event::TapHoldTimeout,
                         ..
                     } => {
-                        // Key held long enough to resolve as hold.
-                        Some(TapHoldState::Hold)
+                        if retro_tap {
+                            // Stay pending until interrupt or self-release.
+                            None
+                        } else {
+                            Some(TapHoldState::Hold)
+                        }
                     }
                     _ => None,
                 }
@@ -208,7 +389,9 @@ impl PendingKeyState {
                         if keymap_index == ki {
                             // TapHold: not interrupted; resolved as tap.
                             Some(TapHoldState::Tap)
-                        } else if Some(ki) == self.other_pressed_keymap_index {
+                        } else if Some(ki) == self.other_pressed_keymap_index
+                            && allows_hold_trigger(ki)
+                        {
                             // TapHold: interrupted by key tap (press + release); resolved as hold.
                             Some(TapHoldState::Hold)
                         } else {
@@ -219,8 +402,11 @@ impl PendingKeyState {
                         key_event: Event::TapHoldTimeout,
                         ..
                     } => {
-                        // Key held long enough to resolve as hold.
-                        Some(TapHoldState::Hold)
+                        if retro_tap {
+                            None
+                        } else {
+                            Some(TapHoldState::Hold)
+                        }
                     }
                     _ => None,
                 }
@@ -239,8 +425,11 @@ impl PendingKeyState {
                         key_event: Event::TapHoldTimeout,
                         ..
                     } => {
-                        // Key held long enough to resolve as hold.
-                        Some(TapHoldState::Hold)
+                        if retro_tap {
+                            None
+                        } else {
+                            Some(TapHoldState::Hold)
+                        }
                     }
                     _ => None,
                 }
@@ -254,6 +443,7 @@ impl PendingKeyState {
         context: &Context,
         keymap_index: u16,
         event: key::Event<Event>,
+        allows_hold_trigger: impl Fn(u16) -> bool,
     ) -> Option<TapHoldState> {
         // Check for interrupting taps
         // (track other key press)
@@ -263,7 +453,13 @@ impl PendingKeyState {
 
         // Resolve tap-hold state per the event.
         let Context { config, .. } = context;
-        self.hold_resolution(config.interrupt_response, keymap_index, event)
+        self.hold_resolution(
+            config.interrupt_response,
+            config.retro_tap,
+            keymap_index,
+            event,
+            allows_hold_trigger,
+        )
     }
 }
 
@@ -297,6 +493,25 @@ impl<R, Keys: Index<usize, Output = Key<R>>> System<R, Keys> {
         });
         (pending, scheduled)
     }
+
+    fn resolve_as_tap(
+        &self,
+        key_index: u8,
+    ) -> (
+        key::PressedKeyResult<R, PendingKeyState, KeyState>,
+        key::KeyEvents<Event>,
+    )
+    where
+        R: Copy,
+    {
+        let Key {
+            tap: tap_key_ref, ..
+        } = self.keys[key_index as usize];
+        (
+            key::PressedKeyResult::NewPressedKey(key::NewPressedKey::key(tap_key_ref)),
+            key::KeyEvents::no_events(),
+        )
+    }
 }
 
 impl<R: Copy + Debug, Keys: Debug + Index<usize, Output = Key<R>>> key::System<R>
@@ -317,6 +532,11 @@ impl<R: Copy + Debug, Keys: Debug + Index<usize, Output = Key<R>>> key::System<R
         key::PressedKeyResult<R, Self::PendingKeyState, Self::KeyState>,
         key::KeyEvents<Self::Event>,
     ) {
+        // ZMK quick-tap: re-press within window of prior press → force tap.
+        if context.is_quick_tap(keymap_index) {
+            return self.resolve_as_tap(key_index);
+        }
+
         match context.config.required_idle_time {
             Some(required_idle_time) => {
                 if context.idle_time_ms >= required_idle_time as u32 {
@@ -333,13 +553,7 @@ impl<R: Copy + Debug, Keys: Debug + Index<usize, Output = Key<R>>> key::System<R
                 } else {
                     // Keymap has not been idle for long enough;
                     // immediately resolve as tap.
-                    let Key {
-                        tap: tap_key_ref, ..
-                    } = self.keys[key_index as usize];
-                    (
-                        key::PressedKeyResult::NewPressedKey(key::NewPressedKey::key(tap_key_ref)),
-                        key::KeyEvents::no_events(),
-                    )
+                    self.resolve_as_tap(key_index)
                 }
             }
             None => {
@@ -363,9 +577,12 @@ impl<R: Copy + Debug, Keys: Debug + Index<usize, Output = Key<R>>> key::System<R
         Ref(key_index): Ref,
         event: key::Event<Self::Event>,
     ) -> (Option<key::NewPressedKey<R>>, key::KeyEvents<Self::Event>) {
-        let th_state = pending_state.handle_event(context, keymap_index, event);
+        let key_def = &self.keys[key_index as usize];
+        let th_state = pending_state.handle_event(context, keymap_index, event, |ki| {
+            key_def.allows_hold_trigger(ki)
+        });
         if let Some(th_state) = th_state {
-            let Key { tap, hold } = self.keys[key_index as usize];
+            let Key { tap, hold, .. } = *key_def;
             let new_key_ref = match th_state {
                 key::tap_hold::TapHoldState::Tap => tap,
                 key::tap_hold::TapHoldState::Hold => hold,
@@ -412,5 +629,32 @@ mod tests {
     #[test]
     fn test_sizeof_event() {
         assert_eq!(0, core::mem::size_of::<Event>());
+    }
+
+    #[test]
+    fn test_key_position_mask_contains() {
+        let mask = KeyPositionMask::from_indices(&[0, 5, 64, 127]);
+        assert!(mask.contains(0));
+        assert!(mask.contains(5));
+        assert!(mask.contains(64));
+        assert!(mask.contains(127));
+        assert!(!mask.contains(1));
+        assert!(!mask.contains(63));
+        assert!(!mask.contains(65));
+    }
+
+    #[test]
+    fn test_allows_hold_trigger_default() {
+        let key = Key::new(0u8, 1u8);
+        assert!(key.allows_hold_trigger(0));
+        assert!(key.allows_hold_trigger(99));
+    }
+
+    #[test]
+    fn test_allows_hold_trigger_restricted() {
+        let key = Key::with_hold_triggers(0u8, 1u8, KeyPositionMask::from_indices(&[2, 3]));
+        assert!(!key.allows_hold_trigger(0));
+        assert!(key.allows_hold_trigger(2));
+        assert!(key.allows_hold_trigger(3));
     }
 }

--- a/smart-keymap-core/src/keymap.rs
+++ b/smart-keymap-core/src/keymap.rs
@@ -167,6 +167,9 @@ pub enum KeymapCallback {
     Custom(u8, u8),
 }
 
+/// Max recent physical presses tracked in [KeymapContext] (for quick-tap, etc.).
+pub const MAX_RECENT_PRESSES: usize = 8;
+
 /// Context provided from the keymap to the smart keys.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct KeymapContext {
@@ -181,6 +184,14 @@ pub struct KeymapContext {
     /// Updated by the keymap before press handling and on tick
     ///  so families can branch without maintaining their own mod-tracking.
     pub pressed_modifiers: key::KeyboardModifiers,
+
+    /// Recent physical presses as `(keymap_index, time_ms)`, oldest first.
+    ///
+    /// Used by features such as tap-hold `quick_tap_ms` (ZMK-style re-tap).
+    pub recent_presses: [(u16, u32); MAX_RECENT_PRESSES],
+
+    /// Number of valid entries in [Self::recent_presses].
+    pub recent_press_count: u8,
 }
 
 impl KeymapContext {
@@ -190,7 +201,18 @@ impl KeymapContext {
             time_ms: 0,
             idle_time_ms: 0,
             pressed_modifiers: key::KeyboardModifiers::NONE,
+            recent_presses: [(0, 0); MAX_RECENT_PRESSES],
+            recent_press_count: 0,
         }
+    }
+
+    /// Most recent press time for `keymap_index`, if still in the ring.
+    pub fn last_press_time_ms(&self, keymap_index: u16) -> Option<u32> {
+        self.recent_presses[..self.recent_press_count as usize]
+            .iter()
+            .rev()
+            .find(|(ki, _)| *ki == keymap_index)
+            .map(|(_, t)| *t)
     }
 }
 
@@ -243,6 +265,9 @@ pub struct Keymap<I: Index<usize, Output = R>, R, Ctx, Ev: Debug, PKS, KS, S> {
     event_scheduler: EventScheduler<Ev>,
     ms_per_tick: u8,
     idle_time: u32,
+    /// Ring of recent physical presses for [KeymapContext::recent_presses].
+    recent_presses: [(u16, u32); MAX_RECENT_PRESSES],
+    recent_press_count: u8,
     hid_reporter: HIDKeyboardReporter,
     pending_state: Option<pending::PendingState<R, Ev, PKS>>,
     input_queue: InputEventQueue<{ MAX_QUEUED_INPUT_EVENTS }>,
@@ -293,6 +318,8 @@ impl<
             event_scheduler: EventScheduler::new(),
             ms_per_tick: 1,
             idle_time: 0,
+            recent_presses: [(0, 0); MAX_RECENT_PRESSES],
+            recent_press_count: 0,
             hid_reporter: HIDKeyboardReporter::new(),
             pending_state: None,
             input_queue: InputEventQueue::new(),
@@ -314,6 +341,31 @@ impl<
         self.input_queue.clear();
         self.ms_per_tick = 1;
         self.idle_time = 0;
+        self.recent_presses = [(0, 0); MAX_RECENT_PRESSES];
+        self.recent_press_count = 0;
+    }
+
+    /// Record a physical press in the recent-press ring (for quick-tap, etc.).
+    fn record_recent_press(&mut self, keymap_index: u16) {
+        let time_ms = self.event_scheduler.schedule_counter;
+        // Drop any prior entry for this index so a re-press updates the time.
+        let mut write = 0usize;
+        let count = self.recent_press_count as usize;
+        for read in 0..count {
+            if self.recent_presses[read].0 != keymap_index {
+                self.recent_presses[write] = self.recent_presses[read];
+                write += 1;
+            }
+        }
+        if write == MAX_RECENT_PRESSES {
+            // Evict oldest.
+            for i in 0..(MAX_RECENT_PRESSES - 1) {
+                self.recent_presses[i] = self.recent_presses[i + 1];
+            }
+            write = MAX_RECENT_PRESSES - 1;
+        }
+        self.recent_presses[write] = (keymap_index, time_ms);
+        self.recent_press_count = (write + 1) as u8;
     }
 
     /// Clears all registered callbacks.
@@ -554,7 +606,7 @@ impl<
                 input::Event::Press { keymap_index }
                     if !self.has_pressed_input_with_keymap_index(keymap_index) =>
                 {
-                    // Snapshot held mods (incl. sticky/caps_word VKs) before branching.
+                    // Snapshot held mods / recent presses before branching.
                     self.push_keymap_context();
 
                     let mut maybe_key_ref = Some(self.key_refs[keymap_index as usize]);
@@ -618,6 +670,9 @@ impl<
                             }
                         }
                     }
+
+                    // Record after press handling so quick-tap sees the *prior* press.
+                    self.record_recent_press(keymap_index);
                 }
                 input::Event::Release { keymap_index } => {
                     self.pressed_inputs
@@ -737,6 +792,8 @@ impl<
             time_ms: self.event_scheduler.schedule_counter,
             idle_time_ms: self.idle_time,
             pressed_modifiers: self.aggregate_pressed_modifiers(),
+            recent_presses: self.recent_presses,
+            recent_press_count: self.recent_press_count,
         };
         self.context.set_keymap_context(km_context);
     }

--- a/smart-keymap-full-system-std/tests/keymap_full_system.rs
+++ b/smart-keymap-full-system-std/tests/keymap_full_system.rs
@@ -44,10 +44,10 @@ fn tap_hold_interrupt_keymap(
             smart_keymap::key::sequence::System::new(Vec::new(), Vec::new()),
             smart_keymap::key::sticky::System::new(Vec::new()),
             smart_keymap::key::tap_dance::System::new(Vec::new()),
-            smart_keymap::key::tap_hold::System::new(vec![smart_keymap::key::tap_hold::Key {
-                tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(0x04)),
-                hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(0xE0)),
-            }]),
+            smart_keymap::key::tap_hold::System::new(vec![smart_keymap::key::tap_hold::Key::new(
+                key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(0x04)),
+                key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(0xE0)),
+            )]),
         ),
     )
 }

--- a/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
+++ b/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
@@ -491,6 +491,7 @@ pub mod init {
         smart_keymap::key::tap_hold::System::new([smart_keymap::key::tap_hold::Key {
             tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(4)),
             hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(1)),
+            hold_trigger_positions: None,
         }]),
     );
 

--- a/tests/ncl/keymap-1key-tap_hold/expected.rs
+++ b/tests/ncl/keymap-1key-tap_hold/expected.rs
@@ -390,6 +390,7 @@ pub mod init {
         smart_keymap::key::tap_hold::System::new([smart_keymap::key::tap_hold::Key {
             tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(4)),
             hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(224)),
+            hold_trigger_positions: None,
         }]),
     );
 

--- a/tests/ncl/keymap-2key-2layer-composite/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-composite/expected.rs
@@ -492,6 +492,7 @@ pub mod init {
         smart_keymap::key::tap_hold::System::new([smart_keymap::key::tap_hold::Key {
             tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(4)),
             hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(0)),
+            hold_trigger_positions: None,
         }]),
     );
 

--- a/tests/ncl/keymap-2key-chorded-named-th-lmod/expected.rs
+++ b/tests/ncl/keymap-2key-chorded-named-th-lmod/expected.rs
@@ -673,6 +673,7 @@ pub mod init {
         smart_keymap::key::tap_hold::System::new([smart_keymap::key::tap_hold::Key {
             tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(41)),
             hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(0)),
+            hold_trigger_positions: None,
         }]),
     );
 

--- a/tests/ncl/keymap-48key-rgoulter/expected.rs
+++ b/tests/ncl/keymap-48key-rgoulter/expected.rs
@@ -2819,170 +2819,212 @@ pub mod init {
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(4)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(4)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(4)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(4)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(18)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(8)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(22)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(8)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(8)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(1)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(7)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(1)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(24)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(2)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(9)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(2)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(11)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(32)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(13)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(32)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(23)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(1)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(14)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(1)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(17)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(128)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(15)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(128)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(22)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(4)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(51)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(4)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(43)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(24)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(43)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(25)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(43)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(26)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(43)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(27)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(43)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(28)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(41)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(29)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(41)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(30)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(41)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(31)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(41)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(32)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(44)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(33)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(44)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(34)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(44)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(35)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(44)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(36)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(76)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(37)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(40)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(38)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(40)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(39)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(40)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(40)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(40)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(41)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(42)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(42)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(42)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(43)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(42)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(44)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(42)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(45)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(76)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(46)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(76)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(47)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(76)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(48)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(76)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(49)),
+                hold_trigger_positions: None,
             },
         ]),
     );

--- a/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
@@ -450,34 +450,42 @@ pub mod init {
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(4)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(4)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(18)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(8)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(8)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(1)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(24)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(2)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(11)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(32)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(23)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(16)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(17)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(128)),
+                hold_trigger_positions: None,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(22)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(64)),
+                hold_trigger_positions: None,
             },
         ]),
     );

--- a/tests/rust/tap_hold.rs
+++ b/tests/rust/tap_hold.rs
@@ -1,9 +1,12 @@
 mod hold_on_interrupt_press;
 mod hold_on_interrupt_tap;
+mod hold_trigger_positions;
 mod interrupt_ignore;
 mod layered;
 mod no_timeout;
+mod quick_tap;
 mod required_idle_time;
+mod retro_tap;
 
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;

--- a/tests/rust/tap_hold/hold_trigger_positions.rs
+++ b/tests/rust/tap_hold/hold_trigger_positions.rs
@@ -1,0 +1,106 @@
+use smart_keymap::input;
+use smart_keymap::keymap::ObservedKeymap;
+
+use crate::hid_keycodes::*;
+use smart_keymap_macros::keymap;
+
+#[test]
+fn opposite_hand_press_resolves_hold() {
+    // Key 0 is TH; only key 2 may trigger hold (simulating opposite hand).
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.tap_hold.interrupt_response = "HoldOnKeyPress",
+                config.tap_hold.timeout = 200,
+                keys = [
+                    K.A & K.hold K.LeftCtrl & { hold_trigger_key_positions = [2] },
+                    K.B,
+                    K.C,
+                ],
+            }
+        "#
+    ));
+
+    // Act — interrupt with key 2 (allowed trigger)
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 2 });
+    keymap.tick_until_no_scheduled_events();
+
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, KC_C, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn same_hand_press_does_not_resolve_hold() {
+    // Key 0 is TH; only key 2 may trigger hold. Key 1 is "same hand".
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.tap_hold.interrupt_response = "HoldOnKeyPress",
+                config.tap_hold.timeout = 200,
+                keys = [
+                    K.A & K.hold K.LeftCtrl & { hold_trigger_key_positions = [2] },
+                    K.B,
+                    K.C,
+                ],
+            }
+        "#
+    ));
+
+    // Act — press TH, same-hand B, release both (should be taps, not hold)
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+    keymap.tick_until_no_scheduled_events();
+
+    // TH self-release resolves as tap (not hold); B is still held during A.
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, KC_B, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn timeout_still_resolves_hold_with_positional_triggers() {
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.tap_hold.interrupt_response = "HoldOnKeyPress",
+                config.tap_hold.timeout = 200,
+                keys = [
+                    K.A & K.hold K.LeftCtrl & { hold_trigger_key_positions = [2] },
+                    K.B,
+                    K.C,
+                ],
+            }
+        "#
+    ));
+
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    for _ in 0..250 {
+        keymap.tick();
+    }
+
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}

--- a/tests/rust/tap_hold/quick_tap.rs
+++ b/tests/rust/tap_hold/quick_tap.rs
@@ -1,0 +1,87 @@
+use smart_keymap::input;
+use smart_keymap::keymap::ObservedKeymap;
+
+use crate::hid_keycodes::*;
+use smart_keymap_macros::keymap;
+
+#[test]
+fn re_press_within_quick_tap_ms_forces_tap() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.tap_hold.quick_tap_ms = 175,
+                config.tap_hold.timeout = 200,
+                keys = [
+                    K.A & K.hold K.LeftCtrl,
+                ],
+            }
+        "#
+    ));
+
+    // Act — first tap
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+
+    // Re-press soon after first press and hold past timeout
+    for _ in 0..50 {
+        keymap.tick();
+    }
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    for _ in 0..250 {
+        keymap.tick();
+    }
+
+    // Assert — second press stays tap (not hold) despite long hold
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn re_press_after_quick_tap_ms_allows_hold() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.tap_hold.quick_tap_ms = 100,
+                config.tap_hold.timeout = 200,
+                keys = [
+                    K.A & K.hold K.LeftCtrl,
+                ],
+            }
+        "#
+    ));
+
+    // Act — first tap
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+
+    // Wait past quick_tap window, then hold
+    for _ in 0..150 {
+        keymap.tick();
+    }
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    for _ in 0..250 {
+        keymap.tick();
+    }
+
+    // Assert — second press resolves as hold after timeout
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}

--- a/tests/rust/tap_hold/retro_tap.rs
+++ b/tests/rust/tap_hold/retro_tap.rs
@@ -1,0 +1,116 @@
+use smart_keymap::input;
+use smart_keymap::keymap::ObservedKeymap;
+
+use crate::hid_keycodes::*;
+use smart_keymap_macros::keymap;
+
+#[test]
+fn long_hold_alone_resolves_as_tap_with_retro_tap() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.tap_hold.retro_tap = true,
+                config.tap_hold.timeout = 200,
+                config.tap_hold.interrupt_response = "HoldOnKeyPress",
+                keys = [
+                    K.A & K.hold K.LeftCtrl,
+                ],
+            }
+        "#
+    ));
+
+    // Act — press, wait past timeout, release without other keys
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    for _ in 0..250 {
+        keymap.tick();
+    }
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert — retro-tap: alone release is always tap
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn interrupt_press_still_resolves_hold_with_retro_tap() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.tap_hold.retro_tap = true,
+                config.tap_hold.timeout = 200,
+                config.tap_hold.interrupt_response = "HoldOnKeyPress",
+                keys = [
+                    K.A & K.hold K.LeftCtrl,
+                    K.B,
+                ],
+            }
+        "#
+    ));
+
+    // Act — press TH, interrupt with B
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert — hold still activates on interrupting press
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, KC_B, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn interrupt_after_timeout_resolves_hold_with_retro_tap() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.tap_hold.retro_tap = true,
+                config.tap_hold.timeout = 200,
+                config.tap_hold.interrupt_response = "HoldOnKeyPress",
+                keys = [
+                    K.A & K.hold K.LeftCtrl,
+                    K.B,
+                ],
+            }
+        "#
+    ));
+
+    // Act — hold past timeout, then interrupt
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    for _ in 0..250 {
+        keymap.tick();
+    }
+    // Still no output (pending)
+    assert_eq!(
+        &[[0, 0, 0, 0, 0, 0, 0, 0]],
+        keymap.distinct_reports().reports()
+    );
+
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert — hold activates when another key is pressed after timeout
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, KC_B, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}


### PR DESCRIPTION

### Commits

1. `tap_hold: add quick_tap, retro_tap, and hold triggers` — core + keymap context
2. `ncl: wire tap-hold quick_tap, retro_tap, hold triggers` — Nickel config / key surface
3. `test: cover tap-hold quick_tap, retro_tap, hold triggers` — rust integration + cucumber
4. `ncl: refresh keymap snapshots for hold_trigger_positions field`

## Test plan

- [x] `cargo fmt --check` / nickel format clean
- [x] `cargo doc -p smart-keymap-core --no-deps`
- [x] `cargo test -p smart-keymap-core --lib key::tap_hold`
- [x] `cargo test --test rust-integration tap_hold`
- [x] cucumber tap_hold features (incl. new quick_tap / retro_tap / hold_trigger)
- [x] full cucumber suite (93 scenarios)
- [x] `cargo check -p smart-keymap-core --no-default-features` (no_std)

## Out of scope / follow-ups

- QMK `QUICK_TAP_TERM` (release→repress) vs ZMK press→press (this PR matches ZMK)
- `hold-trigger-on-release` (multi-mod same hand)
- Speculative / hold-while-undecided
- Global chordal-hold + handedness string (per-key positions used instead)