### PR TITLE
tap_hold: nest profile 0 as Config.default_profile

### DIFF
--- a/features/keymap/key/tap_hold-profiles.feature
+++ b/features/keymap/key/tap_hold-profiles.feature
@@ -1,9 +1,10 @@
 Feature: TapHold Key (behavior profiles)
 
-  Tap-hold keys use behavior **profiles**. Profile 0 is `config.tap_hold`
-  (timeout, interrupt_response, required_idle_time). Extra profiles are
-  authored as `config.tap_hold.profiles = { name = { … }, … }` and selected
-  per key with `tap_hold_profile` (name string or numeric index).
+  Tap-hold keys use behavior **profiles**. Profile 0 is the default profile
+  (`config.tap_hold` knobs: timeout, interrupt_response, required_idle_time —
+  stored as `Config.default_profile`). Extra profiles are authored as
+  `config.tap_hold.profiles = { name = { … }, … }` and selected per key with
+  `tap_hold_profile` (name string or numeric index).
 
   Names lower to indices 1.. in record field order (JSON array on config).
 

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -569,10 +569,10 @@
       l,
 
   # Tap-hold behavior profiles:
+  #   config.tap_hold flat knobs → JSON default_profile (profile 0)
   #   config.tap_hold.profiles = { hml = { … }, hmr = { … } }  (authoring, name → Profile)
-  # lowers to a JSON array at indices 1.. (alphabetical name order); profile 0 = default fields.
+  # lowers to a JSON array at indices 1.. (record field order).
   # Keys may set `tap_hold_profile = "hml"` (or a number); names resolve before to_json_value.
-  # Name order = Nickel record field order (same idea as named_layers).
   tap_hold_profile_names = fun th_config =>
     if std.record.has_field "profiles" th_config then
       std.record.fields th_config.profiles
@@ -638,17 +638,40 @@
         )
       in
       let th_config_json =
-        let th_base =
-          if std.record.has_field "profiles" th_config then
-            std.record.remove "profiles" th_config
-          else
-            th_config
+        # Flat authoring knobs (timeout, interrupt_response, …) nest as
+        # default_profile for JSON / Rust Config (no serde flatten on no_std).
+        # Pick only real Profile fields — Config contracts leave optional field
+        # stubs that must not be nested into ProfileJson.
+        let default_profile_json =
+          (
+            if std.record.has_field "timeout" th_config then
+              { timeout = th_config.timeout }
+            else
+              {}
+          )
+          & (
+            if std.record.has_field "interrupt_response" th_config then
+              { interrupt_response = th_config.interrupt_response }
+            else
+              {}
+          )
+          & (
+            if std.record.has_field "required_idle_time" th_config then
+              { required_idle_time = th_config.required_idle_time }
+            else
+              {}
+          )
         in
         let profiles_array =
           th_profile_names
           |> std.array.map (fun name => th_config.profiles."%{name}")
         in
-        th_base
+        (
+          if default_profile_json == {} then
+            {}
+          else
+            { default_profile = default_profile_json }
+        )
         & (
           if profiles_array == [] then
             {}

--- a/ncl/smart_keys/tap_hold/keymap-codegen.ncl
+++ b/ncl/smart_keys/tap_hold/keymap-codegen.ncl
@@ -237,17 +237,9 @@
           required_idle_time | optional | Number,
         },
 
+        # Lowered JSON form: nested default_profile + profiles array.
         Json = {
-          timeout
-            | optional
-            | std.contract.from_validator (
-              validators.any_of [
-                validators.is_null,
-                validators.is_number,
-              ]
-            ),
-          interrupt_response | optional | TapHoldInterruptResponseJson,
-          required_idle_time | optional | Number,
+          default_profile | optional | ProfileJson,
           # Lowered form: array of extra profiles (index 1..).
           profiles | optional | Array ProfileJson,
         },
