### PR TITLE
tap_hold: add hold_trigger_positions on profiles

### DIFF
--- a/features/keymap/key/tap_hold-hold_trigger_positions.feature
+++ b/features/keymap/key/tap_hold-hold_trigger_positions.feature
@@ -1,0 +1,112 @@
+Feature: TapHold Key (hold_trigger_key_positions / positional)
+
+  When a tap-hold **profile** sets `hold_trigger_key_positions`, only those
+  keymap indices may resolve an interrupt as hold. Interrupts from other
+  positions are ignored for the hold decision (ZMK positional hold-tap).
+
+  Profile 0 is `config.tap_hold` (including optional
+  `hold_trigger_key_positions`). Named extras may set the field on their
+  profile record. Keys stay thin: `tap` + `hold` + optional profile selector.
+
+  Timeout and self-release behaviour are unchanged.
+
+  For examples of this key in other smart keyboard firmware, see e.g.:
+
+  - [ZMK's hold-tap, hold-trigger-key-positions](https://zmk.dev/docs/keymaps/behaviors/hold-tap#positional-hold-tap-and-hold-trigger-key-positions)
+
+  Background:
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        config.tap_hold = {
+          interrupt_response = "HoldOnKeyPress",
+          timeout = 200,
+          hold_trigger_key_positions = [2],
+        },
+        keys = [
+          K.A & K.hold K.LeftCtrl,
+          K.B,
+          K.C,
+        ]
+      }
+      """
+
+  Example: interrupt from a hold trigger position resolves as hold
+
+    When the keymap registers the following input
+      """
+      [
+        press (K.A & K.hold K.LeftCtrl),
+        press (K.C),
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        press (K.LeftCtrl),
+        press (K.C),
+      ]
+      """
+
+  Example: non-trigger interrupt does not force hold
+
+    Interrupting with a non-trigger key (press & release), then releasing
+     the tap-hold, resolves as tap rather than hold.
+
+    When the keymap registers the following input
+      """
+      [
+        press (K.A & K.hold K.LeftCtrl),
+        tap (K.B),
+        release (K.A & K.hold K.LeftCtrl),
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        press (K.A),
+        tap (K.B),
+        release (K.A),
+      ]
+      """
+
+  Example: named profile with hold_trigger_key_positions
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        config.tap_hold = {
+          interrupt_response = "Ignore",
+          timeout = 200,
+          profiles = {
+            opposite = {
+              interrupt_response = "HoldOnKeyPress",
+              hold_trigger_key_positions = [2],
+            },
+          },
+        },
+        keys = [
+          K.A & K.hold K.LeftCtrl & K.tap_hold_profile "opposite",
+          K.B,
+          K.C,
+        ]
+      }
+      """
+
+    When the keymap registers the following input
+      """
+      [
+        press (K.A & K.hold K.LeftCtrl & K.tap_hold_profile "opposite"),
+        press (K.C),
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        press (K.LeftCtrl),
+        press (K.C),
+      ]
+      """

--- a/features/scripts/generate-doc.sh
+++ b/features/scripts/generate-doc.sh
@@ -42,6 +42,7 @@ keymap_key_features=(
     "tap_hold-config-required_idle_time"
     "tap_hold-config-timeout"
     "tap_hold-config-timeout-none"
+    "tap_hold-hold_trigger_positions"
     "tap_hold-profiles"
 )
 

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -661,6 +661,12 @@
             else
               {}
           )
+          & (
+            if std.record.has_field "hold_trigger_key_positions" th_config then
+              { hold_trigger_key_positions = th_config.hold_trigger_key_positions }
+            else
+              {}
+          )
         in
         let profiles_array =
           th_profile_names

--- a/ncl/smart_keys/tap_hold/keymap-codegen.ncl
+++ b/ncl/smart_keys/tap_hold/keymap-codegen.ncl
@@ -51,6 +51,24 @@
             expected = "smart_keymap::key::tap_hold::Key::with_profile(smart_keymap::key::keyboard::Key::new(4), smart_keymap::key::keyboard::Key::new(224), 1)",
           },
         },
