### PR TITLE
fix: watch relative Nickel imports of custom keymaps

### DIFF
--- a/smart-keymap-nickel-helper/src/lib.rs
+++ b/smart-keymap-nickel-helper/src/lib.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs;
 use std::io::{self, Read, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
 use std::sync::{Mutex, OnceLock};
 use std::thread;
@@ -517,11 +517,97 @@ pub fn nickel_composite_full_vec_rs(ncl_import_path: &str) -> NickelResult {
     )
 }
 
+/// Quoted paths from static `import "…"` / `import '…'` forms in Nickel source.
+///
+/// Dynamic or computed import expressions are ignored. Identifier-adjacent
+/// matches (`imported`, `reimport`) are skipped.
+pub fn ncl_static_import_paths(src: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    let mut search_from = 0;
+    while let Some(rel) = src[search_from..].find("import") {
+        let start = search_from + rel;
+        let after_kw = start + "import".len();
+        let after = &src[after_kw..];
+        let ident_cont = |c: char| c.is_ascii_alphanumeric() || c == '_';
+        let preceded_by_ident = src[..start].chars().next_back().is_some_and(ident_cont);
+        if preceded_by_ident || after.chars().next().is_some_and(ident_cont) {
+            search_from = after_kw;
+            continue;
+        }
+        let ws = after.len() - after.trim_start().len();
+        let trimmed_at = after_kw + ws;
+        let trimmed = &src[trimmed_at..];
+        let Some(quote) = trimmed.chars().next().filter(|c| *c == '"' || *c == '\'') else {
+            search_from = after_kw;
+            continue;
+        };
+        let inner_at = trimmed_at + quote.len_utf8();
+        let inner = &src[inner_at..];
+        match inner.find(quote) {
+            Some(end) => {
+                out.push(&src[inner_at..inner_at + end]);
+                search_from = inner_at + end + quote.len_utf8();
+            }
+            None => break,
+        }
+    }
+    out
+}
+
+fn resolve_relative_ncl_import(importer_dir: &Path, import: &str) -> Option<PathBuf> {
+    let candidate = importer_dir.join(import);
+    if candidate.is_file() {
+        return Some(candidate);
+    }
+    if !import.ends_with(".ncl") {
+        let with_ext = importer_dir.join(format!("{import}.ncl"));
+        if with_ext.is_file() {
+            return Some(with_ext);
+        }
+    }
+    None
+}
+
+/// Files reachable from `root` via relative Nickel `import`s that exist on disk.
+///
+/// Includes `root` itself when it can be canonicalized. Paths that do not
+/// resolve next to the importer (e.g. `keys.ncl` from `--import-path`) are
+/// skipped; those live in the codegen ncl tree, which is watched separately.
+pub fn collect_relative_ncl_imports(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    let mut stack = vec![root.to_path_buf()];
+
+    while let Some(path) = stack.pop() {
+        let Ok(canon) = path.canonicalize() else {
+            continue;
+        };
+        if !seen.insert(canon.clone()) {
+            continue;
+        }
+        out.push(canon.clone());
+        let Ok(src) = fs::read_to_string(&canon) else {
+            continue;
+        };
+        let Some(dir) = canon.parent() else {
+            continue;
+        };
+        for import in ncl_static_import_paths(&src) {
+            if let Some(next) = resolve_relative_ncl_import(dir, import) {
+                stack.push(next);
+            }
+        }
+    }
+    out
+}
+
 /// Generates the code for the given module.
 ///
 /// Cargo invalidation edges are:
 /// - the env value path itself (`SMART_KEYMAP_CUSTOM_KEYMAP` / board env)
 /// - for `.ncl` inputs, the Nickel import tree used by codegen
