### PR TITLE
tap_hold: add hold_trigger_positions on profiles

### DIFF
--- a/features/keymap/key/tap_hold-hold_trigger_positions.feature
+++ b/features/keymap/key/tap_hold-hold_trigger_positions.feature
@@ -1,0 +1,112 @@
+Feature: TapHold Key (hold_trigger_key_positions / positional)
+
+  When a tap-hold **profile** sets `hold_trigger_key_positions`, only those
+  keymap indices may resolve an interrupt as hold. Interrupts from other
+  positions are ignored for the hold decision (ZMK positional hold-tap).
+
+  Profile 0 is `config.tap_hold` (including optional
+  `hold_trigger_key_positions`). Named extras may set the field on their
+  profile record. Keys stay thin: `tap` + `hold` + optional profile selector.
+
+  Timeout and self-release behaviour are unchanged.
+
+  For examples of this key in other smart keyboard firmware, see e.g.:
+
+  - [ZMK's hold-tap, hold-trigger-key-positions](https://zmk.dev/docs/keymaps/behaviors/hold-tap#positional-hold-tap-and-hold-trigger-key-positions)
+
+  Background:
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        config.tap_hold = {
+          interrupt_response = "HoldOnKeyPress",
+          timeout = 200,
+          hold_trigger_key_positions = [2],
+        },
+        keys = [
+          K.A & K.hold K.LeftCtrl,
+          K.B,
+          K.C,
+        ]
+      }
+      """
+
+  Example: allowed interrupt position resolves as hold
+
+    When the keymap registers the following input
+      """
+      [
+        press (K.A & K.hold K.LeftCtrl),
+        press (K.C),
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        press (K.LeftCtrl),
+        press (K.C),
+      ]
+      """
+
+  Example: non-trigger interrupt does not force hold
+
+    Interrupting with a non-trigger key (press & release), then releasing
+     the tap-hold, resolves as tap rather than hold.
+
+    When the keymap registers the following input
+      """
+      [
+        press (K.A & K.hold K.LeftCtrl),
+        tap (K.B),
+        release (K.A & K.hold K.LeftCtrl),
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        press (K.A),
+        tap (K.B),
+        release (K.A),
+      ]
+      """
+
+  Example: named profile with hold_trigger_key_positions
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        config.tap_hold = {
+          interrupt_response = "Ignore",
+          timeout = 200,
+          profiles = {
+            opposite = {
+              interrupt_response = "HoldOnKeyPress",
+              hold_trigger_key_positions = [2],
+            },
+          },
+        },
+        keys = [
+          K.A & K.hold K.LeftCtrl & K.tap_hold_profile "opposite",
+          K.B,
+          K.C,
+        ]
+      }
+      """
+
+    When the keymap registers the following input
+      """
+      [
+        press (K.A & K.hold K.LeftCtrl & K.tap_hold_profile "opposite"),
+        press (K.C),
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        press (K.LeftCtrl),
+        press (K.C),
+      ]
+      """

--- a/features/keymap/key/tap_hold-profiles.feature
+++ b/features/keymap/key/tap_hold-profiles.feature
@@ -1,9 +1,10 @@
 Feature: TapHold Key (behavior profiles)
 
-  Tap-hold keys use behavior **profiles**. Profile 0 is `config.tap_hold`
-  (timeout, interrupt_response, required_idle_time). Extra profiles are
-  authored as `config.tap_hold.profiles = { name = { … }, … }` and selected
-  per key with `tap_hold_profile` (name string or numeric index).
+  Tap-hold keys use behavior **profiles**. Profile 0 is the default profile
+  (`config.tap_hold` knobs: timeout, interrupt_response, required_idle_time —
+  stored as `Config.default_profile`). Extra profiles are authored as
+  `config.tap_hold.profiles = { name = { … }, … }` and selected per key with
+  `tap_hold_profile` (name string or numeric index).
 
   Names lower to indices 1.. in record field order (JSON array on config).
 

--- a/features/scripts/generate-doc.sh
+++ b/features/scripts/generate-doc.sh
@@ -42,6 +42,7 @@ keymap_key_features=(
     "tap_hold-config-required_idle_time"
     "tap_hold-config-timeout"
     "tap_hold-config-timeout-none"
+    "tap_hold-hold_trigger_positions"
     "tap_hold-profiles"
 )
 

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -661,6 +661,12 @@
             else
               {}
           )
+          & (
+            if std.record.has_field "hold_trigger_key_positions" th_config then
+              { hold_trigger_key_positions = th_config.hold_trigger_key_positions }
+            else
+              {}
+          )
         in
         let profiles_array =
           th_profile_names

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -569,10 +569,10 @@
       l,
 
   # Tap-hold behavior profiles:
+  #   config.tap_hold flat knobs → JSON default_profile (profile 0)
   #   config.tap_hold.profiles = { hml = { … }, hmr = { … } }  (authoring, name → Profile)
