### PR TITLE
tap_hold: add quick_tap_ms with recent-press ring

### DIFF
--- a/features/keymap/key/tap_hold-config-quick_tap.feature
+++ b/features/keymap/key/tap_hold-config-quick_tap.feature
@@ -1,0 +1,71 @@
+Feature: TapHold Key (configure quick_tap_ms)
+
+  The `quick_tap_ms` config for tap hold keys means that
+   re-pressing a tap-hold key within the window of its previous press
+   immediately resolves as tap.
+
+  This is useful for hold-to-repeat on the tap behaviour
+   (e.g. backspace) without waiting for the hold timeout.
+
+  Unlike `required_idle_time` (any recent activity forces tap),
+   `quick_tap_ms` only considers re-presses of the same keymap index.
+
+  For examples of this key in other smart keyboard firmware, see e.g.:
+
+  - [QMK's tap-hold, Quick Tap Term](https://docs.qmk.fm/tap_hold#quick-tap-term)
+
+  - [ZMK's hold-tap, quick-tap-ms](https://zmk.dev/docs/keymaps/behaviors/hold-tap#quick-tap-ms)
+
+  - [FAK's complex hold-tap behaviors, Quick tap](https://github.com/semickolon/fak?tab=readme-ov-file#complex-hold-tap-behaviors)
+
+  Background:
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        config.tap_hold.quick_tap_ms = 175,
+        config.tap_hold.timeout = 200,
+        keys = [
+          K.A & K.hold K.LeftCtrl,
+        ]
+      }
+      """
+
+  Example: re-press within quick_tap_ms forces tap even when held
+
+    When the keymap registers the following input
+      """
+      [
+        tap (K.A & K.hold K.LeftCtrl),
+        wait 50,
+        press (K.A & K.hold K.LeftCtrl),
+        wait 250,
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        tap (K.A),
+        press (K.A),
+      ]
+      """
+
+  Example: re-press after quick_tap_ms allows hold
+
+    When the keymap registers the following input
+      """
+      [
+        tap (K.A & K.hold K.LeftCtrl),
+        wait 200,
+        press (K.A & K.hold K.LeftCtrl),
+        wait 250,
+      ]
+      """
+    Then the output should be equivalent to output from
+      """
+      [
+        tap (K.A),
+        press (K.LeftCtrl),
+      ]
+      """

--- a/features/scripts/generate-doc.sh
+++ b/features/scripts/generate-doc.sh
@@ -39,6 +39,7 @@ keymap_key_features=(
     "tap_hold-config-interrupt-ignore"
     "tap_hold-config-interrupt-presses"
     "tap_hold-config-interrupt-tap"
+    "tap_hold-config-quick_tap"
     "tap_hold-config-required_idle_time"
     "tap_hold-config-timeout"
     "tap_hold-config-timeout-none"

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -670,6 +670,12 @@
             else
               {}
           )
+          & (
+            if std.record.has_field "quick_tap_ms" th_config then
+              { quick_tap_ms = th_config.quick_tap_ms }
+            else
+              {}
+          )
         in
         let profiles_array =
           th_profile_names

--- a/ncl/smart_keys/tap_hold/keymap-codegen.ncl
+++ b/ncl/smart_keys/tap_hold/keymap-codegen.ncl
@@ -69,6 +69,24 @@
           }"%,
           },
         },
+
+      check_profile_with_quick_tap_ms =
+        let rust_expr =
+          smart_keymap.tap_hold.profile_rust_expr {
+            interrupt_response = "HoldOnKeyPress",
+            quick_tap_ms = 175,
+          }
+        in
+        {
+          check_rust_expr = {
+            actual = rust_expr,
+            expected = m%"smart_keymap::key::tap_hold::Profile {
+            interrupt_response: smart_keymap::key::tap_hold::InterruptResponse::HoldOnKeyPress,
+            quick_tap_ms: Some(175),
+            ..smart_keymap::key::tap_hold::Profile::new()
+          }"%,
+          },
+        },
     },
   },
 
@@ -127,6 +145,14 @@
           if std.record.has_field "hold_trigger_key_positions" c then
             {
               hold_trigger_positions = hold_trigger_positions_expr c.hold_trigger_key_positions,
+            }
+          else
+            {}
+        )
+        & (
+          if std.record.has_field "quick_tap_ms" c then
+            {
+              quick_tap_ms = "Some(%{std.to_string c.quick_tap_ms})",
             }
           else
             {}
@@ -270,6 +296,7 @@
           interrupt_response | optional | TapHoldInterruptResponseJson,
           required_idle_time | optional | Number,
           hold_trigger_key_positions | optional | Array Number,
+          quick_tap_ms | optional | Number,
         },
 
         # Lowered JSON form: nested default_profile + profiles array.

--- a/ncl/smart_keys/tap_hold/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/tap_hold/keymap-ncl-to-json.ncl
@@ -78,6 +78,8 @@
         required_idle_time | optional | Number,
         # Only listed keymap indices may force interrupt-as-hold; unset = unrestricted.
         hold_trigger_key_positions | optional | Array Number,
+        # Re-press of same key within this many ms forces tap (ZMK quick-tap-ms).
+        quick_tap_ms | optional | Number,
       },
 
       # Authoring keeps default-profile knobs flat on config.tap_hold;
@@ -95,6 +97,8 @@
         required_idle_time | optional | Number,
         # Only listed keymap indices may force interrupt-as-hold; unset = unrestricted.
         hold_trigger_key_positions | optional | Array Number,
+        # Re-press of same key within this many ms forces tap (ZMK quick-tap-ms).
+        quick_tap_ms | optional | Number,
         # Authoring: name → profile record. Lowered to a JSON array (indices 1..).
         profiles | optional | { _ | Profile },
       },

--- a/smart-keymap-core/src/key/tap_hold.rs
+++ b/smart-keymap-core/src/key/tap_hold.rs
@@ -25,7 +25,7 @@ pub const MAX_EXTRA_PROFILES: usize = 7;
 ///  not a dense mask of every key on the board.
 pub const MAX_HOLD_TRIGGER_POSITIONS: usize = 16;
 
-/// One tap-hold behavior profile (timeout, interrupt flavor, idle gate, hold triggers).
+/// One tap-hold behavior profile (timeout, interrupt flavor, idle gate, hold triggers, quick-tap).
 ///
 /// Profile 0 is [`Config::default_profile`];
 ///  extra profiles live in [`Config::profiles`]
@@ -60,6 +60,17 @@ pub struct Profile {
     /// Length is bounded by [`MAX_HOLD_TRIGGER_POSITIONS`].
     #[serde(default, rename = "hold_trigger_key_positions")]
     pub hold_trigger_positions: Option<Slice<u16, MAX_HOLD_TRIGGER_POSITIONS>>,
+
+    /// If this tap-hold key is pressed again within this many milliseconds of its
+    /// previous press (ZMK `quick-tap-ms`), immediately resolve as tap.
+    ///
+    /// Useful for hold-to-repeat on the tap letter (e.g. backspace) without
+    /// waiting for the hold timeout. `None` disables (default).
+    ///
+    /// Unlike [`Self::required_idle_time`] (any recent activity), this is
+    /// scoped to re-presses of the same keymap index.
+    #[serde(default)]
+    pub quick_tap_ms: Option<u16>,
 }
 
 impl Profile {
@@ -193,6 +204,7 @@ pub const DEFAULT_PROFILE: Profile = Profile {
     interrupt_response: DEFAULT_INTERRUPT_RESPONSE,
     required_idle_time: None,
     hold_trigger_positions: None,
+    quick_tap_ms: None,
 };
 
 /// Default tap hold config.
@@ -239,6 +251,9 @@ impl Default for Config {
 pub struct Context {
     config: Config,
     idle_time_ms: u32,
+    time_ms: u32,
+    recent_presses: [(u16, u32); keymap::MAX_RECENT_PRESSES],
+    recent_press_count: u8,
 }
 
 impl Context {
@@ -247,6 +262,9 @@ impl Context {
         Context {
             config,
             idle_time_ms: 0,
+            time_ms: 0,
+            recent_presses: [(0, 0); keymap::MAX_RECENT_PRESSES],
+            recent_press_count: 0,
         }
     }
 
@@ -258,14 +276,41 @@ impl Context {
     /// Updates the context with the given keymap context.
     pub fn update_keymap_context(
         &mut self,
-        keymap::KeymapContext { idle_time_ms, .. }: &keymap::KeymapContext,
+        keymap::KeymapContext {
+            idle_time_ms,
+            time_ms,
+            recent_presses,
+            recent_press_count,
+            ..
+        }: &keymap::KeymapContext,
     ) {
         self.idle_time_ms = *idle_time_ms;
+        self.time_ms = *time_ms;
+        self.recent_presses = *recent_presses;
+        self.recent_press_count = *recent_press_count;
     }
 
     /// Returns the resolved [Profile] for `profile_id`.
     pub const fn profile(&self, profile_id: u8) -> Profile {
         self.config.profile(profile_id)
+    }
+
+    fn last_press_time_ms(&self, keymap_index: u16) -> Option<u32> {
+        self.recent_presses[..self.recent_press_count as usize]
+            .iter()
+            .rev()
+            .find(|(ki, _)| *ki == keymap_index)
+            .map(|(_, t)| *t)
+    }
+
+    /// Whether a re-press of `keymap_index` falls within the profile's `quick_tap_ms`.
+    fn is_quick_tap(&self, profile: &Profile, keymap_index: u16) -> bool {
+        profile
+            .quick_tap_ms
+            .zip(self.last_press_time_ms(keymap_index))
+            .is_some_and(|(quick_tap_ms, last_t)| {
+                self.time_ms.saturating_sub(last_t) < quick_tap_ms as u32
+            })
     }
 }
 
@@ -434,6 +479,25 @@ impl<R, Keys: Index<usize, Output = Key<R>>> System<R, Keys> {
         });
         (pending, scheduled)
     }
+
+    fn resolve_as_tap(
+        &self,
+        key_index: u8,
+    ) -> (
+        key::PressedKeyResult<R, PendingKeyState, KeyState>,
+        key::KeyEvents<Event>,
+    )
+    where
+        R: Copy,
+    {
+        let Key {
+            tap: tap_key_ref, ..
+        } = self.keys[key_index as usize];
+        (
+            key::PressedKeyResult::NewPressedKey(key::NewPressedKey::key(tap_key_ref)),
+            key::KeyEvents::no_events(),
+        )
+    }
 }
 
 impl<R: Copy + Debug, Keys: Debug + Index<usize, Output = Key<R>>> key::System<R>
@@ -457,6 +521,11 @@ impl<R: Copy + Debug, Keys: Debug + Index<usize, Output = Key<R>>> key::System<R
         let key_def = &self.keys[key_index as usize];
         let profile = context.profile(key_def.profile);
 
+        // ZMK quick-tap: re-press within window of prior press → force tap.
+        if context.is_quick_tap(&profile, keymap_index) {
+            return self.resolve_as_tap(key_index);
+        }
+
         match profile.required_idle_time {
             Some(required_idle_time) => {
                 if context.idle_time_ms >= required_idle_time as u32 {
@@ -473,13 +542,7 @@ impl<R: Copy + Debug, Keys: Debug + Index<usize, Output = Key<R>>> key::System<R
                 } else {
                     // Keymap has not been idle for long enough;
                     // immediately resolve as tap.
-                    let Key {
-                        tap: tap_key_ref, ..
-                    } = *key_def;
-                    (
-                        key::PressedKeyResult::NewPressedKey(key::NewPressedKey::key(tap_key_ref)),
-                        key::KeyEvents::no_events(),
-                    )
+                    self.resolve_as_tap(key_index)
                 }
             }
             None => {
@@ -573,6 +636,7 @@ mod tests {
                 interrupt_response,
                 required_idle_time,
                 hold_trigger_positions: None,
+                quick_tap_ms: None,
             },
             profiles: Slice::from_slice(&[]),
         }
@@ -1144,6 +1208,7 @@ mod tests {
                 interrupt_response: InterruptResponse::HoldOnKeyPress,
                 required_idle_time: Some(10),
                 hold_trigger_positions: None,
+                quick_tap_ms: None,
             },
             profiles: Slice::from_slice(&[]),
         };
@@ -1166,6 +1231,7 @@ mod tests {
             interrupt_response: InterruptResponse::HoldOnKeyTap,
             required_idle_time: None,
             hold_trigger_positions: None,
+            quick_tap_ms: None,
         };
         let config = Config {
             default_profile: Profile {
@@ -1173,6 +1239,7 @@ mod tests {
                 interrupt_response: InterruptResponse::Ignore,
                 required_idle_time: None,
                 hold_trigger_positions: None,
+                quick_tap_ms: None,
             },
             profiles: Slice::from_slice(&[extra]),
         };
@@ -1190,6 +1257,7 @@ mod tests {
                 interrupt_response: InterruptResponse::Ignore,
                 required_idle_time: None,
                 hold_trigger_positions: None,
+                quick_tap_ms: None,
             },
             profiles: Slice::from_slice(&[]),
         };
@@ -1263,6 +1331,7 @@ mod tests {
                 interrupt_response: InterruptResponse::HoldOnKeyPress,
                 required_idle_time: None,
                 hold_trigger_positions: Some(Slice::from_slice(&[2])),
+                quick_tap_ms: None,
             },
             profiles: Slice::from_slice(&[]),
         });
@@ -1284,6 +1353,7 @@ mod tests {
                 interrupt_response: InterruptResponse::HoldOnKeyPress,
                 required_idle_time: None,
                 hold_trigger_positions: Some(Slice::from_slice(&[2])),
+                quick_tap_ms: None,
             },
             profiles: Slice::from_slice(&[]),
         });
@@ -1305,6 +1375,7 @@ mod tests {
                 interrupt_response: InterruptResponse::HoldOnKeyTap,
                 required_idle_time: None,
                 hold_trigger_positions: Some(Slice::from_slice(&[2])),
+                quick_tap_ms: None,
             },
             profiles: Slice::from_slice(&[]),
         });
@@ -1328,6 +1399,7 @@ mod tests {
                 interrupt_response: InterruptResponse::HoldOnKeyPress,
                 required_idle_time: None,
                 hold_trigger_positions: Some(triggers),
+                quick_tap_ms: None,
             },
             profiles: Slice::from_slice(&[]),
         };
@@ -1348,6 +1420,7 @@ mod tests {
             interrupt_response: InterruptResponse::HoldOnKeyTap,
             required_idle_time: None,
             hold_trigger_positions: Some(triggers),
+            quick_tap_ms: None,
         };
         let config = Config {
             default_profile: Profile::new(),
@@ -1356,5 +1429,153 @@ mod tests {
 
         // Act / Assert
         assert_eq!(config.profile(1).hold_trigger_positions, Some(triggers));
+    }
+
+    // --- quick_tap_ms ---
+
+    #[test]
+    fn is_quick_tap_when_repress_within_window() {
+        // Assemble: profile with quick_tap_ms; prior press of same index recorded.
+        let mut ctx = context_with(Config {
+            default_profile: Profile {
+                quick_tap_ms: Some(175),
+                ..Profile::new()
+            },
+            profiles: Slice::from_slice(&[]),
+        });
+        ctx.update_keymap_context(&KeymapContext {
+            time_ms: 100,
+            idle_time_ms: 50,
+            pressed_modifiers: key::KeyboardModifiers::NONE,
+            recent_presses: {
+                let mut presses = [(0, 0); keymap::MAX_RECENT_PRESSES];
+                presses[0] = (KEYMAP_INDEX, 50);
+                presses
+            },
+            recent_press_count: 1,
+        });
+
+        // Act / Assert: 50ms since last press of KEYMAP_INDEX < 175.
+        assert!(ctx.is_quick_tap(&ctx.profile(0), KEYMAP_INDEX));
+    }
+
+    #[test]
+    fn is_quick_tap_false_after_window() {
+        // Assemble: prior press outside quick_tap_ms window.
+        let mut ctx = context_with(Config {
+            default_profile: Profile {
+                quick_tap_ms: Some(100),
+                ..Profile::new()
+            },
+            profiles: Slice::from_slice(&[]),
+        });
+        ctx.update_keymap_context(&KeymapContext {
+            time_ms: 200,
+            idle_time_ms: 150,
+            pressed_modifiers: key::KeyboardModifiers::NONE,
+            recent_presses: {
+                let mut presses = [(0, 0); keymap::MAX_RECENT_PRESSES];
+                presses[0] = (KEYMAP_INDEX, 50);
+                presses
+            },
+            recent_press_count: 1,
+        });
+
+        // Act / Assert: 150ms since last press >= 100.
+        assert!(!ctx.is_quick_tap(&ctx.profile(0), KEYMAP_INDEX));
+    }
+
+    #[test]
+    fn is_quick_tap_false_for_other_keymap_index() {
+        // Assemble: recent press is a different index.
+        let mut ctx = context_with(Config {
+            default_profile: Profile {
+                quick_tap_ms: Some(175),
+                ..Profile::new()
+            },
+            profiles: Slice::from_slice(&[]),
+        });
+        ctx.update_keymap_context(&KeymapContext {
+            time_ms: 100,
+            idle_time_ms: 50,
+            pressed_modifiers: key::KeyboardModifiers::NONE,
+            recent_presses: {
+                let mut presses = [(0, 0); keymap::MAX_RECENT_PRESSES];
+                presses[0] = (OTHER_INDEX, 50);
+                presses
+            },
+            recent_press_count: 1,
+        });
+
+        // Act / Assert: no prior press of KEYMAP_INDEX in the ring.
+        assert!(!ctx.is_quick_tap(&ctx.profile(0), KEYMAP_INDEX));
+    }
+
+    #[test]
+    fn is_quick_tap_disabled_when_unset() {
+        // Assemble: default profile has quick_tap_ms = None.
+        let mut ctx = default_context();
+        ctx.update_keymap_context(&KeymapContext {
+            time_ms: 100,
+            idle_time_ms: 50,
+            pressed_modifiers: key::KeyboardModifiers::NONE,
+            recent_presses: {
+                let mut presses = [(0, 0); keymap::MAX_RECENT_PRESSES];
+                presses[0] = (KEYMAP_INDEX, 50);
+                presses
+            },
+            recent_press_count: 1,
+        });
+
+        // Act / Assert
+        assert!(!ctx.is_quick_tap(&ctx.profile(0), KEYMAP_INDEX));
+    }
+
+    #[test]
+    fn new_pressed_key_quick_tap_resolves_as_tap() {
+        // Assemble: quick_tap_ms set; same index pressed recently.
+        let mut ctx = context_with(Config {
+            default_profile: Profile {
+                quick_tap_ms: Some(175),
+                ..Profile::new()
+            },
+            profiles: Slice::from_slice(&[]),
+        });
+        ctx.update_keymap_context(&KeymapContext {
+            time_ms: 100,
+            idle_time_ms: 999,
+            pressed_modifiers: key::KeyboardModifiers::NONE,
+            recent_presses: {
+                let mut presses = [(0, 0); keymap::MAX_RECENT_PRESSES];
+                presses[0] = (KEYMAP_INDEX, 50);
+                presses
+            },
+            recent_press_count: 1,
+        });
+        let sys = system();
+
+        // Act
+        let (pkr, _) = sys.new_pressed_key(KEYMAP_INDEX, &ctx, Ref(0));
+
+        // Assert: immediate tap (not pending), even though idle is long.
+        assert!(matches!(
+            pkr,
+            key::PressedKeyResult::NewPressedKey(key::NewPressedKey::Key(TAP))
+        ));
+    }
+
+    #[test]
+    fn profile_zero_includes_quick_tap_ms() {
+        // Assemble
+        let config = Config {
+            default_profile: Profile {
+                quick_tap_ms: Some(175),
+                ..Profile::new()
+            },
+            profiles: Slice::from_slice(&[]),
+        };
+
+        // Act / Assert
+        assert_eq!(config.profile(0).quick_tap_ms, Some(175));
     }
 }

--- a/smart-keymap-core/src/keymap.rs
+++ b/smart-keymap-core/src/keymap.rs
@@ -167,6 +167,9 @@ pub enum KeymapCallback {
     Custom(u8, u8),
 }
 
+/// Max recent physical presses tracked in [KeymapContext] (for quick-tap, etc.).
+pub const MAX_RECENT_PRESSES: usize = 8;
+
 /// Context provided from the keymap to the smart keys.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct KeymapContext {
@@ -181,6 +184,14 @@ pub struct KeymapContext {
     /// Updated by the keymap before press handling and on tick
     ///  so families can branch without maintaining their own mod-tracking.
     pub pressed_modifiers: key::KeyboardModifiers,
+
+    /// Recent physical presses as `(keymap_index, time_ms)`, oldest first.
+    ///
+    /// Used by features such as tap-hold `quick_tap_ms` (ZMK-style re-tap).
+    pub recent_presses: [(u16, u32); MAX_RECENT_PRESSES],
+
+    /// Number of valid entries in [Self::recent_presses].
+    pub recent_press_count: u8,
 }
 
 impl KeymapContext {
@@ -190,7 +201,18 @@ impl KeymapContext {
             time_ms: 0,
             idle_time_ms: 0,
             pressed_modifiers: key::KeyboardModifiers::NONE,
+            recent_presses: [(0, 0); MAX_RECENT_PRESSES],
+            recent_press_count: 0,
         }
+    }
+
+    /// Most recent press time for `keymap_index`, if still in the ring.
+    pub fn last_press_time_ms(&self, keymap_index: u16) -> Option<u32> {
+        self.recent_presses[..self.recent_press_count as usize]
+            .iter()
+            .rev()
+            .find(|(ki, _)| *ki == keymap_index)
+            .map(|(_, t)| *t)
     }
 }
 
@@ -243,6 +265,9 @@ pub struct Keymap<I: Index<usize, Output = R>, R, Ctx, Ev: Debug, PKS, KS, S> {
     event_scheduler: EventScheduler<Ev>,
     ms_per_tick: u8,
     idle_time: u32,
+    /// Ring of recent physical presses for [KeymapContext::recent_presses].
+    recent_presses: [(u16, u32); MAX_RECENT_PRESSES],
+    recent_press_count: u8,
     hid_reporter: HIDKeyboardReporter,
     pending_state: Option<pending::PendingState<R, Ev, PKS>>,
     input_queue: InputEventQueue<{ MAX_QUEUED_INPUT_EVENTS }>,
@@ -293,6 +318,8 @@ impl<
             event_scheduler: EventScheduler::new(),
             ms_per_tick: 1,
             idle_time: 0,
+            recent_presses: [(0, 0); MAX_RECENT_PRESSES],
+            recent_press_count: 0,
             hid_reporter: HIDKeyboardReporter::new(),
             pending_state: None,
             input_queue: InputEventQueue::new(),
@@ -314,6 +341,31 @@ impl<
         self.input_queue.clear();
         self.ms_per_tick = 1;
         self.idle_time = 0;
+        self.recent_presses = [(0, 0); MAX_RECENT_PRESSES];
+        self.recent_press_count = 0;
+    }
+
+    /// Record a physical press in the recent-press ring (for quick-tap, etc.).
+    fn record_recent_press(&mut self, keymap_index: u16) {
+        let time_ms = self.event_scheduler.schedule_counter;
+        // Drop any prior entry for this index so a re-press updates the time.
+        let mut write = 0usize;
+        let count = self.recent_press_count as usize;
+        for read in 0..count {
+            if self.recent_presses[read].0 != keymap_index {
+                self.recent_presses[write] = self.recent_presses[read];
+                write += 1;
+            }
+        }
+        if write == MAX_RECENT_PRESSES {
+            // Evict oldest.
+            for i in 0..(MAX_RECENT_PRESSES - 1) {
+                self.recent_presses[i] = self.recent_presses[i + 1];
+            }
+            write = MAX_RECENT_PRESSES - 1;
+        }
+        self.recent_presses[write] = (keymap_index, time_ms);
+        self.recent_press_count = (write + 1) as u8;
     }
 
     /// Clears all registered callbacks.
@@ -425,7 +477,7 @@ impl<
         if let Some(ie) = ready {
             // Process before clearing idle_time
             //  so families that snapshot KeymapContext
-            //  (required_idle_time, pressed_modifiers)
+            //  (required_idle_time, pressed_modifiers, recent presses)
             //  still see idle accumulated since the previous input.
             self.process_input(ie);
             self.set_active_input_delay();
@@ -554,7 +606,7 @@ impl<
                 input::Event::Press { keymap_index }
                     if !self.has_pressed_input_with_keymap_index(keymap_index) =>
                 {
-                    // Snapshot held mods (incl. sticky/caps_word VKs) before branching.
+                    // Snapshot held mods / recent presses before branching.
                     self.push_keymap_context();
 
                     let mut maybe_key_ref = Some(self.key_refs[keymap_index as usize]);
@@ -618,6 +670,9 @@ impl<
                             }
                         }
                     }
+
+                    // Record after press handling so quick-tap sees the *prior* press.
+                    self.record_recent_press(keymap_index);
                 }
                 input::Event::Release { keymap_index } => {
                     self.pressed_inputs
@@ -737,6 +792,8 @@ impl<
             time_ms: self.event_scheduler.schedule_counter,
             idle_time_ms: self.idle_time,
             pressed_modifiers: self.aggregate_pressed_modifiers(),
+            recent_presses: self.recent_presses,
+            recent_press_count: self.recent_press_count,
         };
         self.context.set_keymap_context(km_context);
     }

--- a/tests/rust/tap_hold.rs
+++ b/tests/rust/tap_hold.rs
@@ -5,6 +5,7 @@ mod interrupt_ignore;
 mod layered;
 mod no_timeout;
 mod profiles;
+mod quick_tap;
 mod required_idle_time;
 
 use smart_keymap::input;

--- a/tests/rust/tap_hold/quick_tap.rs
+++ b/tests/rust/tap_hold/quick_tap.rs
@@ -1,0 +1,87 @@
+use smart_keymap::input;
+use smart_keymap::keymap::ObservedKeymap;
+
+use crate::hid_keycodes::*;
+use smart_keymap_macros::keymap;
+
+#[test]
+fn re_press_within_quick_tap_ms_forces_tap() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.tap_hold.quick_tap_ms = 175,
+                config.tap_hold.timeout = 200,
+                keys = [
+                    K.A & K.hold K.LeftCtrl,
+                ],
+            }
+        "#
+    ));
+
+    // Act — first tap
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+
+    // Re-press soon after first press and hold past timeout
+    for _ in 0..50 {
+        keymap.tick();
+    }
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    for _ in 0..250 {
+        keymap.tick();
+    }
+
+    // Assert — second press stays tap (not hold) despite long hold
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn re_press_after_quick_tap_ms_allows_hold() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.tap_hold.quick_tap_ms = 100,
+                config.tap_hold.timeout = 200,
+                keys = [
+                    K.A & K.hold K.LeftCtrl,
+                ],
+            }
+        "#
+    ));
+
+    // Act — first tap
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+
+    // Wait past quick_tap window, then hold
+    for _ in 0..150 {
+        keymap.tick();
+    }
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    for _ in 0..250 {
+        keymap.tick();
+    }
+
+    // Assert — second press resolves as hold after timeout
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}


### PR DESCRIPTION
## Summary

If a tap-hold key is re-pressed within `quick_tap_ms` of its prior press, immediately resolve as tap (ZMK `quick-tap-ms`). Backed by a keymap recent-press ring recorded after press handling so re-tap sees the prior press.

Reimplemented on current master after tap-hold profiles and `hold_trigger_positions` landed. The knob lives on **`Profile.quick_tap_ms`**, with flat authoring still available as `config.tap_hold.quick_tap_ms` (lowered into `default_profile`).

Unlike `required_idle_time` (FAK “Global quick tap” / ZMK `require-prior-idle-ms` — any recent activity forces tap), `quick_tap_ms` only considers re-presses of the **same keymap index**. That enables hold-to-repeat on the tap behaviour (e.g. backspace) without waiting for the hold timeout, while still allowing hold soon after other keys when `required_idle_time` is unset.

- `Profile.quick_tap_ms` + force-tap path in `new_pressed_key`
- `Keymap` / `KeymapContext` recent-press ring
- Nickel authoring / lowering / codegen wiring
- Unit tests, Rust integration tests, cucumber feature

## Supersedes

Supersedes #682 (old stacked PR on `feat/tap-hold-retro-tap`; rebased history could not retarget that stack).

Prior stack status:

1. ~~hold_trigger_positions~~ — merged via #691
2. ~~retro_tap~~ — closed as redundant (`timeout = null` + interrupt) in #681
3. **This PR** — quick_tap_ms

## Test plan

- [x] `cargo test -p smart-keymap-core --lib key::tap_hold`
- [x] `cargo test --test rust-integration quick_tap`
- [x] `just ncl::checks`
- [x] `just check-quick` (fmt / clippy / doc)
- [ ] CI green

## Notes

- QMK `QUICK_TAP_TERM` is release→repress; this matches ZMK press→press
- `required_idle_time` remains the right tool for “global” force-tap while typing quickly