### PR TITLE
make: document firmware packages for their target triples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,11 @@ test-clippy:
 # Match CI cargo-doc steps (host + firmware packages).
 # Host: .github/workflows/rust.yaml
 # Firmware: rust-stm32f4.yaml, rust-thumbv6m-none-eabi.yaml
+#
+# Firmware packages pull in PAC crates that use ELF `#[link_section =
+# ".vector_table.interrupts"]`. Documenting them for the *host* triple works on
+# Linux CI (ELF) but fails on macOS (Mach-O rejects those section names). Pass
+# the firmware `--target` so docs build for the real target on all hosts.
 .PHONY: test-doc
 test-doc: test-doc-host test-doc-firmware
 
@@ -82,19 +87,25 @@ test-doc-host:
 .PHONY: test-doc-firmware
 test-doc-firmware: test-doc-stm32f4 test-doc-rp2040
 
-# Match .github/workflows/rust-stm32f4.yaml "Run Cargo Doc"
+# Match .github/workflows/rust-stm32f4.yaml "Run Cargo Doc" packages/flags,
+# with --target so this also works on Darwin hosts (see comment above).
 .PHONY: test-doc-stm32f4
 test-doc-stm32f4:
 	RUSTDOCFLAGS="--deny warnings" $(CARGO) doc \
+		--target=$(STM32F4_TARGET) \
 		--no-default-features \
 		--package=stm32f4-rtic-smart-keyboard \
 		--package=smart-keymap \
 		--package=keyberon-smart-keyboard
 
-# Match .github/workflows/rust-thumbv6m-none-eabi.yaml "Run Cargo Doc"
+# Match .github/workflows/rust-thumbv6m-none-eabi.yaml "Run Cargo Doc" packages,
+# with --target (and --no-default-features) for Darwin hosts (see comment above).
+# CI currently omits both flags and relies on Linux host ELF; we need them here.
 .PHONY: test-doc-rp2040
 test-doc-rp2040:
 	RUSTDOCFLAGS="--deny warnings" $(CARGO) doc \
+		--target=$(RP2040_TARGET) \
+		--no-default-features \
 		--package=rp2040-rtic-smart-keyboard \
 		--package=smart-keymap \
 		--package=keyberon-smart-keyboard

--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,6 @@ test-clippy:
 # Match CI cargo-doc steps (host + firmware packages).
 # Host: .github/workflows/rust.yaml
 # Firmware: rust-stm32f4.yaml, rust-thumbv6m-none-eabi.yaml
-#
-# Firmware packages pull in PAC crates that use ELF `#[link_section =
-# ".vector_table.interrupts"]`. Documenting them for the *host* triple works on
-# Linux CI (ELF) but fails on macOS (Mach-O rejects those section names). Pass
-# the firmware `--target` so docs build for the real target on all hosts.
 .PHONY: test-doc
 test-doc: test-doc-host test-doc-firmware
 
@@ -84,11 +79,14 @@ test-doc-host:
 		--package=smart-keymap \
 		--package=keyberon-smart-keyboard
 
+# Firmware package docs must use the firmware `--target`.
+# PAC crates use ELF `#[link_section = ".vector_table.interrupts"]`;
+# documenting them for the host triple works on Linux CI (ELF)
+# but fails on Darwin (Mach-O rejects those section names).
 .PHONY: test-doc-firmware
 test-doc-firmware: test-doc-stm32f4 test-doc-rp2040
 
-# Match .github/workflows/rust-stm32f4.yaml "Run Cargo Doc" packages/flags,
-# with --target so this also works on Darwin hosts (see comment above).
+# Match .github/workflows/rust-stm32f4.yaml "Run Cargo Doc".
 .PHONY: test-doc-stm32f4
 test-doc-stm32f4:
 	RUSTDOCFLAGS="--deny warnings" $(CARGO) doc \
@@ -98,9 +96,8 @@ test-doc-stm32f4:
 		--package=smart-keymap \
 		--package=keyberon-smart-keyboard
 
-# Match .github/workflows/rust-thumbv6m-none-eabi.yaml "Run Cargo Doc" packages,
-# with --target (and --no-default-features) for Darwin hosts (see comment above).
-# CI currently omits both flags and relies on Linux host ELF; we need them here.
+# Match .github/workflows/rust-thumbv6m-none-eabi.yaml "Run Cargo Doc".
+# `--no-default-features` keeps the no_std graph on the thumb target.
 .PHONY: test-doc-rp2040
 test-doc-rp2040:
 	RUSTDOCFLAGS="--deny warnings" $(CARGO) doc \


### PR DESCRIPTION
## Summary

`make test-doc` / `just check-quick` (and thus `just test`) fail on **macOS** when documenting stm32f4/rp2040 packages for the host triple:

```text
error: invalid Mach-O section specifier
  --> …/stm32f4-staging-…/src/stm32f401/mod.rs
   | #[link_section = ".vector_table.interrupts"]
```

PAC crates use ELF section names. That is fine on Linux CI host docs; Mach-O rejects them.

Not caused by the tap-hold profiles work. The failure surfaces after `test-doc` was expanded to cover firmware packages (`dcc8c543`). A devenv/fenix bump can make this more obvious but the underlying issue is host vs target.

## Fix

- `test-doc-stm32f4`: `--target=thumbv7em-none-eabihf` (+ existing `--no-default-features`)
- `test-doc-rp2040`: `--target=thumbv6m-none-eabi --no-default-features`

## Test plan

- [x] `make test-doc-stm32f4` on Darwin
- [x] `make test-doc-rp2040` on Darwin  
- [x] `make test-doc` (host + firmware) on Darwin
- [ ] CI green