-  # lowers to a JSON array at indices 1.. (alphabetical name order); profile 0 = default fields.
+  # lowers to a JSON array at indices 1.. (record field order).
   # Keys may set `tap_hold_profile = "hml"` (or a number); names resolve before to_json_value.
-  # Name order = Nickel record field order (same idea as named_layers).
   tap_hold_profile_names = fun th_config =>
     if std.record.has_field "profiles" th_config then
       std.record.fields th_config.profiles
@@ -638,17 +638,40 @@
         )
       in
       let th_config_json =
-        let th_base =
-          if std.record.has_field "profiles" th_config then
-            std.record.remove "profiles" th_config
-          else
-            th_config
+        # Flat authoring knobs (timeout, interrupt_response, …) nest as
+        # default_profile for JSON / Rust Config (no serde flatten on no_std).
+        # Pick only real Profile fields — Config contracts leave optional field
+        # stubs that must not be nested into ProfileJson.
+        let default_profile_json =
+          (
+            if std.record.has_field "timeout" th_config then
+              { timeout = th_config.timeout }
+            else
+              {}
+          )
+          & (
+            if std.record.has_field "interrupt_response" th_config then
+              { interrupt_response = th_config.interrupt_response }
+            else
+              {}
+          )
+          & (
+            if std.record.has_field "required_idle_time" th_config then
+              { required_idle_time = th_config.required_idle_time }
+            else
+              {}
+          )
         in
         let profiles_array =
           th_profile_names
           |> std.array.map (fun name => th_config.profiles."%{name}")
         in
-        th_base
+        (
+          if default_profile_json == {} then
+            {}
+          else
+            { default_profile = default_profile_json }
+        )
         & (
           if profiles_array == [] then
             {}

--- a/ncl/smart_keys/tap_hold/keymap-codegen.ncl
+++ b/ncl/smart_keys/tap_hold/keymap-codegen.ncl
@@ -51,6 +51,24 @@
             expected = "smart_keymap::key::tap_hold::Key::with_profile(smart_keymap::key::keyboard::Key::new(4), smart_keymap::key::keyboard::Key::new(224), 1)",
           },
         },
+
+      check_profile_with_hold_triggers =
+        let rust_expr =
+          smart_keymap.tap_hold.profile_rust_expr {
+            interrupt_response = "HoldOnKeyPress",
+            hold_trigger_key_positions = [2, 3],
+          }
+        in
+        {
+          check_rust_expr = {
+            actual = rust_expr,
+            expected = m%"smart_keymap::key::tap_hold::Profile {
+            hold_trigger_positions: Some(smart_keymap::key::tap_hold::KeyPositionMask::from_indices(&[2, 3])),
+            interrupt_response: smart_keymap::key::tap_hold::InterruptResponse::HoldOnKeyPress,
+            ..smart_keymap::key::tap_hold::Profile::new()
+          }"%,
+          },
+        },
     },
   },
 
@@ -67,6 +85,14 @@
         ),
 
       module = "smart_keymap::key::tap_hold",
+
+      hold_trigger_positions_expr = fun positions =>
+        let idxs =
+          positions
+          |> std.array.map (fun i => "%{std.to_string i}")
+          |> std.string.join ", "
+        in
+        "Some(%{module}::KeyPositionMask::from_indices(&[%{idxs}]))",
 
       profile_field_expr = fun c =>
         (
@@ -93,6 +119,14 @@
           if std.record.has_field "required_idle_time" c then
             {
               required_idle_time = "Some(%{std.to_string c.required_idle_time})",
+            }
+          else
+            {}
+        )
+        & (
+          if std.record.has_field "hold_trigger_key_positions" c then
+            {
+              hold_trigger_positions = hold_trigger_positions_expr c.hold_trigger_key_positions,
             }
           else
             {}
@@ -235,6 +269,7 @@
             ),
           interrupt_response | optional | TapHoldInterruptResponseJson,
           required_idle_time | optional | Number,
+          hold_trigger_key_positions | optional | Array Number,
         },
 
         # Lowered JSON form: nested default_profile + profiles array.

--- a/ncl/smart_keys/tap_hold/keymap-codegen.ncl
+++ b/ncl/smart_keys/tap_hold/keymap-codegen.ncl
@@ -237,17 +237,9 @@
           required_idle_time | optional | Number,
         },
 
+        # Lowered JSON form: nested default_profile + profiles array.
         Json = {
-          timeout
-            | optional
-            | std.contract.from_validator (
-              validators.any_of [
-                validators.is_null,
-                validators.is_number,
-              ]
-            ),
-          interrupt_response | optional | TapHoldInterruptResponseJson,
-          required_idle_time | optional | Number,
+          default_profile | optional | ProfileJson,
           # Lowered form: array of extra profiles (index 1..).
           profiles | optional | Array ProfileJson,
         },
