### PR TITLE
nickel-helper: content-addressed disk cache for JSON exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-device-driver"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +311,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "cortex-m"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,6 +378,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc-any"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +425,15 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
 
 [[package]]
 name = "cucumber"
@@ -571,6 +604,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.91",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
 ]
 
 [[package]]
@@ -1232,6 +1276,15 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "ident_case"
@@ -2123,6 +2176,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2196,6 +2260,9 @@ dependencies = [
 [[package]]
 name = "smart-keymap-nickel-helper"
 version = "0.18.0-dev"
+dependencies = [
+ "sha2",
+]
 
 [[package]]
 name = "smart_keymap"
@@ -2624,9 +2691,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ufmt-write"

--- a/smart-keymap-nickel-helper/Cargo.toml
+++ b/smart-keymap-nickel-helper/Cargo.toml
@@ -6,3 +6,4 @@ edition.workspace = true
 authors.workspace = true
 
 [dependencies]
+sha2 = "0.11.0"

--- a/smart-keymap-nickel-helper/src/disk_cache.rs
+++ b/smart-keymap-nickel-helper/src/disk_cache.rs
@@ -1,0 +1,588 @@
+//! Content-addressed on-disk cache for Nickel → JSON exports.
+//!
+//! ## Functional core / imperative shell
+//!
+//! - **Core** ([`content_digest`], [`entry_rel_path`], [`parse_disk_cache_mode`],
+//!   [`parse_cache_log_enabled`]): pure; no filesystem, no process, no env.
+//! - **Shell** ([`ncl_tree_digest`], [`read_entry`], [`write_entry_atomic`],
+//!   [`configured_cache_dir`], [`nickel_version_string`]): I/O and process.
+//!
+//! Entries are only written for successful JSON exports. Errors/timeouts are
+//! never stored. Cache key includes export kind, Nickel version, docstring
+//! bodies, and a digest of the entire `ncl` import tree (coarse invalidation).
+
+use std::env;
+use std::fs::{self, File};
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::{Mutex, OnceLock};
+
+use sha2::{Digest, Sha256};
+
+use crate::NickelJsonExport;
+
+fn sha256_hash(data: &[u8]) -> [u8; 32] {
+    Sha256::digest(data).into()
+}
+
+/// Directory layout version prefix under the cache root.
+pub const CACHE_LAYOUT_VERSION: &str = "v1";
+
+/// Domain separator baked into digests (algorithm / layout changes bump this).
+const DIGEST_DOMAIN: &[u8] = b"smart-keymap-nickel-json-cache\0v1\0";
+
+/// Env: `0` / `false` / `off` / `no` / `disabled` disables disk cache;
+/// unset or other values enable.
+pub const NICKEL_JSON_CACHE_ENV: &str = "SMART_KEYMAP_NICKEL_JSON_CACHE";
+
+/// Env: absolute or relative path for the cache root directory.
+pub const NICKEL_JSON_CACHE_DIR_ENV: &str = "SMART_KEYMAP_NICKEL_JSON_CACHE_DIR";
+
+/// Env: `1` / `true` / `yes` / `on` / `enabled` logs hit/miss/store to stderr.
+pub const NICKEL_JSON_CACHE_LOG_ENV: &str = "SMART_KEYMAP_NICKEL_JSON_CACHE_LOG";
+
+// ---------------------------------------------------------------------------
+// Functional core
+// ---------------------------------------------------------------------------
+
+/// Shared truthy values for boolean-ish env flags (`1`, `true`, `yes`, `on`, `enabled`).
+fn is_env_true(s: &str) -> bool {
+    s.eq_ignore_ascii_case("1")
+        || s.eq_ignore_ascii_case("true")
+        || s.eq_ignore_ascii_case("yes")
+        || s.eq_ignore_ascii_case("on")
+        || s.eq_ignore_ascii_case("enabled")
+}
+
+/// Shared falsy values for boolean-ish env flags (`0`, `false`, `no`, `off`, `disabled`).
+fn is_env_false(s: &str) -> bool {
+    s.eq_ignore_ascii_case("0")
+        || s.eq_ignore_ascii_case("false")
+        || s.eq_ignore_ascii_case("no")
+        || s.eq_ignore_ascii_case("off")
+        || s.eq_ignore_ascii_case("disabled")
+}
+
+/// Whether the disk layer should be used (pure parse of the enable flag).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DiskCacheMode {
+    Enabled,
+    Disabled,
+}
+
+/// Parse `SMART_KEYMAP_NICKEL_JSON_CACHE` (value only; presence of dir is separate).
+///
+/// - missing / empty → enabled (default on)
+/// - falsy (`0` / `false` / `off` / `no` / `disabled`) → disabled
+/// - anything else (including truthy) → enabled (forward-compatible)
+pub fn parse_disk_cache_mode(raw: Option<&str>) -> DiskCacheMode {
+    match raw.map(str::trim) {
+        None | Some("") => DiskCacheMode::Enabled,
+        Some(s) if is_env_false(s) => DiskCacheMode::Disabled,
+        Some(_) => DiskCacheMode::Enabled,
+    }
+}
+
+/// Parse `SMART_KEYMAP_NICKEL_JSON_CACHE_LOG` (default off).
+///
+/// - missing / empty → disabled
+/// - truthy (`1` / `true` / `yes` / `on` / `enabled`) → enabled
+/// - anything else → disabled
+pub fn parse_cache_log_enabled(raw: Option<&str>) -> bool {
+    match raw.map(str::trim) {
+        None | Some("") => false,
+        Some(s) => is_env_true(s),
+    }
+}
+
+/// Field name passed to `nickel export --field=…` for this export kind.
+pub fn export_field_name(key: &NickelJsonExport) -> &'static str {
+    match key {
+        NickelJsonExport::Keymap { .. } => "json_deserializable_keymap",
+        NickelJsonExport::Inputs { .. } => "inputs_as_json_value_input_events",
+        NickelJsonExport::HidReport { .. } => "as_bytes",
+    }
+}
+
+/// Kind tag included in the digest (distinct from field name for stability).
+fn kind_tag(key: &NickelJsonExport) -> &'static str {
+    match key {
+        NickelJsonExport::Keymap { .. } => "keymap",
+        NickelJsonExport::Inputs { .. } => "inputs",
+        NickelJsonExport::HidReport { .. } => "hid",
+    }
+}
+
+/// Length-prefixed UTF-8 chunk for domain-separated hashing.
+fn push_lp(buf: &mut Vec<u8>, s: &str) {
+    let bytes = s.as_bytes();
+    buf.extend_from_slice(&(bytes.len() as u64).to_le_bytes());
+    buf.extend_from_slice(bytes);
+}
+
+/// Pure content digest for a JSON export cache entry.
+///
+/// Inputs:
+/// - `key` — export kind + docstring bodies (not import path string)
+/// - `nickel_version` — `nickel --version` line
+/// - `ncl_tree_digest` — hash of files under the import root (relative paths)
+///
+/// Import path absolute strings are intentionally omitted so the same tree +
+/// docstrings share digests across machines/CI checkouts.
+pub fn content_digest(
+    key: &NickelJsonExport,
+    nickel_version: &str,
+    ncl_tree_digest: &[u8; 32],
+) -> [u8; 32] {
+    let mut buf = Vec::with_capacity(256);
+    buf.extend_from_slice(DIGEST_DOMAIN);
+    push_lp(&mut buf, kind_tag(key));
+    push_lp(&mut buf, export_field_name(key));
+    push_lp(&mut buf, "json");
+    push_lp(&mut buf, nickel_version);
+    buf.extend_from_slice(ncl_tree_digest);
+
+    match key {
+        NickelJsonExport::Keymap { keymap_ncl, .. } => {
+            push_lp(&mut buf, keymap_ncl);
+        }
+        NickelJsonExport::Inputs {
+            keymap_ncl,
+            inputs_ncl,
+            ..
+        } => {
+            push_lp(&mut buf, keymap_ncl);
+            push_lp(&mut buf, inputs_ncl);
+        }
+        NickelJsonExport::HidReport { hid_report_ncl, .. } => {
+            push_lp(&mut buf, hid_report_ncl);
+        }
+    }
+
+    sha256_hash(&buf)
+}
+
+/// Hex-encode a 32-byte digest (lowercase).
+pub fn digest_hex(digest: &[u8; 32]) -> String {
+    let mut s = String::with_capacity(64);
+    for b in digest {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+/// Relative path under the cache root: `v1/ab/abcd…ef.json`.
+pub fn entry_rel_path(hex: &str) -> PathBuf {
+    debug_assert_eq!(hex.len(), 64);
+    let prefix = &hex[..2];
+    PathBuf::from(CACHE_LAYOUT_VERSION)
+        .join(prefix)
+        .join(format!("{hex}.json"))
+}
+
+// ---------------------------------------------------------------------------
+// Imperative shell
+// ---------------------------------------------------------------------------
+
+/// Resolve cache directory from env, or `None` if disk cache is disabled.
+///
+/// Default root: `$CARGO_TARGET_DIR/nickel-json-cache` if set, else
+/// `target/nickel-json-cache` relative to the process cwd (workspace root for
+/// normal `cargo test` / cucumber).
+pub fn configured_cache_dir() -> Option<PathBuf> {
+    let mode = parse_disk_cache_mode(env::var(NICKEL_JSON_CACHE_ENV).ok().as_deref());
+    if mode == DiskCacheMode::Disabled {
+        return None;
+    }
+    if let Ok(dir) = env::var(NICKEL_JSON_CACHE_DIR_ENV) {
+        let dir = dir.trim();
+        if !dir.is_empty() {
+            return Some(PathBuf::from(dir));
+        }
+    }
+    if let Ok(target) = env::var("CARGO_TARGET_DIR") {
+        return Some(Path::new(&target).join("nickel-json-cache"));
+    }
+    Some(PathBuf::from("target/nickel-json-cache"))
+}
+
+fn cache_log_enabled() -> bool {
+    parse_cache_log_enabled(env::var(NICKEL_JSON_CACHE_LOG_ENV).ok().as_deref())
+}
+
+fn log_cache(event: &str, hex: &str) {
+    if cache_log_enabled() {
+        eprintln!("smart-keymap nickel-json-cache {event} {hex}");
+    }
+}
+
+/// Log a disk miss when [`NICKEL_JSON_CACHE_LOG_ENV`] is enabled.
+pub(crate) fn log_miss(digest: &[u8; 32]) {
+    log_cache("miss", &digest_hex(digest));
+}
+
+/// `nickel --version` stdout (trimmed), memoized per process.
+pub fn nickel_version_string() -> String {
+    static VERSION: OnceLock<String> = OnceLock::new();
+    VERSION
+        .get_or_init(|| {
+            Command::new("nickel")
+                .arg("--version")
+                .output()
+                .ok()
+                .and_then(|o| {
+                    if o.status.success() {
+                        String::from_utf8(o.stdout).ok()
+                    } else {
+                        None
+                    }
+                })
+                .map(|s| s.trim().to_owned())
+                .unwrap_or_else(|| "nickel-unavailable".to_owned())
+        })
+        .clone()
+}
+
+/// Digest of all files under `ncl_import_path` (sorted relative paths + contents).
+///
+/// Memoized per absolute/normalized path string for the process lifetime.
+pub fn ncl_tree_digest(ncl_import_path: &str) -> [u8; 32] {
+    static CACHE: OnceLock<Mutex<std::collections::HashMap<String, [u8; 32]>>> = OnceLock::new();
+    let map = CACHE.get_or_init(|| Mutex::new(std::collections::HashMap::new()));
+
+    {
+        let guard = map.lock().unwrap();
+        if let Some(d) = guard.get(ncl_import_path) {
+            return *d;
+        }
+    }
+
+    let digest = ncl_tree_digest_uncached(Path::new(ncl_import_path));
+    map.lock()
+        .unwrap()
+        .insert(ncl_import_path.to_owned(), digest);
+    digest
+}
+
+/// Walk `root` and hash relative paths + file bytes (no memo).
+pub fn ncl_tree_digest_uncached(root: &Path) -> [u8; 32] {
+    let mut files: Vec<(String, Vec<u8>)> = Vec::new();
+    if root.is_dir() {
+        collect_files(root, root, &mut files);
+    }
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut hasher = Sha256::new();
+    hasher.update(DIGEST_DOMAIN);
+    hasher.update(b"ncl-tree\0");
+    for (rel, bytes) in files {
+        let rb = rel.as_bytes();
+        hasher.update((rb.len() as u64).to_le_bytes());
+        hasher.update(rb);
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update(&bytes);
+    }
+    hasher.finalize().into()
+}
+
+fn collect_files(root: &Path, dir: &Path, out: &mut Vec<(String, Vec<u8>)>) {
+    let read = match fs::read_dir(dir) {
+        Ok(r) => r,
+        Err(_) => return,
+    };
+    for entry in read.flatten() {
+        let path = entry.path();
+        let Ok(meta) = entry.metadata() else {
+            continue;
+        };
+        if meta.is_dir() {
+            collect_files(root, &path, out);
+        } else if meta.is_file() {
+            let rel = path
+                .strip_prefix(root)
+                .map(|p| p.to_string_lossy().replace('\\', "/"))
+                .unwrap_or_else(|_| path.to_string_lossy().into_owned());
+            if let Ok(bytes) = fs::read(&path) {
+                out.push((rel, bytes));
+            }
+        }
+    }
+}
+
+fn entry_path(cache_dir: &Path, hex: &str) -> PathBuf {
+    cache_dir.join(entry_rel_path(hex))
+}
+
+/// Read a cache entry if present and non-empty.
+pub fn read_entry(cache_dir: &Path, digest: &[u8; 32]) -> Option<String> {
+    let hex = digest_hex(digest);
+    let path = entry_path(cache_dir, &hex);
+    let mut file = File::open(&path).ok()?;
+    let mut buf = String::new();
+    file.read_to_string(&mut buf).ok()?;
+    if buf.is_empty() {
+        return None;
+    }
+    log_cache("hit", &hex);
+    Some(buf)
+}
+
+/// Atomically write `json` for `digest` under `cache_dir`.
+///
+/// Uses a unique temp name per write so concurrent writers for the same digest
+/// cannot clobber each other's partial content before rename.
+pub fn write_entry_atomic(cache_dir: &Path, digest: &[u8; 32], json: &str) -> io::Result<()> {
+    let hex = digest_hex(digest);
+    let final_path = entry_path(cache_dir, &hex);
+    if let Some(parent) = final_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let tmp_name = format!(
+        "{hex}.{}.{}.json.tmp",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    );
+    let tmp_path = final_path.parent().unwrap_or(cache_dir).join(tmp_name);
+    {
+        let mut f = File::create(&tmp_path)?;
+        f.write_all(json.as_bytes())?;
+        f.sync_all()?;
+    }
+    fs::rename(&tmp_path, &final_path)?;
+    log_cache("store", &hex);
+    Ok(())
+}
+
+/// Import path string for tree digest (from the export key).
+pub fn import_path_of(key: &NickelJsonExport) -> &str {
+    match key {
+        NickelJsonExport::Keymap { import_path, .. }
+        | NickelJsonExport::Inputs { import_path, .. }
+        | NickelJsonExport::HidReport { import_path, .. } => import_path.as_str(),
+    }
+}
+
+/// Compute digest for `key` using live Nickel version + ncl tree (shell).
+pub fn content_digest_for_key(key: &NickelJsonExport) -> [u8; 32] {
+    let ncl = ncl_tree_digest(import_path_of(key));
+    content_digest(key, &nickel_version_string(), &ncl)
+}
+
+/// Look up disk then, on miss, leave to caller; used by tests with fixed digests.
+#[cfg(test)]
+pub fn try_read(
+    cache_dir: &Path,
+    key: &NickelJsonExport,
+    nickel_version: &str,
+    ncl: &[u8; 32],
+) -> Option<String> {
+    let digest = content_digest(key, nickel_version, ncl);
+    read_entry(cache_dir, &digest)
+}
+
+/// Store under the digest for `key` / version / ncl tree.
+#[cfg(test)]
+pub fn try_store(
+    cache_dir: &Path,
+    key: &NickelJsonExport,
+    nickel_version: &str,
+    ncl: &[u8; 32],
+    json: &str,
+) -> io::Result<()> {
+    let digest = content_digest(key, nickel_version, ncl);
+    write_entry_atomic(cache_dir, &digest, json)
+}
+
+// ---------------------------------------------------------------------------
+// Tests (core + shell with temp dirs; no Nickel binary required)
+// ---------------------------------------------------------------------------
+
+/// Serialize env mutations that touch disk-cache configuration across parallel tests.
+#[cfg(test)]
+pub(crate) fn test_env_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::NickelJsonExport;
+
+    #[test]
+    fn parse_mode_defaults_enabled() {
+        assert_eq!(parse_disk_cache_mode(None), DiskCacheMode::Enabled);
+        assert_eq!(parse_disk_cache_mode(Some("")), DiskCacheMode::Enabled);
+        for s in ["1", "true", "YES", "On", "enabled", "whatever"] {
+            assert_eq!(
+                parse_disk_cache_mode(Some(s)),
+                DiskCacheMode::Enabled,
+                "{s}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_mode_disables() {
+        for s in ["0", "false", "OFF", "No", "disabled", " DISABLED "] {
+            assert_eq!(
+                parse_disk_cache_mode(Some(s)),
+                DiskCacheMode::Disabled,
+                "{s}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_log_defaults_off() {
+        assert!(!parse_cache_log_enabled(None));
+        assert!(!parse_cache_log_enabled(Some("")));
+        assert!(!parse_cache_log_enabled(Some("0")));
+        assert!(!parse_cache_log_enabled(Some("false")));
+        assert!(!parse_cache_log_enabled(Some("nope")));
+    }
+
+    #[test]
+    fn parse_log_enables() {
+        for s in ["1", "true", "YES", "On", "enabled", " ENABLED "] {
+            assert!(parse_cache_log_enabled(Some(s)), "{s}");
+        }
+    }
+
+    #[test]
+    fn entry_rel_path_layout() {
+        let hex = "ab".to_owned() + &"cd".repeat(31);
+        assert_eq!(hex.len(), 64);
+        let p = entry_rel_path(&hex);
+        assert_eq!(
+            p,
+            PathBuf::from("v1").join("ab").join(format!("{hex}.json"))
+        );
+    }
+
+    #[test]
+    fn content_digest_stable_and_kind_sensitive() {
+        let ncl = [7u8; 32];
+        let ver = "nickel-lang-cli nickel 1.16.0";
+        let km = NickelJsonExport::keymap("/any", "{ keys = [] }");
+        let d1 = content_digest(&km, ver, &ncl);
+        let d2 = content_digest(&km, ver, &ncl);
+        assert_eq!(d1, d2);
+
+        let inputs = NickelJsonExport::inputs("/any", "{ keys = [] }", "[]");
+        assert_ne!(content_digest(&inputs, ver, &ncl), d1);
+
+        let km2 = NickelJsonExport::keymap("/any", "{ keys = [1] }");
+        assert_ne!(content_digest(&km2, ver, &ncl), d1);
+
+        let ncl2 = [8u8; 32];
+        assert_ne!(content_digest(&km, ver, &ncl2), d1);
+        assert_ne!(content_digest(&km, "other-ver", &ncl), d1);
+    }
+
+    #[test]
+    fn content_digest_ignores_import_path_string() {
+        let ncl = [1u8; 32];
+        let ver = "v";
+        let a = NickelJsonExport::keymap("/home/a/ncl", "{ keys = [] }");
+        let b = NickelJsonExport::keymap("/ci/ncl", "{ keys = [] }");
+        assert_eq!(content_digest(&a, ver, &ncl), content_digest(&b, ver, &ncl));
+    }
+
+    #[test]
+    fn ncl_tree_digest_changes_when_file_changes() {
+        let dir = tempfile_dir("ncl-tree");
+        fs::write(dir.join("a.ncl"), "1").unwrap();
+        let d1 = ncl_tree_digest_uncached(&dir);
+        fs::write(dir.join("a.ncl"), "2").unwrap();
+        let d2 = ncl_tree_digest_uncached(&dir);
+        assert_ne!(d1, d2);
+        fs::write(dir.join("b.ncl"), "x").unwrap();
+        let d3 = ncl_tree_digest_uncached(&dir);
+        assert_ne!(d2, d3);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn atomic_write_then_read_roundtrip() {
+        let dir = tempfile_dir("cache-rw");
+        let digest = [0xab; 32];
+        write_entry_atomic(&dir, &digest, "{\"ok\":true}").unwrap();
+        let got = read_entry(&dir, &digest).unwrap();
+        assert_eq!(got, "{\"ok\":true}");
+        // empty rejected
+        let empty = [0xcd; 32];
+        let path = entry_path(&dir, &digest_hex(&empty));
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "").unwrap();
+        assert!(read_entry(&dir, &empty).is_none());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn try_store_try_read_with_key() {
+        let dir = tempfile_dir("cache-key");
+        let ncl = ncl_tree_digest_uncached(&dir);
+        let key = NickelJsonExport::keymap(dir.to_str().unwrap(), "let K = 1 in {}");
+        let ver = "test-nickel";
+        assert!(try_read(&dir, &key, ver, &ncl).is_none());
+        try_store(&dir, &key, ver, &ncl, "[1,2,3]").unwrap();
+        assert_eq!(try_read(&dir, &key, ver, &ncl).as_deref(), Some("[1,2,3]"));
+        // docstring change → miss
+        let key2 = NickelJsonExport::keymap(dir.to_str().unwrap(), "let K = 2 in {}");
+        assert!(try_read(&dir, &key2, ver, &ncl).is_none());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn configured_dir_respects_disable_env() {
+        let _g = test_env_lock();
+        let prev = env::var_os(NICKEL_JSON_CACHE_ENV);
+        env::set_var(NICKEL_JSON_CACHE_ENV, "0");
+        assert!(configured_cache_dir().is_none());
+        match prev {
+            Some(v) => env::set_var(NICKEL_JSON_CACHE_ENV, v),
+            None => env::remove_var(NICKEL_JSON_CACHE_ENV),
+        }
+    }
+
+    #[test]
+    fn configured_dir_respects_dir_env() {
+        let _g = test_env_lock();
+        let prev_mode = env::var_os(NICKEL_JSON_CACHE_ENV);
+        let prev_dir = env::var_os(NICKEL_JSON_CACHE_DIR_ENV);
+        env::remove_var(NICKEL_JSON_CACHE_ENV);
+        env::set_var(NICKEL_JSON_CACHE_DIR_ENV, "/tmp/sk-ncl-json-cache-test");
+        assert_eq!(
+            configured_cache_dir().as_deref(),
+            Some(Path::new("/tmp/sk-ncl-json-cache-test"))
+        );
+        match prev_mode {
+            Some(v) => env::set_var(NICKEL_JSON_CACHE_ENV, v),
+            None => env::remove_var(NICKEL_JSON_CACHE_ENV),
+        }
+        match prev_dir {
+            Some(v) => env::set_var(NICKEL_JSON_CACHE_DIR_ENV, v),
+            None => env::remove_var(NICKEL_JSON_CACHE_DIR_ENV),
+        }
+    }
+
+    fn tempfile_dir(label: &str) -> PathBuf {
+        let mut p = env::temp_dir();
+        p.push(format!("sk-ncl-cache-{}-{}", label, std::process::id()));
+        // unique-ish
+        p.push(format!(
+            "{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&p).unwrap();
+        p
+    }
+}

--- a/smart-keymap-nickel-helper/src/lib.rs
+++ b/smart-keymap-nickel-helper/src/lib.rs
@@ -19,6 +19,10 @@ pub const NICKEL_TIMEOUT_ENV: &str = "SMART_KEYMAP_NICKEL_TIMEOUT_SECS";
 /// Default Nickel subprocess timeout when [`NICKEL_TIMEOUT_ENV`] is unset.
 pub const DEFAULT_NICKEL_TIMEOUT_SECS: u64 = 60;
 
+mod disk_cache;
+
+pub use disk_cache::{NICKEL_JSON_CACHE_DIR_ENV, NICKEL_JSON_CACHE_ENV, NICKEL_JSON_CACHE_LOG_ENV};
+
 /// Identifies a cached Nickel JSON export (keymap, inputs, or HID report).
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 enum NickelJsonExport {
@@ -85,6 +89,38 @@ mod eval_cache {
 /// Clears the in-process Nickel JSON eval cache (for tests).
 pub fn clear_nickel_eval_cache() {
     eval_cache::clear();
+}
+
+/// RAM cache, then optional content-addressed disk cache, then `eval`.
+///
+/// Successful JSON is stored in RAM and (when enabled) on disk. Errors are not.
+fn get_or_eval_json(key: NickelJsonExport, eval: impl FnOnce() -> NickelResult) -> NickelResult {
+    if let Some(json) = eval_cache::get(&key) {
+        return Ok(json);
+    }
+
+    if let Some(cache_dir) = disk_cache::configured_cache_dir() {
+        let digest = disk_cache::content_digest_for_key(&key);
+        if let Some(json) = disk_cache::read_entry(&cache_dir, &digest) {
+            eval_cache::insert(key, json.clone());
+            return Ok(json);
+        }
+        disk_cache::log_miss(&digest);
+
+        let result = eval();
+        if let Ok(ref json) = result {
+            eval_cache::insert(key, json.clone());
+            // Best-effort: a failed disk write must not fail the export.
+            let _ = disk_cache::write_entry_atomic(&cache_dir, &digest, json);
+        }
+        return result;
+    }
+
+    let result = eval();
+    if let Ok(ref json) = result {
+        eval_cache::insert(key, json.clone());
+    }
+    result
 }
 
 /// Inputs for Nickel evaluation.
@@ -344,15 +380,9 @@ pub fn rustfmt(rust_src: String) -> String {
 /// Evaluates the Nickel expr for a keymap, returning the json serialization.
 pub fn nickel_json_value_for_keymap(ncl_import_path: String, keymap_ncl: &str) -> NickelResult {
     let cache_key = NickelJsonExport::keymap(&ncl_import_path, keymap_ncl);
-    if let Some(json) = eval_cache::get(&cache_key) {
-        return Ok(json);
-    }
-
-    let result = nickel_json_value_for_keymap_uncached(&ncl_import_path, keymap_ncl);
-    if let Ok(ref json) = result {
-        eval_cache::insert(cache_key, json.clone());
-    }
-    result
+    get_or_eval_json(cache_key, || {
+        nickel_json_value_for_keymap_uncached(&ncl_import_path, keymap_ncl)
+    })
 }
 
 fn nickel_json_value_for_keymap_uncached(ncl_import_path: &str, keymap_ncl: &str) -> NickelResult {
@@ -378,15 +408,9 @@ pub fn nickel_json_value_for_inputs(
     inputs_ncl: &str,
 ) -> NickelResult {
     let cache_key = NickelJsonExport::inputs(&ncl_import_path, keymap_ncl, inputs_ncl);
-    if let Some(json) = eval_cache::get(&cache_key) {
-        return Ok(json);
-    }
-
-    let result = nickel_json_value_for_inputs_uncached(&ncl_import_path, keymap_ncl, inputs_ncl);
-    if let Ok(ref json) = result {
-        eval_cache::insert(cache_key, json.clone());
-    }
-    result
+    get_or_eval_json(cache_key, || {
+        nickel_json_value_for_inputs_uncached(&ncl_import_path, keymap_ncl, inputs_ncl)
+    })
 }
 
 fn nickel_json_value_for_inputs_uncached(
@@ -435,13 +459,9 @@ pub fn nickel_to_json_for_hid_report(
     hid_report_ncl: &str,
 ) -> NickelResult {
     let cache_key = NickelJsonExport::hid_report(&ncl_import_path, hid_report_ncl);
-    if let Some(json) = eval_cache::get(&cache_key) {
-        return Ok(json);
-    }
-
-    let json = nickel_to_json_for_hid_report_uncached(&ncl_import_path, hid_report_ncl)?;
-    eval_cache::insert(cache_key, json.clone());
-    Ok(json)
+    get_or_eval_json(cache_key, || {
+        nickel_to_json_for_hid_report_uncached(&ncl_import_path, hid_report_ncl)
+    })
 }
 
 fn nickel_to_json_for_hid_report_uncached(
@@ -556,10 +576,12 @@ pub fn codegen_rust_module(
 #[cfg(test)]
 mod tests {
     use super::{
-        clear_nickel_eval_cache, eval_cache, nickel_timeout, wait_with_optional_timeout,
-        NickelError, NickelJsonExport, DEFAULT_NICKEL_TIMEOUT_SECS, NICKEL_TIMEOUT_ENV,
+        clear_nickel_eval_cache, disk_cache, eval_cache, get_or_eval_json, nickel_timeout,
+        wait_with_optional_timeout, NickelError, NickelJsonExport, DEFAULT_NICKEL_TIMEOUT_SECS,
+        NICKEL_TIMEOUT_ENV,
     };
     use std::process::{Command, Stdio};
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::{Duration, Instant};
 
     #[test]
@@ -638,5 +660,228 @@ mod tests {
             "kill path should return promptly, elapsed {:?}",
             elapsed
         );
+    }
+
+    fn temp_cache_and_ncl(label: &str) -> (std::path::PathBuf, String) {
+        let dir = std::env::temp_dir().join(format!(
+            "sk-ncl-goe-{}-{}-{}",
+            label,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let ncl_root = dir.join("ncl");
+        std::fs::create_dir_all(&ncl_root).unwrap();
+        std::fs::write(ncl_root.join("x.ncl"), "1").unwrap();
+        let ncl_path = ncl_root.to_str().unwrap().to_owned();
+        (dir, ncl_path)
+    }
+
+    fn restore_cache_env(
+        prev_dir: Option<std::ffi::OsString>,
+        prev_mode: Option<std::ffi::OsString>,
+    ) {
+        match prev_dir {
+            Some(v) => std::env::set_var(disk_cache::NICKEL_JSON_CACHE_DIR_ENV, v),
+            None => std::env::remove_var(disk_cache::NICKEL_JSON_CACHE_DIR_ENV),
+        }
+        match prev_mode {
+            Some(v) => std::env::set_var(disk_cache::NICKEL_JSON_CACHE_ENV, v),
+            None => std::env::remove_var(disk_cache::NICKEL_JSON_CACHE_ENV),
+        }
+        clear_nickel_eval_cache();
+    }
+
+    /// Live Nickel: cold export fills disk; second process-clear (RAM only)
+    /// should hit disk. Requires `nickel` and workspace `ncl/` cwd layout.
+    ///
+    /// ```text
+    /// cargo test -p smart-keymap-nickel-helper --lib live_keymap_disk_cache -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "requires nickel + ncl/; run manually for smoke timing"]
+    fn live_keymap_disk_cache_cold_then_warm() {
+        use super::nickel_json_value_for_keymap;
+
+        let _g = disk_cache::test_env_lock();
+        let nickel_ok = Command::new("nickel")
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        assert!(nickel_ok, "nickel not available");
+
+        let ncl = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../ncl");
+        assert!(ncl.is_dir(), "expected ncl next to crate: {:?}", ncl);
+        let ncl = ncl.canonicalize().unwrap();
+        let ncl_s = ncl.to_str().unwrap().to_owned();
+
+        let cache_dir = std::env::temp_dir().join(format!(
+            "sk-ncl-live-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&cache_dir).unwrap();
+
+        let prev_dir = std::env::var_os(disk_cache::NICKEL_JSON_CACHE_DIR_ENV);
+        let prev_mode = std::env::var_os(disk_cache::NICKEL_JSON_CACHE_ENV);
+        let prev_log = std::env::var_os(disk_cache::NICKEL_JSON_CACHE_LOG_ENV);
+        std::env::set_var(disk_cache::NICKEL_JSON_CACHE_DIR_ENV, &cache_dir);
+        std::env::remove_var(disk_cache::NICKEL_JSON_CACHE_ENV);
+        std::env::set_var(disk_cache::NICKEL_JSON_CACHE_LOG_ENV, "1");
+
+        // Minimal valid keymap docstring (matches feature style).
+        let keymap_ncl = r#"
+            let K = import "keys.ncl" in
+            { keys = [ K.A, K.B ] }
+        "#;
+
+        clear_nickel_eval_cache();
+        let t0 = Instant::now();
+        let json1 = nickel_json_value_for_keymap(ncl_s.clone(), keymap_ncl)
+            .unwrap_or_else(|e| panic!("cold eval failed: {:?}", e));
+        let cold = t0.elapsed();
+        assert!(
+            json1.contains('['),
+            "expected JSON array-ish keymap: {json1}"
+        );
+
+        clear_nickel_eval_cache(); // force disk path, not RAM
+        let t1 = Instant::now();
+        let json2 = nickel_json_value_for_keymap(ncl_s, keymap_ncl)
+            .unwrap_or_else(|e| panic!("warm eval failed: {:?}", e));
+        let warm = t1.elapsed();
+        assert_eq!(json1, json2);
+        eprintln!("live nickel-json disk cache: cold={cold:?} warm={warm:?}");
+        assert!(
+            warm < cold || warm.as_millis() < 50,
+            "warm path should beat cold Nickel (cold={cold:?}, warm={warm:?})"
+        );
+
+        match prev_log {
+            Some(v) => std::env::set_var(disk_cache::NICKEL_JSON_CACHE_LOG_ENV, v),
+            None => std::env::remove_var(disk_cache::NICKEL_JSON_CACHE_LOG_ENV),
+        }
+        restore_cache_env(prev_dir, prev_mode);
+        let _ = std::fs::remove_dir_all(&cache_dir);
+    }
+
+    #[test]
+    fn get_or_eval_disk_hit_skips_eval() {
+        let _g = disk_cache::test_env_lock();
+        let (dir, ncl_path) = temp_cache_and_ncl("hit");
+
+        let prev_dir = std::env::var_os(disk_cache::NICKEL_JSON_CACHE_DIR_ENV);
+        let prev_mode = std::env::var_os(disk_cache::NICKEL_JSON_CACHE_ENV);
+        std::env::set_var(disk_cache::NICKEL_JSON_CACHE_DIR_ENV, &dir);
+        std::env::remove_var(disk_cache::NICKEL_JSON_CACHE_ENV);
+
+        let key = NickelJsonExport::keymap(&ncl_path, "{ keys = [] }");
+        let digest = disk_cache::content_digest_for_key(&key);
+        disk_cache::write_entry_atomic(&dir, &digest, r#"{"from":"disk"}"#).unwrap();
+
+        clear_nickel_eval_cache();
+        let calls = AtomicUsize::new(0);
+        let got = get_or_eval_json(key, || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            panic!("eval must not run on disk hit");
+        })
+        .unwrap();
+        assert_eq!(got, r#"{"from":"disk"}"#);
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+
+        // RAM should now serve without disk/eval.
+        let got2 = get_or_eval_json(NickelJsonExport::keymap(&ncl_path, "{ keys = [] }"), || {
+            panic!("eval must not run on ram hit");
+        })
+        .unwrap();
+        assert_eq!(got2, r#"{"from":"disk"}"#);
+
+        restore_cache_env(prev_dir, prev_mode);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn get_or_eval_does_not_store_errors() {
+        let _g = disk_cache::test_env_lock();
+        let (dir, ncl_path) = temp_cache_and_ncl("err");
+
+        let prev_dir = std::env::var_os(disk_cache::NICKEL_JSON_CACHE_DIR_ENV);
+        let prev_mode = std::env::var_os(disk_cache::NICKEL_JSON_CACHE_ENV);
+        std::env::set_var(disk_cache::NICKEL_JSON_CACHE_DIR_ENV, &dir);
+        std::env::remove_var(disk_cache::NICKEL_JSON_CACHE_ENV);
+        clear_nickel_eval_cache();
+
+        let key = NickelJsonExport::keymap(&ncl_path, "{ keys = [error] }");
+        let digest = disk_cache::content_digest_for_key(&key);
+        let calls = AtomicUsize::new(0);
+
+        let err = get_or_eval_json(key.clone(), || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Err(NickelError::EvalError("boom".into()))
+        })
+        .expect_err("error");
+        match err {
+            NickelError::EvalError(m) => assert_eq!(m, "boom"),
+            other => panic!("unexpected: {:?}", other),
+        }
+        assert!(disk_cache::read_entry(&dir, &digest).is_none());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        // Second call still invokes eval (nothing cached).
+        let _ = get_or_eval_json(key, || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Err(NickelError::EvalError("boom".into()))
+        });
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+
+        restore_cache_env(prev_dir, prev_mode);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn get_or_eval_stores_ok_on_disk() {
+        let _g = disk_cache::test_env_lock();
+        let (dir, ncl_path) = temp_cache_and_ncl("store");
+
+        let prev_dir = std::env::var_os(disk_cache::NICKEL_JSON_CACHE_DIR_ENV);
+        let prev_mode = std::env::var_os(disk_cache::NICKEL_JSON_CACHE_ENV);
+        std::env::set_var(disk_cache::NICKEL_JSON_CACHE_DIR_ENV, &dir);
+        std::env::remove_var(disk_cache::NICKEL_JSON_CACHE_ENV);
+        clear_nickel_eval_cache();
+
+        let key = NickelJsonExport::keymap(&ncl_path, "{ keys = [ok] }");
+        let digest = disk_cache::content_digest_for_key(&key);
+        let calls = AtomicUsize::new(0);
+
+        let got = get_or_eval_json(key.clone(), || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok(r#"{"ok":1}"#.into())
+        })
+        .unwrap();
+        assert_eq!(got, r#"{"ok":1}"#);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            disk_cache::read_entry(&dir, &digest).as_deref(),
+            Some(r#"{"ok":1}"#)
+        );
+
+        clear_nickel_eval_cache();
+        let got2 = get_or_eval_json(key, || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            panic!("should hit disk");
+        })
+        .unwrap();
+        assert_eq!(got2, r#"{"ok":1}"#);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        restore_cache_env(prev_dir, prev_mode);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }


### PR DESCRIPTION
## Summary

- Add a content-addressed on-disk cache in `smart-keymap-nickel-helper` for the three cucumber JSON export paths (`keymap`, `inputs`, HID report).
- Lookup order: in-process RAM → disk → `nickel` subprocess; only successful JSON is stored (errors/timeouts are never cached).
- Cache key digests export kind, Nickel version, docstring bodies, and a full walk of the `ncl` import tree (import path *string* is omitted so CI and local share digests). Atomic write via `.json.tmp` + rename.

This is aimed at warm CI / second-process runs of the cucumber suite, which today re-pay full Nickel export cost (~1s+ wall per unique docstring) even when `ncl/` and feature docstrings are unchanged. Cold empty cache still pays full Nickel (plus tiny hash/I/O overhead).

### Configuration

| Env | Meaning |
|-----|---------|
| `SMART_KEYMAP_NICKEL_JSON_CACHE` | `0` / `false` / `off` disables disk layer; default enabled |
| `SMART_KEYMAP_NICKEL_JSON_CACHE_DIR` | cache root (default: `$CARGO_TARGET_DIR/nickel-json-cache` or `target/nickel-json-cache`) |
| `SMART_KEYMAP_NICKEL_JSON_CACHE_LOG` | `1` → stderr `hit` / `miss` / `store` |

### Out of scope (follow-up)

GitHub Actions `actions/cache` restore/save for `target/nickel-json-cache` so warm runners skip Nickel on PR re-runs with unchanged `ncl/` + docstrings.

## Test plan

- [x] `cargo test -p smart-keymap-nickel-helper --lib` (digest, atomic I/O, env, hit skips eval, errors not stored)
- [x] Live smoke: `cargo test -p smart-keymap-nickel-helper --lib live_keymap_disk_cache -- --ignored --nocapture` (cold ~1.2s, warm ~disk µs)
- [ ] Optional: run cucumber twice with `SMART_KEYMAP_NICKEL_JSON_CACHE_LOG=1` and confirm second process is mostly hits
- [ ] CI green on this PR (cold cache path must still pass)