+
+      check_profile_with_hold_triggers =
+        let rust_expr =
+          smart_keymap.tap_hold.profile_rust_expr {
+            interrupt_response = "HoldOnKeyPress",
+            hold_trigger_key_positions = [2, 3],
+          }
+        in
+        {
+          check_rust_expr = {
+            actual = rust_expr,
+            expected = m%"smart_keymap::key::tap_hold::Profile {
+            hold_trigger_positions: Some(smart_keymap::slice::Slice::from_slice(&[2, 3])),
+            interrupt_response: smart_keymap::key::tap_hold::InterruptResponse::HoldOnKeyPress,
+            ..smart_keymap::key::tap_hold::Profile::new()
+          }"%,
+          },
+        },
     },
   },
 
@@ -67,6 +85,14 @@
         ),
 
       module = "smart_keymap::key::tap_hold",
+
+      hold_trigger_positions_expr = fun positions =>
+        let idxs =
+          positions
+          |> std.array.map (fun i => "%{std.to_string i}")
+          |> std.string.join ", "
+        in
+        "Some(smart_keymap::slice::Slice::from_slice(&[%{idxs}]))",
 
       profile_field_expr = fun c =>
         (
@@ -93,6 +119,14 @@
           if std.record.has_field "required_idle_time" c then
             {
               required_idle_time = "Some(%{std.to_string c.required_idle_time})",
+            }
+          else
+            {}
+        )
+        & (
+          if std.record.has_field "hold_trigger_key_positions" c then
+            {
+              hold_trigger_positions = hold_trigger_positions_expr c.hold_trigger_key_positions,
             }
           else
             {}
@@ -235,6 +269,7 @@
             ),
           interrupt_response | optional | TapHoldInterruptResponseJson,
           required_idle_time | optional | Number,
+          hold_trigger_key_positions | optional | Array Number,
         },
 
         # Lowered JSON form: nested default_profile + profiles array.

--- a/ncl/smart_keys/tap_hold/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/tap_hold/keymap-ncl-to-json.ncl
@@ -76,6 +76,8 @@
           ),
         interrupt_response | optional | TapHoldInterruptResponse,
         required_idle_time | optional | Number,
+        # Only listed keymap indices may force interrupt-as-hold; unset = unrestricted.
+        hold_trigger_key_positions | optional | Array Number,
       },
 
       # Authoring keeps default-profile knobs flat on config.tap_hold;
@@ -91,6 +93,8 @@
           ),
         interrupt_response | optional | TapHoldInterruptResponse,
         required_idle_time | optional | Number,
+        # Only listed keymap indices may force interrupt-as-hold; unset = unrestricted.
+        hold_trigger_key_positions | optional | Array Number,
         # Authoring: name → profile record. Lowered to a JSON array (indices 1..).
         profiles | optional | { _ | Profile },
       },

--- a/smart-keymap-core/src/key/tap_hold.rs
+++ b/smart-keymap-core/src/key/tap_hold.rs
@@ -18,7 +18,13 @@ pub struct Ref(pub u8);
 /// `1..` into [`Config::profiles`]. Total usable profiles = `1 + MAX_EXTRA_PROFILES`.
 pub const MAX_EXTRA_PROFILES: usize = 7;
 
-/// One tap-hold behavior profile (timeout, interrupt flavor, idle gate).
+/// Maximum keymap indices listed in one profile's `hold_trigger_key_positions`.
+///
+/// Sparse opposite-hand lists are expected (on the order of ~10), not a dense
+/// mask of every key on the board.
+pub const MAX_HOLD_TRIGGER_POSITIONS: usize = 16;
+
+/// One tap-hold behavior profile (timeout, interrupt flavor, idle gate, hold triggers).
 ///
 /// Profile 0 is [`Config::default_profile`]; extra profiles live in
 /// [`Config::profiles`] and are selected per key via [`Key::profile`].
