### PR TITLE
layered: bare transparent layer exit (K.tlex)

### DIFF
--- a/features/keymap/key/layer_modifier-tlex.feature
+++ b/features/keymap/key/layer_modifier-tlex.feature
@@ -1,0 +1,77 @@
+Feature: Transparent Layer Exit
+
+  `K.tlex` deactivates the layer that owns the binding (when that layer was
+   activated non-persistently — hold, toggle, or sticky), then registers the
+   key as if that layer were off (continue-eval to the next lower defined
+   active layer, or base).
+
+  This is an alternative to "smart layers": exit by pressing a key on the
+   layer rather than only by releasing the layer modifier.
+
+  For examples of this feature in other smart keyboard firmware, see e.g.:
+
+  - [Fak's transparent layer exit (`tap.tlex` / `hold.tlex`)](https://github.com/semickolon/fak#transparent-layer-exit)
+
+  Background:
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        layers = [
+          [
+            K.layer_mod.toggle 1,
+            K.A,
+            K.C,
+          ],
+          [
+            K.TTTT,
+            K.tlex,
+            K.B,
+          ],
+        ],
+      }
+      """
+
+  Example: tlex types the base key and leaves the layer off
+
+    When the keymap registers the following input
+      """
+      [
+        tap (K.layer_mod.toggle 1),
+        press (K.tlex),
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { key_codes = [K.A] }
+      """
+
+  Example: after tlex, other keys on that layer use base bindings
+
+    When the keymap registers the following input
+      """
+      [
+        tap (K.layer_mod.toggle 1),
+        tap (K.tlex),
+        press (K.C),
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { key_codes = [K.C] }
+      """
+
+  Example: without tlex, the layer key would still be active
+
+    When the keymap registers the following input
+      """
+      [
+        tap (K.layer_mod.toggle 1),
+        press (K.B),
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { key_codes = [K.B] }
+      """

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -287,6 +287,26 @@
     map_accum = fun f acc k => { include acc, include k },
   },
 
+  # Transparent layer exit leaf (FAK tap.tlex). Layer-cell only in practice;
+  # registered so `K.tlex` validates as a Key. Projected to a hole + exit bit
+  # on the parent LayeredKey (not a nested key JSON value).
+  keymap_ncl.transparent_layer_exit = {
+    key_validator = fun k =>
+      k
+      |> match {
+        { transparent_layer_exit = true } => 'Ok,
+        { transparent_layer_exit = {} } => 'Ok,
+        _ => 'Error { message = "expected { transparent_layer_exit = true }" },
+      },
+
+    is_key = fun k => 'Ok == key_validator k,
+
+    # Should not appear as a nested JSON key; layered to_json lowers tlex cells.
+    to_json_value = fun _k => null,
+
+    map_accum = fun f acc k => { include acc, include k },
+  },
+
   keymap_ncl.key = {
     # Dispatch order = outermost wrapper wins when several modules' is_key match
     # the same record (Nickel record "abuse"). Used by key_validator and
@@ -311,6 +331,7 @@
       keymap_ncl.layered,
       keymap_ncl.tap_hold,
       keymap_ncl.layer_modifier,
+      keymap_ncl.transparent_layer_exit,
       keymap_ncl.keyboard,
     ],
 

--- a/ncl/layered-key.ncl
+++ b/ncl/layered-key.ncl
@@ -93,6 +93,14 @@
     else
       false,
 
+  is_tlex_key = fun k =>
+    k
+    |> match {
+      { transparent_layer_exit = true } => true,
+      { transparent_layer_exit = {} } => true,
+      _ => false,
+    },
+
   # `..` keeps the pattern open so locked_layers (and future fields) are accepted.
   update_layer_state_for_input = fun input layer_state @ { default_layer, active_layers, .. } =>
     input
@@ -212,6 +220,28 @@
       'Release { layer_modifier = { default_ }, .. } =>
         let { default_layer, ..layer_state } = layer_state in
         { default_layer = default_ } & layer_state,
+      # Transparent layer exit: deactivate the highest active (defining) layer.
+      # Avoid deep record patterns here (Nickel match tax); use is_tlex_key.
+      'Press k =>
+        if is_tlex_key k then
+          let { active_layers = al, ..layer_state } = layer_state in
+          highest_active_layer al
+          |> match {
+            null => layer_state,
+            layer_idx => { active_layers = deactivate_layer al layer_idx } & layer_state,
+          }
+        else
+          layer_state,
+      'Tap k =>
+        if is_tlex_key k then
+          let { active_layers = al, ..layer_state } = layer_state in
+          highest_active_layer al
+          |> match {
+            null => layer_state,
+            layer_idx => { active_layers = deactivate_layer al layer_idx } & layer_state,
+          }
+        else
+          layer_state,
       _ => layer_state,
     },
 
@@ -253,10 +283,13 @@
             (fun { layer_is_active, .. } => layer_is_active)
             zipped_layered_keys
         in
+        # Walk high → low among active layers; skip null (TTTT). Tlex is a real
+        # non-null cell for cucumber lookup (`press (K.tlex)`).
         let active_keys =
           std.array.map
             (fun { key, .. } => key)
             zipped_active_keys
+          |> std.array.filter ((!=) null)
         in
         if (std.array.length active_keys) > 0 then
           std.array.last active_keys

--- a/ncl/smart_keys/layered/key-extensions.ncl
+++ b/ncl/smart_keys/layered/key-extensions.ncl
@@ -50,6 +50,10 @@
     # Layer Transparency
     TTTT = null,
 
+    # Transparent layer exit (FAK tap.tlex): hole that also deactivates
+    # the defining layer. Lowered to null + exit_on_skip bit for runtime.
+    tlex = { transparent_layer_exit = true },
+
     # Semantic / variant key sugar: `named_layers` form of LayeredKey.
     # Unit `{}` base (keyboard noop) so callers can use `K.semantic {..}` without
     # `K.NO &`. Indices for names are assigned globally when compiling the keymap.

--- a/ncl/smart_keys/layered/keymap-codegen.ncl
+++ b/ncl/smart_keys/layered/keymap-codegen.ncl
@@ -266,10 +266,14 @@
         #     "layered": [5, null, 7]
         #   }
         # ```
-        # JSON serialization of key::layered::Layered has fields: { base, layered }
+        # JSON serialization of key::layered::LayeredKey: { base, layered, exit_on_skip? }
         json_validator =
           validators.record.validator {
-            fields_validator = validators.record.has_exact_fields ["base", "layered"],
+            fields_validator =
+              validators.all_of [
+                validators.record.has_all_fields ["base", "layered"],
+                validators.record.has_only_fields ["base", "layered", "exit_on_skip"],
+              ],
             field_validators = {
               base = smart_key.json_validator,
               layered =
@@ -279,19 +283,19 @@
                     smart_key.json_validator,
                   ]
                 ),
+              exit_on_skip = validators.is_number,
             },
           },
 
         is_json = fun json => 'Ok == json_validator json,
 
-        codegen_values = fun json @ { base, layered } =>
+        codegen_values = fun json @ { base, layered, .. } =>
           let base_cv = base |> smart_key.codegen_values in
-          let non_null_layered = std.array.filter ((!=) null) layered in
           let layered_cvs =
             std.array.map (fun json => if json != null then json |> smart_key.codegen_values else null) layered
           in
-          let nn_layered_cvs =
-            std.array.filter ((!=) null) layered_cvs
+          let exit_on_skip =
+            if std.record.has_field "exit_on_skip" json then json.exit_on_skip else 0
           in
 
           {
@@ -302,6 +306,7 @@
             include json,
             include module,
             include key_type,
+            include exit_on_skip,
             rust_expr =
               let base_expr = nested.base.rust_expr in
               let layered_exprs =
@@ -309,7 +314,13 @@
                 |> std.array.map (fun cv => if cv == null then "None" else "Some(%{cv.rust_expr})")
                 |> std.string.join ","
               in
-              "smart_keymap::key::layered::LayeredKey::new(%{base_expr}, [%{layered_exprs}])",
+              let new_expr = "smart_keymap::key::layered::LayeredKey::new(%{base_expr}, [%{layered_exprs}])"
+              in
+              if exit_on_skip == 0 then
+                new_expr
+              else
+                let bits = "%{module}::LayerBitset::from_bits(%{std.to_string exit_on_skip})" in
+                "(%{new_expr}).with_exit_on_skip(%{bits})",
           },
 
         map_nested = fun f cv @ { nested, ..rest } =>
@@ -334,7 +345,7 @@
             acc
             nn_layered_cvs,
 
-        data_and_ref = fun key_data cv @ { nested = { base = base_cv, layered = layered_cvs }, .. } =>
+        data_and_ref = fun key_data cv @ { nested = { base = base_cv, layered = layered_cvs }, exit_on_skip, .. } =>
           let { key_data, ref = base_ref } = smart_key.data_and_ref key_data base_cv in
           let base_ref = base_ref |> composite.ref.wrap in
           let { key_data, layered_refs } =
@@ -352,21 +363,40 @@
           in
           let { layered = layered_, ..other_data } = key_data & { layered | default = [] } in
           let new_index = std.array.length layered_ in
-          let new_key = {
-            json = {
-              base = base_ref.json,
-              layered = layered_refs |> std.array.map (fun layer_ref => if layer_ref == null then null else layer_ref.json),
-            },
-            rust_expr = m%"
-            %{module}::LayeredKey::new(
-              %{base_ref.rust_expr},
-              [%{
-                layered_refs
-                |> std.array.map (fun layer_ref => if layer_ref == null then "None" else "Some(%{layer_ref.rust_expr})")
-                |> std.string.join ", "
-              }],
+          let layered_json =
+            layered_refs
+            |> std.array.map (fun layer_ref => if layer_ref == null then null else layer_ref.json)
+          in
+          let layered_rust =
+            layered_refs
+            |> std.array.map (fun layer_ref =>
+              if layer_ref == null then "None" else "Some(%{layer_ref.rust_expr})"
             )
-          "%,
+            |> std.string.join ", "
+          in
+          let new_expr = "%{module}::LayeredKey::new(%{base_ref.rust_expr}, [%{layered_rust}])"
+          in
+          let rust_expr =
+            if exit_on_skip == 0 then
+              new_expr
+            else
+              let bits = "%{module}::LayerBitset::from_bits(%{std.to_string exit_on_skip})" in
+              "(%{new_expr}).with_exit_on_skip(%{bits})"
+          in
+          let exit_bits = exit_on_skip in
+          let new_key = {
+            json =
+              {
+                base = base_ref.json,
+                layered = layered_json,
+              }
+              & (
+                if exit_bits == 0 then
+                  {}
+                else
+                  { exit_on_skip = exit_bits }
+              ),
+            include rust_expr,
           }
           in
           {

--- a/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
@@ -384,7 +384,16 @@
 
       Key = std.contract.from_validator key_validator,
 
-      # Element of a layered / named_layers slot: Key or transparent null.
+      # Transparent layer exit authoring cell (lowered to null + exit_on_skip).
+      is_tlex_key = fun k =>
+        k
+        |> match {
+          { transparent_layer_exit = true } => true,
+          { transparent_layer_exit = {} } => true,
+          _ => false,
+        },
+
+      # Element of a layered / named_layers slot: Key, tlex, or transparent null.
       layer_element_validator =
         validators.any_of [validators.is_null, keymap_ncl.key.key_validator],
 
@@ -432,19 +441,44 @@
 
       # JSON projection expects dense array form only (`layered` array, no `named_layers`).
       # Named layers must be lowered first (see keymap-ncl-to-json named layer transform).
+      # `K.tlex` cells become null and contribute bit i+1 to `exit_on_skip`.
       to_json_value = fun k =>
         k
         |> match {
           { named_layers = _, .. } =>
             std.fail_with "named_layers must be lowered to array form before to_json_value",
           { layered = layered_keys, ..base_key } =>
+            let exit_indices =
+              layered_keys
+              |> std.array.map_with_index (fun i cell =>
+                if is_tlex_key cell then i + 1 else null
+              )
+              |> std.array.filter ((!=) null)
+            in
+            let exit_bits =
+              if exit_indices == [] then
+                null
+              else
+                layer_indices_to_bitset exit_indices
+            in
             {
               base = keymap_ncl.key.to_json_value base_key,
               layered =
                 std.array.map
-                  (fun k => if k != null then keymap_ncl.key.to_json_value k else null)
+                  (fun cell =>
+                    if cell == null || is_tlex_key cell then
+                      null
+                    else
+                      keymap_ncl.key.to_json_value cell
+                  )
                   layered_keys,
-            },
+            }
+            & (
+              if exit_bits == null then
+                {}
+              else
+                { exit_on_skip = exit_bits }
+            ),
         },
 
       # Visit children under `layered` (array) and/or `named_layers` (record), then base.

--- a/smart-keymap-core/src/key/layered.rs
+++ b/smart-keymap-core/src/key/layered.rs
@@ -924,9 +924,19 @@ pub struct LayeredKey<R: Copy + Debug + PartialEq, const LAYER_COUNT: usize> {
     /// The base key, used when no layers are active.
     pub base: R,
     /// The layered keys, used when the corresponding layer is active.
+    ///
+    /// `None` is full transparency for that layer (`K.TTTT` / `null` in JSON).
     #[serde(deserialize_with = "deserialize_layered")]
     #[serde(bound(deserialize = "R: Deserialize<'de>"))]
     pub layered: [Option<R>; LAYER_COUNT],
+    /// Layers that exit when their cell is a hole (`None`) and is skipped.
+    ///
+    /// Bit `i` is layer index `i` (same layout as [LayerBitset] / `SetActiveLayers`).
+    /// Used for FAK-style transparent layer exit (`K.tlex`): skip the hole, schedule
+    ///  [LayerEvent::Deactivated] for a non-persistent activation, and continue the walk.
+    /// Ordinary transparency leaves this empty.
+    #[serde(default)]
+    pub exit_on_skip: LayerBitset,
 }
 
 /// Deserialize a [Layers].
@@ -941,25 +951,103 @@ where
 }
 
 impl<R: Copy + Debug + PartialEq, const LAYER_COUNT: usize> LayeredKey<R, LAYER_COUNT> {
-    /// Constructs a new [LayeredKey].
+    /// Constructs a new [LayeredKey] with no exit-on-skip holes.
     pub const fn new<const L: usize>(base: R, layered: [Option<R>; L]) -> Self {
         let layered = layered_keys(layered);
-        Self { base, layered }
+        Self {
+            base,
+            layered,
+            exit_on_skip: LayerBitset::EMPTY,
+        }
+    }
+
+    /// Sets layers that deactivate when a transparent cell is skipped on that layer.
+    pub const fn with_exit_on_skip(self, exit_on_skip: LayerBitset) -> Self {
+        Self {
+            exit_on_skip,
+            ..self
+        }
     }
 }
 
+/// Whether exit-on-skip should schedule [LayerEvent::Deactivated] for `layer`.
+///
+/// Only non-persistent activations (regular hold/toggle and sticky).
+/// A layer that is only the default (not Regular/Sticky-active) is not cleared.
+///
+/// `layer` is a 1-based [LayerIndex] (same as [LayerState::activate]): array
+///  slots and `exit_on_skip` cells use `layer - 1` / bit `layer`.
+fn is_exit_deactivatable<const LAYER_COUNT: usize, const CONDITIONAL_LAYER_COUNT: usize>(
+    context: &Context<LAYER_COUNT, CONDITIONAL_LAYER_COUNT>,
+    layer: LayerIndex,
+) -> bool {
+    let layer_index = layer as usize;
+    (1..=LAYER_COUNT).contains(&layer_index)
+        && matches!(
+            context.active_layers[layer_index - 1],
+            Activity::Active(ActivationStyle::Regular | ActivationStyle::Sticky)
+        )
+}
+
 impl<R: Copy + Debug + PartialEq, const LAYER_COUNT: usize> LayeredKey<R, LAYER_COUNT> {
-    /// Presses the key, using the highest active key, if any.
+    /// Presses the key: highest defined active binding, with exit-on-skip side effects.
     fn new_pressed_key<const CONDITIONAL_LAYER_COUNT: usize>(
         &self,
         context: &Context<LAYER_COUNT, CONDITIONAL_LAYER_COUNT>,
-    ) -> key::NewPressedKey<R> {
-        let (_layer, passthrough_ref) = self
-            .layered
-            .highest_active_key(context.layer_state(), context.default_layer)
-            .unwrap_or((0, self.base));
+        keymap_index: u16,
+    ) -> (key::NewPressedKey<R>, key::KeyEvents<LayerEvent>) {
+        // Active layers high → low, in range for this key's layered array.
+        // `layer_index` stays 1-based; array access is always `layer_index - 1`.
+        let active_in_range = || {
+            context
+                .layer_state()
+                .active_layers()
+                .filter(|&layer_index| {
+                    let layer_index = layer_index as usize;
+                    (1..=LAYER_COUNT).contains(&layer_index)
+                })
+        };
 
-        key::NewPressedKey::key(passthrough_ref)
+        // First defined cell among active layers (and its 1-based layer index).
+        let picked = active_in_range().find_map(|layer_index| {
+            self.layered[layer_index as usize - 1].map(|r| (layer_index, r))
+        });
+
+        // Exit holes strictly above the pick (or all active holes if none defined).
+        // `exit_on_skip` bits are 1-based layer indices (same as [LayerBitset]).
+        let events = active_in_range()
+            .take_while(|&layer_index| {
+                picked
+                    .map(|(picked_layer, _)| layer_index != picked_layer)
+                    .unwrap_or(true)
+            })
+            .filter(|&layer_index| {
+                self.layered[layer_index as usize - 1].is_none()
+                    && self.exit_on_skip.contains(layer_index as usize)
+                    && is_exit_deactivatable(context, layer_index)
+            })
+            .fold(key::KeyEvents::no_events(), |mut events, layer_index| {
+                events.add_event(key::Event::key_event(
+                    keymap_index,
+                    LayerEvent::Deactivated(layer_index),
+                ));
+                events
+            });
+
+        let passthrough_ref = picked
+            .map(|(_, r)| r)
+            .or_else(|| {
+                context.default_layer.and_then(|layer_index| {
+                    let layer_index = layer_index as usize;
+                    (1..=LAYER_COUNT)
+                        .contains(&layer_index)
+                        .then(|| self.layered[layer_index - 1])
+                        .flatten()
+                })
+            })
+            .unwrap_or(self.base);
+
+        (key::NewPressedKey::key(passthrough_ref), events)
     }
 }
 
@@ -1161,11 +1249,8 @@ impl<
             }
             Ref::Layered(i) => {
                 let key = &self.layered_keys[i as usize];
-                let npk = key.new_pressed_key(context);
-                (
-                    key::PressedKeyResult::NewPressedKey(npk),
-                    key::KeyEvents::no_events(),
-                )
+                let (npk, pke) = key.new_pressed_key(context, keymap_index);
+                (key::PressedKeyResult::NewPressedKey(npk), pke)
             }
         }
     }
@@ -1649,6 +1734,75 @@ mod tests {
             Some(LayerEvent::LockInvert(LayerLockTarget::Layer(2))),
             layer_event
         );
+    }
+
+    #[test]
+    fn test_exit_on_skip_emits_deactivated_and_resolves_to_base() {
+        // Assemble: layer 1 cell is a tlex hole over base A
+        let mut context = Context::default();
+        let base = keyboard::Ref::KeyCode(0x04);
+        let layered_key = LayeredKey::new(base, [None]).with_exit_on_skip(LayerBitset::from_bits(
+            // bit 1 = layer 1
+            1 << 1,
+        ));
+        let system = System::new([], [layered_key]);
+
+        // Act: activate layer 1, press the layered key
+        context.handle_layer_event(LayerEvent::Activated(1));
+        let keymap_index = 3;
+        let (pkr, pke) = system.new_pressed_key(keymap_index, &context, Ref::Layered(0));
+
+        // Assert: this press is base; Deactivated(1) is scheduled
+        assert_eq!(
+            key::PressedKeyResult::NewPressedKey(key::NewPressedKey::Key(base)),
+            pkr,
+        );
+        let events: Vec<_> = pke.into_iter().collect();
+        assert_eq!(1, events.len());
+        assert_eq!(
+            key::ScheduledEvent::immediate(key::Event::key_event(
+                keymap_index,
+                LayerEvent::Deactivated(1)
+            )),
+            events[0],
+        );
+    }
+
+    #[test]
+    fn test_exit_on_skip_does_not_exit_default_only_layer() {
+        // Assemble: layer 1 is only the default, not Regular/Sticky
+        let mut context = Context::default();
+        let base = keyboard::Ref::KeyCode(0x04);
+        let layered_key =
+            LayeredKey::new(base, [None]).with_exit_on_skip(LayerBitset::from_bits(1 << 1));
+        let system = System::new([], [layered_key]);
+
+        // Act: set default layer 1 (not Regular activation)
+        context.handle_layer_event(LayerEvent::SetDefault(1));
+        let (pkr, pke) = system.new_pressed_key(0, &context, Ref::Layered(0));
+
+        // Assert: resolves via default path without Deactivated
+        assert_eq!(
+            key::PressedKeyResult::NewPressedKey(key::NewPressedKey::Key(base)),
+            pkr,
+        );
+        assert_eq!(0, pke.into_iter().count());
+    }
+
+    #[test]
+    fn test_tttt_without_exit_bit_does_not_emit_deactivated() {
+        // Assemble: ordinary transparency (no exit_on_skip)
+        let mut context = Context::default();
+        let base = keyboard::Ref::KeyCode(0x04);
+        let layered_key = LayeredKey::new(base, [None]);
+        let system = System::new([], [layered_key]);
+
+        // Act
+        context.handle_layer_event(LayerEvent::Activated(1));
+        let (_pkr, pke) = system.new_pressed_key(0, &context, Ref::Layered(0));
+
+        // Assert
+        assert_eq!(0, pke.into_iter().count());
     }
 
     #[test]

--- a/tests/rust/layered.rs
+++ b/tests/rust/layered.rs
@@ -5,6 +5,7 @@ mod set_active_layers;
 mod sticky;
 mod sticky_timeout;
 mod tap_hold;
+mod tlex;
 mod toggle;
 
 use smart_keymap::input;

--- a/tests/rust/layered/tlex.rs
+++ b/tests/rust/layered/tlex.rs
@@ -1,0 +1,97 @@
+use smart_keymap::input;
+use smart_keymap::keymap::ObservedKeymap;
+
+use crate::hid_keycodes::*;
+use smart_keymap_macros::keymap;
+
+#[test]
+fn tlex_acts_as_base_and_deactivates_toggle_layer() {
+    // Assemble -- toggle layer 1, tlex over base A
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                layers = [
+                    [K.layer_mod.toggle 1, K.A],
+                    [K.TTTT, K.tlex],
+                ],
+            }
+        "#
+    ));
+
+    // Act -- enable layer 1, press tlex key
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+
+    // Assert -- this press is base A, and layer is off afterward
+    let expected_report: [u8; 8] = [0, 0, KC_A, 0, 0, 0, 0, 0];
+    assert_eq!(expected_report, keymap.boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+
+    // Second press of the same key still base (layer exited)
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    assert_eq!(expected_report, keymap.boot_keyboard_report());
+}
+
+#[test]
+fn tlex_differs_from_full_transparency() {
+    // Assemble -- without tlex, layer stays on after a transparent-adjacent key
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                layers = [
+                    [K.layer_mod.toggle 1, K.A, K.C],
+                    [K.TTTT, K.tlex, K.B],
+                ],
+            }
+        "#
+    ));
+
+    // Act -- enable layer 1
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+
+    // Layer-1 key B works
+    keymap.handle_input(input::Event::Press { keymap_index: 2 });
+    let expected_b: [u8; 8] = [0, 0, KC_B, 0, 0, 0, 0, 0];
+    assert_eq!(expected_b, keymap.boot_keyboard_report());
+    keymap.handle_input(input::Event::Release { keymap_index: 2 });
+
+    // tlex on index 1 → base A, deactivates layer 1
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    let expected_a: [u8; 8] = [0, 0, KC_A, 0, 0, 0, 0, 0];
+    assert_eq!(expected_a, keymap.boot_keyboard_report());
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+
+    // Assert -- same physical key that was B is now base C
+    keymap.handle_input(input::Event::Press { keymap_index: 2 });
+    let expected_c: [u8; 8] = [0, 0, KC_C, 0, 0, 0, 0, 0];
+    assert_eq!(expected_c, keymap.boot_keyboard_report());
+}
+
+#[test]
+fn tlex_under_hold_layer_still_active_resolves_base_for_this_press() {
+    // Assemble -- hold-layer still held; tlex continue-evals for this press
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                layers = [
+                    [K.layer_mod.hold 1, K.A],
+                    [K.TTTT, K.tlex],
+                ],
+            }
+        "#
+    ));
+
+    // Act
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+
+    // Assert
+    let expected_a: [u8; 8] = [0, 0, KC_A, 0, 0, 0, 0, 0];
+    assert_eq!(expected_a, keymap.boot_keyboard_report());
+}


### PR DESCRIPTION
## Summary

FAK-style **bare transparent layer exit** (`K.tlex` / `tap.tlex`):

- Keep layered cells as `Option<R>` (`null` = hole).
- `LayeredKey::exit_on_skip` bitset: when a hole on a marked layer is skipped, schedule `LayerEvent::Deactivated` for Regular/Sticky activations and continue-eval to the next defined binding or base.
- Nickel: `K.tlex` authoring leaf (for cucumber lookup), lower to `null` + `exit_on_skip` bits, input-sim deactivation.
- Tests: core unit, rust-integration, cucumber `layer_modifier-tlex.feature`.

No third cell type / untagged serde (unlike closed #674).

## Stack

This is **PR 1 of 3**:

1. **This PR** — bare tlex
2. `exit_on_transparent` smart-stay sugar (depends on this)
3. TH portion transparency + `hold.tlex` (depends on 2)

## Test plan

- [x] `cargo test -p smart-keymap-core --lib key::layered::tests`
- [x] `cargo test -p smart-keymap --test rust-integration tlex`
- [x] `cargo test -p smart-keymap-full-system-std --test cucumber-keymap -- -n "tlex|without tlex"`
- [ ] CI green