### PR TITLE
Feat/transparent layer exit

### DIFF
--- a/features/keymap/key/layer_modifier-tlex.feature
+++ b/features/keymap/key/layer_modifier-tlex.feature
@@ -1,0 +1,77 @@
+Feature: Transparent Layer Exit
+
+  `K.tlex` deactivates the layer that owns the binding (when that layer was
+   activated non-persistently — hold, toggle, or sticky), then registers the
+   key as if that layer were off (continue-eval to the next lower defined
+   active layer, or base).
+
+  This is an alternative to "smart layers": exit by pressing a key on the
+   layer rather than only by releasing the layer modifier.
+
+  For examples of this feature in other smart keyboard firmware, see e.g.:
+
+  - [Fak's transparent layer exit (`tap.tlex` / `hold.tlex`)](https://github.com/semickolon/fak#transparent-layer-exit)
+
+  Background:
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        layers = [
+          [
+            K.layer_mod.toggle 1,
+            K.A,
+            K.C,
+          ],
+          [
+            K.TTTT,
+            K.tlex,
+            K.B,
+          ],
+        ],
+      }
+      """
+
+  Example: tlex types the base key and leaves the layer off
+
+    When the keymap registers the following input
+      """
+      [
+        tap (K.layer_mod.toggle 1),
+        press (K.tlex),
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { key_codes = [K.A] }
+      """
+
+  Example: after tlex, other keys on that layer use base bindings
+
+    When the keymap registers the following input
+      """
+      [
+        tap (K.layer_mod.toggle 1),
+        tap (K.tlex),
+        press (K.C),
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { key_codes = [K.C] }
+      """
+
+  Example: without tlex, the layer key would still be active
+
+    When the keymap registers the following input
+      """
+      [
+        tap (K.layer_mod.toggle 1),
+        press (K.B),
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { key_codes = [K.B] }
+      """

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -283,6 +283,24 @@
     map_accum = fun f acc k => { include acc, include k },
   },
 
+  # Transparent layer exit leaf (Fak tap.tlex). Layer-cell only in practice;
+  # registered so `K.tlex` validates as a Key and projects to runtime JSON.
+  keymap_ncl.transparent_layer_exit = {
+    key_validator = fun k =>
+      k
+      |> match {
+        { transparent_layer_exit = true } => 'Ok,
+        { transparent_layer_exit = {} } => 'Ok,
+        _ => 'Error { message = "expected { transparent_layer_exit = true }" },
+      },
+
+    is_key = fun k => 'Ok == key_validator k,
+
+    to_json_value = fun _k => { TransparentLayerExit = null },
+
+    map_accum = fun f acc k => { include acc, include k },
+  },
+
   keymap_ncl.key = {
     # Dispatch order = outermost wrapper wins when several modules' is_key match
     # the same record (Nickel record "abuse"). Used by key_validator and
@@ -306,6 +324,7 @@
       keymap_ncl.layered,
       keymap_ncl.tap_hold,
       keymap_ncl.layer_modifier,
+      keymap_ncl.transparent_layer_exit,
       keymap_ncl.keyboard,
     ],
 

--- a/ncl/layered-key.ncl
+++ b/ncl/layered-key.ncl
@@ -68,6 +68,24 @@
     },
   },
 
+  # Highest 1-based layer index that is active, or null if none.
+  highest_active_layer = fun active_layers =>
+    active_layers
+    |> std.array.map_with_index (fun i is_active => if is_active then i + 1 else null)
+    |> std.array.filter ((!=) null)
+    |> match {
+      [] => null,
+      indices => std.array.last indices,
+    },
+
+  is_tlex_key = fun k =>
+    k
+    |> match {
+      { transparent_layer_exit = true } => true,
+      { transparent_layer_exit = {} } => true,
+      _ => false,
+    },
+
   update_layer_state_for_input = fun input layer_state @ { default_layer, active_layers } =>
     input
     |> match {
@@ -97,6 +115,27 @@
       'Release { layer_modifier = { default_ }, .. } =>
         let { default_layer, ..layer_state } = layer_state in
         { default_layer = default_ } & layer_state,
+      # Transparent layer exit: deactivate the highest active (defining) layer.
+      'Press k =>
+        if is_tlex_key k then
+          let { active_layers = al, ..layer_state } = layer_state in
+          highest_active_layer al
+          |> match {
+            null => layer_state,
+            layer_idx => { active_layers = deactivate_layer al layer_idx } & layer_state,
+          }
+        else
+          layer_state,
+      'Tap k =>
+        if is_tlex_key k then
+          let { active_layers = al, ..layer_state } = layer_state in
+          highest_active_layer al
+          |> match {
+            null => layer_state,
+            layer_idx => { active_layers = deactivate_layer al layer_idx } & layer_state,
+          }
+        else
+          layer_state,
       _ => layer_state,
     },
 
@@ -138,10 +177,13 @@
             (fun { layer_is_active, .. } => layer_is_active)
             zipped_layered_keys
         in
+        # Walk high → low; skip null (transparency). Tlex is a real cell for
+        # lookup matching (input uses K.tlex), not continue-eval here.
         let active_keys =
           std.array.map
             (fun { key, .. } => key)
             zipped_active_keys
+          |> std.array.filter ((!=) null)
         in
         if (std.array.length active_keys) > 0 then
           std.array.last active_keys

--- a/ncl/smart_keys/layered/key-extensions.ncl
+++ b/ncl/smart_keys/layered/key-extensions.ncl
@@ -43,6 +43,10 @@
     # Layer Transparency
     TTTT = null,
 
+    # Transparent layer exit (Fak `tap.tlex`): deactivate the defining layer
+    # (non-persistent) and act as the lower binding under the finger.
+    tlex = { transparent_layer_exit = true },
+
     # Semantic / variant key sugar: `named_layers` form of LayeredKey.
     # Unit `{}` base (keyboard noop) so callers can use `K.semantic {..}` without
     # `K.NO &`. Indices for names are assigned globally when compiling the keymap.

--- a/ncl/smart_keys/layered/keymap-codegen.ncl
+++ b/ncl/smart_keys/layered/keymap-codegen.ncl
@@ -228,6 +228,7 @@
         #   }
         # ```
         # JSON serialization of key::layered::Layered has fields: { base, layered }
+        # Layer cells: null | { TransparentLayerExit = null } | nested key JSON
         json_validator =
           validators.record.validator {
             fields_validator = validators.record.has_exact_fields ["base", "layered"],
@@ -237,6 +238,13 @@
                 validators.array.validator (
                   validators.any_of [
                     validators.is_null,
+                    fun json =>
+                      json
+                      |> match {
+                        { TransparentLayerExit = null } => 'Ok,
+                        { TransparentLayerExit = _ } => 'Ok,
+                        _ => 'Error { message = "not tlex" },
+                      },
                     smart_key.json_validator,
                   ]
                 ),
@@ -245,14 +253,37 @@
 
         is_json = fun json => 'Ok == json_validator json,
 
+        # Layer cell JSON: null | { TransparentLayerExit = null } | nested key JSON
+        is_tlex_json = fun json =>
+          json
+          |> match {
+            { TransparentLayerExit = null } => true,
+            { TransparentLayerExit = _ } => true,
+            _ => false,
+          },
+
         codegen_values = fun json @ { base, layered } =>
           let base_cv = base |> smart_key.codegen_values in
-          let non_null_layered = std.array.filter ((!=) null) layered in
           let layered_cvs =
-            std.array.map (fun json => if json != null then json |> smart_key.codegen_values else null) layered
+            std.array.map
+              (fun json =>
+                if json == null then
+                  null
+                else if is_tlex_json json then
+                  {
+                    kind = 'tlex,
+                    rust_expr = "%{module}::LayeredBinding::TransparentLayerExit",
+                    json = { TransparentLayerExit = null },
+                  }
+                else
+                  (json |> smart_key.codegen_values) & { kind = 'key }
+              )
+              layered
           in
-          let nn_layered_cvs =
-            std.array.filter ((!=) null) layered_cvs
+          let has_tlex =
+            std.array.any
+              (fun cv => cv != null && std.record.has_field "kind" cv && cv.kind == 'tlex)
+              layered_cvs
           in
 
           {
@@ -263,14 +294,28 @@
             include json,
             include module,
             include key_type,
+            include has_tlex,
             rust_expr =
               let base_expr = nested.base.rust_expr in
               let layered_exprs =
                 nested.layered
-                |> std.array.map (fun cv => if cv == null then "None" else "Some(%{cv.rust_expr})")
+                |> std.array.map (fun cv =>
+                  if cv == null then
+                    "None"
+                  else if has_tlex then
+                    if cv.kind == 'tlex then
+                      "Some(%{cv.rust_expr})"
+                    else
+                      "Some(%{module}::LayeredBinding::Key(%{cv.rust_expr}))"
+                  else
+                    "Some(%{cv.rust_expr})"
+                )
                 |> std.string.join ","
               in
-              "smart_keymap::key::layered::LayeredKey::new(%{base_expr}, [%{layered_exprs}])",
+              if has_tlex then
+                "smart_keymap::key::layered::LayeredKey::with_bindings(%{base_expr}, [%{layered_exprs}])"
+              else
+                "smart_keymap::key::layered::LayeredKey::new(%{base_expr}, [%{layered_exprs}])",
           },
 
         map_nested = fun f cv @ { nested, ..rest } =>
@@ -278,24 +323,38 @@
           & {
             nested = {
               base = f cv.nested.base,
-              layered = std.array.map (fun cv => if cv != null then f cv else null) cv.nested.layered,
+              layered =
+                std.array.map
+                  (fun cv =>
+                    if cv == null then
+                      null
+                    else if std.record.has_field "kind" cv && cv.kind == 'tlex then
+                      cv
+                    else
+                      f cv
+                  )
+                  cv.nested.layered,
             },
           },
 
         # Traverse by visiting the layered key itself,
-        #  then traversing the base, non-null nested layered keys.
+        #  then traversing the base, non-null nested layered keys (not tlex markers).
         traverse = fun f acc cv =>
           let acc = f acc cv in
           let acc = smart_key.traverse f acc cv.nested.base in
           let nn_layered_cvs =
-            std.array.filter ((!=) null) cv.nested.layered
+            cv.nested.layered
+            |> std.array.filter (fun nested_cv =>
+              nested_cv != null
+              && !(std.record.has_field "kind" nested_cv && nested_cv.kind == 'tlex)
+            )
           in
           std.array.fold_left
             (fun acc nested_cv => smart_key.traverse f acc nested_cv)
             acc
             nn_layered_cvs,
 
-        data_and_ref = fun key_data cv @ { nested = { base = base_cv, layered = layered_cvs }, .. } =>
+        data_and_ref = fun key_data cv @ { nested = { base = base_cv, layered = layered_cvs }, has_tlex, .. } =>
           let { key_data, ref = base_ref } = smart_key.data_and_ref key_data base_cv in
           let base_ref = base_ref |> composite.ref.wrap in
           let { key_data, layered_refs } =
@@ -303,27 +362,68 @@
               (fun { key_data, layered_refs = parts } cv =>
                 if cv == null then
                   { include key_data, layered_refs = std.array.append null parts }
+                else if std.record.has_field "kind" cv && cv.kind == 'tlex then
+                  {
+                    include key_data,
+                    layered_refs =
+                      std.array.append
+                        {
+                          kind = 'tlex,
+                          json = { TransparentLayerExit = null },
+                          rust_expr = "%{module}::LayeredBinding::TransparentLayerExit",
+                        }
+                        parts,
+                  }
                 else
                   let { key_data, ref = layer_ref } = smart_key.data_and_ref key_data cv in
                   let layer_ref = layer_ref |> composite.ref.wrap in
-                  { include key_data, layered_refs = std.array.append layer_ref parts }
+                  {
+                    include key_data,
+                    layered_refs =
+                      std.array.append (layer_ref & { kind = 'key }) parts,
+                  }
               )
               { include key_data, layered_refs = [] }
               layered_cvs
           in
           let { layered = layered_, ..other_data } = key_data & { layered | default = [] } in
           let new_index = std.array.length layered_ in
+          let cell_json = fun layer_ref =>
+            if layer_ref == null then
+              null
+            else if layer_ref.kind == 'tlex then
+              layer_ref.json
+            else
+              layer_ref.json
+          in
+          let cell_rust = fun layer_ref =>
+            if layer_ref == null then
+              "None"
+            else if has_tlex then
+              if layer_ref.kind == 'tlex then
+                "Some(%{layer_ref.rust_expr})"
+              else
+                "Some(%{module}::LayeredBinding::Key(%{layer_ref.rust_expr}))"
+            else
+              "Some(%{layer_ref.rust_expr})"
+          in
+          let ctor =
+            if has_tlex then
+              "%{module}::LayeredKey::with_bindings"
+            else
+              "%{module}::LayeredKey::new"
+          in
           let new_key = {
             json = {
               base = base_ref.json,
-              layered = layered_refs |> std.array.map (fun layer_ref => if layer_ref == null then null else layer_ref.json),
+              layered = layered_refs |> std.array.map cell_json,
             },
             rust_expr = m%"
-            %{module}::LayeredKey::new(
+            %{ctor}(
               %{base_ref.rust_expr},
               [%{
                 layered_refs
-                |> std.array.map (fun layer_ref => if layer_ref == null then "None" else "Some(%{layer_ref.rust_expr})")
+                |> std.array.map cell_rust
                 |> std.string.join ", "
               }],
             )

--- a/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
@@ -314,9 +314,13 @@
 
       Key = std.contract.from_validator key_validator,
 
-      # Element of a layered / named_layers slot: Key or transparent null.
+      # Element of a layered / named_layers slot: Key, tlex, or transparent null.
       layer_element_validator =
-        validators.any_of [validators.is_null, keymap_ncl.key.key_validator],
+        validators.any_of [
+          validators.is_null,
+          keymap_ncl.transparent_layer_exit.key_validator,
+          keymap_ncl.key.key_validator,
+        ],
 
       layered_array_validator =
         validators.array.validator layer_element_validator,
@@ -372,7 +376,14 @@
               base = keymap_ncl.key.to_json_value base_key,
               layered =
                 std.array.map
-                  (fun k => if k != null then keymap_ncl.key.to_json_value k else null)
+                  (fun k =>
+                    if k == null then
+                      null
+                    else if keymap_ncl.transparent_layer_exit.is_key k then
+                      keymap_ncl.transparent_layer_exit.to_json_value k
+                    else
+                      keymap_ncl.key.to_json_value k
+                  )
                   layered_keys,
             },
         },

--- a/smart-keymap-core/src/key/layered.rs
+++ b/smart-keymap-core/src/key/layered.rs
@@ -720,40 +720,132 @@ impl core::fmt::Display for LayersError {
     }
 }
 
-/// Trait for layers of [LayeredKey].
-pub trait Layers<R>: Copy + Debug {
-    /// Get the highest active key, if any, for the given [LayerState].
-    fn highest_active_key<LS: LayerState>(
-        &self,
-        layer_state: &LS,
-        default_layer: Option<LayerIndex>,
-    ) -> Option<(LayerIndex, R)>;
-    /// Constructs layers; return Err if the iterable has more keys than Layers can store.
-    fn from_iterable<I: IntoIterator<Item = Option<R>>>(keys: I) -> Result<Self, LayersError>;
+/// Which layers participate in a layered lookup.
+///
+/// Orthogonal to which layers are active in [Context]: this filters the walk
+/// over the active set (and default layer) for one resolution.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum LayerResolution {
+    /// All currently active layers (and default layer), high → low.
+    #[default]
+    Active,
+    /// Active layers except `0`, still consulting default/base as usual.
+    ActiveExcluding(LayerIndex),
 }
 
-impl<R: Copy + Debug, const L: usize> Layers<R> for [Option<R>; L] {
+impl LayerResolution {
+    /// Returns true if `layer` is excluded from this resolution set.
+    pub const fn excludes(self, layer: LayerIndex) -> bool {
+        match self {
+            LayerResolution::Active => false,
+            LayerResolution::ActiveExcluding(excluded) => excluded == layer,
+        }
+    }
+}
+
+/// A non-transparent binding on a layer of a [LayeredKey].
+///
+/// Full transparency remains [None] in the layered array (`null` in JSON / `K.TTTT`).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LayeredBinding<R> {
+    /// Concrete nested key reference.
+    Key(R),
+    /// Transparent layer exit (Fak `tap.tlex`): deactivate this defining layer
+    /// (when non-persistent) and continue resolving this slot without it.
+    TransparentLayerExit,
+}
+
+impl<R> LayeredBinding<R> {
+    /// Wraps a nested key ref.
+    pub const fn key(r: R) -> Self {
+        LayeredBinding::Key(r)
+    }
+
+    /// Transparent layer exit marker.
+    pub const fn transparent_layer_exit() -> Self {
+        LayeredBinding::TransparentLayerExit
+    }
+}
+
+impl<'de, R: Deserialize<'de>> Deserialize<'de> for LayeredBinding<R> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        // Untagged: try nested key first, then tlex marker.
+        // JSON: <R> | `{"TransparentLayerExit": null}`
+        //
+        // Key-first avoids matching ordinary key objects as tlex under
+        // `#[serde(untagged)]` (extra fields are ignored by default).
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Helper<R> {
+            Key(R),
+            Tlex {
+                #[serde(rename = "TransparentLayerExit")]
+                _marker: (),
+            },
+        }
+
+        match Helper::<R>::deserialize(deserializer)? {
+            Helper::Key(r) => Ok(LayeredBinding::Key(r)),
+            Helper::Tlex { .. } => Ok(LayeredBinding::TransparentLayerExit),
+        }
+    }
+}
+
+/// Resolved non-transparent pick from a layered walk (before tlex continue-eval).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LayerPick<R> {
+    /// Nested key on the defining layer.
+    Key(R),
+    /// Transparent layer exit on the defining layer.
+    TransparentLayerExit,
+}
+
+/// Trait for layers of [LayeredKey].
+pub trait Layers<R>: Copy + Debug {
+    /// Highest defined binding among layers allowed by `resolution`.
+    ///
+    /// Walks active layers high → low, then the default layer. Skips
+    /// transparent (`None`) cells and layers excluded by `resolution`.
     fn highest_active_key<LS: LayerState>(
         &self,
         layer_state: &LS,
         default_layer: Option<LayerIndex>,
-    ) -> Option<(LayerIndex, R)> {
+        resolution: LayerResolution,
+    ) -> Option<(LayerIndex, LayerPick<R>)>;
+    /// Constructs layers; return Err if the iterable has more keys than Layers can store.
+    fn from_iterable<I: IntoIterator<Item = Option<LayeredBinding<R>>>>(
+        keys: I,
+    ) -> Result<Self, LayersError>;
+}
+
+impl<R: Copy + Debug, const L: usize> Layers<R> for [Option<LayeredBinding<R>>; L] {
+    fn highest_active_key<LS: LayerState>(
+        &self,
+        layer_state: &LS,
+        default_layer: Option<LayerIndex>,
+        resolution: LayerResolution,
+    ) -> Option<(LayerIndex, LayerPick<R>)> {
         for layer_index in layer_state.active_layers() {
-            if self[layer_index as usize - 1].is_some() {
-                return self[layer_index as usize - 1].map(|k| (layer_index, k));
+            if resolution.excludes(layer_index) {
+                continue;
+            }
+            if let Some(pick) = layer_pick_from_cell(self[layer_index as usize - 1]) {
+                return Some((layer_index, pick));
             }
         }
 
         match default_layer {
-            Some(layer_index) if self[layer_index as usize - 1].is_some() => {
-                self[layer_index as usize - 1].map(|k| (layer_index, k))
+            Some(layer_index) if !resolution.excludes(layer_index) => {
+                layer_pick_from_cell(self[layer_index as usize - 1]).map(|pick| (layer_index, pick))
             }
             _ => None,
         }
     }
 
-    fn from_iterable<I: IntoIterator<Item = Option<R>>>(keys: I) -> Result<Self, LayersError> {
-        let mut layered: [Option<R>; L] = [None; L];
+    fn from_iterable<I: IntoIterator<Item = Option<LayeredBinding<R>>>>(
+        keys: I,
+    ) -> Result<Self, LayersError> {
+        let mut layered: [Option<LayeredBinding<R>>; L] = [None; L];
         for (i, maybe_key) in keys.into_iter().enumerate() {
             if i < L {
                 layered[i] = maybe_key;
@@ -765,14 +857,45 @@ impl<R: Copy + Debug, const L: usize> Layers<R> for [Option<R>; L] {
     }
 }
 
-/// Constructs an array of keys for the given array.
+fn layer_pick_from_cell<R: Copy>(cell: Option<LayeredBinding<R>>) -> Option<LayerPick<R>> {
+    match cell {
+        Some(LayeredBinding::Key(r)) => Some(LayerPick::Key(r)),
+        Some(LayeredBinding::TransparentLayerExit) => Some(LayerPick::TransparentLayerExit),
+        None => None,
+    }
+}
+
+/// Constructs a layer array from nested key options (`Some(r)` → key binding).
 pub const fn layered_keys<K: Copy, const L: usize, const LAYER_COUNT: usize>(
     keys: [Option<K>; L],
-) -> [Option<K>; LAYER_COUNT] {
-    let mut layered: [Option<K>; LAYER_COUNT] = [None; LAYER_COUNT];
+) -> [Option<LayeredBinding<K>>; LAYER_COUNT] {
+    let mut layered: [Option<LayeredBinding<K>>; LAYER_COUNT] = [None; LAYER_COUNT];
 
     if L > LAYER_COUNT {
         panic!("Too many layers for layered_keys");
+    }
+
+    let mut i = 0;
+
+    while i < L {
+        layered[i] = match keys[i] {
+            Some(r) => Some(LayeredBinding::Key(r)),
+            None => None,
+        };
+        i += 1;
+    }
+
+    layered
+}
+
+/// Constructs a layer array from explicit [LayeredBinding] options (supports tlex).
+pub const fn layered_bindings<K: Copy, const L: usize, const LAYER_COUNT: usize>(
+    keys: [Option<LayeredBinding<K>>; L],
+) -> [Option<LayeredBinding<K>>; LAYER_COUNT] {
+    let mut layered: [Option<LayeredBinding<K>>; LAYER_COUNT] = [None; LAYER_COUNT];
+
+    if L > LAYER_COUNT {
+        panic!("Too many layers for layered_bindings");
     }
 
     let mut i = 0;
@@ -791,9 +914,12 @@ pub struct LayeredKey<R: Copy + Debug + PartialEq, const LAYER_COUNT: usize> {
     /// The base key, used when no layers are active.
     pub base: R,
     /// The layered keys, used when the corresponding layer is active.
+    ///
+    /// `None` is full transparency for that layer. `Some(Key(r))` is a nested
+    /// key. `Some(TransparentLayerExit)` is Fak-style transparent layer exit.
     #[serde(deserialize_with = "deserialize_layered")]
     #[serde(bound(deserialize = "R: Deserialize<'de>"))]
-    pub layered: [Option<R>; LAYER_COUNT],
+    pub layered: [Option<LayeredBinding<R>>; LAYER_COUNT],
 }
 
 /// Deserialize a [Layers].
@@ -802,32 +928,100 @@ where
     R: Deserialize<'de>,
     D: serde::Deserializer<'de>,
 {
-    let keys_vec: heapless::Vec<Option<R>, 64> = Deserialize::deserialize(deserializer)?;
+    let keys_vec: heapless::Vec<Option<LayeredBinding<R>>, 64> =
+        Deserialize::deserialize(deserializer)?;
 
     L::from_iterable(keys_vec).map_err(serde::de::Error::custom)
 }
 
 impl<R: Copy + Debug + PartialEq, const LAYER_COUNT: usize> LayeredKey<R, LAYER_COUNT> {
-    /// Constructs a new [LayeredKey].
+    /// Constructs a new [LayeredKey] from nested key options.
     pub const fn new<const L: usize>(base: R, layered: [Option<R>; L]) -> Self {
         let layered = layered_keys(layered);
         Self { base, layered }
     }
-}
 
-impl<R: Copy + Debug + PartialEq, const LAYER_COUNT: usize> LayeredKey<R, LAYER_COUNT> {
-    /// Presses the key, using the highest active key, if any.
+    /// Constructs a [LayeredKey] from explicit bindings (including tlex cells).
+    pub const fn with_bindings<const L: usize>(
+        base: R,
+        layered: [Option<LayeredBinding<R>>; L],
+    ) -> Self {
+        let layered = layered_bindings(layered);
+        Self { base, layered }
+    }
+
+    /// `eval(LK, S)` — defining layer (0 = base) and selected nested ref, or tlex pick.
+    pub fn resolve<const CONDITIONAL_LAYER_COUNT: usize>(
+        &self,
+        context: &Context<LAYER_COUNT, CONDITIONAL_LAYER_COUNT>,
+        resolution: LayerResolution,
+    ) -> (LayerIndex, LayerPick<R>) {
+        self.layered
+            .highest_active_key(context.layer_state(), context.default_layer, resolution)
+            .unwrap_or((0, LayerPick::Key(self.base)))
+    }
+
+    /// Presses the key: resolve under [LayerResolution::Active], applying tlex
+    /// continue-eval (and scheduling [LayerEvent::Deactivated] for non-persistent
+    /// defining layers).
     fn new_pressed_key<const CONDITIONAL_LAYER_COUNT: usize>(
         &self,
         context: &Context<LAYER_COUNT, CONDITIONAL_LAYER_COUNT>,
-    ) -> key::NewPressedKey<R> {
-        let (_layer, passthrough_ref) = self
-            .layered
-            .highest_active_key(context.layer_state(), context.default_layer)
-            .unwrap_or((0, self.base));
+        keymap_index: u16,
+    ) -> (key::NewPressedKey<R>, key::KeyEvents<LayerEvent>) {
+        let mut resolution = LayerResolution::Active;
+        let mut events = key::KeyEvents::no_events();
 
-        key::NewPressedKey::key(passthrough_ref)
+        // Bound stacked tlex (pathological) by layer count.
+        for _ in 0..=LAYER_COUNT {
+            let (layer, pick) = self.resolve(context, resolution);
+
+            match pick {
+                LayerPick::Key(r) => {
+                    return (key::NewPressedKey::key(r), events);
+                }
+                LayerPick::TransparentLayerExit => {
+                    // Base (layer 0) tlex is a no-op marker: fall through to base key.
+                    if layer == 0 {
+                        return (key::NewPressedKey::key(self.base), events);
+                    }
+
+                    // Real exit for later presses when the layer is non-persistent.
+                    // (Default layer alone is persistent-like; Hold/Toggle/Sticky are not.)
+                    if is_tlex_deactivatable(context, layer) {
+                        events.add_event(key::Event::key_event(
+                            keymap_index,
+                            LayerEvent::Deactivated(layer),
+                        ));
+                    }
+
+                    // This press: continue-eval without mutating Context yet.
+                    resolution = LayerResolution::ActiveExcluding(layer);
+                }
+            }
+        }
+
+        // All layers tlex / exhausted — act as base.
+        (key::NewPressedKey::key(self.base), events)
     }
+}
+
+/// Whether tlex should schedule a real [LayerEvent::Deactivated] for `layer`.
+///
+/// Mirrors Fak: only non-persistent activations (regular hold/toggle and sticky).
+/// A layer that is only the default (not Regular/Sticky-active) is not cleared.
+fn is_tlex_deactivatable<const LAYER_COUNT: usize, const CONDITIONAL_LAYER_COUNT: usize>(
+    context: &Context<LAYER_COUNT, CONDITIONAL_LAYER_COUNT>,
+    layer: LayerIndex,
+) -> bool {
+    let idx = layer as usize;
+    if idx == 0 || idx > LAYER_COUNT {
+        return false;
+    }
+    matches!(
+        context.active_layers[idx - 1],
+        Activity::Active(ActivationStyle::Regular | ActivationStyle::Sticky)
+    )
 }
 
 /// Events from [ModifierKey] which affect [Context].
@@ -1023,11 +1217,8 @@ impl<
             }
             Ref::Layered(i) => {
                 let key = &self.layered_keys[i as usize];
-                let npk = key.new_pressed_key(context);
-                (
-                    key::PressedKeyResult::NewPressedKey(npk),
-                    key::KeyEvents::no_events(),
-                )
+                let (npk, pke) = key.new_pressed_key(context, keymap_index);
+                (key::PressedKeyResult::NewPressedKey(npk), pke)
             }
         }
     }
@@ -1461,5 +1652,133 @@ mod tests {
 
         // Assert
         assert_eq!(Some(LayerEvent::Toggled(layer)), layer_event);
+    }
+
+    #[test]
+    fn test_active_excluding_selects_next_lower_defined_layer() {
+        let mut context = Context::default();
+        let base = keyboard::Ref::KeyCode(0x04);
+        let mid = keyboard::Ref::KeyCode(0x05);
+        let high = keyboard::Ref::KeyCode(0x06);
+        let layered_key = LayeredKey::new(base, [Some(mid), Some(high)]);
+
+        context.handle_layer_event(LayerEvent::Activated(1));
+        context.handle_layer_event(LayerEvent::Activated(2));
+
+        let (layer, pick) = layered_key.resolve(&context, LayerResolution::Active);
+        assert_eq!(2, layer);
+        assert_eq!(LayerPick::Key(high), pick);
+
+        let (layer, pick) = layered_key.resolve(&context, LayerResolution::ActiveExcluding(2));
+        assert_eq!(1, layer);
+        assert_eq!(LayerPick::Key(mid), pick);
+
+        let (layer, pick) = layered_key.resolve(&context, LayerResolution::ActiveExcluding(1));
+        // Layer 2 still active and not excluded.
+        assert_eq!(2, layer);
+        assert_eq!(LayerPick::Key(high), pick);
+    }
+
+    #[test]
+    fn test_active_excluding_falls_to_base_when_no_lower_defined() {
+        let mut context = Context::default();
+        let base = keyboard::Ref::KeyCode(0x04);
+        let high = keyboard::Ref::KeyCode(0x06);
+        let layered_key = LayeredKey::new(base, [None, Some(high)]);
+
+        context.handle_layer_event(LayerEvent::Activated(2));
+
+        let (layer, pick) = layered_key.resolve(&context, LayerResolution::ActiveExcluding(2));
+        assert_eq!(0, layer);
+        assert_eq!(LayerPick::Key(base), pick);
+    }
+
+    #[test]
+    fn test_tlex_emits_deactivated_and_resolves_to_lower_key() {
+        let mut context = Context::default();
+        let base = keyboard::Ref::KeyCode(0x04);
+        let layered_key =
+            LayeredKey::with_bindings(base, [Some(LayeredBinding::TransparentLayerExit), None]);
+        let system = System::new([], [layered_key]);
+
+        context.handle_layer_event(LayerEvent::Activated(1));
+        let keymap_index = 3;
+        let (pkr, pke) = system.new_pressed_key(keymap_index, &context, Ref::Layered(0));
+
+        assert_eq!(
+            key::PressedKeyResult::NewPressedKey(key::NewPressedKey::Key(base)),
+            pkr,
+        );
+
+        let events: Vec<_> = pke.into_iter().collect();
+        assert_eq!(1, events.len());
+        assert_eq!(
+            key::ScheduledEvent::immediate(key::Event::key_event(
+                keymap_index,
+                LayerEvent::Deactivated(1)
+            )),
+            events[0],
+        );
+    }
+
+    #[test]
+    fn test_tlex_deactivates_sticky_layer() {
+        // Sticky is non-persistent → tlex schedules Deactivated.
+        let mut context = Context::default();
+        let base = keyboard::Ref::KeyCode(0x04);
+        let layered_key =
+            LayeredKey::with_bindings(base, [Some(LayeredBinding::TransparentLayerExit)]);
+        let system = System::new([], [layered_key]);
+
+        context.handle_layer_event(LayerEvent::StickyActivated(1));
+
+        let (pkr, pke) = system.new_pressed_key(0, &context, Ref::Layered(0));
+        assert_eq!(
+            key::PressedKeyResult::NewPressedKey(key::NewPressedKey::Key(base)),
+            pkr,
+        );
+        let events: Vec<_> = pke.into_iter().collect();
+        assert_eq!(1, events.len());
+    }
+
+    #[test]
+    fn test_tlex_resolution_local_until_deactivated_handled() {
+        // ActiveExcluding alone does not clear context.
+        let mut context = Context::default();
+        let base = keyboard::Ref::KeyCode(0x04);
+        let other = keyboard::Ref::KeyCode(0x10);
+        let tlex_key =
+            LayeredKey::with_bindings(base, [Some(LayeredBinding::TransparentLayerExit)]);
+        let normal_key = LayeredKey::new(other, [Some(keyboard::Ref::KeyCode(0x11))]);
+        let system = System::new([], [tlex_key, normal_key]);
+
+        context.handle_layer_event(LayerEvent::Activated(1));
+
+        let (_pkr, _pke) = system.new_pressed_key(0, &context, Ref::Layered(0));
+        // Context still has layer 1 active (event not handled yet).
+        assert!(context.layer_state()[0].is_active());
+
+        // Other key still sees layer 1.
+        let (pkr, _) = system.new_pressed_key(1, &context, Ref::Layered(1));
+        assert_eq!(
+            key::PressedKeyResult::NewPressedKey(key::NewPressedKey::Key(keyboard::Ref::KeyCode(
+                0x11
+            ))),
+            pkr,
+        );
+    }
+
+    #[test]
+    fn deserialize_layered_binding_tlex_json() {
+        let cell: Option<LayeredBinding<keyboard::Ref>> =
+            serde_json::from_str(r#"{"TransparentLayerExit": null}"#).unwrap();
+        assert_eq!(Some(LayeredBinding::TransparentLayerExit), cell);
+
+        let cell: Option<LayeredBinding<keyboard::Ref>> =
+            serde_json::from_str(r#"{"KeyCode": 4}"#).unwrap();
+        assert_eq!(Some(LayeredBinding::Key(keyboard::Ref::KeyCode(4))), cell,);
+
+        let cell: Option<LayeredBinding<keyboard::Ref>> = serde_json::from_str("null").unwrap();
+        assert_eq!(None, cell);
     }
 }

--- a/tests/rust/layered.rs
+++ b/tests/rust/layered.rs
@@ -4,6 +4,7 @@ mod set_active_layers;
 mod sticky;
 mod sticky_timeout;
 mod tap_hold;
+mod tlex;
 mod toggle;
 
 use smart_keymap::input;

--- a/tests/rust/layered/tlex.rs
+++ b/tests/rust/layered/tlex.rs
@@ -1,0 +1,97 @@
+use smart_keymap::input;
+use smart_keymap::keymap::ObservedKeymap;
+
+use crate::hid_keycodes::*;
+use smart_keymap_macros::keymap;
+
+#[test]
+fn tlex_acts_as_base_and_deactivates_toggle_layer() {
+    // Assemble: toggle layer 1, then tlex over base A
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                layers = [
+                    [K.layer_mod.toggle 1, K.A],
+                    [K.TTTT, K.tlex],
+                ],
+            }
+        "#
+    ));
+
+    // Act: enable layer 1, press tlex key
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+
+    // Assert: this press is base A, and layer is off afterward
+    let expected_report: [u8; 8] = [0, 0, KC_A, 0, 0, 0, 0, 0];
+    assert_eq!(expected_report, keymap.boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+
+    // Second press of the same key still base (layer exited)
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    assert_eq!(expected_report, keymap.boot_keyboard_report());
+}
+
+#[test]
+fn tlex_differs_from_full_transparency() {
+    // Without tlex, pressing B on layer 1 then a transparent key leaves layer on.
+    // With tlex on a different key pattern: after tlex, other layer-1 keys fall to base.
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                layers = [
+                    [K.layer_mod.toggle 1, K.A, K.C],
+                    [K.TTTT, K.tlex, K.B],
+                ],
+            }
+        "#
+    ));
+
+    // Enable layer 1
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+
+    // Layer-1 key B works
+    keymap.handle_input(input::Event::Press { keymap_index: 2 });
+    let expected_b: [u8; 8] = [0, 0, KC_B, 0, 0, 0, 0, 0];
+    assert_eq!(expected_b, keymap.boot_keyboard_report());
+    keymap.handle_input(input::Event::Release { keymap_index: 2 });
+
+    // tlex on index 1 → base A, deactivates layer 1
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    let expected_a: [u8; 8] = [0, 0, KC_A, 0, 0, 0, 0, 0];
+    assert_eq!(expected_a, keymap.boot_keyboard_report());
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+
+    // Same physical key that was B is now base C
+    keymap.handle_input(input::Event::Press { keymap_index: 2 });
+    let expected_c: [u8; 8] = [0, 0, KC_C, 0, 0, 0, 0, 0];
+    assert_eq!(expected_c, keymap.boot_keyboard_report());
+}
+
+#[test]
+fn tlex_under_hold_layer_still_active_resolves_base_for_this_press() {
+    // Hold-layer still held: tlex still continue-evals for this press and emits Deactivated.
+    // Hold release also deactivates (idempotent).
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                layers = [
+                    [K.layer_mod.hold 1, K.A],
+                    [K.TTTT, K.tlex],
+                ],
+            }
+        "#
+    ));
+
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+
+    let expected_a: [u8; 8] = [0, 0, KC_A, 0, 0, 0, 0, 0];
+    assert_eq!(expected_a, keymap.boot_keyboard_report());
+}


### PR DESCRIPTION
## Summary

Adds Fak-style **transparent layer exit** (`K.tlex`): when a layer cell is tlex, deactivate that non-persistent defining layer and continue-eval the same slot as if the layer were off.

- **Engine:** `LayerResolution::{Active, ActiveExcluding}`, `LayeredBinding::{Key, TransparentLayerExit}`, selection-loop continue-eval + `LayerEvent::Deactivated` for Regular/Sticky activations (this press does not wait on context).
- **Nickel:** `K.tlex` authoring, JSON `{"TransparentLayerExit": null}`, codegen via `LayeredKey::with_bindings`, input-sim deactivation for cucumber.
- **Tests:** core unit tests, rust-integration (`tests/rust/layered/tlex.rs`), cucumber `layer_modifier-tlex.feature`.

Not in this PR: partial TH / only-on-hold transparency, or `hold.tlex` (those can reuse `LayerResolution`).

## Commits

1. `layered: LayerResolution, LayeredBinding, and transparent layer exit`
2. `ncl: author and codegen K.tlex transparent layer exit`
3. `test: transparent layer exit integration and cucumber`

## Test plan

- [x] `cargo test -p smart-keymap-core --lib key::layered::tests`
- [x] `cargo test -p smart-keymap --test rust-integration tlex`
- [x] `cargo test -p smart-keymap-full-system-std --test cucumber-keymap -- -n 'tlex|without tlex'`
- [x] `cargo doc -p smart-keymap-core --no-deps` and `cargo doc -p smart-keymap --no-deps`
- [ ] CI green on the PR