@@ -256,30 +248,8 @@
           if std.record.has_field "tap_hold" json_keymap.config then
             let c = json_keymap.config.tap_hold in
             (
-              if std.record.has_field "timeout" c then
-                {
-                  timeout =
-                    if c.timeout == null then
-                      "None"
-                    else
-                      "Some(%{std.to_string c.timeout})",
-                }
-              else
-                {}
-            )
-            & (
-              if std.record.has_field "interrupt_response" c then
-                {
-                  interrupt_response = "%{module}::InterruptResponse::%{c.interrupt_response}",
-                }
-              else
-                {}
-            )
-            & (
-              if std.record.has_field "required_idle_time" c then
-                {
-                  required_idle_time = "Some(%{std.to_string c.required_idle_time})",
-                }
+              if std.record.has_field "default_profile" c then
+                { default_profile = profile_rust_expr c.default_profile }
               else
                 {}
             )

--- a/ncl/smart_keys/tap_hold/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/tap_hold/keymap-ncl-to-json.ncl
@@ -63,7 +63,8 @@
           ]
         ),
 
-      # One behavior profile (same fields as default config.tap_hold).
+      # One behavior profile. Profile 0 is Config's default (flat on config.tap_hold);
+      # extras live under config.tap_hold.profiles.
       Profile = {
         timeout
           | optional
@@ -77,6 +78,8 @@
         required_idle_time | optional | Number,
       },
 
+      # Authoring keeps default-profile knobs flat on config.tap_hold;
+      # lowering nests them as default_profile for JSON / Rust Config.
       Config = {
         timeout
           | optional

--- a/ncl/smart_keys/tap_hold/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/tap_hold/keymap-ncl-to-json.ncl
@@ -76,6 +76,8 @@
           ),
         interrupt_response | optional | TapHoldInterruptResponse,
         required_idle_time | optional | Number,
+        # Only listed keymap indices may force interrupt-as-hold; unset = unrestricted.
+        hold_trigger_key_positions | optional | Array Number,
       },
 
       # Authoring keeps default-profile knobs flat on config.tap_hold;
@@ -91,6 +93,8 @@
           ),
         interrupt_response | optional | TapHoldInterruptResponse,
         required_idle_time | optional | Number,
+        # Only listed keymap indices may force interrupt-as-hold; unset = unrestricted.
+        hold_trigger_key_positions | optional | Array Number,
         # Authoring: name → profile record. Lowered to a JSON array (indices 1..).
         profiles | optional | { _ | Profile },
       },

--- a/smart-keymap-core/src/key/tap_hold.rs
+++ b/smart-keymap-core/src/key/tap_hold.rs
@@ -14,13 +14,13 @@ pub struct Ref(pub u8);
 
 /// Maximum number of *extra* tap-hold profiles beyond the default (profile 0).
 ///
-/// Profile indices on keys are `0` (default / [`Config`] top-level fields) then
+/// Profile indices on keys are `0` ([`Config::default_profile`]) then
 /// `1..` into [`Config::profiles`]. Total usable profiles = `1 + MAX_EXTRA_PROFILES`.
 pub const MAX_EXTRA_PROFILES: usize = 7;
 
 /// One tap-hold behavior profile (timeout, interrupt flavor, idle gate).
 ///
