### PR TITLE
docs/just: AGENTS.md and check-quick pre-push hygiene

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,97 @@
+# Agent instructions for smart-keymap
+
+Use this file for day-to-day agent work in this repository. Human-oriented
+contributing notes live in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Task runner
+
+Prefer **`just`** from the repo root. Make is still the engine for CI / dependency
+graphs; do not remove or rename Make targets that workflows call.
+
+```text
+just                    # list recipes
+just choose             # interactive picker
+just check-quick        # quick pre-push hygiene (fmt, clippy, doc, nickel format)
+just test-fast          # daily tests: ncl checks + rust lib + integration
+just test               # full matrix via Make (pre-push / CI-ish)
+```
+
+Modules: `just/ncl.just`, `just/rust.just`, `just/ceedling.just`.
+
+### Recipe naming
+
+| Form | Meaning | Examples |
+| --- | --- | --- |
+| `module::recipe` | Just **submodule** path (language feature) | `ncl::checks`, `rust::clippy` |
+| `kebab-case` | Multi-word **recipe** names | `test-fast`, `check-quick`, `fmt-check` |
+| `path/to/file` | **Filesystem** only (mod paths, scripts) | `mod ncl "just/ncl.just"` |
+
+Root recipes such as `test-ncl` / `test-rust` are convenience aliases over
+module recipes (`ncl::all`, `rust::all`). Prefer either form; do not invent a
+third separator style.
+
+## Before you push (common CI failures)
+
+Pushes often fail on **lint/format/doc**, not on the unit tests agents run by
+default. After substantive edits — and **before pushing** — run:
+
+```sh
+just check-quick
+```
+
+That is the quick pre-push surface:
+
+| Check | Recipe | What CI enforces |
+| --- | --- | --- |
+| rustfmt | `just rust::fmt-check` | `cargo fmt --all -- --check` |
+| clippy | `just rust::clippy` | workspace clippy with `-D warnings` (firmware crates excluded on host) |
+| cargo doc | `just rust::doc` | `RUSTDOCFLAGS=--deny warnings` for core **and** firmware packages |
+| Nickel format | `just ncl::format-check` | `make ncl-format` then clean tree for whitelisted `.ncl` files |
+
+Fix failures before push:
+
+```sh
+just fmt                # write rustfmt + nickel format
+# then re-run: just check-quick
+```
+
+Firmware doc is a frequent surprise: host `cargo test` can pass while
+`cargo doc` fails on embedded packages (`rp2040-rtic-smart-keyboard`,
+`stm32f4-rtic-smart-keyboard`, `keyberon-smart-keyboard`, etc.).
+`just check-quick` / `just rust::doc` cover the same packages CI docs.
+
+When changing Nickel under `ncl/` (or other whitelisted paths), always format
+before commit. CI runs format and fails if the tree is dirty.
+
+## Broader verification
+
+| Goal | Command |
+| --- | --- |
+| Fast daily loop (no full lint matrix) | `just test-fast` |
+| Full local matrix (NCL + Rust + Ceedling + lint + cross builds) | `just test` |
+| Nickel only | `just test-ncl` / `just ncl::checks` / `just ncl::snapshots` |
+| Rust only (CI-ish suites) | `just test-rust` |
+| Firmware clippy (target-specific; not in host `just rust::clippy`) | see `.github/workflows/rust-stm32f4.yaml` and `rust-thumbv6m-none-eabi.yaml` |
+
+`just test` is the comprehensive local stand-in for CI. Prefer `just check-quick`
+when you mainly need to avoid the format/clippy/doc footguns, then `just test`
+when the change is large or touches codegen, FFI, or firmware.
+
+## Layout (short)
+
+| Path | Role |
+| --- | --- |
+| `smart-keymap-core/` | Core keymap library |
+| `smart_keymap/` / root package | C-facing / facade crates |
+| `ncl/` | Nickel keymap language, codegen, format whitelist |
+| `tests/ncl/`, `tests/rust/` | Snapshot fixtures and Rust integration tests |
+| `keyberon-smart-keyboard/`, `rp2040-…`, `stm32…` | Rust firmware packages |
+| `firmware/` | C firmware (CH32X, CH58x) |
+| `.github/workflows/` | CI source of truth for exact flags |
+
+## Conventions
+
+- Keep changes focused; match existing style in the file you edit.
+- Prefer extending existing Make / just recipes over one-off shell in docs.
+- CI calls `make` / `cargo` directly; keep those entry points stable.
+- For commit and PR conventions, use the user-scope **git-workflow** skill.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,26 +37,40 @@ Day-to-day commands are exposed through the root [justfile](justfile)
 ([just](https://just.systems/)). Make remains the engine for dependency graphs
 and CI; `just` is the human-facing catalog.
 
+Agent-oriented notes (including the pre-push checklist and recipe naming) live in
+[AGENTS.md](AGENTS.md).
+
 ```text
 just                              # list recipes (default)
 just choose                       # interactive picker (fzf / JUST_CHOOSER)
+just check-quick                  # quick pre-push hygiene: fmt, clippy, doc, nickel format
 just test-fast                    # daily loop: ncl checks + rust lib + integration
-just test                         # full matrix via Make (pre-push / CI-ish)
+just test                         # full matrix via Make (comprehensive / CI-ish)
 
 just ncl::checks                  # Nickel evaluated_checks
 just ncl::snapshot keymap-…       # one codegen snapshot fixture
 just ncl::snapshot-pick           # fzf a fixture, then run it
 just ncl::save [fixture]          # refresh expected.rs (one or all)
+just ncl::format-check            # format Nickel and fail if files would change
 
 just rust::lib                    # smart-keymap-core + smart-keymap unit tests
 just rust::integration [module]   # tests/rust integration suite / filter
 just rust::cucumber [filter]      # cucumber features (slow)
 just rust::clippy                 # workspace clippy (firmware crates excluded)
+just rust::doc                    # cargo doc with --deny warnings (core + firmware)
 
 just ceedling::all                # all C/FFI suites
 just ceedling::suite keyboard     # one suite (make test-ceedling-<name>)
 just ceedling::suite-pick         # fzf a suite
 ```
+
+Recipe names use **kebab-case** (`test-fast`, `check-quick`). Module recipes use
+Just's **`module::recipe`** form (`ncl::checks`, `rust::clippy`). Paths with `/`
+are filesystem only (e.g. `just/ncl.just`), not recipe names.
+
+Before pushing, prefer `just check-quick` so rustfmt, clippy, `cargo doc`
+(including firmware packages), and Nickel formatting match CI. Use `just test`
+for the full local matrix.
 
 Modules live under `just/` (`ncl`, `rust`, `ceedling`). Firmware packages keep
 their own justfiles (e.g. `rp2040-rtic-smart-keyboard`).

--- a/Makefile
+++ b/Makefile
@@ -66,11 +66,36 @@ test-clippy:
 		--exclude stm32-embassy-smart-keyboard \
 		-- -D warnings
 
-# Match .github/workflows/rust.yaml cargo-build "Run Cargo Doc" step.
+# Match CI cargo-doc steps (host + firmware packages).
+# Host: .github/workflows/rust.yaml
+# Firmware: rust-stm32f4.yaml, rust-thumbv6m-none-eabi.yaml
 .PHONY: test-doc
-test-doc:
+test-doc: test-doc-host test-doc-firmware
+
+.PHONY: test-doc-host
+test-doc-host:
 	RUSTDOCFLAGS="--deny warnings" $(CARGO) doc \
 		--package=smart-keymap-core \
+		--package=smart-keymap \
+		--package=keyberon-smart-keyboard
+
+.PHONY: test-doc-firmware
+test-doc-firmware: test-doc-stm32f4 test-doc-rp2040
+
+# Match .github/workflows/rust-stm32f4.yaml "Run Cargo Doc"
+.PHONY: test-doc-stm32f4
+test-doc-stm32f4:
+	RUSTDOCFLAGS="--deny warnings" $(CARGO) doc \
+		--no-default-features \
+		--package=stm32f4-rtic-smart-keyboard \
+		--package=smart-keymap \
+		--package=keyberon-smart-keyboard
+
+# Match .github/workflows/rust-thumbv6m-none-eabi.yaml "Run Cargo Doc"
+.PHONY: test-doc-rp2040
+test-doc-rp2040:
+	RUSTDOCFLAGS="--deny warnings" $(CARGO) doc \
+		--package=rp2040-rtic-smart-keyboard \
 		--package=smart-keymap \
 		--package=keyberon-smart-keyboard
 

--- a/just/ncl.just
+++ b/just/ncl.just
@@ -59,3 +59,21 @@ save-pick:
 [group('ncl')]
 format:
     make ncl-format
+
+# Format Nickel sources and fail if whitelisted files would change (CI-style)
+[group('ncl')]
+format-check:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    make ncl-format
+    files=()
+    while IFS= read -r f; do
+      [[ -n "$f" ]] && files+=("$f")
+    done < <(ncl/scripts/ncl-format-files.sh)
+    if [[ ${#files[@]} -eq 0 ]]; then
+      exit 0
+    fi
+    if ! git diff --exit-code -- "${files[@]}"; then
+      echo "Nickel formatting changed files. Run 'just ncl::format' (or 'just fmt') and commit." >&2
+      exit 1
+    fi

--- a/just/rust.just
+++ b/just/rust.just
@@ -77,7 +77,17 @@ fmt-check:
 fmt:
     cargo fmt --all
 
-# cargo doc with deny warnings (core packages)
+# cargo doc with deny warnings (core + firmware packages; matches CI)
 [group('rust')]
 doc:
     make test-doc
+
+# Host/core packages only (rust.yaml cargo-build doc step)
+[group('rust')]
+doc-host:
+    make test-doc-host
+
+# Firmware package docs (stm32f4 + rp2040 workflows)
+[group('rust')]
+doc-firmware:
+    make test-doc-firmware

--- a/justfile
+++ b/justfile
@@ -2,7 +2,12 @@
 #
 # Make remains the engine for dependency graphs and CI.
 # Day-to-day: `just` / `just choose` / `just test-fast`
-# Pre-push:   `just test` (full matrix via Make)
+# Pre-push:   `just check-quick` (fmt/clippy/doc/nickel) then `just test` when needed
+# Full matrix: `just test` (via Make)
+#
+# Naming: `module::recipe` is Just submodule syntax; multi-word recipes use
+# kebab-case (`test-fast`, `fmt-check`). `/` is only for filesystem paths
+# (e.g. mod ncl "just/ncl.just"), never recipe names. See AGENTS.md.
 #
 #   just --list --list-submodules
 #   just --choose
@@ -60,7 +65,11 @@ test-rust: rust::all
 [group('test')]
 test-ceedling: ceedling::all
 
-# ── lint / format ────────────────────────────────────────────────────
+# ── lint / format / pre-push ─────────────────────────────────────────
+
+# Quick pre-push hygiene: rustfmt, clippy, cargo doc (core+firmware), nickel format
+[group('lint')]
+check-quick: rust::fmt-check rust::clippy rust::doc ncl::format-check
 
 # rustfmt --check + clippy; also runs ncl-format (writes Nickel sources)
 [group('lint')]


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` so agents/humans know the pre-push surface and how Just recipes are named (`module::recipe` vs kebab-case; `/` is filesystem-only).
- Add `just check-quick` for the common CI footguns: rustfmt, clippy, `cargo doc` (core + firmware), and Nickel format-check.
- Expand `make test-doc` to match firmware workflow `cargo doc` jobs so firmware doc failures show up in `just test` / `make test`.

## Commits

1. **make:** expand `test-doc` for stm32f4 + rp2040 packages (CI parity)
2. **just:** `check-quick`, `ncl::format-check`, `rust::doc{,-host,-firmware}`
3. **docs:** `AGENTS.md` + `CONTRIBUTING.md` updates

## Recipe naming (no renames)

| Form | Role |
| --- | --- |
| `ncl::checks` | Just submodule syntax |
| `check-quick` / `test-fast` | kebab-case multi-word recipes |
| `just/ncl.just` | filesystem paths only |

Root aliases like `test-ncl` remain convenience wrappers over `ncl::all`. Not worth a mass rename.

## Test plan

- [x] `just --list` shows `check-quick`
- [x] `make -n test-doc` expands host + firmware doc commands
- [ ] `just ncl::format-check` on a clean tree
- [ ] Optional: `just check-quick` (clippy/doc are slower)