### PR TITLE
tap_hold: add retro_tap config

### DIFF
--- a/features/keymap/key/tap_hold-config-retro_tap.feature
+++ b/features/keymap/key/tap_hold-config-retro_tap.feature
@@ -1,0 +1,60 @@
+Feature: TapHold Key (configure retro_tap)
+
+  The `retro_tap` config (ZMK `retro-tap`) means that
+   timeout alone never resolves a tap-hold as hold.
+   Hold activates only when another key interrupts;
+   releasing alone always yields tap.
+
+  For examples of this key in other smart keyboard firmware, see e.g.:
+
+  - [ZMK's hold-tap, retro-tap](https://zmk.dev/docs/keymaps/behaviors/hold-tap#retro-tap)
+
+  Background:
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        config.tap_hold.retro_tap = true,
+        config.tap_hold.timeout = 200,
+        config.tap_hold.interrupt_response = "HoldOnKeyPress",
+        keys = [
+          K.A & K.hold K.LeftCtrl,
+          K.B,
+        ]
+      }
+      """
+
+  Example: long hold alone resolves as tap
+
+    When the keymap registers the following input
+      """
+      [
+        press (K.A & K.hold K.LeftCtrl),
+        wait 250,
+        release (K.A & K.hold K.LeftCtrl),
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        tap (K.A),
+      ]
+      """
+
+  Example: interrupting press still resolves as hold
+
+    When the keymap registers the following input
+      """
+      [
+        press (K.A & K.hold K.LeftCtrl),
+        press (K.B),
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        press (K.LeftCtrl),
+        press (K.B),
+      ]
+      """

--- a/features/scripts/generate-doc.sh
+++ b/features/scripts/generate-doc.sh
@@ -40,6 +40,7 @@ keymap_key_features=(
     "tap_hold-config-interrupt-presses"
     "tap_hold-config-interrupt-tap"
     "tap_hold-config-required_idle_time"
+    "tap_hold-config-retro_tap"
     "tap_hold-config-timeout"
     "tap_hold-config-timeout-none"
     "tap_hold-hold_trigger_positions"

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -670,6 +670,12 @@
             else
               {}
           )
+          & (
+            if std.record.has_field "retro_tap" th_config then
+              { retro_tap = th_config.retro_tap }
+            else
+              {}
+          )
         in
         let profiles_array =
           th_profile_names

--- a/ncl/smart_keys/tap_hold/keymap-codegen.ncl
+++ b/ncl/smart_keys/tap_hold/keymap-codegen.ncl
@@ -69,6 +69,24 @@
           }"%,
           },
         },
+
+      check_profile_with_retro_tap =
+        let rust_expr =
+          smart_keymap.tap_hold.profile_rust_expr {
+            interrupt_response = "HoldOnKeyPress",
+            retro_tap = true,
+          }
+        in
+        {
+          check_rust_expr = {
+            actual = rust_expr,
+            expected = m%"smart_keymap::key::tap_hold::Profile {
+            interrupt_response: smart_keymap::key::tap_hold::InterruptResponse::HoldOnKeyPress,
+            retro_tap: true,
+            ..smart_keymap::key::tap_hold::Profile::new()
+          }"%,
+          },
+        },
     },
   },
 
@@ -127,6 +145,14 @@
           if std.record.has_field "hold_trigger_key_positions" c then
             {
               hold_trigger_positions = hold_trigger_positions_expr c.hold_trigger_key_positions,
+            }
+          else
+            {}
+        )
+        & (
+          if std.record.has_field "retro_tap" c then
+            {
+              retro_tap = if c.retro_tap then "true" else "false",
             }
           else
             {}
@@ -270,6 +296,7 @@
           interrupt_response | optional | TapHoldInterruptResponseJson,
           required_idle_time | optional | Number,
           hold_trigger_key_positions | optional | Array Number,
+          retro_tap | optional | Bool,
         },
 
         # Lowered JSON form: nested default_profile + profiles array.

--- a/ncl/smart_keys/tap_hold/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/tap_hold/keymap-ncl-to-json.ncl
@@ -78,6 +78,8 @@
         required_idle_time | optional | Number,
         # Only listed keymap indices may force interrupt-as-hold; unset = unrestricted.
         hold_trigger_key_positions | optional | Array Number,
+        # When true, timeout alone never resolves as hold (ZMK retro-tap).
+        retro_tap | optional | Bool,
       },
 
       # Authoring keeps default-profile knobs flat on config.tap_hold;
@@ -95,6 +97,8 @@
         required_idle_time | optional | Number,
         # Only listed keymap indices may force interrupt-as-hold; unset = unrestricted.
         hold_trigger_key_positions | optional | Array Number,
+        # When true, timeout alone never resolves as hold (ZMK retro-tap).
+        retro_tap | optional | Bool,
         # Authoring: name → profile record. Lowered to a JSON array (indices 1..).
         profiles | optional | { _ | Profile },
       },

--- a/smart-keymap-core/src/key/tap_hold.rs
+++ b/smart-keymap-core/src/key/tap_hold.rs
@@ -25,7 +25,7 @@ pub const MAX_EXTRA_PROFILES: usize = 7;
 ///  not a dense mask of every key on the board.
 pub const MAX_HOLD_TRIGGER_POSITIONS: usize = 16;
 
-/// One tap-hold behavior profile (timeout, interrupt flavor, idle gate, hold triggers).
+/// One tap-hold behavior profile (timeout, interrupt flavor, idle gate, hold triggers, retro-tap).
 ///
 /// Profile 0 is [`Config::default_profile`];
 ///  extra profiles live in [`Config::profiles`]
@@ -60,6 +60,14 @@ pub struct Profile {
     /// Length is bounded by [`MAX_HOLD_TRIGGER_POSITIONS`].
     #[serde(default, rename = "hold_trigger_key_positions")]
     pub hold_trigger_positions: Option<Slice<u16, MAX_HOLD_TRIGGER_POSITIONS>>,
+
+    /// When true, timeout alone never resolves as hold (ZMK `retro-tap`).
+    ///
+    /// Hold activates only when another key interrupts (per
+    /// [InterruptResponse]); releasing the key alone always yields tap,
+    /// even after the timeout has elapsed.
+    #[serde(default)]
+    pub retro_tap: bool,
 }
 
 impl Profile {
@@ -193,6 +201,7 @@ pub const DEFAULT_PROFILE: Profile = Profile {
     interrupt_response: DEFAULT_INTERRUPT_RESPONSE,
     required_idle_time: None,
     hold_trigger_positions: None,
+    retro_tap: false,
 };
 
 /// Default tap hold config.
@@ -332,8 +341,13 @@ impl PendingKeyState {
                         key_event: Event::TapHoldTimeout,
                         ..
                     } => {
-                        // Key held long enough to resolve as hold.
-                        Some(TapHoldState::Hold)
+                        if profile.retro_tap {
+                            // Stay pending until interrupt or self-release.
+                            None
+                        } else {
+                            // Key held long enough to resolve as hold.
+                            Some(TapHoldState::Hold)
+                        }
                     }
                     _ => None,
                 }
@@ -357,8 +371,12 @@ impl PendingKeyState {
                         key_event: Event::TapHoldTimeout,
                         ..
                     } => {
-                        // Key held long enough to resolve as hold.
-                        Some(TapHoldState::Hold)
+                        if profile.retro_tap {
+                            None
+                        } else {
+                            // Key held long enough to resolve as hold.
+                            Some(TapHoldState::Hold)
+                        }
                     }
                     _ => None,
                 }
@@ -377,8 +395,12 @@ impl PendingKeyState {
                         key_event: Event::TapHoldTimeout,
                         ..
                     } => {
-                        // Key held long enough to resolve as hold.
-                        Some(TapHoldState::Hold)
+                        if profile.retro_tap {
+                            None
+                        } else {
+                            // Key held long enough to resolve as hold.
+                            Some(TapHoldState::Hold)
+                        }
                     }
                     _ => None,
                 }
@@ -573,6 +595,7 @@ mod tests {
                 interrupt_response,
                 required_idle_time,
                 hold_trigger_positions: None,
+                retro_tap: false,
             },
             profiles: Slice::from_slice(&[]),
         }
@@ -1144,6 +1167,7 @@ mod tests {
                 interrupt_response: InterruptResponse::HoldOnKeyPress,
                 required_idle_time: Some(10),
                 hold_trigger_positions: None,
+                retro_tap: false,
             },
             profiles: Slice::from_slice(&[]),
         };
@@ -1166,6 +1190,7 @@ mod tests {
             interrupt_response: InterruptResponse::HoldOnKeyTap,
             required_idle_time: None,
             hold_trigger_positions: None,
+            retro_tap: false,
         };
         let config = Config {
             default_profile: Profile {
@@ -1173,6 +1198,7 @@ mod tests {
                 interrupt_response: InterruptResponse::Ignore,
                 required_idle_time: None,
                 hold_trigger_positions: None,
+                retro_tap: false,
             },
             profiles: Slice::from_slice(&[extra]),
         };
@@ -1190,6 +1216,7 @@ mod tests {
                 interrupt_response: InterruptResponse::Ignore,
                 required_idle_time: None,
                 hold_trigger_positions: None,
+                retro_tap: false,
             },
             profiles: Slice::from_slice(&[]),
         };
@@ -1263,6 +1290,7 @@ mod tests {
                 interrupt_response: InterruptResponse::HoldOnKeyPress,
                 required_idle_time: None,
                 hold_trigger_positions: Some(Slice::from_slice(&[2])),
+                retro_tap: false,
             },
             profiles: Slice::from_slice(&[]),
         });
@@ -1284,6 +1312,7 @@ mod tests {
                 interrupt_response: InterruptResponse::HoldOnKeyPress,
                 required_idle_time: None,
                 hold_trigger_positions: Some(Slice::from_slice(&[2])),
+                retro_tap: false,
             },
             profiles: Slice::from_slice(&[]),
         });
@@ -1305,6 +1334,7 @@ mod tests {
                 interrupt_response: InterruptResponse::HoldOnKeyTap,
                 required_idle_time: None,
                 hold_trigger_positions: Some(Slice::from_slice(&[2])),
+                retro_tap: false,
             },
             profiles: Slice::from_slice(&[]),
         });
@@ -1328,6 +1358,7 @@ mod tests {
                 interrupt_response: InterruptResponse::HoldOnKeyPress,
                 required_idle_time: None,
                 hold_trigger_positions: Some(triggers),
+                retro_tap: false,
             },
             profiles: Slice::from_slice(&[]),
         };
@@ -1348,6 +1379,7 @@ mod tests {
             interrupt_response: InterruptResponse::HoldOnKeyTap,
             required_idle_time: None,
             hold_trigger_positions: Some(triggers),
+            retro_tap: false,
         };
         let config = Config {
             default_profile: Profile::new(),
@@ -1356,5 +1388,98 @@ mod tests {
 
         // Act / Assert
         assert_eq!(config.profile(1).hold_trigger_positions, Some(triggers));
+    }
+
+    // --- retro_tap ---
+
+    #[test]
+    fn retro_tap_timeout_does_not_resolve_as_hold() {
+        // Assemble: retro_tap on default profile; pending TH.
+        let ctx = context_with(Config {
+            default_profile: Profile {
+                timeout: Some(DEFAULT_TIMEOUT),
+                interrupt_response: InterruptResponse::HoldOnKeyPress,
+                required_idle_time: None,
+                hold_trigger_positions: None,
+                retro_tap: true,
+            },
+            profiles: Slice::from_slice(&[]),
+        });
+        let mut pks = PendingKeyState::new();
+
+        // Act: timeout elapses alone.
+        let resolution =
+            pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, timeout_event(KEYMAP_INDEX));
+
+        // Assert: stays pending (timeout alone never hold).
+        assert_eq!(None, resolution);
+    }
+
+    #[test]
+    fn retro_tap_self_release_after_timeout_resolves_as_tap() {
+        // Assemble: retro_tap; timeout already ignored.
+        let ctx = context_with(Config {
+            default_profile: Profile {
+                timeout: Some(DEFAULT_TIMEOUT),
+                interrupt_response: InterruptResponse::HoldOnKeyPress,
+                required_idle_time: None,
+                hold_trigger_positions: None,
+                retro_tap: true,
+            },
+            profiles: Slice::from_slice(&[]),
+        });
+        let mut pks = PendingKeyState::new();
+        let _ = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, timeout_event(KEYMAP_INDEX));
+
+        // Act: release the TH key alone.
+        let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, release(KEYMAP_INDEX));
+
+        // Assert: alone release is always tap.
+        assert_eq!(Some(TapHoldState::Tap), resolution);
+    }
+
+    #[test]
+    fn retro_tap_interrupt_press_resolves_as_hold() {
+        // Assemble: retro_tap + HoldOnKeyPress.
+        let ctx = context_with(Config {
+            default_profile: Profile {
+                timeout: Some(DEFAULT_TIMEOUT),
+                interrupt_response: InterruptResponse::HoldOnKeyPress,
+                required_idle_time: None,
+                hold_trigger_positions: None,
+                retro_tap: true,
+            },
+            profiles: Slice::from_slice(&[]),
+        });
+        let mut pks = PendingKeyState::new();
+
+        // Act: interrupting press.
+        let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, press(OTHER_INDEX));
+
+        // Assert: hold still activates on interrupt.
+        assert_eq!(Some(TapHoldState::Hold), resolution);
+    }
+
+    #[test]
+    fn retro_tap_interrupt_after_timeout_resolves_as_hold() {
+        // Assemble: retro_tap; timeout first, then interrupt.
+        let ctx = context_with(Config {
+            default_profile: Profile {
+                timeout: Some(DEFAULT_TIMEOUT),
+                interrupt_response: InterruptResponse::HoldOnKeyPress,
+                required_idle_time: None,
+                hold_trigger_positions: None,
+                retro_tap: true,
+            },
+            profiles: Slice::from_slice(&[]),
+        });
+        let mut pks = PendingKeyState::new();
+        let _ = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, timeout_event(KEYMAP_INDEX));
+
+        // Act: interrupt after timeout.
+        let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, press(OTHER_INDEX));
+
+        // Assert: hold activates when another key is pressed after timeout.
+        assert_eq!(Some(TapHoldState::Hold), resolution);
     }
 }

--- a/tests/rust/tap_hold.rs
+++ b/tests/rust/tap_hold.rs
@@ -6,6 +6,7 @@ mod layered;
 mod no_timeout;
 mod profiles;
 mod required_idle_time;
+mod retro_tap;
 
 use smart_keymap::input;
 use smart_keymap::keymap::ObservedKeymap;

--- a/tests/rust/tap_hold/retro_tap.rs
+++ b/tests/rust/tap_hold/retro_tap.rs
@@ -1,0 +1,120 @@
+//! Retro-tap: timeout alone never resolves as hold (ZMK-style).
+//!
+//! Hold activates only on interrupt; releasing alone always yields tap.
+
+use smart_keymap::input;
+use smart_keymap::keymap::ObservedKeymap;
+
+use crate::hid_keycodes::*;
+use smart_keymap_macros::keymap;
+
+#[test]
+fn long_hold_alone_resolves_as_tap_with_retro_tap() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.tap_hold.retro_tap = true,
+                config.tap_hold.timeout = 200,
+                config.tap_hold.interrupt_response = "HoldOnKeyPress",
+                keys = [
+                    K.A & K.hold K.LeftCtrl,
+                ],
+            }
+        "#
+    ));
+
+    // Act — press, wait past timeout, release without other keys
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    for _ in 0..250 {
+        keymap.tick();
+    }
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert — retro-tap: alone release is always tap
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn interrupt_press_still_resolves_hold_with_retro_tap() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.tap_hold.retro_tap = true,
+                config.tap_hold.timeout = 200,
+                config.tap_hold.interrupt_response = "HoldOnKeyPress",
+                keys = [
+                    K.A & K.hold K.LeftCtrl,
+                    K.B,
+                ],
+            }
+        "#
+    ));
+
+    // Act — press TH, interrupt with B
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert — hold still activates on interrupting press
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, KC_B, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn interrupt_after_timeout_resolves_hold_with_retro_tap() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.tap_hold.retro_tap = true,
+                config.tap_hold.timeout = 200,
+                config.tap_hold.interrupt_response = "HoldOnKeyPress",
+                keys = [
+                    K.A & K.hold K.LeftCtrl,
+                    K.B,
+                ],
+            }
+        "#
+    ));
+
+    // Act — hold past timeout, then interrupt
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    for _ in 0..250 {
+        keymap.tick();
+    }
+    // Still no output (pending)
+    assert_eq!(
+        &[[0, 0, 0, 0, 0, 0, 0, 0]],
+        keymap.distinct_reports().reports()
+    );
+
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert — hold activates when another key is pressed after timeout
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, KC_B, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}


### PR DESCRIPTION
## Summary

When `config.tap_hold.retro_tap` is true, timeout alone never resolves as hold; hold activates only via interrupt, and alone-release always yields tap (ZMK retro-tap).

Rebased onto current master after tap-hold profiles and `hold_trigger_positions` landed. The knob is now a **profile** field (`Profile.retro_tap`), with flat authoring still available as `config.tap_hold.retro_tap` (lowered into `default_profile`).

- `Profile.retro_tap` + hold-resolution timeout behaviour
- Nickel authoring / lowering / codegen wiring
- Unit tests, Rust integration tests, cucumber feature

## Prior stack (landed)

1. ~~hold_trigger_positions~~ — merged via #691
2. **This PR** — retro_tap
3. quick_tap_ms — #682 (still open; needs similar rebased brush-up)

## Test plan

- [x] `cargo test -p smart-keymap-core --lib key::tap_hold`
- [x] `cargo test --test rust-integration retro_tap`
- [x] `just ncl::checks` (includes `check_profile_with_retro_tap`)
- [x] `just fmt` (rustfmt + nickel format)
- [ ] CI green