-/// Profile 0 is the default [`Config`] fields; extra profiles live in
+/// Profile 0 is [`Config::default_profile`]; extra profiles live in
 /// [`Config::profiles`] and are selected per key via [`Key::profile`].
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct Profile {
@@ -65,7 +65,7 @@ pub struct Key<R> {
     pub tap: R,
     /// The 'hold' key.
     pub hold: R,
-    /// Behavior profile index: `0` = default [`Config`] fields; `1..` = [`Config::profiles`].
+    /// Behavior profile index: `0` = [`Config::default_profile`]; `1..` = [`Config::profiles`].
     #[serde(default)]
     pub profile: u8,
 }
@@ -112,30 +112,19 @@ pub enum InterruptResponse {
 
 /// Configuration settings for tap hold keys.
 ///
-/// Top-level fields are **profile 0** (the default). Optional [`Config::profiles`]
+/// [`Config::default_profile`] is **profile 0**. Optional [`Config::profiles`]
 /// are extra behaviors at indices `1..`. Keys select a profile via [`Key::profile`].
+///
+/// Nickel authoring keeps profile-0 knobs flat on `config.tap_hold`
+/// (`timeout`, `interrupt_response`, …); lowering nests them as
+/// `default_profile` in JSON (no `serde(flatten)` — that needs alloc).
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct Config {
-    /// The timeout (in number of milliseconds) for a tap-hold key to resolve as hold.
-    ///
-    /// When `None`, the tap/hold decision does not timeout;
-    /// the key resolves only on release (as tap) or interruption
-    /// (depending on [InterruptResponse]).
-    #[serde(default = "default_timeout")]
-    pub timeout: Option<u16>,
+    /// Default behavior (profile index 0).
+    #[serde(default = "default_profile_value")]
+    pub default_profile: Profile,
 
-    /// How the tap-hold key should respond to interruptions.
-    #[serde(default = "default_interrupt_response")]
-    pub interrupt_response: InterruptResponse,
-
-    /// Amount of time (in milliseconds) the keymap must have been idle
-    ///  in order for tap hold to support 'hold' functionality.
-    ///
-    /// This reduces disruption from unexpected hold resolutions
-    ///  when typing quickly.
-    pub required_idle_time: Option<u16>,
-
-    /// Extra behavior profiles (indices `1..=len`). Profile `0` is the top-level fields.
+    /// Extra behavior profiles (indices `1..=len`).
     #[serde(default)]
     pub profiles: Slice<Profile, MAX_EXTRA_PROFILES>,
 }
@@ -154,7 +143,11 @@ fn default_interrupt_response() -> InterruptResponse {
     DEFAULT_INTERRUPT_RESPONSE
 }
 
-/// Default profile (same values as default [`Config`] top-level fields).
+fn default_profile_value() -> Profile {
+    DEFAULT_PROFILE
+}
+
+/// Default profile (also the contents of [`DEFAULT_CONFIG`]'s default profile).
 pub const DEFAULT_PROFILE: Profile = Profile {
     timeout: Some(DEFAULT_TIMEOUT),
     interrupt_response: DEFAULT_INTERRUPT_RESPONSE,
@@ -163,9 +156,7 @@ pub const DEFAULT_PROFILE: Profile = Profile {
 
 /// Default tap hold config.
 pub const DEFAULT_CONFIG: Config = Config {
-    timeout: Some(DEFAULT_TIMEOUT),
-    interrupt_response: DEFAULT_INTERRUPT_RESPONSE,
-    required_idle_time: None,
+    default_profile: DEFAULT_PROFILE,
     profiles: Slice::from_slice(&[]),
 };
 
@@ -177,28 +168,20 @@ impl Config {
 
     /// Resolves the behavior profile for `profile_id`.
     ///
-    /// - `0` → top-level default fields
+    /// - `0` → [`Self::default_profile`]
     /// - `1..` → [`Self::profiles`] entry `id - 1`
     ///
     /// Out-of-range ids fall back to the default profile.
     pub const fn profile(&self, profile_id: u8) -> Profile {
         if profile_id == 0 {
-            return Profile {
-                timeout: self.timeout,
-                interrupt_response: self.interrupt_response,
-                required_idle_time: self.required_idle_time,
-            };
+            return self.default_profile;
         }
         let idx = (profile_id - 1) as usize;
         let extras = self.profiles.as_slice();
         if idx < extras.len() {
             extras[idx]
         } else {
-            Profile {
-                timeout: self.timeout,
-                interrupt_response: self.interrupt_response,
-                required_idle_time: self.required_idle_time,
-            }
+            self.default_profile
         }
     }
 }
@@ -537,9 +520,11 @@ mod tests {
         required_idle_time: Option<u16>,
     ) -> Config {
         Config {
-            timeout,
-            interrupt_response,
-            required_idle_time,
+            default_profile: Profile {
+                timeout,
+                interrupt_response,
+                required_idle_time,
+            },
             profiles: Slice::from_slice(&[]),
         }
     }
@@ -1104,12 +1089,15 @@ mod tests {
     #[test]
     fn test_profile_zero_is_default_fields() {
         let config = Config {
-            timeout: Some(50),
-            interrupt_response: InterruptResponse::HoldOnKeyPress,
-            required_idle_time: Some(10),
+            default_profile: Profile {
+                timeout: Some(50),
+                interrupt_response: InterruptResponse::HoldOnKeyPress,
+                required_idle_time: Some(10),
+            },
             profiles: Slice::from_slice(&[]),
         };
         let p = config.profile(0);
+        assert_eq!(p, config.default_profile);
         assert_eq!(p.timeout, Some(50));
         assert_eq!(p.interrupt_response, InterruptResponse::HoldOnKeyPress);
         assert_eq!(p.required_idle_time, Some(10));
@@ -1123,9 +1111,11 @@ mod tests {
             required_idle_time: None,
         };
         let config = Config {
-            timeout: Some(200),
-            interrupt_response: InterruptResponse::Ignore,
-            required_idle_time: None,
+            default_profile: Profile {
+                timeout: Some(200),
+                interrupt_response: InterruptResponse::Ignore,
+                required_idle_time: None,
+            },
             profiles: Slice::from_slice(&[extra]),
         };
         assert_eq!(config.profile(1).timeout, Some(300));
@@ -1135,6 +1125,7 @@ mod tests {
         );
         // OOR falls back to default
         assert_eq!(config.profile(9).timeout, Some(200));
+        assert_eq!(config.profile(9), config.default_profile);
     }
 
     #[test]

--- a/smart-keymap-core/src/key/tap_hold.rs
+++ b/smart-keymap-core/src/key/tap_hold.rs
@@ -12,13 +12,95 @@ use crate::slice::Slice;
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct Ref(pub u8);
 
+/// Bitmask of keymap indices (0..128) used for positional hold triggers.
+///
+/// Empty mask means "no restriction" only when wrapped in [`Option::None`] on
+/// [Profile] / [Config]; a `Some(empty)` mask matches no positions.
+///
+/// JSON accepts an array of keymap indices (e.g. `[2, 3, 18]`), matching the
+/// Nickel authoring surface `hold_trigger_key_positions`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct KeyPositionMask {
+    /// Bits for keymap indices 0..63.
+    pub lo: u64,
+    /// Bits for keymap indices 64..127.
+    pub hi: u64,
+}
+
+impl<'de> Deserialize<'de> for KeyPositionMask {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = KeyPositionMask;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.write_str("an array of keymap indices")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let mut mask = KeyPositionMask::EMPTY;
+                while let Some(idx) = seq.next_element::<u16>()? {
+                    mask = mask.with(idx);
+                }
+                Ok(mask)
+            }
+        }
+
+        deserializer.deserialize_seq(Visitor)
+    }
+}
+
+impl KeyPositionMask {
+    /// Empty mask (matches no indices).
+    pub const EMPTY: Self = Self { lo: 0, hi: 0 };
+
+    /// Whether `keymap_index` is set in the mask.
+    pub const fn contains(self, keymap_index: u16) -> bool {
+        if keymap_index < 64 {
+            (self.lo & (1u64 << keymap_index)) != 0
+        } else if keymap_index < 128 {
+            (self.hi & (1u64 << (keymap_index - 64))) != 0
+        } else {
+            false
+        }
+    }
+
+    /// Returns a copy with `keymap_index` set (indices ≥ 128 are ignored).
+    pub const fn with(mut self, keymap_index: u16) -> Self {
+        if keymap_index < 64 {
+            self.lo |= 1u64 << keymap_index;
+        } else if keymap_index < 128 {
+            self.hi |= 1u64 << (keymap_index - 64);
+        }
+        self
+    }
+
+    /// Build a mask from a list of keymap indices.
+    pub const fn from_indices(indices: &[u16]) -> Self {
+        let mut mask = Self::EMPTY;
+        let mut i = 0;
+        while i < indices.len() {
+            mask = mask.with(indices[i]);
+            i += 1;
+        }
+        mask
+    }
+}
+
 /// Maximum number of *extra* tap-hold profiles beyond the default (profile 0).
 ///
 /// Profile indices on keys are `0` ([`Config::default_profile`]) then
 /// `1..` into [`Config::profiles`]. Total usable profiles = `1 + MAX_EXTRA_PROFILES`.
 pub const MAX_EXTRA_PROFILES: usize = 7;
 
-/// One tap-hold behavior profile (timeout, interrupt flavor, idle gate).
+/// One tap-hold behavior profile (timeout, interrupt flavor, idle gate, hold triggers).
 ///
 /// Profile 0 is [`Config::default_profile`]; extra profiles live in
 /// [`Config::profiles`] and are selected per key via [`Key::profile`].
@@ -43,12 +125,31 @@ pub struct Profile {
     ///  when typing quickly.
     #[serde(default)]
     pub required_idle_time: Option<u16>,
+
+    /// When set, only these keymap indices may force an interrupt-as-hold
+    /// resolution. When unset, any interrupting key may force hold
+    /// (subject to [InterruptResponse]).
+    ///
+    /// JSON field name matches the Nickel authoring surface
+    /// (`hold_trigger_key_positions`).
+    #[serde(default, rename = "hold_trigger_key_positions")]
+    pub hold_trigger_positions: Option<KeyPositionMask>,
 }
 
 impl Profile {
     /// Constructs a new default [Profile].
     pub const fn new() -> Self {
         DEFAULT_PROFILE
+    }
+
+    /// Whether `other_keymap_index` is allowed to resolve this profile as hold.
+    ///
+    /// Unrestricted when [`Self::hold_trigger_positions`] is `None`.
+    pub const fn allows_hold_trigger(&self, other_keymap_index: u16) -> bool {
+        match self.hold_trigger_positions {
+            None => true,
+            Some(mask) => mask.contains(other_keymap_index),
+        }
     }
 }
 
@@ -152,6 +253,7 @@ pub const DEFAULT_PROFILE: Profile = Profile {
     timeout: Some(DEFAULT_TIMEOUT),
     interrupt_response: DEFAULT_INTERRUPT_RESPONSE,
     required_idle_time: None,
+    hold_trigger_positions: None,
 };
 
 /// Default tap hold config.
@@ -260,19 +362,24 @@ impl PendingKeyState {
     }
 
     /// Compute whether the tap-hold key should resolve as tap or hold,
-    ///  given the tap hold config, the current state, and the key event.
+    ///  given the behavior profile, the current state, and the key event.
     fn hold_resolution(
         &self,
-        interrupt_response: InterruptResponse,
+        profile: &Profile,
         keymap_index: u16,
         event: key::Event<Event>,
     ) -> Option<TapHoldState> {
-        match interrupt_response {
+        match profile.interrupt_response {
             InterruptResponse::HoldOnKeyPress => {
                 match event {
-                    key::Event::Input(input::Event::Press { .. }) => {
-                        // TapHold: any interruption resolves pending TapHold as Hold.
-                        Some(TapHoldState::Hold)
+                    key::Event::Input(input::Event::Press { keymap_index: ki }) => {
+                        // Interruption resolves as Hold when the positional
+                        // filter (if any) allows the interrupting key.
+                        if profile.allows_hold_trigger(ki) {
+                            Some(TapHoldState::Hold)
+                        } else {
+                            None
+                        }
                     }
                     key::Event::Input(input::Event::Release { keymap_index: ki }) => {
                         if keymap_index == ki {
@@ -298,7 +405,9 @@ impl PendingKeyState {
                         if keymap_index == ki {
                             // TapHold: not interrupted; resolved as tap.
                             Some(TapHoldState::Tap)
-                        } else if Some(ki) == self.other_pressed_keymap_index {
+                        } else if Some(ki) == self.other_pressed_keymap_index
+                            && profile.allows_hold_trigger(ki)
+                        {
                             // TapHold: interrupted by key tap (press + release); resolved as hold.
                             Some(TapHoldState::Hold)
                         } else {
@@ -352,7 +461,7 @@ impl PendingKeyState {
         }
 
         // Resolve tap-hold state per the event.
-        self.hold_resolution(profile.interrupt_response, keymap_index, event)
+        self.hold_resolution(profile, keymap_index, event)
     }
 }
 
@@ -524,6 +633,7 @@ mod tests {
                 timeout,
                 interrupt_response,
                 required_idle_time,
+                hold_trigger_positions: None,
             },
             profiles: Slice::from_slice(&[]),
         }
@@ -1093,6 +1203,7 @@ mod tests {
                 timeout: Some(50),
                 interrupt_response: InterruptResponse::HoldOnKeyPress,
                 required_idle_time: Some(10),
+                hold_trigger_positions: Some(KeyPositionMask::from_indices(&[2, 3])),
             },
             profiles: Slice::from_slice(&[]),
         };
@@ -1101,6 +1212,10 @@ mod tests {
         assert_eq!(p.timeout, Some(50));
         assert_eq!(p.interrupt_response, InterruptResponse::HoldOnKeyPress);
         assert_eq!(p.required_idle_time, Some(10));
+        assert_eq!(
+            p.hold_trigger_positions,
+            Some(KeyPositionMask::from_indices(&[2, 3]))
+        );
     }
 
     #[test]
@@ -1109,12 +1224,14 @@ mod tests {
             timeout: Some(300),
             interrupt_response: InterruptResponse::HoldOnKeyTap,
             required_idle_time: None,
+            hold_trigger_positions: Some(KeyPositionMask::from_indices(&[5])),
         };
         let config = Config {
             default_profile: Profile {
                 timeout: Some(200),
                 interrupt_response: InterruptResponse::Ignore,
                 required_idle_time: None,
+                hold_trigger_positions: None,
             },
             profiles: Slice::from_slice(&[extra]),
         };
@@ -1122,6 +1239,10 @@ mod tests {
         assert_eq!(
             config.profile(1).interrupt_response,
             InterruptResponse::HoldOnKeyTap
+        );
+        assert_eq!(
+            config.profile(1).hold_trigger_positions,
+            Some(KeyPositionMask::from_indices(&[5]))
         );
         // OOR falls back to default
         assert_eq!(config.profile(9).timeout, Some(200));
@@ -1134,5 +1255,90 @@ mod tests {
         assert_eq!(key.profile, 0);
         let key = Key::with_profile(0u8, 1u8, 2);
         assert_eq!(key.profile, 2);
+    }
+
+    // --- hold_trigger_positions ---
+
+    #[test]
+    fn test_key_position_mask_contains() {
+        let mask = KeyPositionMask::from_indices(&[0, 5, 64, 127]);
+        assert!(mask.contains(0));
+        assert!(mask.contains(5));
+        assert!(mask.contains(64));
+        assert!(mask.contains(127));
+        assert!(!mask.contains(1));
+        assert!(!mask.contains(63));
+        assert!(!mask.contains(65));
+    }
+
+    #[test]
+    fn test_allows_hold_trigger_default() {
+        let profile = Profile::new();
+        assert!(profile.allows_hold_trigger(0));
+        assert!(profile.allows_hold_trigger(99));
+    }
+
+    #[test]
+    fn test_allows_hold_trigger_restricted() {
+        let profile = Profile {
+            hold_trigger_positions: Some(KeyPositionMask::from_indices(&[2, 3])),
+            ..Profile::new()
+        };
+        assert!(!profile.allows_hold_trigger(0));
+        assert!(profile.allows_hold_trigger(2));
+        assert!(profile.allows_hold_trigger(3));
+    }
+
+    #[test]
+    fn hold_on_key_press_non_trigger_press_does_not_resolve() {
+        let ctx = context_with(Config {
+            default_profile: Profile {
+                timeout: Some(DEFAULT_TIMEOUT),
+                interrupt_response: InterruptResponse::HoldOnKeyPress,
+                required_idle_time: None,
+                hold_trigger_positions: Some(KeyPositionMask::from_indices(&[2])),
+            },
+            profiles: Slice::from_slice(&[]),
+        });
+        let mut pks = PendingKeyState::new();
+
+        // OTHER_INDEX is 1; only index 2 is allowed.
+        let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, press(OTHER_INDEX));
+        assert_eq!(None, resolution);
+    }
+
+    #[test]
+    fn hold_on_key_press_allowed_trigger_resolves_as_hold() {
+        let ctx = context_with(Config {
+            default_profile: Profile {
+                timeout: Some(DEFAULT_TIMEOUT),
+                interrupt_response: InterruptResponse::HoldOnKeyPress,
+                required_idle_time: None,
+                hold_trigger_positions: Some(KeyPositionMask::from_indices(&[2])),
+            },
+            profiles: Slice::from_slice(&[]),
+        });
+        let mut pks = PendingKeyState::new();
+
+        let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, press(2));
+        assert_eq!(Some(TapHoldState::Hold), resolution);
+    }
+
+    #[test]
+    fn hold_on_key_tap_non_trigger_tap_does_not_resolve() {
+        let ctx = context_with(Config {
+            default_profile: Profile {
+                timeout: Some(DEFAULT_TIMEOUT),
+                interrupt_response: InterruptResponse::HoldOnKeyTap,
+                required_idle_time: None,
+                hold_trigger_positions: Some(KeyPositionMask::from_indices(&[2])),
+            },
+            profiles: Slice::from_slice(&[]),
+        });
+        let mut pks = PendingKeyState::new();
+        let _ = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, press(OTHER_INDEX));
+
+        let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, release(OTHER_INDEX));
+        assert_eq!(None, resolution);
     }
 }

--- a/smart-keymap-full-system-std/tests/keymap_full_system.rs
+++ b/smart-keymap-full-system-std/tests/keymap_full_system.rs
@@ -21,7 +21,7 @@ fn tap_hold_interrupt_keymap(
     use smart_keymap_full_system_std::key_system;
 
     let mut config = key_system::Config::new();
-    config.tap_hold.interrupt_response = interrupt_response;
+    config.tap_hold.default_profile.interrupt_response = interrupt_response;
 
     smart_keymap::keymap::Keymap::new(
         [

--- a/tests/ncl/keymap-48key-rgoulter/expected.rs
+++ b/tests/ncl/keymap-48key-rgoulter/expected.rs
@@ -1011,7 +1011,10 @@ pub mod init {
         sticky: smart_keymap::key::sticky::Config::new(),
         tap_dance: smart_keymap::key::tap_dance::Config::new(),
         tap_hold: smart_keymap::key::tap_hold::Config {
-            interrupt_response: smart_keymap::key::tap_hold::InterruptResponse::HoldOnKeyTap,
+            default_profile: smart_keymap::key::tap_hold::Profile {
+                interrupt_response: smart_keymap::key::tap_hold::InterruptResponse::HoldOnKeyTap,
+                ..smart_keymap::key::tap_hold::Profile::new()
+            },
             ..smart_keymap::key::tap_hold::Config::new()
         },
     };
@@ -1031,7 +1034,10 @@ pub mod init {
         sticky: smart_keymap::key::sticky::Config::new(),
         tap_dance: smart_keymap::key::tap_dance::Config::new(),
         tap_hold: smart_keymap::key::tap_hold::Config {
-            interrupt_response: smart_keymap::key::tap_hold::InterruptResponse::HoldOnKeyTap,
+            default_profile: smart_keymap::key::tap_hold::Profile {
+                interrupt_response: smart_keymap::key::tap_hold::InterruptResponse::HoldOnKeyTap,
+                ..smart_keymap::key::tap_hold::Profile::new()
+            },
             ..smart_keymap::key::tap_hold::Config::new()
         },
     });

--- a/tests/rust/tap_hold.rs
+++ b/tests/rust/tap_hold.rs
@@ -1,5 +1,6 @@
 mod hold_on_interrupt_press;
 mod hold_on_interrupt_tap;
+mod hold_trigger_positions;
 mod interrupt_ignore;
 mod layered;
 mod no_timeout;

--- a/tests/rust/tap_hold/hold_trigger_positions.rs
+++ b/tests/rust/tap_hold/hold_trigger_positions.rs
@@ -1,0 +1,154 @@
+use smart_keymap::input;
+use smart_keymap::keymap::ObservedKeymap;
+
+use crate::hid_keycodes::*;
+use smart_keymap_macros::keymap;
+
+#[test]
+fn opposite_hand_press_resolves_hold() {
+    // Default profile: only key 2 may trigger hold (simulating opposite hand).
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.tap_hold = {
+                    interrupt_response = "HoldOnKeyPress",
+                    timeout = 200,
+                    hold_trigger_key_positions = [2],
+                },
+                keys = [
+                    K.A & K.hold K.LeftCtrl,
+                    K.B,
+                    K.C,
+                ],
+            }
+        "#
+    ));
+
+    // Act — interrupt with key 2 (allowed trigger)
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 2 });
+    keymap.tick_until_no_scheduled_events();
+
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, KC_C, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn same_hand_press_does_not_resolve_hold() {
+    // Default profile: only key 2 may trigger hold. Key 1 is "same hand".
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.tap_hold = {
+                    interrupt_response = "HoldOnKeyPress",
+                    timeout = 200,
+                    hold_trigger_key_positions = [2],
+                },
+                keys = [
+                    K.A & K.hold K.LeftCtrl,
+                    K.B,
+                    K.C,
+                ],
+            }
+        "#
+    ));
+
+    // Act — press TH, same-hand B, release both (should be taps, not hold)
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+    keymap.tick_until_no_scheduled_events();
+
+    // TH self-release resolves as tap (not hold); B is still held during A.
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, KC_B, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn timeout_still_resolves_hold_with_positional_triggers() {
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.tap_hold = {
+                    interrupt_response = "HoldOnKeyPress",
+                    timeout = 200,
+                    hold_trigger_key_positions = [2],
+                },
+                keys = [
+                    K.A & K.hold K.LeftCtrl,
+                    K.B,
+                    K.C,
+                ],
+            }
+        "#
+    ));
+
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    for _ in 0..250 {
+        keymap.tick();
+    }
+
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn named_profile_hold_trigger_positions() {
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.tap_hold = {
+                    interrupt_response = "Ignore",
+                    timeout = 200,
+                    profiles = {
+                        opposite = {
+                            interrupt_response = "HoldOnKeyPress",
+                            hold_trigger_key_positions = [2],
+                        },
+                    },
+                },
+                keys = [
+                    K.A & K.hold K.LeftCtrl & K.tap_hold_profile "opposite",
+                    K.B,
+                    K.C,
+                ],
+            }
+        "#
+    ));
+
+    // Allowed trigger (key 2) → hold
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 2 });
+    keymap.tick_until_no_scheduled_events();
+
+    #[rustfmt::skip]
+    let expected: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, KC_C, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected, keymap.distinct_reports().reports());
+}


