### PR TITLE
test: ceedling suite for split 3x5+3 thumb keys

### DIFF
--- a/tests/ceedling/ceedling.mk
+++ b/tests/ceedling/ceedling.mk
@@ -1,5 +1,5 @@
 CEEDLING = ceedling
-CEEDLING_KEYMAP_SUITES = consumer callback keyboard layered conditional_layers mouse sticky tap_hold remap_named_layers
+CEEDLING_KEYMAP_SUITES = consumer callback keyboard layered conditional_layers mouse sticky tap_hold remap_named_layers thumbs
 CEEDLING_CARGO_TARGET = tests/ceedling/cargo-target
 
 # Rebuild copied libs when smart_keymap crate inputs change (not only keymap.ncl).

--- a/tests/ceedling/keymaps/thumbs/keymap.ncl
+++ b/tests/ceedling/keymaps/thumbs/keymap.ncl
@@ -1,0 +1,48 @@
+# Split 3x5+3 thumbs: six tap-hold layer-mods and the two inner-pair chords.
+# Resembles thumb keys from rgoulter's split 3x5+3.
+let K = import "keys.ncl" in
+let HoldLayerMod = fun name => K.hold (K.layer_mod.hold name) in
+{
+  config.tap_hold.interrupt_response = "HoldOnKeyTap",
+  config.tap_hold.timeout = 200,
+  config.chorded.required_idle_time = 125,
+  chords = [
+    {
+      indices = [2, 3],
+      key = K.Tab & HoldLayerMod "mou_r",
+    },
+    {
+      indices = [4, 5],
+      key = K.Delete & HoldLayerMod "fun_l",
+    },
+  ],
+  layers = [
+    [
+      K.A,
+      K.Tab & HoldLayerMod "mou_r",
+      K.Escape & HoldLayerMod "med_r",
+      K.Space & HoldLayerMod "nav_r",
+      K.Return & HoldLayerMod "sym_l",
+      K.Backspace & HoldLayerMod "num_l",
+      K.Delete & HoldLayerMod "fun_l",
+    ],
+  ],
+  named_layers = {
+    mou_r = [K.B, K.TTTT, K.TTTT, K.TTTT, K.TTTT, K.TTTT, K.TTTT],
+    med_r = [K.C, K.TTTT, K.TTTT, K.TTTT, K.TTTT, K.TTTT, K.TTTT],
+    nav_r = [K.Left, K.TTTT, K.TTTT, K.TTTT, K.TTTT, K.TTTT, K.TTTT],
+    sym_l = [K.D, K.TTTT, K.TTTT, K.TTTT, K.TTTT, K.TTTT, K.TTTT],
+    num_l = [K.N1, K.TTTT, K.TTTT, K.TTTT, K.TTTT, K.TTTT, K.TTTT],
+    fun_l = [K.F1, K.TTTT, K.TTTT, K.TTTT, K.TTTT, K.TTTT, K.TTTT],
+  },
+  ceedling_fixture = {
+    suite = "THUMBS",
+    PROBE_KEY = 0,
+    TAB_MOUR = 1,
+    ESC_MEDR = 2,
+    SPC_NAVR = 3,
+    ENT_NSSL = 4,
+    BKSP_NSL = 5,
+    DEL_FUNL = 6,
+  },
+}

--- a/tests/ceedling/mixins/thumbs.yml
+++ b/tests/ceedling/mixins/thumbs.yml
@@ -1,0 +1,7 @@
+:paths:
+  :libraries:
+    - libs
+
+:libraries:
+  :system:
+    - smart_keymap_thumbs

--- a/tests/ceedling/test/support/hid_keycodes.h
+++ b/tests/ceedling/test/support/hid_keycodes.h
@@ -5,6 +5,15 @@
 #define KC_B 0x05
 #define KC_C 0x06
 #define KC_D 0x07
+#define KC_N1 0x1E
+#define KC_RETURN 0x28
+#define KC_ESCAPE 0x29
+#define KC_BACKSPACE 0x2A
+#define KC_TAB 0x2B
+#define KC_SPACE 0x2C
+#define KC_F1 0x3A
+#define KC_DELETE 0x4C
+#define KC_LEFT 0x50
 
 // Modifier bits in KeymapHidReport.keyboard[0]
 #define MOD_LCTL 0x01

