### PR TITLE
tap_hold: add behavior profiles (default + named extras)

### DIFF
--- a/features/keymap/key/tap_hold-profiles.feature
+++ b/features/keymap/key/tap_hold-profiles.feature
@@ -1,0 +1,79 @@
+Feature: TapHold Key (behavior profiles)
+
+  Tap-hold keys use behavior **profiles**. Profile 0 is `config.tap_hold`
+  (timeout, interrupt_response, required_idle_time). Extra profiles are
+  authored as `config.tap_hold.profiles = { name = { … }, … }` and selected
+  per key with `tap_hold_profile` (name string or numeric index).
+
+  Names lower to indices 1.. in record field order (JSON array on config).
+
+  For similar ideas in other firmware, see e.g.:
+
+  - [ZMK custom hold-tap behaviors](https://zmk.dev/docs/keymaps/behaviors/hold-tap#custom-hold-tap-examples)
+  - FAK `hold_tap_behaviors[]` + behavior index on the key
+
+  Background:
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        config.tap_hold = {
+          interrupt_response = "Ignore",
+          timeout = 200,
+          profiles = {
+            hold_press = {
+              interrupt_response = "HoldOnKeyPress",
+              timeout = 200,
+            },
+          },
+        },
+        keys = [
+          K.A & K.hold K.LeftCtrl,
+          K.B,
+          K.C & K.hold K.LeftShift & K.tap_hold_profile "hold_press",
+        ],
+      }
+      """
+
+  Example: default profile ignores interrupt (hold only on timeout)
+
+    When the keymap registers the following input
+      """
+      [
+        press (K.A & K.hold K.LeftCtrl),
+        press (K.B),
+        release (K.A & K.hold K.LeftCtrl),
+        release (K.B),
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        press (K.A),
+        press (K.B),
+        release (K.A),
+        release (K.B),
+      ]
+      """
+
+  Example: named profile hold_press resolves interrupt as hold
+
+    When the keymap registers the following input
+      """
+      [
+        press (K.C & K.hold K.LeftShift & K.tap_hold_profile "hold_press"),
+        press (K.B),
+        release (K.C & K.hold K.LeftShift & K.tap_hold_profile "hold_press"),
+        release (K.B),
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        press (K.LeftShift),
+        press (K.B),
+        release (K.LeftShift),
+        release (K.B),
+      ]
+      """

--- a/features/scripts/generate-doc.sh
+++ b/features/scripts/generate-doc.sh
@@ -42,6 +42,7 @@ keymap_key_features=(
     "tap_hold-config-required_idle_time"
     "tap_hold-config-timeout"
     "tap_hold-config-timeout-none"
+    "tap_hold-profiles"
 )
 
 keymap_ncl_features=(

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -40,6 +40,7 @@
 #       named_layers -> dense `layered` array layout: [numbered slots…] ++ [named slots…]
 #       named slots ordered by `named_layer_order` (else alphabetical)
 #       resolve layer_mod name strings -> 1-based indices
+#   - resolve tap_hold_profile names -> indices (1.. from config.tap_hold.profiles)
 #   - pad layered arrays   every layered key shares the same array length
 #   - to_json_value        per-key module projection (array-form layered only)
 #
@@ -49,7 +50,8 @@
 #              & { automation.instructions? }
 #              & { chorded.chords = indices }
 #              & { sequence.sequences = indices }
-#              & { layered.conditional_layers?  (from top-level field) },
+#              & { layered.conditional_layers?  (from top-level field) }
+#              & { tap_hold.profiles? as array (indices 1..) },
 #     keys   = [ json key, … ],
 #   }
 #
@@ -566,6 +568,49 @@
     else
       l,
 
+  # Tap-hold behavior profiles:
+  #   config.tap_hold.profiles = { hml = { … }, hmr = { … } }  (authoring, name → Profile)
+  # lowers to a JSON array at indices 1.. (alphabetical name order); profile 0 = default fields.
+  # Keys may set `tap_hold_profile = "hml"` (or a number); names resolve before to_json_value.
+  # Name order = Nickel record field order (same idea as named_layers).
+  tap_hold_profile_names = fun th_config =>
+    if std.record.has_field "profiles" th_config then
+      std.record.fields th_config.profiles
+    else
+      [],
+
+  tap_hold_name_to_index = fun names =>
+    names
+    |> std.array.fold_left
+      (fun state name =>
+        # Let-bind fields so the result record does not recurse on `acc`/`i`.
+        let idx = state.i in
+        let prev = state.acc in
+        {
+          i = idx + 1,
+          acc = prev & { "%{name}" = idx },
+        }
+      )
+      { i = 1, acc = {} }
+    |> (fun state => state.acc),
+
+  resolve_tap_hold_profile_on_key = fun name_to_index acc k =>
+    if std.is_record k
+    && std.record.has_field "hold" k
+    && std.record.has_field "tap_hold_profile" k then
+      let p = k.tap_hold_profile in
+      if std.is_string p then
+        if std.record.has_field p name_to_index then
+          let idx = name_to_index."%{p}" in
+          let new_k = std.record.update "tap_hold_profile" idx k in
+          { include acc, k = new_k }
+        else
+          std.fail_with "unknown tap_hold_profile \"%{p}\" (not in config.tap_hold.profiles)"
+      else
+        { include acc, include k }
+    else
+      { include acc, include k },
+
   json_keymap
     | default
     | doc "The keymap.json output value."
@@ -582,6 +627,35 @@
       # Named order: `named_layer_order` if set, else alphabetical. Skipped if unused.
       # Layer_mod fields may use those names as strings; resolve to 1-based indices.
       let keys = prepare_keys_named_layers keys in
+      # Tap-hold profiles: lower name map → array; resolve key name selectors → indices.
+      let { tap_hold = th_config, ..km_config_after_th } = config & { tap_hold = {} } in
+      let th_profile_names = tap_hold_profile_names th_config in
+      let th_name_to_index = tap_hold_name_to_index th_profile_names in
+      let keys =
+        keys
+        |> std.array.map (fun k =>
+          (keymap_ncl.nullable_key.map_tree (resolve_tap_hold_profile_on_key th_name_to_index) {} k).k
+        )
+      in
+      let th_config_json =
+        let th_base =
+          if std.record.has_field "profiles" th_config then
+            std.record.remove "profiles" th_config
+          else
+            th_config
+        in
+        let profiles_array =
+          th_profile_names
+          |> std.array.map (fun name => th_config.profiles."%{name}")
+        in
+        th_base
+        & (
+          if profiles_array == [] then
+            {}
+          else
+            { profiles = profiles_array }
+        )
+      in
       # Equalise layered array lengths (pad shorter with null / transparency).
       let layer_count =
         keys |> std.array.fold_left max_layered_length_accum 0
@@ -591,7 +665,7 @@
         |> std.array.map (pad_key_layered_arrays layer_count)
         |> std.array.map keymap_ncl.key.to_json_value
       in
-      let { chorded = km_config_chorded, ..km_config } = config & { chorded = {} } in
+      let { chorded = km_config_chorded, ..km_config } = km_config_after_th & { chorded = {} } in
       let chord_indices = chords |> std.array.map (fun { key, indices, .. } => indices) in
       let { sequence = km_config_sequence, ..km_config } = km_config & { sequence = {} } in
       let sequence_indices = sequences |> std.array.map (fun { key, indices, .. } => indices) in
@@ -614,6 +688,12 @@
       let config_json_value =
         km_config
         & automation_config
+        & (
+          if th_config_json == {} then
+            {}
+          else
+            { tap_hold = th_config_json }
+        )
         & {
           chorded =
             km_config_chorded

--- a/ncl/smart_keys/tap_hold/key-extensions.ncl
+++ b/ncl/smart_keys/tap_hold/key-extensions.ncl
@@ -5,6 +5,13 @@
         | doc "creates a hold key modifier"
         = fun key => { hold = key },
 
+      # Select a named (or numeric) tap-hold behavior profile.
+      # Names resolve against config.tap_hold.profiles in keymap.ncl → json.
+      # Example: K.A & K.hold K.LeftCtrl & K.tap_hold_profile "hml"
+      tap_hold_profile
+        | doc "selects a tap-hold behavior profile by name or index"
+        = fun name_or_index => { tap_hold_profile = name_or_index },
+
       H_LCtrl = hold keys.LeftCtrl,
       H_LShift = hold keys.LeftShift,
       H_LAlt = hold keys.LeftAlt,

--- a/ncl/smart_keys/tap_hold/keymap-codegen.ncl
+++ b/ncl/smart_keys/tap_hold/keymap-codegen.ncl
@@ -36,6 +36,21 @@
             expected = "smart_keymap::key::tap_hold::Key::new(smart_keymap::key::keyboard::Key::new(4), smart_keymap::key::keyboard::Key::new(224))",
           },
         },
+
+      check_taphold_with_profile =
+        let json = {
+          hold = { key_code = 224 },
+          tap = { key_code = 4 },
+          profile = 1,
+        }
+        in
+        let cv = smart_keymap.tap_hold.key.codegen_values json in
+        {
+          check_rust_expr = {
+            actual = cv.rust_expr,
+            expected = "smart_keymap::key::tap_hold::Key::with_profile(smart_keymap::key::keyboard::Key::new(4), smart_keymap::key::keyboard::Key::new(224), 1)",
+          },
+        },
     },
   },
 
@@ -53,40 +68,100 @@
 
       module = "smart_keymap::key::tap_hold",
 
+      profile_field_expr = fun c =>
+        (
+          if std.record.has_field "timeout" c then
+            {
+              timeout =
+                if c.timeout == null then
+                  "None"
+                else
+                  "Some(%{std.to_string c.timeout})",
+            }
+          else
+            {}
+        )
+        & (
+          if std.record.has_field "interrupt_response" c then
+            {
+              interrupt_response = "%{module}::InterruptResponse::%{c.interrupt_response}",
+            }
+          else
+            {}
+        )
+        & (
+          if std.record.has_field "required_idle_time" c then
+            {
+              required_idle_time = "Some(%{std.to_string c.required_idle_time})",
+            }
+          else
+            {}
+        ),
+
+      profile_rust_expr = fun c =>
+        let fields = profile_field_expr c in
+        if fields == {} then
+          "%{module}::Profile::new()"
+        else
+          let field_lines =
+            fields
+            |> std.record.to_array
+            |> std.array.map (fun { field, value } => "%{field}: %{value},")
+            |> std.string.join "\n"
+          in
+          m%"%{module}::Profile {
+            %{field_lines}
+            ..%{module}::Profile::new()
+          }"%,
+
       key = {
         Json = std.contract.from_validator json_validator,
 
         key_type = "%{module}::Key",
 
-        # c.f. doc_de_tap_hold.md.
-        # JSON serialization of key::tap_hold::Key is { tap: key, hold: key }
+        # JSON: { tap, hold, profile? }
         json_validator =
           validators.record.validator {
-            fields_validator = validators.record.has_exact_fields ["tap", "hold"],
+            fields_validator =
+              validators.all_of [
+                validators.record.has_all_fields ["tap", "hold"],
+                validators.record.has_only_fields ["tap", "hold", "profile"],
+              ],
             field_validators = {
               tap = smart_key.json_validator,
               hold = smart_key.json_validator,
+              profile = validators.is_number,
             },
           },
 
         is_json = fun json => 'Ok == json_validator json,
 
-        codegen_values = fun json @ { hold, tap } =>
+        codegen_values = fun json @ { hold, tap, ..rest } =>
           let hold_cv = hold |> smart_key.codegen_values in
           let tap_cv = tap |> smart_key.codegen_values in
+          let profile =
+            if std.record.has_field "profile" rest then
+              rest.profile
+            else
+              0
+          in
 
           {
             nested = {
               tap = tap_cv,
               hold = hold_cv,
             },
+            include profile,
             include json,
             include module,
             include key_type,
             rust_expr =
               let hold_expr = nested.hold.rust_expr in
               let tap_expr = nested.tap.rust_expr in
-              "%{module}::Key::new(%{tap_expr}, %{hold_expr})",
+              if profile == 0 then
+                "%{module}::Key::new(%{tap_expr}, %{hold_expr})"
+              else
+                "%{module}::Key::with_profile(%{tap_expr}, %{hold_expr}, %{std.to_string profile})",
           },
 
         map_nested = fun f cv @ { nested, ..rest } =>
@@ -105,22 +180,35 @@
           let acc = smart_key.traverse f acc cv.nested.tap in
           smart_key.traverse f acc cv.nested.hold,
 
-        data_and_ref = fun key_data cv @ { nested = { tap = tap_cv, hold = hold_cv }, .. } =>
+        data_and_ref = fun key_data cv @ {
+          nested = { tap = tap_cv, hold = hold_cv },
+          profile = profile_id,
+          ..
+        } =>
           let { key_data, ref = tap_ref } = smart_key.data_and_ref key_data tap_cv in
           let tap_ref = tap_ref |> composite.ref.wrap in
           let { key_data, ref = hold_ref } = smart_key.data_and_ref key_data hold_cv in
           let hold_ref = hold_ref |> composite.ref.wrap in
           let { tap_hold = tap_hold_, ..other_data } = key_data & { tap_hold | default = [] } in
           let new_index = std.array.length tap_hold_ in
+          let profile_json =
+            if profile_id == 0 then
+              {}
+            else
+              { profile = profile_id }
+          in
           let new_key = {
-            json = {
-              tap = tap_ref.json,
-              hold = hold_ref.json,
-            },
+            json =
+              {
+                tap = tap_ref.json,
+                hold = hold_ref.json,
+              }
+              & profile_json,
             rust_expr = m%"
             %{module}::Key {
               tap: %{tap_ref.rust_expr},
               hold: %{hold_ref.rust_expr},
+              profile: %{std.to_string profile_id},
             }
           "%,
           }
@@ -136,6 +224,19 @@
       },
 
       config = {
+        ProfileJson = {
+          timeout
+            | optional
+            | std.contract.from_validator (
+              validators.any_of [
+                validators.is_null,
+                validators.is_number,
+              ]
+            ),
+          interrupt_response | optional | TapHoldInterruptResponseJson,
+          required_idle_time | optional | Number,
+        },
+
         Json = {
           timeout
             | optional
@@ -147,6 +248,8 @@
             ),
           interrupt_response | optional | TapHoldInterruptResponseJson,
           required_idle_time | optional | Number,
+          # Lowered form: array of extra profiles (index 1..).
+          profiles | optional | Array ProfileJson,
         },
 
         expr =
@@ -176,6 +279,19 @@
               if std.record.has_field "required_idle_time" c then
                 {
                   required_idle_time = "Some(%{std.to_string c.required_idle_time})",
+                }
+              else
+                {}
+            )
+            & (
+              if std.record.has_field "profiles" c && c.profiles != [] then
+                let profiles_fragment =
+                  c.profiles
+                  |> std.array.map (fun p => profile_rust_expr p)
+                  |> std.string.join ", "
+                in
+                {
+                  profiles = "smart_keymap::slice::Slice::from_slice(&[%{profiles_fragment}])",
                 }
               else
                 {}

--- a/ncl/smart_keys/tap_hold/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/tap_hold/keymap-ncl-to-json.ncl
@@ -27,6 +27,28 @@
         actual = K.A & K.hold K.LeftCtrl |> keymap_ncl.key.to_json_value,
         expected = { tap = { key_code = 4 }, hold = { modifiers = 1 } },
       },
+
+      check_profile_name_to_json = {
+        actual =
+          K.A
+          & K.hold K.LeftCtrl
+          & { tap_hold_profile = 1 }
+          |> keymap_ncl.tap_hold.to_json_value,
+        expected = {
+          tap = { key_code = 4 },
+          hold = { modifiers = 1 },
+          profile = 1,
+        },
+      },
+
+      check_default_profile_omitted_from_json = {
+        actual =
+          K.A
+          & K.hold K.LeftCtrl
+          & { tap_hold_profile = 0 }
+          |> keymap_ncl.tap_hold.to_json_value,
+        expected = { tap = { key_code = 4 }, hold = { modifiers = 1 } },
+      },
     },
 
   keymap_ncl.tap_hold
@@ -41,7 +63,8 @@
           ]
         ),
 
-      Config = {
+      # One behavior profile (same fields as default config.tap_hold).
+      Profile = {
         timeout
           | optional
           | std.contract.from_validator (
@@ -54,28 +77,86 @@
         required_idle_time | optional | Number,
       },
 
+      Config = {
+        timeout
+          | optional
+          | std.contract.from_validator (
+            validators.any_of [
+              validators.is_null,
+              validators.is_number,
+            ]
+          ),
+        interrupt_response | optional | TapHoldInterruptResponse,
+        required_idle_time | optional | Number,
+        # Authoring: name → profile record. Lowered to a JSON array (indices 1..).
+        profiles | optional | { _ | Profile },
+      },
+
       Key = std.contract.from_validator key_validator,
+
+      # Optional profile selector metadata on the key (not part of the tap leaf).
+      # After name→index resolution: number. Before: profile name string or number.
+      strip_profile_meta = fun r =>
+        if std.record.has_field "tap_hold_profile" r then
+          std.record.remove "tap_hold_profile" r
+        else
+          r,
 
       key_validator = fun k =>
         k
         |> match {
-          { hold = hold_key, ..tap_key } =>
+          { hold = hold_key, ..rest } =>
+            let tap_key = strip_profile_meta rest in
+            let profile_ok =
+              if std.record.has_field "tap_hold_profile" rest then
+                let p = rest.tap_hold_profile in
+                if std.is_number p || std.is_string p then
+                  'Ok
+                else
+                  'Error {
+                    message = "tap_hold_profile must be a profile name (string) or index (number)",
+                  }
+              else
+                'Ok
+            in
             validators.all_ok [
               keymap_ncl.key.key_validator hold_key,
               keymap_ncl.key.key_validator tap_key,
+              profile_ok,
             ],
           _ => 'Error { message = "expected { hold = Key, ..tap_key }" },
         },
 
       is_key = fun k => 'Ok == key_validator k,
 
-      to_json_value = fun { hold = hold_key, ..tap_key } =>
+      to_json_value = fun { hold = hold_key, ..rest } =>
+        let tap_key = strip_profile_meta rest in
+        let profile_json =
+          if std.record.has_field "tap_hold_profile" rest then
+            let p = rest.tap_hold_profile in
+            if std.is_number p && p != 0 then
+              { profile = p }
+            else if std.is_string p then
+              std.fail_with "tap_hold_profile name \"%{p}\" must be resolved to an index before to_json_value"
+            else
+              {}
+          else
+            {}
+        in
         {
           hold = keymap_ncl.key.to_json_value hold_key,
           tap = keymap_ncl.key.to_json_value tap_key,
-        },
+        }
+        & profile_json,
 
-      map_accum = fun f acc k @ { hold = hold_key, ..tap_key } =>
+      map_accum = fun f acc { hold = hold_key, ..rest } =>
+        let profile_meta =
+          if std.record.has_field "tap_hold_profile" rest then
+            { tap_hold_profile = rest.tap_hold_profile }
+          else
+            {}
+        in
+        let tap_key = strip_profile_meta rest in
         let { acc, k = tap_key } = f acc tap_key in
         let { acc, k = hold_key } = f acc hold_key in
         {
@@ -84,6 +165,7 @@
             {
               hold = hold_key,
             }
+            & profile_meta
             & tap_key,
         },
     },

--- a/smart-keymap-core/src/key/tap_hold.rs
+++ b/smart-keymap-core/src/key/tap_hold.rs
@@ -6,10 +6,57 @@ use serde::Deserialize;
 use crate::input;
 use crate::key;
 use crate::keymap;
+use crate::slice::Slice;
 
 /// Reference for a tap_hold key.
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct Ref(pub u8);
+
+/// Maximum number of *extra* tap-hold profiles beyond the default (profile 0).
+///
+/// Profile indices on keys are `0` (default / [`Config`] top-level fields) then
+/// `1..` into [`Config::profiles`]. Total usable profiles = `1 + MAX_EXTRA_PROFILES`.
+pub const MAX_EXTRA_PROFILES: usize = 7;
+
+/// One tap-hold behavior profile (timeout, interrupt flavor, idle gate).
+///
+/// Profile 0 is the default [`Config`] fields; extra profiles live in
+/// [`Config::profiles`] and are selected per key via [`Key::profile`].
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
+pub struct Profile {
+    /// The timeout (in number of milliseconds) for a tap-hold key to resolve as hold.
+    ///
+    /// When `None`, the tap/hold decision does not timeout;
+    /// the key resolves only on release (as tap) or interruption
+    /// (depending on [InterruptResponse]).
+    #[serde(default = "default_timeout")]
+    pub timeout: Option<u16>,
+
+    /// How the tap-hold key should respond to interruptions.
+    #[serde(default = "default_interrupt_response")]
+    pub interrupt_response: InterruptResponse,
+
+    /// Amount of time (in milliseconds) the keymap must have been idle
+    ///  in order for tap hold to support 'hold' functionality.
+    ///
+    /// This reduces disruption from unexpected hold resolutions
+    ///  when typing quickly.
+    #[serde(default)]
+    pub required_idle_time: Option<u16>,
+}
+
+impl Profile {
+    /// Constructs a new default [Profile].
+    pub const fn new() -> Self {
+        DEFAULT_PROFILE
+    }
+}
+
+impl Default for Profile {
+    fn default() -> Self {
+        DEFAULT_PROFILE
+    }
+}
 
 /// A key with tap-hold functionality.
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
@@ -18,12 +65,24 @@ pub struct Key<R> {
     pub tap: R,
     /// The 'hold' key.
     pub hold: R,
+    /// Behavior profile index: `0` = default [`Config`] fields; `1..` = [`Config::profiles`].
+    #[serde(default)]
+    pub profile: u8,
 }
 
 impl<R> Key<R> {
-    /// Constructs a new tap-hold key.
+    /// Constructs a new tap-hold key using the default profile (0).
     pub const fn new(tap: R, hold: R) -> Key<R> {
-        Key { tap, hold }
+        Key {
+            tap,
+            hold,
+            profile: 0,
+        }
+    }
+
+    /// Constructs a tap-hold key that uses the given behavior profile index.
+    pub const fn with_profile(tap: R, hold: R, profile: u8) -> Key<R> {
+        Key { tap, hold, profile }
     }
 }
 
@@ -33,6 +92,7 @@ impl<R: Default> Default for Key<R> {
         Key {
             tap: R::default(),
             hold: R::default(),
+            profile: 0,
         }
     }
 }
@@ -51,6 +111,9 @@ pub enum InterruptResponse {
 }
 
 /// Configuration settings for tap hold keys.
+///
+/// Top-level fields are **profile 0** (the default). Optional [`Config::profiles`]
+/// are extra behaviors at indices `1..`. Keys select a profile via [`Key::profile`].
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct Config {
     /// The timeout (in number of milliseconds) for a tap-hold key to resolve as hold.
@@ -71,6 +134,10 @@ pub struct Config {
     /// This reduces disruption from unexpected hold resolutions
     ///  when typing quickly.
     pub required_idle_time: Option<u16>,
+
+    /// Extra behavior profiles (indices `1..=len`). Profile `0` is the top-level fields.
+    #[serde(default)]
+    pub profiles: Slice<Profile, MAX_EXTRA_PROFILES>,
 }
 
 /// The default timeout.
@@ -87,17 +154,52 @@ fn default_interrupt_response() -> InterruptResponse {
     DEFAULT_INTERRUPT_RESPONSE
 }
 
+/// Default profile (same values as default [`Config`] top-level fields).
+pub const DEFAULT_PROFILE: Profile = Profile {
+    timeout: Some(DEFAULT_TIMEOUT),
+    interrupt_response: DEFAULT_INTERRUPT_RESPONSE,
+    required_idle_time: None,
+};
+
 /// Default tap hold config.
 pub const DEFAULT_CONFIG: Config = Config {
     timeout: Some(DEFAULT_TIMEOUT),
     interrupt_response: DEFAULT_INTERRUPT_RESPONSE,
     required_idle_time: None,
+    profiles: Slice::from_slice(&[]),
 };
 
 impl Config {
     /// Constructs a new default [Config].
     pub const fn new() -> Self {
         DEFAULT_CONFIG
+    }
+
+    /// Resolves the behavior profile for `profile_id`.
+    ///
+    /// - `0` → top-level default fields
+    /// - `1..` → [`Self::profiles`] entry `id - 1`
+    ///
+    /// Out-of-range ids fall back to the default profile.
+    pub const fn profile(&self, profile_id: u8) -> Profile {
+        if profile_id == 0 {
+            return Profile {
+                timeout: self.timeout,
+                interrupt_response: self.interrupt_response,
+                required_idle_time: self.required_idle_time,
+            };
+        }
+        let idx = (profile_id - 1) as usize;
+        let extras = self.profiles.as_slice();
+        if idx < extras.len() {
+            extras[idx]
+        } else {
+            Profile {
+                timeout: self.timeout,
+                interrupt_response: self.interrupt_response,
+                required_idle_time: self.required_idle_time,
+            }
+        }
     }
 }
 
@@ -135,6 +237,11 @@ impl Context {
         keymap::KeymapContext { idle_time_ms, .. }: &keymap::KeymapContext,
     ) {
         self.idle_time_ms = *idle_time_ms;
+    }
+
+    /// Returns the resolved [Profile] for `profile_id`.
+    pub const fn profile(&self, profile_id: u8) -> Profile {
+        self.config.profile(profile_id)
     }
 }
 
@@ -251,7 +358,7 @@ impl PendingKeyState {
     /// Returns at most 2 events
     pub fn handle_event(
         &mut self,
-        context: &Context,
+        profile: &Profile,
         keymap_index: u16,
         event: key::Event<Event>,
     ) -> Option<TapHoldState> {
@@ -262,8 +369,7 @@ impl PendingKeyState {
         }
 
         // Resolve tap-hold state per the event.
-        let Context { config, .. } = context;
-        self.hold_resolution(config.interrupt_response, keymap_index, event)
+        self.hold_resolution(profile.interrupt_response, keymap_index, event)
     }
 }
 
@@ -285,11 +391,11 @@ impl<R, Keys: Index<usize, Output = Key<R>>> System<R, Keys> {
 
     fn new_pending_key(
         &self,
-        context: &Context,
+        profile: &Profile,
         keymap_index: u16,
     ) -> (PendingKeyState, Option<key::ScheduledEvent<Event>>) {
         let pending = PendingKeyState::new();
-        let scheduled = context.config.timeout.map(|timeout| {
+        let scheduled = profile.timeout.map(|timeout| {
             key::ScheduledEvent::after(
                 timeout,
                 key::Event::key_event(keymap_index, Event::TapHoldTimeout),
@@ -317,11 +423,14 @@ impl<R: Copy + Debug, Keys: Debug + Index<usize, Output = Key<R>>> key::System<R
         key::PressedKeyResult<R, Self::PendingKeyState, Self::KeyState>,
         key::KeyEvents<Self::Event>,
     ) {
-        match context.config.required_idle_time {
+        let key_def = &self.keys[key_index as usize];
+        let profile = context.profile(key_def.profile);
+
+        match profile.required_idle_time {
             Some(required_idle_time) => {
                 if context.idle_time_ms >= required_idle_time as u32 {
                     // Keymap has been idle long enough; use pending tap-hold key state.
-                    let (th_pks, maybe_sch_ev) = self.new_pending_key(context, keymap_index);
+                    let (th_pks, maybe_sch_ev) = self.new_pending_key(&profile, keymap_index);
                     let pk = key::PressedKeyResult::Pending(th_pks);
                     let pke = match maybe_sch_ev {
                         Some(sch_ev) => {
@@ -335,7 +444,7 @@ impl<R: Copy + Debug, Keys: Debug + Index<usize, Output = Key<R>>> key::System<R
                     // immediately resolve as tap.
                     let Key {
                         tap: tap_key_ref, ..
-                    } = self.keys[key_index as usize];
+                    } = *key_def;
                     (
                         key::PressedKeyResult::NewPressedKey(key::NewPressedKey::key(tap_key_ref)),
                         key::KeyEvents::no_events(),
@@ -344,7 +453,7 @@ impl<R: Copy + Debug, Keys: Debug + Index<usize, Output = Key<R>>> key::System<R
             }
             None => {
                 // Idle time not considered. Use pending tap-hold key state.
-                let (th_pks, maybe_sch_ev) = self.new_pending_key(context, keymap_index);
+                let (th_pks, maybe_sch_ev) = self.new_pending_key(&profile, keymap_index);
                 let pk = key::PressedKeyResult::Pending(th_pks);
                 let pke = match maybe_sch_ev {
                     Some(sch_ev) => key::KeyEvents::scheduled_event(sch_ev.into_scheduled_event()),
@@ -363,9 +472,11 @@ impl<R: Copy + Debug, Keys: Debug + Index<usize, Output = Key<R>>> key::System<R
         Ref(key_index): Ref,
         event: key::Event<Self::Event>,
     ) -> (Option<key::NewPressedKey<R>>, key::KeyEvents<Self::Event>) {
-        let th_state = pending_state.handle_event(context, keymap_index, event);
+        let key_def = &self.keys[key_index as usize];
+        let profile = context.profile(key_def.profile);
+        let th_state = pending_state.handle_event(&profile, keymap_index, event);
         if let Some(th_state) = th_state {
-            let Key { tap, hold } = self.keys[key_index as usize];
+            let Key { tap, hold, .. } = *key_def;
             let new_key_ref = match th_state {
                 key::tap_hold::TapHoldState::Tap => tap,
                 key::tap_hold::TapHoldState::Hold => hold,
@@ -429,6 +540,7 @@ mod tests {
             timeout,
             interrupt_response,
             required_idle_time,
+            profiles: Slice::from_slice(&[]),
         }
     }
 
@@ -473,7 +585,7 @@ mod tests {
         let mut pks = PendingKeyState::new();
 
         // Act
-        let resolution = pks.handle_event(&ctx, KEYMAP_INDEX, release(KEYMAP_INDEX));
+        let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, release(KEYMAP_INDEX));
 
         // Assert
         assert_eq!(Some(TapHoldState::Tap), resolution);
@@ -490,7 +602,8 @@ mod tests {
         let mut pks = PendingKeyState::new();
 
         // Act
-        let resolution = pks.handle_event(&ctx, KEYMAP_INDEX, timeout_event(KEYMAP_INDEX));
+        let resolution =
+            pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, timeout_event(KEYMAP_INDEX));
 
         // Assert
         assert_eq!(Some(TapHoldState::Hold), resolution);
@@ -507,7 +620,7 @@ mod tests {
         let mut pks = PendingKeyState::new();
 
         // Act
-        let resolution = pks.handle_event(&ctx, KEYMAP_INDEX, press(OTHER_INDEX));
+        let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, press(OTHER_INDEX));
 
         // Assert
         assert_eq!(None, resolution);
@@ -524,7 +637,7 @@ mod tests {
         let mut pks = PendingKeyState::new();
 
         // Act
-        let resolution = pks.handle_event(&ctx, KEYMAP_INDEX, release(OTHER_INDEX));
+        let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, release(OTHER_INDEX));
 
         // Assert
         assert_eq!(None, resolution);
@@ -543,7 +656,7 @@ mod tests {
         let mut pks = PendingKeyState::new();
 
         // Act
-        let resolution = pks.handle_event(&ctx, KEYMAP_INDEX, press(OTHER_INDEX));
+        let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, press(OTHER_INDEX));
 
         // Assert
         assert_eq!(Some(TapHoldState::Hold), resolution);
@@ -560,7 +673,7 @@ mod tests {
         let mut pks = PendingKeyState::new();
 
         // Act
-        let resolution = pks.handle_event(&ctx, KEYMAP_INDEX, release(KEYMAP_INDEX));
+        let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, release(KEYMAP_INDEX));
 
         // Assert
         assert_eq!(Some(TapHoldState::Tap), resolution);
@@ -577,7 +690,8 @@ mod tests {
         let mut pks = PendingKeyState::new();
 
         // Act
-        let resolution = pks.handle_event(&ctx, KEYMAP_INDEX, timeout_event(KEYMAP_INDEX));
+        let resolution =
+            pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, timeout_event(KEYMAP_INDEX));
 
         // Assert
         assert_eq!(Some(TapHoldState::Hold), resolution);
@@ -594,7 +708,7 @@ mod tests {
         let mut pks = PendingKeyState::new();
 
         // Act
-        let resolution = pks.handle_event(&ctx, KEYMAP_INDEX, release(OTHER_INDEX));
+        let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, release(OTHER_INDEX));
 
         // Assert
         assert_eq!(None, resolution);
@@ -613,7 +727,7 @@ mod tests {
         let mut pks = PendingKeyState::new();
 
         // Act
-        let resolution = pks.handle_event(&ctx, KEYMAP_INDEX, release(KEYMAP_INDEX));
+        let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, release(KEYMAP_INDEX));
 
         // Assert
         assert_eq!(Some(TapHoldState::Tap), resolution);
@@ -630,7 +744,8 @@ mod tests {
         let mut pks = PendingKeyState::new();
 
         // Act
-        let resolution = pks.handle_event(&ctx, KEYMAP_INDEX, timeout_event(KEYMAP_INDEX));
+        let resolution =
+            pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, timeout_event(KEYMAP_INDEX));
 
         // Assert
         assert_eq!(Some(TapHoldState::Hold), resolution);
@@ -647,7 +762,7 @@ mod tests {
         let mut pks = PendingKeyState::new();
 
         // Act
-        let resolution = pks.handle_event(&ctx, KEYMAP_INDEX, press(OTHER_INDEX));
+        let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, press(OTHER_INDEX));
 
         // Assert
         assert_eq!(None, resolution);
@@ -662,10 +777,10 @@ mod tests {
             None,
         ));
         let mut pks = PendingKeyState::new();
-        let _ = pks.handle_event(&ctx, KEYMAP_INDEX, press(OTHER_INDEX));
+        let _ = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, press(OTHER_INDEX));
 
         // Act
-        let resolution = pks.handle_event(&ctx, KEYMAP_INDEX, release(OTHER_INDEX));
+        let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, release(OTHER_INDEX));
 
         // Assert
         assert_eq!(Some(TapHoldState::Hold), resolution);
@@ -682,7 +797,7 @@ mod tests {
         let mut pks = PendingKeyState::new();
 
         // Act
-        let resolution = pks.handle_event(&ctx, KEYMAP_INDEX, release(OTHER_INDEX));
+        let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, release(OTHER_INDEX));
 
         // Assert
         assert_eq!(None, resolution);
@@ -697,10 +812,10 @@ mod tests {
             None,
         ));
         let mut pks = PendingKeyState::new();
-        let _ = pks.handle_event(&ctx, KEYMAP_INDEX, press(OTHER_INDEX));
+        let _ = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, press(OTHER_INDEX));
 
         // Act
-        let resolution = pks.handle_event(&ctx, KEYMAP_INDEX, release(2));
+        let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, release(2));
 
         // Assert
         assert_eq!(None, resolution);
@@ -982,5 +1097,51 @@ mod tests {
 
         // Assert
         assert_eq!(config, ctx.config);
+    }
+
+    // --- profiles ---
+
+    #[test]
+    fn test_profile_zero_is_default_fields() {
+        let config = Config {
+            timeout: Some(50),
+            interrupt_response: InterruptResponse::HoldOnKeyPress,
+            required_idle_time: Some(10),
+            profiles: Slice::from_slice(&[]),
+        };
+        let p = config.profile(0);
+        assert_eq!(p.timeout, Some(50));
+        assert_eq!(p.interrupt_response, InterruptResponse::HoldOnKeyPress);
+        assert_eq!(p.required_idle_time, Some(10));
+    }
+
+    #[test]
+    fn test_profile_extra_lookup() {
+        let extra = Profile {
+            timeout: Some(300),
+            interrupt_response: InterruptResponse::HoldOnKeyTap,
+            required_idle_time: None,
+        };
+        let config = Config {
+            timeout: Some(200),
+            interrupt_response: InterruptResponse::Ignore,
+            required_idle_time: None,
+            profiles: Slice::from_slice(&[extra]),
+        };
+        assert_eq!(config.profile(1).timeout, Some(300));
+        assert_eq!(
+            config.profile(1).interrupt_response,
+            InterruptResponse::HoldOnKeyTap
+        );
+        // OOR falls back to default
+        assert_eq!(config.profile(9).timeout, Some(200));
+    }
+
+    #[test]
+    fn test_key_default_profile_is_zero() {
+        let key = Key::new(0u8, 1u8);
+        assert_eq!(key.profile, 0);
+        let key = Key::with_profile(0u8, 1u8, 2);
+        assert_eq!(key.profile, 2);
     }
 }

--- a/smart-keymap-full-system-std/tests/keymap_full_system.rs
+++ b/smart-keymap-full-system-std/tests/keymap_full_system.rs
@@ -47,6 +47,7 @@ fn tap_hold_interrupt_keymap(
             smart_keymap::key::tap_hold::System::new(vec![smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(0x04)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(0xE0)),
+                profile: 0,
             }]),
         ),
     )

--- a/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
+++ b/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
@@ -491,6 +491,7 @@ pub mod init {
         smart_keymap::key::tap_hold::System::new([smart_keymap::key::tap_hold::Key {
             tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(4)),
             hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(1)),
+            profile: 0,
         }]),
     );
 

--- a/tests/ncl/keymap-1key-tap_hold/expected.rs
+++ b/tests/ncl/keymap-1key-tap_hold/expected.rs
@@ -390,6 +390,7 @@ pub mod init {
         smart_keymap::key::tap_hold::System::new([smart_keymap::key::tap_hold::Key {
             tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(4)),
             hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(224)),
+            profile: 0,
         }]),
     );
 

--- a/tests/ncl/keymap-2key-2layer-composite/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-composite/expected.rs
@@ -492,6 +492,7 @@ pub mod init {
         smart_keymap::key::tap_hold::System::new([smart_keymap::key::tap_hold::Key {
             tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(4)),
             hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(0)),
+            profile: 0,
         }]),
     );
 

--- a/tests/ncl/keymap-2key-chorded-named-th-lmod/expected.rs
+++ b/tests/ncl/keymap-2key-chorded-named-th-lmod/expected.rs
@@ -673,6 +673,7 @@ pub mod init {
         smart_keymap::key::tap_hold::System::new([smart_keymap::key::tap_hold::Key {
             tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(41)),
             hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(0)),
+            profile: 0,
         }]),
     );
 

--- a/tests/ncl/keymap-48key-rgoulter/expected.rs
+++ b/tests/ncl/keymap-48key-rgoulter/expected.rs
@@ -2819,170 +2819,212 @@ pub mod init {
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(4)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(4)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(4)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(4)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(18)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(8)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(22)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(8)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(8)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(1)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(7)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(1)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(24)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(2)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(9)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(2)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(11)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(32)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(13)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(32)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(23)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(1)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(14)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(1)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(17)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(128)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(15)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(128)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(22)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(4)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(51)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(4)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(43)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(24)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(43)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(25)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(43)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(26)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(43)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(27)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(43)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(28)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(41)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(29)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(41)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(30)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(41)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(31)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(41)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(32)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(44)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(33)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(44)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(34)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(44)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(35)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(44)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(36)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(76)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(37)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(40)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(38)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(40)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(39)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(40)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(40)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(40)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(41)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(42)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(42)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(42)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(43)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(42)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(44)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(42)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(45)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(76)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(46)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(76)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(47)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(76)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(48)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(76)),
                 hold: key_system::Ref::Layered(smart_keymap::key::layered::Ref::Modifier(49)),
+                profile: 0,
             },
         ]),
     );

--- a/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
@@ -450,34 +450,42 @@ pub mod init {
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(4)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(4)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(18)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(8)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(8)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(1)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(24)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(2)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(11)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(32)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(23)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(16)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(17)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(128)),
+                profile: 0,
             },
             smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(22)),
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::Modifiers(64)),
+                profile: 0,
             },
         ]),
     );

--- a/tests/rust/tap_hold.rs
+++ b/tests/rust/tap_hold.rs
@@ -3,6 +3,7 @@ mod hold_on_interrupt_tap;
 mod interrupt_ignore;
 mod layered;
 mod no_timeout;
+mod profiles;
 mod required_idle_time;
 
 use smart_keymap::input;

--- a/tests/rust/tap_hold/profiles.rs
+++ b/tests/rust/tap_hold/profiles.rs
@@ -1,0 +1,144 @@
+use smart_keymap::input;
+use smart_keymap::keymap::ObservedKeymap;
+
+use crate::hid_keycodes::*;
+use smart_keymap_macros::keymap;
+
+/// Profile 0 (default) ignores interrupts; named profile forces hold-on-press.
+#[test]
+fn named_profile_uses_distinct_interrupt_response() {
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.tap_hold = {
+                    # default profile: ignore interrupts (hold only on timeout)
+                    interrupt_response = "Ignore",
+                    timeout = 200,
+                    profiles = {
+                        aggressive = {
+                            interrupt_response = "HoldOnKeyPress",
+                            timeout = 200,
+                        },
+                    },
+                },
+                keys = [
+                    # default profile — interrupt does not force hold
+                    K.A & K.hold K.LeftCtrl,
+                    K.B,
+                    # named profile — interrupt forces hold
+                    K.C & K.hold K.LeftShift & K.tap_hold_profile "aggressive",
+                ],
+            }
+        "#
+    ));
+
+    // Default-profile key: press TH, press B, release TH → tap (Ignore)
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+    keymap.tick_until_no_scheduled_events();
+
+    // Same order as interrupt_ignore::rolled_presses (pending TH, then B, release TH as tap).
+    #[rustfmt::skip]
+    let expected_after_default: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, KC_B, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(
+        expected_after_default,
+        keymap.distinct_reports().reports(),
+        "default profile should ignore interrupt"
+    );
+
+    // Reset reports by creating a fresh keymap for the second scenario clarity
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.tap_hold = {
+                    interrupt_response = "Ignore",
+                    timeout = 200,
+                    profiles = {
+                        aggressive = {
+                            interrupt_response = "HoldOnKeyPress",
+                            timeout = 200,
+                        },
+                    },
+                },
+                keys = [
+                    K.A & K.hold K.LeftCtrl,
+                    K.B,
+                    K.C & K.hold K.LeftShift & K.tap_hold_profile "aggressive",
+                ],
+            }
+        "#
+    ));
+
+    // Profile key at index 2: press TH, press B → hold
+    keymap.handle_input(input::Event::Press { keymap_index: 2 });
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.handle_input(input::Event::Release { keymap_index: 2 });
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+    keymap.tick_until_no_scheduled_events();
+
+    #[rustfmt::skip]
+    let expected_aggressive: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, KC_B, 0, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(
+        expected_aggressive,
+        keymap.distinct_reports().reports(),
+        "named profile should hold on interrupt press"
+    );
+}
+
+#[test]
+fn numeric_profile_index_selects_extra_profile() {
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.tap_hold = {
+                    interrupt_response = "Ignore",
+                    timeout = 200,
+                    profiles = {
+                        # alphabetical: only one extra → index 1
+                        hold_press = {
+                            interrupt_response = "HoldOnKeyPress",
+                            timeout = 200,
+                        },
+                    },
+                },
+                keys = [
+                    K.A & K.hold K.LeftCtrl & { tap_hold_profile = 1 },
+                    K.B,
+                ],
+            }
+        "#
+    ));
+
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+    keymap.tick_until_no_scheduled_events();
+
+    #[rustfmt::skip]
+    let expected: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, KC_B, 0, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected, keymap.distinct_reports().reports());
+}


### PR DESCRIPTION
## Summary

Adds tap-hold **behavior profiles** so extra configs can share a small table instead of growing every `Key`.

- **Profile 0** = existing `config.tap_hold` fields (`timeout`, `interrupt_response`, `required_idle_time`)
- **Extras** = `config.tap_hold.profiles = { name = { … }, … }` → JSON array at indices `1..` (record field order)
- **Key** gains `profile: u8` (default `0`); resolve via `Config::profile` / `Context::profile`
- Authoring: `K.tap_hold_profile "name"` or `{ tap_hold_profile = 1 }`

## Authoring example

```ncl
config.tap_hold = {
  interrupt_response = "Ignore",
  profiles = {
    hold_press = {
      interrupt_response = "HoldOnKeyPress",
      timeout = 200,
    },
  },
},
keys = [
  K.A & K.hold K.LeftCtrl,
  K.C & K.hold K.LeftShift & K.tap_hold_profile "hold_press",
]
```

## Test plan

- [x] `cargo test -p smart-keymap-core --lib key::tap_hold`
- [x] `cargo test --test rust-integration tap_hold` (incl. `profiles`)
- [x] `just ncl::checks` / `just ncl::snapshots` (blessed)
- [x] Host `check-quick` surface: fmt, clippy, `test-doc-host`, nickel format
- [ ] CI green