### PR DESCRIPTION
## Summary

First of three stacked PRs splitting #673 by feature. Restacked onto #687 (behavior profiles).

Adds optional `hold_trigger_key_positions` so only listed keymap indices may force interrupt-as-hold (ZMK positional hold-tap). The mask lives on **Profile** / profile-0 **Config**, not on every `Key` — keys stay `{ tap, hold, profile }`.

- `KeyPositionMask` + `Profile`/`Config.hold_trigger_positions` (JSON: `hold_trigger_key_positions`)
- Nickel authoring on `config.tap_hold` and named profile records
- Unit, integration, and cucumber feature coverage (default profile + named profile)

### Authoring

```nickel
config.tap_hold = {
  interrupt_response = "HoldOnKeyPress",
  hold_trigger_key_positions = [2],  # profile 0
  profiles = {
    opposite = {
      interrupt_response = "HoldOnKeyPress",
      hold_trigger_key_positions = [2, 3],
    },
  },
},
keys = [
  K.A & K.hold K.LeftCtrl,
  K.C & K.hold K.LeftShift & K.tap_hold_profile "opposite",
]
```

## Stack

1. **This PR** — hold_trigger_positions (on Profile)
2. retro_tap — next (#681), same model
3. quick_tap_ms — next (#682), same model

## Test plan

- [x] `cargo test -p smart-keymap-core --lib key::tap_hold`
- [x] `cargo test --test rust-integration tap_hold::hold_trigger`
- [x] `just ncl::checks`
- [ ] CI green

## Out of scope

- `retro_tap`, `quick_tap_ms` (follow-up PRs in this stack)
- `hold-trigger-on-release` / global chordal-hold