--- a/tests/ceedling/test/thumbs/test_sophisticated_thumbkeys.c
+++ b/tests/ceedling/test/thumbs/test_sophisticated_thumbkeys.c
@@ -1,0 +1,317 @@
+#include "thumbs_test_ceedling_fixture.h"
+
+#ifdef SUITE_THUMBS
+
+#include "hid_keycodes.h"
+#include "smart_keymap.h"
+#include "unity.h"
+
+void setUp(void) {}
+
+void tearDown(void) {}
+
+static void press_key(uint16_t key) {
+  keymap_register_input_event(
+      (struct KeymapInputEvent){.event_type = KeymapEventPress, .value = key});
+}
+
+static void release_key(uint16_t key) {
+  keymap_register_input_event((struct KeymapInputEvent){
+      .event_type = KeymapEventRelease, .value = key});
+}
+
+static void tick_n(KeymapHidReport *report, int n) {
+  for (int i = 0; i < n; i++) {
+    keymap_tick(report);
+  }
+}
+
+static void assert_kc(const KeymapHidReport *report, uint8_t kc) {
+  uint8_t expected[8] = {0, 0, kc, 0, 0, 0, 0, 0};
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, report->keyboard, 8);
+}
+
+static void tick_until_kc(KeymapHidReport *report, uint8_t kc, int max_ticks) {
+  for (int i = 0; i < max_ticks; i++) {
+    if (report->keyboard[2] == kc) {
+      return;
+    }
+    keymap_tick(report);
+  }
+  assert_kc(report, kc);
+}
+
+static void tap_thumb(uint16_t thumb, KeymapHidReport *report) {
+  press_key(thumb);
+  keymap_tick(report);
+  release_key(thumb);
+  /* One tick resolves the tap; more ticks clear it from the report. */
+  keymap_tick(report);
+}
+
+static void idle_then_hold_probe(uint16_t thumb, KeymapHidReport *report) {
+  tick_n(report, 2000);
+  press_key(thumb);
+  /* Chord wait (200) + tap-hold timeout (200), plus pacing slack. */
+  tick_n(report, 500);
+  press_key(KM_PROBE_KEY);
+  tick_n(report, 20);
+}
+
+void test_thumb_tab_taps(void) {
+  KeymapHidReport report = {};
+
+  // assemble
+  keymap_init();
+
+  // act: single tap of Tab/mouse thumb
+  tap_thumb(KM_TAB_MOUR, &report);
+
+  // assert: tap is Tab, not the mouse layer
+  assert_kc(&report, KC_TAB);
+}
+
+void test_thumb_esc_taps(void) {
+  KeymapHidReport report = {};
+
+  // assemble
+  keymap_init();
+
+  // act: single tap of Esc/media thumb
+  tap_thumb(KM_ESC_MEDR, &report);
+
+  // assert: tap is Escape, not the media layer
+  assert_kc(&report, KC_ESCAPE);
+}
+
+void test_thumb_spc_taps(void) {
+  KeymapHidReport report = {};
+
+  // assemble
+  keymap_init();
+
+  // act: single tap of Space/nav thumb
+  tap_thumb(KM_SPC_NAVR, &report);
+
+  // assert: tap is Space, not the nav layer
+  assert_kc(&report, KC_SPACE);
+}
+
+void test_thumb_ent_taps(void) {
+  KeymapHidReport report = {};
+
+  // assemble
+  keymap_init();
+
+  // act: single tap of Enter/sym thumb
+  tap_thumb(KM_ENT_NSSL, &report);
+
+  // assert: tap is Return, not the sym layer
+  assert_kc(&report, KC_RETURN);
+}
+
+void test_thumb_bksp_taps(void) {
+  KeymapHidReport report = {};
+
+  // assemble
+  keymap_init();
+
+  // act: single tap of Backspace/num thumb
+  tap_thumb(KM_BKSP_NSL, &report);
+
+  // assert: tap is Backspace, not the num layer
+  assert_kc(&report, KC_BACKSPACE);
+}
+
+void test_thumb_del_taps(void) {
+  KeymapHidReport report = {};
+
+  // assemble
+  keymap_init();
+
+  // act: single tap of Delete/fun thumb
+  tap_thumb(KM_DEL_FUNL, &report);
+
+  // assert: tap is Delete, not the fun layer
+  assert_kc(&report, KC_DELETE);
+}
+
+void test_thumb_tab_hold_activates_mou(void) {
+  KeymapHidReport report = {};
+
+  // assemble
+  keymap_init();
+
+  // act: hold Tab/mouse past timeout, then press the probe key
+  idle_then_hold_probe(KM_TAB_MOUR, &report);
+
+  // assert: hold is the mouse layer (probe is B)
+  assert_kc(&report, KC_B);
+}
+
+void test_thumb_esc_hold_activates_med(void) {
+  KeymapHidReport report = {};
+
+  // assemble
+  keymap_init();
+
+  // act: hold Esc/media past timeout, then press the probe key
+  idle_then_hold_probe(KM_ESC_MEDR, &report);
+
+  // assert: hold is the media layer (probe is C)
+  assert_kc(&report, KC_C);
+}
+
+void test_thumb_spc_hold_activates_nav(void) {
+  KeymapHidReport report = {};
+
+  // assemble
+  keymap_init();
+
+  // act: hold Space/nav past timeout, then press the probe key
+  idle_then_hold_probe(KM_SPC_NAVR, &report);
+
+  // assert: hold is the nav layer (probe is Left)
+  assert_kc(&report, KC_LEFT);
+}
+
+void test_thumb_ent_hold_activates_sym(void) {
+  KeymapHidReport report = {};
+
+  // assemble
+  keymap_init();
+
+  // act: hold Enter/sym past timeout, then press the probe key
+  idle_then_hold_probe(KM_ENT_NSSL, &report);
+
+  // assert: hold is the sym layer (probe is D)
+  assert_kc(&report, KC_D);
+}
+
+void test_thumb_bksp_hold_activates_num(void) {
+  KeymapHidReport report = {};
+
+  // assemble
+  keymap_init();
+
+  // act: hold Backspace/num past timeout, then press the probe key
+  idle_then_hold_probe(KM_BKSP_NSL, &report);
+
+  // assert: hold is the num layer (probe is 1)
+  assert_kc(&report, KC_N1);
+}
+
+void test_thumb_del_hold_activates_fun(void) {
+  KeymapHidReport report = {};
+
+  // assemble
+  keymap_init();
+
+  // act: hold Delete/fun past timeout, then press the probe key
+  idle_then_hold_probe(KM_DEL_FUNL, &report);
+
+  // assert: hold is the fun layer (probe is F1)
+  assert_kc(&report, KC_F1);
+}
+
+void test_thumb_bksp_interrupt_tap_resolves_hold(void) {
+  KeymapHidReport report = {};
+
+  // assemble
+  keymap_init();
+
+  // act: press Backspace/num, then tap the probe key (HoldOnKeyTap)
+  press_key(KM_BKSP_NSL);
+  keymap_tick(&report);
+  press_key(KM_PROBE_KEY);
+  keymap_tick(&report);
+  release_key(KM_PROBE_KEY);
+  tick_until_kc(&report, KC_N1, 50);
+
+  // assert: interrupting tap resolves the thumb as hold; probe is 1 from num
+  assert_kc(&report, KC_N1);
+}
+
+void test_chord_esc_spc_taps_tab(void) {
+  KeymapHidReport report = {};
+
+  // assemble
+  keymap_init();
+  tick_n(&report, 2000);
+
+  // act: tap the Esc+Space chord (press both, release both)
+  press_key(KM_ESC_MEDR);
+  keymap_tick(&report);
+  press_key(KM_SPC_NAVR);
+  keymap_tick(&report);
+  release_key(KM_ESC_MEDR);
+  keymap_tick(&report);
+  release_key(KM_SPC_NAVR);
+  tick_until_kc(&report, KC_TAB, 50);
+
+  // assert: chord tap is Tab, not Esc or Space
+  assert_kc(&report, KC_TAB);
+}
+
+void test_chord_ent_bksp_taps_delete(void) {
+  KeymapHidReport report = {};
+
+  // assemble
+  keymap_init();
+  tick_n(&report, 2000);
+
+  // act: tap the Enter+Backspace chord (press both, release both)
+  press_key(KM_ENT_NSSL);
+  keymap_tick(&report);
+  press_key(KM_BKSP_NSL);
+  keymap_tick(&report);
+  release_key(KM_ENT_NSSL);
+  keymap_tick(&report);
+  release_key(KM_BKSP_NSL);
+  tick_until_kc(&report, KC_DELETE, 50);
+
+  // assert: chord tap is Delete, not Enter or Backspace
+  assert_kc(&report, KC_DELETE);
+}
+
+void test_chord_esc_spc_hold_activates_mou(void) {
+  KeymapHidReport report = {};
+
+  // assemble
+  keymap_init();
+  tick_n(&report, 2000);
+
+  // act: hold the Esc+Space chord past timeout, then press the probe key
+  press_key(KM_ESC_MEDR);
+  keymap_tick(&report);
+  press_key(KM_SPC_NAVR);
+  tick_n(&report, 500);
+  press_key(KM_PROBE_KEY);
+  tick_n(&report, 20);
+
+  // assert: chord hold is the mouse layer (probe is B)
+  assert_kc(&report, KC_B);
+}
+
+void test_chord_ent_bksp_hold_activates_fun(void) {
+  KeymapHidReport report = {};
+
+  // assemble
+  keymap_init();
+  tick_n(&report, 2000);
+
+  // act: hold the Enter+Backspace chord past timeout, then press the probe key
+  press_key(KM_ENT_NSSL);
+  keymap_tick(&report);
+  press_key(KM_BKSP_NSL);
+  tick_n(&report, 500);
+  press_key(KM_PROBE_KEY);
+  tick_n(&report, 20);
+
+  // assert: chord hold is the fun layer (probe is F1)
+  assert_kc(&report, KC_F1);
+}
+
+#else
+#error "requires SUITE_THUMBS"
+#endif


### PR DESCRIPTION
## Summary

Ceedling fixture for a 7-key cut of the split 3x5+3 thumbs: six tap-hold layer-mods (Tab/Esc/Space, Enter/Backspace/Delete) and the two inner-pair chords (Esc+Space → Tab/mou, Enter+Backspace → Delete/fun).

Config matches the usual userspace interrupt/idle knobs (`HoldOnKeyTap`, `chorded.required_idle_time = 125`) but does **not** set `quick_tap_ms`. Each thumb is checked as tap and as hold-after-idle; each chord as tap and as hold.

## Test plan

- [x] `just ceedling::suite thumbs` (16/16)