@@ -43,12 +49,43 @@ pub struct Profile {
     ///  when typing quickly.
     #[serde(default)]
     pub required_idle_time: Option<u16>,
+
+    /// When set, only these keymap indices may force an interrupt-as-hold
+    /// resolution. When unset, any interrupting key may force hold
+    /// (subject to [InterruptResponse]).
+    ///
+    /// JSON field name matches the Nickel authoring surface
+    /// (`hold_trigger_key_positions`). Length is bounded by
+    /// [`MAX_HOLD_TRIGGER_POSITIONS`].
+    #[serde(default, rename = "hold_trigger_key_positions")]
+    pub hold_trigger_positions: Option<Slice<u16, MAX_HOLD_TRIGGER_POSITIONS>>,
 }
 
 impl Profile {
     /// Constructs a new default [Profile].
     pub const fn new() -> Self {
         DEFAULT_PROFILE
+    }
+
+    /// Whether an interrupt from `other_keymap_index` may force hold.
+    ///
+    /// When [`Self::hold_trigger_positions`] is set, only those indices count as
+    /// hold triggers. When unset, any other key may force hold.
+    pub const fn allows_hold_trigger(&self, other_keymap_index: u16) -> bool {
+        match self.hold_trigger_positions {
+            None => true,
+            Some(positions) => {
+                let list = positions.as_slice();
+                let mut i = 0;
+                while i < list.len() {
+                    if list[i] == other_keymap_index {
+                        return true;
+                    }
+                    i += 1;
+                }
+                false
+            }
+        }
     }
 }
 
@@ -152,6 +189,7 @@ pub const DEFAULT_PROFILE: Profile = Profile {
     timeout: Some(DEFAULT_TIMEOUT),
     interrupt_response: DEFAULT_INTERRUPT_RESPONSE,
     required_idle_time: None,
+    hold_trigger_positions: None,
 };
 
 /// Default tap hold config.
@@ -260,19 +298,24 @@ impl PendingKeyState {
     }
 
     /// Compute whether the tap-hold key should resolve as tap or hold,
