### PR TITLE
ncl: exit_on_transparent as layer-row map sugar

### DIFF
--- a/ncl/smart_keys/layered/key-extensions.ncl
+++ b/ncl/smart_keys/layered/key-extensions.ncl
@@ -54,6 +54,13 @@
     # the defining layer. Lowered to null + exit_on_skip bit for runtime.
     tlex = { transparent_layer_exit = true },
 
+    # Smart-stay sugar: map a layer row, replacing null / TTTT cells with tlex.
+    # Authoring: `my_layer |> K.exit_on_transparent`
+    # (Array of keys only — not string layer tokens.)
+    exit_on_transparent = fun layer =>
+      layer
+      |> std.array.map (fun cell => if cell == null then tlex else cell),
+
     # Semantic / variant key sugar: `named_layers` form of LayeredKey.
     # Unit `{}` base (keyboard noop) so callers can use `K.semantic {..}` without
     # `K.NO &`. Indices for names are assigned globally when compiling the keymap.

--- a/tests/rust/layered/tlex.rs
+++ b/tests/rust/layered/tlex.rs
@@ -73,6 +73,37 @@ fn tlex_differs_from_full_transparency() {
 }
 
 #[test]
+fn exit_on_transparent_maps_null_cells_to_tlex() {
+    // Assemble -- layer row piped through K.exit_on_transparent
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                layers = [
+                    [K.layer_mod.toggle 1, K.A, K.C],
+                    [K.TTTT, K.TTTT, K.B] |> K.exit_on_transparent,
+                ],
+            }
+        "#
+    ));
+
+    // Act -- enable layer 1, press a hole that was only TTTT
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+
+    // Assert -- base A and layer exits
+    let expected_a: [u8; 8] = [0, 0, KC_A, 0, 0, 0, 0, 0];
+    assert_eq!(expected_a, keymap.boot_keyboard_report());
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+
+    // Layer-1 key B would have been on layer; after hole-exit, base C
+    keymap.handle_input(input::Event::Press { keymap_index: 2 });
+    let expected_c: [u8; 8] = [0, 0, KC_C, 0, 0, 0, 0, 0];
+    assert_eq!(expected_c, keymap.boot_keyboard_report());
+}
+
+#[test]
 fn tlex_under_hold_layer_still_active_resolves_base_for_this_press() {
     // Assemble -- hold-layer still held; tlex continue-evals for this press
     let mut keymap = ObservedKeymap::new(keymap!(


### PR DESCRIPTION
## Summary

Smart-stay sugar as an **explicit layer-row map**, not a top-level layer-index stamp:

```nickel
layers = [
  [K.layer_mod.toggle 1, K.A, K.C],
  [K.TTTT, K.TTTT, K.B] |> K.exit_on_transparent,
]
```

`K.exit_on_transparent` maps `null` / `TTTT` cells to `K.tlex` on that row. Fold/codegen then lower tlex as usual (`exit_on_skip` bits).

## Stack

**PR 2 of 3** — base: `master` (after #701)

1. #701 — bare tlex (merged)
2. **This PR** — `K.exit_on_transparent` layer map
3. #703 — TH portion transparency + `hold.tlex`

## Test plan

- [x] `cargo test -p smart-keymap --test rust-integration exit_on_transparent`
- [ ] CI green