### PR TITLE
fix: watch custom keymap source in codegen_rust_module

### DIFF
--- a/smart-keymap-nickel-helper/src/lib.rs
+++ b/smart-keymap-nickel-helper/src/lib.rs
@@ -518,6 +518,10 @@ pub fn nickel_composite_full_vec_rs(ncl_import_path: &str) -> NickelResult {
 }
 
 /// Generates the code for the given module.
+///
+/// Cargo invalidation edges are:
+/// - the env value path itself (`SMART_KEYMAP_CUSTOM_KEYMAP` / board env)
+/// - for `.ncl` inputs, the Nickel import tree used by codegen
 pub fn codegen_rust_module(
     CodegenInputs {
         env_var,
@@ -533,13 +537,19 @@ pub fn codegen_rust_module(
     if let Some(custom_module_path) = env::var(env_var).ok().filter(|s| !s.is_empty()) {
         let out_dir = env::var("OUT_DIR").unwrap();
         let dest_path = Path::new(&out_dir).join(module_basename);
-        println!("cargo:rerun-if-changed={}", dest_path.to_str().unwrap());
+
+        // Input edges — source path (and ncl tree for Nickel eval), not OUT_DIR.
+        println!("cargo:rerun-if-changed={}", custom_module_path);
+        if custom_module_path.ends_with(".ncl") {
+            // Coarse: codegen pulls keymap-codegen.ncl, smart_keys, etc.
+            println!("cargo:rerun-if-changed={}", ncl_import_path);
+        }
 
         if custom_module_path.ends_with(".rs") {
             println!("cargo:rustc-cfg={}", cfg_name);
 
             // Copy the custom module file to the output directory
-            fs::copy(custom_module_path, &dest_path).unwrap();
+            fs::copy(&custom_module_path, &dest_path).unwrap();
         } else if custom_module_path.ends_with(".ncl") {
             println!("cargo:rustc-cfg={}", cfg_name);
 


### PR DESCRIPTION
## Summary

- `codegen_rust_module` was emitting `cargo:rerun-if-changed` for the **generated** `$OUT_DIR/keymap.rs` (or `board.rs`), not the source path from `SMART_KEYMAP_CUSTOM_KEYMAP` / board env vars.
- That meant editing a custom `.ncl` with an unchanged env value could leave `smart-keymap` Fresh and install a stale `libsmart_keymap.a`.
- Fix: watch the source path; for `.ncl` also watch the Nickel import tree; stop treating OUT_DIR outputs as inputs.

Affects root `build.rs` and board firmware build scripts that share the helper (`rp2040` / `stm32f4` / `stm32-embassy`).

## Test plan

- [x] `SMART_KEYMAP_CUSTOM_KEYMAP=<path/to/keymap.ncl> cargo build -p smart-keymap -v` — build-script output lists the source `.ncl` and `ncl/`, not `$OUT_DIR/...`
- [x] Rebuild without edits → Fresh
- [x] `touch` the custom `.ncl` then rebuild → Dirty with reason citing that `.ncl` path
- [ ] CI green