-    ///  given the tap hold config, the current state, and the key event.
+    ///  given the behavior profile, the current state, and the key event.
     fn hold_resolution(
         &self,
-        interrupt_response: InterruptResponse,
+        profile: &Profile,
         keymap_index: u16,
         event: key::Event<Event>,
     ) -> Option<TapHoldState> {
-        match interrupt_response {
+        match profile.interrupt_response {
             InterruptResponse::HoldOnKeyPress => {
                 match event {
-                    key::Event::Input(input::Event::Press { .. }) => {
-                        // TapHold: any interruption resolves pending TapHold as Hold.
-                        Some(TapHoldState::Hold)
+                    key::Event::Input(input::Event::Press { keymap_index: ki }) => {
+                        // Interruption resolves as Hold when the interrupting
+                        // key is a hold trigger position (or triggers unset).
+                        if profile.allows_hold_trigger(ki) {
+                            Some(TapHoldState::Hold)
+                        } else {
+                            None
+                        }
                     }
                     key::Event::Input(input::Event::Release { keymap_index: ki }) => {
                         if keymap_index == ki {
@@ -298,7 +341,9 @@ impl PendingKeyState {
                         if keymap_index == ki {
                             // TapHold: not interrupted; resolved as tap.
                             Some(TapHoldState::Tap)
-                        } else if Some(ki) == self.other_pressed_keymap_index {
+                        } else if Some(ki) == self.other_pressed_keymap_index
+                            && profile.allows_hold_trigger(ki)
+                        {
                             // TapHold: interrupted by key tap (press + release); resolved as hold.
                             Some(TapHoldState::Hold)
                         } else {
@@ -352,7 +397,7 @@ impl PendingKeyState {
         }
 
         // Resolve tap-hold state per the event.
-        self.hold_resolution(profile.interrupt_response, keymap_index, event)
+        self.hold_resolution(profile, keymap_index, event)
     }
 }
 
@@ -524,6 +569,7 @@ mod tests {
                 timeout,
                 interrupt_response,
                 required_idle_time,
+                hold_trigger_positions: None,
             },
             profiles: Slice::from_slice(&[]),
         }
@@ -1088,15 +1134,21 @@ mod tests {
 
     #[test]
     fn test_profile_zero_is_default_fields() {
+        // Assemble: non-default knobs only on default_profile.
         let config = Config {
             default_profile: Profile {
                 timeout: Some(50),
                 interrupt_response: InterruptResponse::HoldOnKeyPress,
                 required_idle_time: Some(10),
+                hold_trigger_positions: None,
             },
             profiles: Slice::from_slice(&[]),
         };
+
+        // Act
         let p = config.profile(0);
+
+        // Assert: profile 0 is default_profile by identity and field values.
         assert_eq!(p, config.default_profile);
         assert_eq!(p.timeout, Some(50));
         assert_eq!(p.interrupt_response, InterruptResponse::HoldOnKeyPress);
@@ -1105,34 +1157,201 @@ mod tests {
 
     #[test]
     fn test_profile_extra_lookup() {
+        // Assemble: one extra profile at index 1.
         let extra = Profile {
             timeout: Some(300),
             interrupt_response: InterruptResponse::HoldOnKeyTap,
             required_idle_time: None,
+            hold_trigger_positions: None,
         };
         let config = Config {
             default_profile: Profile {
                 timeout: Some(200),
                 interrupt_response: InterruptResponse::Ignore,
                 required_idle_time: None,
+                hold_trigger_positions: None,
             },
             profiles: Slice::from_slice(&[extra]),
         };
-        assert_eq!(config.profile(1).timeout, Some(300));
-        assert_eq!(
-            config.profile(1).interrupt_response,
-            InterruptResponse::HoldOnKeyTap
-        );
-        // OOR falls back to default
-        assert_eq!(config.profile(9).timeout, Some(200));
+
+        // Act / Assert: index 1 is the extra profile.
+        assert_eq!(config.profile(1), extra);
+    }
+
+    #[test]
+    fn test_profile_out_of_range_falls_back_to_default() {
+        // Assemble: only default_profile populated.
+        let config = Config {
+            default_profile: Profile {
+                timeout: Some(200),
+                interrupt_response: InterruptResponse::Ignore,
+                required_idle_time: None,
+                hold_trigger_positions: None,
+            },
+            profiles: Slice::from_slice(&[]),
+        };
+
+        // Act / Assert: unknown id uses default_profile.
         assert_eq!(config.profile(9), config.default_profile);
     }
 
     #[test]
-    fn test_key_default_profile_is_zero() {
+    fn test_key_new_uses_profile_zero() {
+        // Assemble / Act
         let key = Key::new(0u8, 1u8);
+
+        // Assert
         assert_eq!(key.profile, 0);
+    }
+
+    #[test]
+    fn test_key_with_profile_stores_index() {
+        // Assemble / Act
         let key = Key::with_profile(0u8, 1u8, 2);
+
+        // Assert
         assert_eq!(key.profile, 2);
+    }
+
+    // --- hold_trigger_positions ---
+
+    #[test]
+    fn allows_hold_trigger_when_unset_accepts_any_index() {
+        // Assemble: no hold_trigger_positions on the profile.
+        let profile = Profile::new();
+
+        // Act / Assert: any keymap index may force hold.
+        assert!(profile.allows_hold_trigger(0));
+        assert!(profile.allows_hold_trigger(99));
+    }
+
+    #[test]
+    fn allows_hold_trigger_when_set_accepts_trigger_position() {
+        // Assemble: hold trigger positions {2, 3}.
+        let profile = Profile {
+            hold_trigger_positions: Some(Slice::from_slice(&[2, 3])),
+            ..Profile::new()
+        };
+
+        // Act / Assert
+        assert!(profile.allows_hold_trigger(2));
+        assert!(profile.allows_hold_trigger(3));
+    }
+
+    #[test]
+    fn allows_hold_trigger_when_set_rejects_non_trigger_position() {
+        // Assemble: hold trigger positions {2, 3}.
+        let profile = Profile {
+            hold_trigger_positions: Some(Slice::from_slice(&[2, 3])),
+            ..Profile::new()
+        };
+
+        // Act / Assert
+        assert!(!profile.allows_hold_trigger(0));
+        assert!(!profile.allows_hold_trigger(1));
+    }
+
+    #[test]
+    fn hold_on_key_press_non_trigger_press_does_not_resolve() {
+        // Assemble: HoldOnKeyPress with hold trigger positions {2}; pending TH.
+        let ctx = context_with(Config {
+            default_profile: Profile {
+                timeout: Some(DEFAULT_TIMEOUT),
+                interrupt_response: InterruptResponse::HoldOnKeyPress,
+                required_idle_time: None,
+                hold_trigger_positions: Some(Slice::from_slice(&[2])),
+            },
+            profiles: Slice::from_slice(&[]),
+        });
+        let mut pks = PendingKeyState::new();
+
+        // Act: interrupt from a non-trigger position (OTHER_INDEX = 1).
+        let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, press(OTHER_INDEX));
+
+        // Assert: still pending (not forced to hold).
+        assert_eq!(None, resolution);
+    }
+
+    #[test]
+    fn hold_on_key_press_trigger_position_resolves_as_hold() {
+        // Assemble: HoldOnKeyPress with hold trigger positions {2}.
+        let ctx = context_with(Config {
+            default_profile: Profile {
+                timeout: Some(DEFAULT_TIMEOUT),
+                interrupt_response: InterruptResponse::HoldOnKeyPress,
+                required_idle_time: None,
+                hold_trigger_positions: Some(Slice::from_slice(&[2])),
+            },
+            profiles: Slice::from_slice(&[]),
+        });
+        let mut pks = PendingKeyState::new();
+
+        // Act: interrupt from trigger position 2.
+        let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, press(2));
+
+        // Assert: resolves as hold.
+        assert_eq!(Some(TapHoldState::Hold), resolution);
+    }
+
+    #[test]
+    fn hold_on_key_tap_non_trigger_tap_does_not_resolve() {
+        // Assemble: HoldOnKeyTap with hold trigger positions {2}; track non-trigger press.
+        let ctx = context_with(Config {
+            default_profile: Profile {
+                timeout: Some(DEFAULT_TIMEOUT),
+                interrupt_response: InterruptResponse::HoldOnKeyTap,
+                required_idle_time: None,
+                hold_trigger_positions: Some(Slice::from_slice(&[2])),
+            },
+            profiles: Slice::from_slice(&[]),
+        });
+        let mut pks = PendingKeyState::new();
+        let _ = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, press(OTHER_INDEX));
+
+        // Act: complete the non-trigger key's tap (release).
+        let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, release(OTHER_INDEX));
+
+        // Assert: tap of a non-trigger key does not force hold.
+        assert_eq!(None, resolution);
+    }
+
+    #[test]
+    fn profile_zero_includes_hold_trigger_positions() {
+        // Assemble: default_profile carries hold trigger positions.
+        let triggers = Slice::from_slice(&[2, 3]);
+        let config = Config {
+            default_profile: Profile {
+                timeout: Some(DEFAULT_TIMEOUT),
+                interrupt_response: InterruptResponse::HoldOnKeyPress,
+                required_idle_time: None,
+                hold_trigger_positions: Some(triggers),
+            },
+            profiles: Slice::from_slice(&[]),
+        };
+
+        // Act
+        let p = config.profile(0);
+
+        // Assert: profile 0 exposes the same hold trigger positions.
+        assert_eq!(p.hold_trigger_positions, Some(triggers));
+    }
+
+    #[test]
+    fn profile_extra_includes_hold_trigger_positions() {
+        // Assemble: extra profile (index 1) with its own hold trigger positions.
+        let triggers = Slice::from_slice(&[5]);
+        let extra = Profile {
+            timeout: Some(300),
+            interrupt_response: InterruptResponse::HoldOnKeyTap,
+            required_idle_time: None,
+            hold_trigger_positions: Some(triggers),
+        };
+        let config = Config {
+            default_profile: Profile::new(),
+            profiles: Slice::from_slice(&[extra]),
+        };
+
+        // Act / Assert
+        assert_eq!(config.profile(1).hold_trigger_positions, Some(triggers));
     }
 }

--- a/tests/rust/tap_hold.rs
+++ b/tests/rust/tap_hold.rs
@@ -1,5 +1,6 @@
 mod hold_on_interrupt_press;
 mod hold_on_interrupt_tap;
+mod hold_trigger_positions;
 mod interrupt_ignore;
 mod layered;
 mod no_timeout;

--- a/tests/rust/tap_hold/hold_trigger_positions.rs
+++ b/tests/rust/tap_hold/hold_trigger_positions.rs
@@ -1,0 +1,140 @@
+//! Positional hold triggers (ZMK-style opposite-hand trigger positions).
+//!
+//! Layout used by these fixtures (indices in `keys`):
+//! - 0: tap-hold (e.g. A / LeftCtrl) — the key under test
+//! - 1: "same hand" letter (B) — not a hold trigger position
+//! - 2: "opposite hand" letter (C) — hold trigger position
+
+use smart_keymap::input;
+use smart_keymap::keymap::ObservedKeymap;
+
+use crate::hid_keycodes::*;
+use smart_keymap_macros::keymap;
+
+/// Default profile: HoldOnKeyPress; only keymap index 2 is a hold trigger position.
+macro_rules! keymap_triggers_only_index_2 {
+    () => {
+        ObservedKeymap::new(keymap!(
+            r#"
+                let K = import "keys.ncl" in
+                {
+                    config.tap_hold = {
+                        interrupt_response = "HoldOnKeyPress",
+                        timeout = 200,
+                        hold_trigger_key_positions = [2],
+                    },
+                    keys = [
+                        K.A & K.hold K.LeftCtrl,
+                        K.B,
+                        K.C,
+                    ],
+                }
+            "#
+        ))
+    };
+}
+
+#[test]
+fn opposite_hand_press_resolves_hold() {
+    // Assemble: TH on index 0; only index 2 is a hold trigger position.
+    let mut keymap = keymap_triggers_only_index_2!();
+
+    // Act: press TH, then opposite-hand key (index 2).
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 2 });
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert: interrupt forced hold (LeftCtrl), then C down with mod.
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, KC_C, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, keymap.distinct_reports().reports());
+}
+
+#[test]
+fn same_hand_press_does_not_resolve_hold() {
+    // Assemble: TH on index 0; index 2 is a trigger position — index 1 is "same hand".
+    let mut keymap = keymap_triggers_only_index_2!();
+
+    // Act: press TH, same-hand B, release both (no timeout).
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert: TH resolved as tap (A), not hold; B is a normal press/release.
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, KC_B, 0, 0, 0, 0],
+        [0, 0, KC_B, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, keymap.distinct_reports().reports());
+}
+
+#[test]
+fn timeout_still_resolves_hold_with_positional_triggers() {
+    // Assemble: hold trigger positions set, but we never press a trigger key.
+    let mut keymap = keymap_triggers_only_index_2!();
+
+    // Act: press TH alone and wait past timeout.
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    for _ in 0..250 {
+        keymap.tick();
+    }
+
+    // Assert: timeout still resolves as hold regardless of hold trigger positions.
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, keymap.distinct_reports().reports());
+}
+
+#[test]
+fn named_profile_trigger_position_resolves_hold() {
+    // Assemble: default profile ignores interrupts; named profile has hold trigger positions.
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.tap_hold = {
+                    interrupt_response = "Ignore",
+                    timeout = 200,
+                    profiles = {
+                        opposite = {
+                            interrupt_response = "HoldOnKeyPress",
+                            hold_trigger_key_positions = [2],
+                        },
+                    },
+                },
+                keys = [
+                    K.A & K.hold K.LeftCtrl & K.tap_hold_profile "opposite",
+                    K.B,
+                    K.C,
+                ],
+            }
+        "#
+    ));
+
+    // Act: press named-profile TH (index 0), then trigger position (index 2).
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 2 });
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert: named profile's hold trigger positions forced hold.
+    #[rustfmt::skip]
+    let expected: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, KC_C, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected, keymap.distinct_reports().reports());
+}


