### PR TITLE
firmware: ch58x: board-driven DEBUG UART via debug.ncl

### DIFF
--- a/firmware/ch58x-ble-hid-keyboard-c/CMakeLists.txt
+++ b/firmware/ch58x-ble-hid-keyboard-c/CMakeLists.txt
@@ -21,10 +21,14 @@ add_subdirectory(Profile)
 # Use LSI=32.768kHz.
 target_compile_definitions(HID_Keyboard PUBLIC CLK_OSC32K=2)
 
-target_compile_definitions(HID_Keyboard PUBLIC HAL_SLEEP=TRUE)
-
 add_subdirectory(keyboard)
 target_link_libraries(HID_Keyboard keyboard)
+
+# HAL_SLEEP=TRUE unless keyboard INTERFACE already has DEBUG= (board.debug).
+get_target_property(_kb_defs keyboard INTERFACE_COMPILE_DEFINITIONS)
+if(NOT _kb_defs OR _kb_defs STREQUAL "NOTFOUND" OR NOT _kb_defs MATCHES "DEBUG=")
+  target_compile_definitions(HID_Keyboard PUBLIC HAL_SLEEP=TRUE)
+endif()
 
 add_subdirectory(sdk sdk)
 

--- a/firmware/ch58x-ble-hid-keyboard-c/keyboard/CMakeLists.txt
+++ b/firmware/ch58x-ble-hid-keyboard-c/keyboard/CMakeLists.txt
@@ -23,6 +23,7 @@ endif()
 set(
     CODEGEN_DEPS_LIST
     "${BOARD_FULL_PATH}"
+    "${NCL_CODEGEN_DIR}/debug.ncl"
     "${NCL_CODEGEN_DIR}/gpio.ncl"
     "${NCL_CODEGEN_DIR}/keyboard_matrix.ncl"
 )

--- a/firmware/ch58x-ble-hid-keyboard-c/keyboard/ncl/keyboard/contracts.ncl
+++ b/firmware/ch58x-ble-hid-keyboard-c/keyboard/ncl/keyboard/contracts.ncl
@@ -1,3 +1,4 @@
-(import "gpio.ncl").contracts
+(import "debug.ncl").contracts
+& (import "gpio.ncl").contracts
 & (import "keyboard_gpio.ncl").contracts
 & (import "keyboard_matrix.ncl").contracts

--- a/firmware/ch58x-ble-hid-keyboard-c/keyboard/ncl/keyboard/debug.ncl
+++ b/firmware/ch58x-ble-hid-keyboard-c/keyboard/ncl/keyboard/debug.ncl
@@ -1,0 +1,35 @@
+let C = import "contracts.ncl" in
+
+{
+  contracts = {
+    Board = {
+      # Optional; tx is Debug_UART0..3 (CH58x_common.h).
+      debug
+        | optional
+        | {
+          tx | Number,
+          ..
+        },
+
+      ..
+    },
+  },
+
+  board
+    | C.Board,
+
+  cmakelists =
+    if std.record.has_field "debug" board then
+      let tx = board.debug.tx in
+      {
+        debug =
+          [
+            "target_compile_definitions(keyboard INTERFACE DEBUG=%{std.to_string tx})",
+            # Sleep would drop UART after the first PRINT.
+            "target_compile_definitions(keyboard INTERFACE HAL_SLEEP=FALSE)",
+          ]
+          |> std.string.join "\n",
+      }
+    else
+      {},
+}


### PR DESCRIPTION
## Summary

- Port `keyboard/ncl/keyboard/debug.ncl` from the hogp-device worktree (without APP/Profile PRINT troubleshooting).
- Optional `board.debug.tx` → CMake `DEBUG=<uart>` + `HAL_SLEEP=FALSE` on the keyboard INTERFACE.
- Production boards still get `HAL_SLEEP=TRUE` when no `DEBUG=` codegen is present.
- Wire `debug.ncl` into keyboard Nickel merge inputs; merge its contracts into `contracts.ncl`.

Pairs with #675 (`wabble-60-with-debug` sets `debug.tx = 1`). Alone, production `wabble-60` is unchanged.

## Test plan

- [ ] `just board=ncl/boards/wabble-60.ncl build` — no `DEBUG` define; sleep stays on
- [ ] With #675 board: `just board=ncl/boards/wabble-60-with-debug.ncl build` — `DEBUG=1`, `HAL_SLEEP=FALSE`