@@ -256,30 +248,8 @@
           if std.record.has_field "tap_hold" json_keymap.config then
             let c = json_keymap.config.tap_hold in
             (
-              if std.record.has_field "timeout" c then
-                {
-                  timeout =
-                    if c.timeout == null then
-                      "None"
-                    else
-                      "Some(%{std.to_string c.timeout})",
-                }
-              else
-                {}
-            )
-            & (
-              if std.record.has_field "interrupt_response" c then
-                {
-                  interrupt_response = "%{module}::InterruptResponse::%{c.interrupt_response}",
-                }
-              else
-                {}
-            )
-            & (
-              if std.record.has_field "required_idle_time" c then
-                {
-                  required_idle_time = "Some(%{std.to_string c.required_idle_time})",
-                }
+              if std.record.has_field "default_profile" c then
+                { default_profile = profile_rust_expr c.default_profile }
               else
                 {}
             )

--- a/ncl/smart_keys/tap_hold/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/tap_hold/keymap-ncl-to-json.ncl
@@ -63,7 +63,8 @@
           ]
         ),
 
-      # One behavior profile (same fields as default config.tap_hold).
+      # One behavior profile. Profile 0 is Config's default (flat on config.tap_hold);
+      # extras live under config.tap_hold.profiles.
       Profile = {
         timeout
           | optional
@@ -77,6 +78,8 @@
         required_idle_time | optional | Number,
       },
 