### PR DESCRIPTION
## Summary

Adds optional `hold_trigger_key_positions` so only listed keymap indices may force interrupt-as-hold (ZMK positional hold-tap). The list lives on **Profile** (including profile 0 via flat `config.tap_hold` → `default_profile` from #689), not on every `Key`.

Representation is a short `Option<Slice<u16, MAX_HOLD_TRIGGER_POSITIONS>>` (bound 16) — sparse opposite-hand lists, not a dense board bitmask.

- `MAX_HOLD_TRIGGER_POSITIONS` + linear membership check
- Nickel authoring on flat `config.tap_hold` and named profile records
- Unit, integration, and cucumber feature coverage

### Authoring

```nickel
config.tap_hold = {
  interrupt_response = "HoldOnKeyPress",
  hold_trigger_key_positions = [2],  # → default_profile
  profiles = {
    opposite = {
      interrupt_response = "HoldOnKeyPress",
      hold_trigger_key_positions = [2, 3],
    },
  },
},
keys = [
  K.A & K.hold K.LeftCtrl,
  K.C & K.hold K.LeftShift & K.tap_hold_profile "opposite",
]
```

## Stack

1. #689 — Config.default_profile (**merged**)
2. **This PR** — hold_trigger_positions on Profile
3. #681 / #682 — retro_tap / quick_tap on Profile

## Test plan

- [x] `cargo test -p smart-keymap-core --lib key::tap_hold`
- [x] `cargo test --test rust-integration tap_hold::hold_trigger`
- [x] `just ncl::checks`
- [ ] CI green