### PR TITLE
ncl: add Seq.indices layout-string helper

### DIFF
--- a/features/keymap/ncl/readme.md
+++ b/features/keymap/ncl/readme.md
@@ -2,3 +2,33 @@
 
 The Nickel code in `ncl/` has some functions
 which help when writing `keymap.ncl` files.
+
+## Chord indices (`chording.ncl`)
+
+Mark chord members with any non-`_` character (typically `X`).
+Indices are collected in scan order (left-to-right, top-to-bottom).
+
+```nickel
+let CH = import "chording.ncl" in
+{
+  indices = m%"
+    _ _ X X _
+  "% |> CH.indices,
+}
+```
+
+## Sequence indices (`sequence.ncl`)
+
+Mark sequence steps with `0 1 2 …`.
+Returned indices are sorted by those markers, so the tap order
+can differ from scan order.
+
+```nickel
+let Seq = import "sequence.ncl" in
+{
+  indices = m%"
+    _ _ 1 _ _
+    _ _ 0 _ _
+  "% |> Seq.indices, # first the `0` key, then the `1` key
+}
+```

--- a/features/keymap/ncl/sequences.feature
+++ b/features/keymap/ncl/sequences.feature
@@ -9,6 +9,16 @@ Feature: Sequences
 
   This is a similar idea to Vim's "leader key sequences".
 
+  Sequence `indices` may be a raw array (`[1, 2]`), or a layout string
+  via `sequence.ncl`. Non-`_` markers are sorted so tap order can
+  differ from scan order (unlike chord `X` marks):
+
+      let Seq = import "sequence.ncl" in
+      { indices = "1 0 _" |> Seq.indices, key = K.C }
+
+  `"1 0 _"` is keys 0 then 1 in scan order, but the sequence is
+  key 1 then key 0.
+
   For examples of this feature in other smart keyboard firmware, see e.g.:
 
   - [QMK's Leader Key](https://docs.qmk.fm/features/leader_key)
@@ -18,9 +28,10 @@ Feature: Sequences
     Given a keymap.ncl:
       """
       let K = import "keys.ncl" in
+      let Seq = import "sequence.ncl" in
       {
         sequences = [
-          { indices = [1, 2], key = K.C },
+          { indices = "_ 0 1 _" |> Seq.indices, key = K.C },
         ],
         config.sequence.timeout = 500,
         keys = [

--- a/ncl/format-whitelist
+++ b/ncl/format-whitelist
@@ -14,6 +14,7 @@ ncl/layouts/remap.ncl
 ncl/layouts/remap-36keys.ncl
 ncl/checks.ncl
 ncl/chording.ncl
+ncl/sequence.ncl
 ncl/hid-report.ncl
 ncl/hid-usage-consumer.ncl
 ncl/hid-usage-keyboard.ncl

--- a/ncl/scripts/run-ncl-checks.sh
+++ b/ncl/scripts/run-ncl-checks.sh
@@ -9,12 +9,21 @@ set -e
 SCRIPTS_DIR="$(dirname "$0")"
 REPOSITORY_DIR="${SCRIPTS_DIR}/../.."
 
-nickel \
-  eval \
-  --import-path="${REPOSITORY_DIR}/ncl" \
-  --field="evaluated_checks" \
-  checks.ncl \
+nickel_eval_checks() {
+  nickel \
+    eval \
+    --import-path="${REPOSITORY_DIR}/ncl" \
+    --field="evaluated_checks" \
+    checks.ncl \
+    "$@"
+}
+
+# Modules that export the same field names (e.g. `indices`) cannot be
+# merged in one eval; each is checked with checks.ncl on its own.
+nickel_eval_checks \
   chording.ncl \
   keymap-ncl-to-json.ncl \
   keymap-codegen.ncl \
   layouts/remap.ncl
+
+nickel_eval_checks sequence.ncl

--- a/ncl/sequence.ncl
+++ b/ncl/sequence.ncl
@@ -1,0 +1,52 @@
+{
+  checks.sequence_indices = {
+    trivial_empty = {
+      expected = [],
+      actual = "_" |> indices,
+    },
+    trivial_nonempty = {
+      expected = [0],
+      actual = "0" |> indices,
+    },
+    in_scan_order = {
+      expected = [1, 3],
+      actual = " _ 0 _ 1 _ " |> indices,
+    },
+    reverse_of_scan_order = {
+      expected = [3, 1],
+      actual = " _ 1 _ 0 _ " |> indices,
+    },
+    same_markers_keep_scan_order = {
+      expected = [1, 3],
+      actual = " _ X _ X _ " |> indices,
+    },
+    layout_string = {
+      expected = [9, 35],
+      actual =
+        m%"
+          _ _ _ _ _   _ _ _ _ 0
+          _ _ _ _ _   _ _ _ _ _
+          _ _ _ _ _   _ _ _ _ _
+              _ _ _   _ _ 1
+        "%
+        |> indices,
+    },
+  },
+
+  indices
+    | doc "calculate keymap indices for sequence steps, ordered by the non-'_' markers."
+    = fun s =>
+      s
+      |> std.string.replace_regex "\\s+" ""
+      |> std.string.characters
+      |> std.array.map_with_index (fun i c => if c == "_" then [] else [{ label = c, index = i }])
+      |> std.array.flatten
+      |> std.array.sort (fun a b =>
+        std.string.compare a.label b.label
+        |> match {
+          'Equal => std.number.compare a.index b.index,
+          cmp => cmp,
+        }
+      )
+      |> std.array.map (fun { index, .. } => index),
+}

--- a/tests/rust/sequence.rs
+++ b/tests/rust/sequence.rs
@@ -152,3 +152,47 @@ fn sequence_timeout_aborts_incomplete() {
         reports
     );
 }
+
+#[test]
+fn sequence_indices_layout_string_reverse_of_scan_order() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            let Seq = import "sequence.ncl" in
+            {
+                sequences = [
+                    { indices = "1 0 _" |> Seq.indices, key = K.C },
+                ],
+                config.sequence.timeout = 500,
+                keys = [
+                    K.A,
+                    K.B,
+                    K.sequence_start,
+                ],
+            }
+        "#
+    ));
+
+    // Act
+    // start, then B (marker 0), then A (marker 1)
+    keymap.handle_input(input::Event::Press { keymap_index: 2 });
+    keymap.handle_input(input::Event::Release { keymap_index: 2 });
+
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, KC_C, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}


### PR DESCRIPTION
## Summary

Sequence `indices` can be written as a layout string, like chord `X` marks, via `sequence.ncl`.

`Seq.indices` keeps every non-`_` character and **sorts keymap slots by those markers**, so tap order can differ from scan order:

```nickel
let Seq = import "sequence.ncl" in
{
  indices = m%"
    _ _ 1 _ _
    _ _ 0 _ _
  "% |> Seq.indices, # first the `0` key, then the `1` key
}
```

Any non-`_` character works (`0 1 2`, `A B C`, …). Identical markers (`X X`) keep scan order, same as `CH.indices`.

Nickel checks for `sequence.ncl` run in a separate `nickel eval` because its top-level `indices` field cannot merge with `chording.ncl`.

## Test plan

- [x] `just ncl::checks`
- [x] `just rust::integration sequence_indices_layout_string_reverse_of_scan_order`
- [x] `just check-quick`
- [ ] CI green