+      # Authoring keeps default-profile knobs flat on config.tap_hold;
+      # lowering nests them as default_profile for JSON / Rust Config.
       Config = {
         timeout
           | optional

--- a/smart-keymap-core/src/key/tap_hold.rs
+++ b/smart-keymap-core/src/key/tap_hold.rs
@@ -14,13 +14,13 @@ pub struct Ref(pub u8);
 
 /// Maximum number of *extra* tap-hold profiles beyond the default (profile 0).
 ///
-/// Profile indices on keys are `0` (default / [`Config`] top-level fields) then
+/// Profile indices on keys are `0` ([`Config::default_profile`]) then
 /// `1..` into [`Config::profiles`]. Total usable profiles = `1 + MAX_EXTRA_PROFILES`.
 pub const MAX_EXTRA_PROFILES: usize = 7;
 
 /// One tap-hold behavior profile (timeout, interrupt flavor, idle gate).
 ///
-/// Profile 0 is the default [`Config`] fields; extra profiles live in
+/// Profile 0 is [`Config::default_profile`]; extra profiles live in
 /// [`Config::profiles`] and are selected per key via [`Key::profile`].
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct Profile {
@@ -65,7 +65,7 @@ pub struct Key<R> {
     pub tap: R,
     /// The 'hold' key.
     pub hold: R,
-    /// Behavior profile index: `0` = default [`Config`] fields; `1..` = [`Config::profiles`].
+    /// Behavior profile index: `0` = [`Config::default_profile`]; `1..` = [`Config::profiles`].
     #[serde(default)]
     pub profile: u8,
 }
@@ -112,30 +112,19 @@ pub enum InterruptResponse {
 
 /// Configuration settings for tap hold keys.
 ///
-/// Top-level fields are **profile 0** (the default). Optional [`Config::profiles`]
+/// [`Config::default_profile`] is **profile 0**. Optional [`Config::profiles`]
 /// are extra behaviors at indices `1..`. Keys select a profile via [`Key::profile`].
+///
+/// Nickel authoring keeps profile-0 knobs flat on `config.tap_hold`
+/// (`timeout`, `interrupt_response`, …); lowering nests them as
+/// `default_profile` in JSON (no `serde(flatten)` — that needs alloc).
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct Config {
-    /// The timeout (in number of milliseconds) for a tap-hold key to resolve as hold.
-    ///
-    /// When `None`, the tap/hold decision does not timeout;
-    /// the key resolves only on release (as tap) or interruption
-    /// (depending on [InterruptResponse]).
-    #[serde(default = "default_timeout")]
-    pub timeout: Option<u16>,
+    /// Default behavior (profile index 0).
+    #[serde(default = "default_profile_value")]
+    pub default_profile: Profile,
 
-    /// How the tap-hold key should respond to interruptions.
-    #[serde(default = "default_interrupt_response")]
-    pub interrupt_response: InterruptResponse,
-
-    /// Amount of time (in milliseconds) the keymap must have been idle
-    ///  in order for tap hold to support 'hold' functionality.
-    ///
-    /// This reduces disruption from unexpected hold resolutions
-    ///  when typing quickly.
-    pub required_idle_time: Option<u16>,
-
-    /// Extra behavior profiles (indices `1..=len`). Profile `0` is the top-level fields.
+    /// Extra behavior profiles (indices `1..=len`).
     #[serde(default)]
     pub profiles: Slice<Profile, MAX_EXTRA_PROFILES>,
 }
@@ -154,7 +143,11 @@ fn default_interrupt_response() -> InterruptResponse {
     DEFAULT_INTERRUPT_RESPONSE
 }
 
-/// Default profile (same values as default [`Config`] top-level fields).
+fn default_profile_value() -> Profile {
+    DEFAULT_PROFILE
+}
+
+/// Default profile (also the contents of [`DEFAULT_CONFIG`]'s default profile).
 pub const DEFAULT_PROFILE: Profile = Profile {
     timeout: Some(DEFAULT_TIMEOUT),
     interrupt_response: DEFAULT_INTERRUPT_RESPONSE,
@@ -163,9 +156,7 @@ pub const DEFAULT_PROFILE: Profile = Profile {
 
 /// Default tap hold config.
 pub const DEFAULT_CONFIG: Config = Config {
-    timeout: Some(DEFAULT_TIMEOUT),
-    interrupt_response: DEFAULT_INTERRUPT_RESPONSE,
-    required_idle_time: None,
+    default_profile: DEFAULT_PROFILE,
     profiles: Slice::from_slice(&[]),
 };
 
@@ -177,28 +168,20 @@ impl Config {
 
     /// Resolves the behavior profile for `profile_id`.
     ///
-    /// - `0` → top-level default fields
+    /// - `0` → [`Self::default_profile`]
     /// - `1..` → [`Self::profiles`] entry `id - 1`
     ///
     /// Out-of-range ids fall back to the default profile.
     pub const fn profile(&self, profile_id: u8) -> Profile {
         if profile_id == 0 {
-            return Profile {
-                timeout: self.timeout,
-                interrupt_response: self.interrupt_response,
-                required_idle_time: self.required_idle_time,
-            };
+            return self.default_profile;
         }
         let idx = (profile_id - 1) as usize;
         let extras = self.profiles.as_slice();
         if idx < extras.len() {
             extras[idx]
         } else {
-            Profile {
-                timeout: self.timeout,
-                interrupt_response: self.interrupt_response,
-                required_idle_time: self.required_idle_time,
-            }
+            self.default_profile
         }
     }
 }
@@ -537,9 +520,11 @@ mod tests {
         required_idle_time: Option<u16>,
     ) -> Config {
         Config {
-            timeout,
-            interrupt_response,
-            required_idle_time,
+            default_profile: Profile {
+                timeout,
+                interrupt_response,
+                required_idle_time,
+            },
             profiles: Slice::from_slice(&[]),
         }
     }
@@ -1104,12 +1089,15 @@ mod tests {
     #[test]
     fn test_profile_zero_is_default_fields() {
         let config = Config {
-            timeout: Some(50),
-            interrupt_response: InterruptResponse::HoldOnKeyPress,
-            required_idle_time: Some(10),
+            default_profile: Profile {
+                timeout: Some(50),
+                interrupt_response: InterruptResponse::HoldOnKeyPress,
+                required_idle_time: Some(10),
+            },
             profiles: Slice::from_slice(&[]),
         };
         let p = config.profile(0);
+        assert_eq!(p, config.default_profile);
         assert_eq!(p.timeout, Some(50));
         assert_eq!(p.interrupt_response, InterruptResponse::HoldOnKeyPress);
         assert_eq!(p.required_idle_time, Some(10));
@@ -1123,9 +1111,11 @@ mod tests {
             required_idle_time: None,
         };
         let config = Config {
-            timeout: Some(200),
-            interrupt_response: InterruptResponse::Ignore,
-            required_idle_time: None,
+            default_profile: Profile {
+                timeout: Some(200),
+                interrupt_response: InterruptResponse::Ignore,
+                required_idle_time: None,
+            },
             profiles: Slice::from_slice(&[extra]),
         };
         assert_eq!(config.profile(1).timeout, Some(300));
@@ -1135,6 +1125,7 @@ mod tests {
         );
         // OOR falls back to default
         assert_eq!(config.profile(9).timeout, Some(200));
+        assert_eq!(config.profile(9), config.default_profile);
     }
 
     #[test]

--- a/smart-keymap-full-system-std/tests/keymap_full_system.rs
+++ b/smart-keymap-full-system-std/tests/keymap_full_system.rs
@@ -21,7 +21,7 @@ fn tap_hold_interrupt_keymap(
     use smart_keymap_full_system_std::key_system;
 
     let mut config = key_system::Config::new();
-    config.tap_hold.interrupt_response = interrupt_response;
+    config.tap_hold.default_profile.interrupt_response = interrupt_response;
 
     smart_keymap::keymap::Keymap::new(
         [

--- a/tests/ncl/keymap-48key-rgoulter/expected.rs
+++ b/tests/ncl/keymap-48key-rgoulter/expected.rs
@@ -1011,7 +1011,10 @@ pub mod init {
         sticky: smart_keymap::key::sticky::Config::new(),
         tap_dance: smart_keymap::key::tap_dance::Config::new(),
         tap_hold: smart_keymap::key::tap_hold::Config {
-            interrupt_response: smart_keymap::key::tap_hold::InterruptResponse::HoldOnKeyTap,
+            default_profile: smart_keymap::key::tap_hold::Profile {
+                interrupt_response: smart_keymap::key::tap_hold::InterruptResponse::HoldOnKeyTap,
+                ..smart_keymap::key::tap_hold::Profile::new()
+            },
             ..smart_keymap::key::tap_hold::Config::new()
         },
     };
@@ -1031,7 +1034,10 @@ pub mod init {
         sticky: smart_keymap::key::sticky::Config::new(),
         tap_dance: smart_keymap::key::tap_dance::Config::new(),
         tap_hold: smart_keymap::key::tap_hold::Config {
-            interrupt_response: smart_keymap::key::tap_hold::InterruptResponse::HoldOnKeyTap,
+            default_profile: smart_keymap::key::tap_hold::Profile {
+                interrupt_response: smart_keymap::key::tap_hold::InterruptResponse::HoldOnKeyTap,
+                ..smart_keymap::key::tap_hold::Profile::new()
+            },
             ..smart_keymap::key::tap_hold::Config::new()
         },
     });


### PR DESCRIPTION
## Summary

Follow-up to #687: profile-0 knobs were duplicated as flat fields on `Config` while extras used `Profile`. Nest them as `Config.default_profile` so:

- `Config = { default_profile: Profile, profiles: … }`
- New behavior knobs only extend `Profile` (next: hold_trigger, retro_tap, quick_tap)
- Authoring stays flat on `config.tap_hold`; lowering nests into JSON `default_profile` (no `serde(flatten)` — needs alloc / breaks no_std)

## Stack

1. **This PR** — default_profile nesting
2. #690 — hold_trigger_positions on Profile
3. #681 / #682 — retro_tap / quick_tap on Profile

## Test plan

- [x] `cargo check -p smart-keymap-core --no-default-features`
- [x] `cargo test -p smart-keymap-core --lib key::tap_hold`
- [x] `cargo test --test rust-integration tap_hold`
- [x] `just ncl::checks` / `just ncl::snapshots`
- [ ] CI green