+/// - for `.ncl` inputs, relative `import`s that resolve on disk (config-repo
+///   keymaps that re-export another layout, e.g. `../split_3x5+3/keymap.ncl`)
 pub fn codegen_rust_module(
     CodegenInputs {
         env_var,
@@ -543,6 +629,10 @@ pub fn codegen_rust_module(
         if custom_module_path.ends_with(".ncl") {
             // Coarse: codegen pulls keymap-codegen.ncl, smart_keys, etc.
             println!("cargo:rerun-if-changed={}", ncl_import_path);
+            // Relative imports outside the ncl tree (config-repo remaps).
+            for path in collect_relative_ncl_imports(Path::new(&custom_module_path)) {
+                println!("cargo:rerun-if-changed={}", path.display());
+            }
         }
 
         if custom_module_path.ends_with(".rs") {
@@ -586,13 +676,69 @@ pub fn codegen_rust_module(
 #[cfg(test)]
 mod tests {
     use super::{
-        clear_nickel_eval_cache, disk_cache, eval_cache, get_or_eval_json, nickel_timeout,
-        wait_with_optional_timeout, NickelError, NickelJsonExport, DEFAULT_NICKEL_TIMEOUT_SECS,
-        NICKEL_TIMEOUT_ENV,
+        clear_nickel_eval_cache, collect_relative_ncl_imports, disk_cache, eval_cache,
+        get_or_eval_json, ncl_static_import_paths, nickel_timeout, wait_with_optional_timeout,
+        NickelError, NickelJsonExport, DEFAULT_NICKEL_TIMEOUT_SECS, NICKEL_TIMEOUT_ENV,
     };
     use std::process::{Command, Stdio};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::{Duration, Instant};
+
+    #[test]
+    fn ncl_static_import_paths_extracts_quoted() {
+        let src = r#"
+            let K = import "keys.ncl" in
+            (import "../split_3x5+3/keymap.ncl")
+            let x = import 'other.ncl' in
+            let imported = 1 in
+            let y = reimport "nope.ncl" in
+        "#;
+        assert_eq!(
+            ncl_static_import_paths(src),
+            vec!["keys.ncl", "../split_3x5+3/keymap.ncl", "other.ncl"]
+        );
+    }
+
+    #[test]
+    fn collect_relative_ncl_imports_follows_existing_files() {
+        let dir = std::env::temp_dir().join(format!(
+            "sk-ncl-imports-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let ortho = dir.join("ortho-4x12");
+        let split = dir.join("split_3x5+3");
+        std::fs::create_dir_all(&ortho).unwrap();
+        std::fs::create_dir_all(&split).unwrap();
+        std::fs::write(
+            split.join("keymap.ncl"),
+            r#"let K = import "keys.ncl" in { keys = [] }"#,
+        )
+        .unwrap();
+        let root = ortho.join("keymap.ncl");
+        std::fs::write(&root, r#"(import "../split_3x5+3/keymap.ncl")"#).unwrap();
+
+        // Both keymap files; keys.ncl is not next to the importer so it is skipped.
+        let paths = collect_relative_ncl_imports(&root);
+        assert_eq!(paths.len(), 2);
+        let as_str: Vec<String> = paths
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            as_str.iter().any(|p| p.ends_with("ortho-4x12/keymap.ncl")),
+            "{as_str:?}"
+        );
+        assert!(
+            as_str.iter().any(|p| p.ends_with("split_3x5+3/keymap.ncl")),
+            "{as_str:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     #[test]
     fn nickel_json_export_distinguishes_eval_kinds() {

--- a/smart-keymap-nickel-helper/src/lib.rs
+++ b/smart-keymap-nickel-helper/src/lib.rs
@@ -1,8 +1,8 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::io::{self, Read, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::{Child, Command, Output, Stdio};
 use std::sync::{Mutex, OnceLock};
 use std::thread;
@@ -20,8 +20,10 @@ pub const NICKEL_TIMEOUT_ENV: &str = "SMART_KEYMAP_NICKEL_TIMEOUT_SECS";
 pub const DEFAULT_NICKEL_TIMEOUT_SECS: u64 = 60;
 
 mod disk_cache;
+mod ncl_imports;
 
 pub use disk_cache::{NICKEL_JSON_CACHE_DIR_ENV, NICKEL_JSON_CACHE_ENV, NICKEL_JSON_CACHE_LOG_ENV};
+pub use ncl_imports::{collect_relative_ncl_imports, ncl_static_import_paths};
 
 /// Identifies a cached Nickel JSON export (keymap, inputs, or HID report).
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
@@ -517,90 +519,6 @@ pub fn nickel_composite_full_vec_rs(ncl_import_path: &str) -> NickelResult {
     )
 }
 
-/// Quoted paths from static `import "…"` / `import '…'` forms in Nickel source.
-///
-/// Dynamic or computed import expressions are ignored. Identifier-adjacent
-/// matches (`imported`, `reimport`) are skipped.
-pub fn ncl_static_import_paths(src: &str) -> Vec<&str> {
-    let mut out = Vec::new();
-    let mut search_from = 0;
-    while let Some(rel) = src[search_from..].find("import") {
-        let start = search_from + rel;
-        let after_kw = start + "import".len();
-        let after = &src[after_kw..];
-        let ident_cont = |c: char| c.is_ascii_alphanumeric() || c == '_';
-        let preceded_by_ident = src[..start].chars().next_back().is_some_and(ident_cont);
-        if preceded_by_ident || after.chars().next().is_some_and(ident_cont) {
-            search_from = after_kw;
-            continue;
-        }
-        let ws = after.len() - after.trim_start().len();
-        let trimmed_at = after_kw + ws;
-        let trimmed = &src[trimmed_at..];
-        let Some(quote) = trimmed.chars().next().filter(|c| *c == '"' || *c == '\'') else {
-            search_from = after_kw;
-            continue;
-        };
-        let inner_at = trimmed_at + quote.len_utf8();
-        let inner = &src[inner_at..];
-        match inner.find(quote) {
-            Some(end) => {
-                out.push(&src[inner_at..inner_at + end]);
-                search_from = inner_at + end + quote.len_utf8();
-            }
-            None => break,
-        }
-    }
-    out
-}
-
-fn resolve_relative_ncl_import(importer_dir: &Path, import: &str) -> Option<PathBuf> {
-    let candidate = importer_dir.join(import);
-    if candidate.is_file() {
-        return Some(candidate);
-    }
-    if !import.ends_with(".ncl") {
-        let with_ext = importer_dir.join(format!("{import}.ncl"));
-        if with_ext.is_file() {
-            return Some(with_ext);
-        }
-    }
-    None
-}
-
-/// Files reachable from `root` via relative Nickel `import`s that exist on disk.
-///
-/// Includes `root` itself when it can be canonicalized. Paths that do not
-/// resolve next to the importer (e.g. `keys.ncl` from `--import-path`) are
-/// skipped; those live in the codegen ncl tree, which is watched separately.
-pub fn collect_relative_ncl_imports(root: &Path) -> Vec<PathBuf> {
-    let mut out = Vec::new();
-    let mut seen = HashSet::new();
-    let mut stack = vec![root.to_path_buf()];
-
-    while let Some(path) = stack.pop() {
-        let Ok(canon) = path.canonicalize() else {
-            continue;
-        };
-        if !seen.insert(canon.clone()) {
-            continue;
-        }
-        out.push(canon.clone());
-        let Ok(src) = fs::read_to_string(&canon) else {
-            continue;
-        };
-        let Some(dir) = canon.parent() else {
-            continue;
-        };
-        for import in ncl_static_import_paths(&src) {
-            if let Some(next) = resolve_relative_ncl_import(dir, import) {
-                stack.push(next);
-            }
-        }
-    }
-    out
-}
-
 /// Generates the code for the given module.
 ///
 /// Cargo invalidation edges are:
@@ -676,69 +594,13 @@ pub fn codegen_rust_module(
 #[cfg(test)]
 mod tests {
     use super::{
-        clear_nickel_eval_cache, collect_relative_ncl_imports, disk_cache, eval_cache,
-        get_or_eval_json, ncl_static_import_paths, nickel_timeout, wait_with_optional_timeout,
-        NickelError, NickelJsonExport, DEFAULT_NICKEL_TIMEOUT_SECS, NICKEL_TIMEOUT_ENV,
+        clear_nickel_eval_cache, disk_cache, eval_cache, get_or_eval_json, nickel_timeout,
+        wait_with_optional_timeout, NickelError, NickelJsonExport, DEFAULT_NICKEL_TIMEOUT_SECS,
+        NICKEL_TIMEOUT_ENV,
     };
     use std::process::{Command, Stdio};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::{Duration, Instant};
-
-    #[test]
-    fn ncl_static_import_paths_extracts_quoted() {
-        let src = r#"
-            let K = import "keys.ncl" in
-            (import "../split_3x5+3/keymap.ncl")
-            let x = import 'other.ncl' in
-            let imported = 1 in
-            let y = reimport "nope.ncl" in
-        "#;
-        assert_eq!(
-            ncl_static_import_paths(src),
-            vec!["keys.ncl", "../split_3x5+3/keymap.ncl", "other.ncl"]
-        );
-    }
-
-    #[test]
-    fn collect_relative_ncl_imports_follows_existing_files() {
-        let dir = std::env::temp_dir().join(format!(
-            "sk-ncl-imports-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        let ortho = dir.join("ortho-4x12");
-        let split = dir.join("split_3x5+3");
-        std::fs::create_dir_all(&ortho).unwrap();
-        std::fs::create_dir_all(&split).unwrap();
-        std::fs::write(
-            split.join("keymap.ncl"),
-            r#"let K = import "keys.ncl" in { keys = [] }"#,
-        )
-        .unwrap();
-        let root = ortho.join("keymap.ncl");
-        std::fs::write(&root, r#"(import "../split_3x5+3/keymap.ncl")"#).unwrap();
-
-        // Both keymap files; keys.ncl is not next to the importer so it is skipped.
-        let paths = collect_relative_ncl_imports(&root);
-        assert_eq!(paths.len(), 2);
-        let as_str: Vec<String> = paths
-            .iter()
-            .map(|p| p.to_string_lossy().into_owned())
-            .collect();
-        assert!(
-            as_str.iter().any(|p| p.ends_with("ortho-4x12/keymap.ncl")),
-            "{as_str:?}"
-        );
-        assert!(
-            as_str.iter().any(|p| p.ends_with("split_3x5+3/keymap.ncl")),
-            "{as_str:?}"
-        );
-
-        let _ = std::fs::remove_dir_all(&dir);
-    }
 
     #[test]
     fn nickel_json_export_distinguishes_eval_kinds() {

--- a/smart-keymap-nickel-helper/src/ncl_imports.rs
+++ b/smart-keymap-nickel-helper/src/ncl_imports.rs
@@ -1,0 +1,244 @@
+//! Relative Nickel `import` graph for `cargo:rerun-if-changed`.
+//!
+//! ## Functional core / imperative shell
+//!
+//! - **Core** ([`ncl_static_import_paths`], [`relative_import_candidates`]):
+//!   parse and join; no filesystem.
+//! - **Shell** ([`collect_relative_ncl_imports`]): canonicalize, `is_file`,
+//!   `read_to_string`.
+//!
+//! File imports are a string literal (`import "foo.ncl"`). Package imports
+//! (`import gh`) have no quotes and are ignored. Paths that do not exist next
+//! to the importer (e.g. `keys.ncl` from `--import-path`) are skipped; those
+//! live in the codegen `ncl/` tree, which is watched separately.
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+// ---------------------------------------------------------------------------
+// Functional core
+// ---------------------------------------------------------------------------
+
+fn is_ident_cont(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_'
+}
+
+/// Byte index of the next `import` keyword at or after `from`.
+fn find_import_keyword(src: &str, from: usize) -> Option<usize> {
+    let mut i = from;
+    while let Some(rel) = src[i..].find("import") {
+        let start = i + rel;
+        let after_kw = start + "import".len();
+        let preceded_by_ident = src[..start].chars().next_back().is_some_and(is_ident_cont);
+        let followed_by_ident = src[after_kw..].chars().next().is_some_and(is_ident_cont);
+        if !preceded_by_ident && !followed_by_ident {
+            return Some(start);
+        }
+        i = after_kw;
+    }
+    None
+}
+
+/// Leading quoted string: optional whitespace, then `"…"` or `'…'`.
+///
+/// Returns `(contents, rest_after_closing_quote)`.
+fn take_quoted_string(s: &str) -> Option<(&str, &str)> {
+    let s = s.trim_start();
+    let quote = s.chars().next().filter(|c| *c == '"' || *c == '\'')?;
+    let inner = &s[quote.len_utf8()..];
+    let end = inner.find(quote)?;
+    Some((&inner[..end], &inner[end + quote.len_utf8()..]))
+}
+
+/// Quoted paths from static `import "…"` / `import '…'` forms in Nickel source.
+///
+/// Dynamic or computed import expressions are a parse error in Nickel and are
+/// not produced here. Identifier-adjacent matches (`imported`, `reimport`) and
+/// package imports (`import gh`) are skipped.
+pub fn ncl_static_import_paths(src: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    let mut from = 0;
+    while let Some(kw) = find_import_keyword(src, from) {
+        let after_kw = kw + "import".len();
+        match take_quoted_string(&src[after_kw..]) {
+            Some((path, rest)) => {
+                out.push(path);
+                from = src.len() - rest.len();
+            }
+            None => from = after_kw,
+        }
+    }
+    out
+}
+
+/// Paths to try for one quoted import, relative to the importing file's directory.
+///
+/// Does not check existence. A bare name also yields a `.ncl` sibling, matching
+/// Nickel's optional-extension lookup.
+pub fn relative_import_candidates(importer_dir: &Path, import: &str) -> Vec<PathBuf> {
+    let mut out = vec![importer_dir.join(import)];
+    if !import.ends_with(".ncl") {
+        out.push(importer_dir.join(format!("{import}.ncl")));
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Imperative shell
+// ---------------------------------------------------------------------------
+
+fn first_existing_relative_import(importer_dir: &Path, import: &str) -> Option<PathBuf> {
+    relative_import_candidates(importer_dir, import)
+        .into_iter()
+        .find_map(|candidate| candidate.canonicalize().ok().filter(|p| p.is_file()))
+}
+
+/// Files reachable from `root` via relative Nickel `import`s that exist on disk.
+///
+/// Includes `root` itself when it can be canonicalized.
+pub fn collect_relative_ncl_imports(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    let mut stack = vec![root.to_path_buf()];
+
+    while let Some(path) = stack.pop() {
+        let Ok(canon) = path.canonicalize() else {
+            continue;
+        };
+        if !seen.insert(canon.clone()) {
+            continue;
+        }
+        out.push(canon.clone());
+
+        let Ok(src) = fs::read_to_string(&canon) else {
+            continue;
+        };
+        let Some(dir) = canon.parent() else {
+            continue;
+        };
+        for import in ncl_static_import_paths(&src) {
+            if let Some(next) = first_existing_relative_import(dir, import) {
+                stack.push(next);
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        collect_relative_ncl_imports, ncl_static_import_paths, relative_import_candidates,
+        take_quoted_string,
+    };
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn take_quoted_string_double_and_single() {
+        assert_eq!(
+            take_quoted_string(r#"  "foo.ncl" rest"#),
+            Some(("foo.ncl", " rest"))
+        );
+        assert_eq!(take_quoted_string("'other.ncl'"), Some(("other.ncl", "")));
+        assert_eq!(take_quoted_string("gh"), None);
+        assert_eq!(take_quoted_string(r#""unterminated"#), None);
+    }
+
+    #[test]
+    fn ncl_static_import_paths_table() {
+        let cases: &[(&str, &[&str])] = &[
+            ("", &[]),
+            ("{ keys = [] }", &[]),
+            (r#"let K = import "keys.ncl" in K"#, &["keys.ncl"]),
+            (
+                r#"(import "../split_3x5+3/keymap.ncl")"#,
+                &["../split_3x5+3/keymap.ncl"],
+            ),
+            (r#"let x = import 'other.ncl' in x"#, &["other.ncl"]),
+            (r#"import"keys.ncl""#, &["keys.ncl"]),
+            ("import\n  \"keys.ncl\"", &["keys.ncl"]),
+            (r#"import "data.json" as 'Json"#, &["data.json"]),
+            ("import gh", &[]),
+            ("let imported = 1 in imported", &[]),
+            (r#"let y = reimport "nope.ncl" in y"#, &[]),
+            (
+                r#"
+                    let K = import "keys.ncl" in
+                    (import "../split_3x5+3/keymap.ncl")
+                    let x = import 'other.ncl' in
+                    let imported = 1 in
+                    let y = reimport "nope.ncl" in
+                    import gh
+                "#,
+                &["keys.ncl", "../split_3x5+3/keymap.ncl", "other.ncl"],
+            ),
+        ];
+        for (src, expected) in cases {
+            assert_eq!(
+                ncl_static_import_paths(src),
+                expected.to_vec(),
+                "src={src:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn relative_import_candidates_with_and_without_extension() {
+        let dir = Path::new("/keymaps/ortho-4x12");
+        assert_eq!(
+            relative_import_candidates(dir, "../split_3x5+3/keymap.ncl"),
+            vec![PathBuf::from(
+                "/keymaps/ortho-4x12/../split_3x5+3/keymap.ncl"
+            )]
+        );
+        assert_eq!(
+            relative_import_candidates(dir, "keys"),
+            vec![
+                PathBuf::from("/keymaps/ortho-4x12/keys"),
+                PathBuf::from("/keymaps/ortho-4x12/keys.ncl"),
+            ]
+        );
+    }
+
+    #[test]
+    fn collect_relative_ncl_imports_follows_existing_files() {
+        let dir = std::env::temp_dir().join(format!(
+            "sk-ncl-imports-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let ortho = dir.join("ortho-4x12");
+        let split = dir.join("split_3x5+3");
+        std::fs::create_dir_all(&ortho).unwrap();
+        std::fs::create_dir_all(&split).unwrap();
+        std::fs::write(
+            split.join("keymap.ncl"),
+            r#"let K = import "keys.ncl" in { keys = [] }"#,
+        )
+        .unwrap();
+        let root = ortho.join("keymap.ncl");
+        std::fs::write(&root, r#"(import "../split_3x5+3/keymap.ncl")"#).unwrap();
+
+        // Both keymap files; keys.ncl is not next to the importer so it is skipped.
+        let paths = collect_relative_ncl_imports(&root);
+        assert_eq!(paths.len(), 2);
+        let as_str: Vec<String> = paths
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            as_str.iter().any(|p| p.ends_with("ortho-4x12/keymap.ncl")),
+            "{as_str:?}"
+        );
+        assert!(
+            as_str.iter().any(|p| p.ends_with("split_3x5+3/keymap.ncl")),
+            "{as_str:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}


### PR DESCRIPTION
## Summary

- Follow-up to #693: `codegen_rust_module` watches `SMART_KEYMAP_CUSTOM_KEYMAP` and the submodule `ncl/` tree, but not sibling files pulled in by Nickel `import`.
- Config-repo remaps such as `ortho-4x12/keymap.ncl` → `import "../split_3x5+3/keymap.ncl"` therefore left `smart-keymap` Fresh after timeout/layout edits (cargo finished in ~0.04s; generated `keymap.rs` kept the old value).
- Nickel file imports are static string literals, so walk `import "…"` / `import '…'` paths that exist next to the importer and emit `cargo:rerun-if-changed` for each. `--import-path` files (`keys.ncl`, etc.) stay covered by the existing `ncl/` watch.

## Test plan

- [x] `cargo test -p smart-keymap-nickel-helper --lib` (new import-walker unit tests)
- [x] `just check-quick` (fmt, clippy, cargo doc host+firmware, nickel format)
- [x] Firmware repro: build ch32x 48 rev2025_2, change `config.sequence.timeout` in `split_3x5+3/keymap.ncl`, rebuild → `Compiling smart-keymap` and generated `timeout:` matches
- [ ] CI green