### PR TITLE
ncl: TH portion transparency and hold.tlex

### DIFF
--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -307,6 +307,25 @@
     map_accum = fun f acc k => { include acc, include k },
   },
 
+  # Portion transparency leaf (FAK tap.trans / hold.trans). Must be rewritten by
+  # lower_th_portions before to_json_value; not a runtime key by itself.
+  keymap_ncl.portion_transparent = {
+    key_validator = fun k =>
+      k
+      |> match {
+        { transparent = true } => 'Ok,
+        { transparent = {} } => 'Ok,
+        _ => 'Error { message = "expected { transparent = true }" },
+      },
+
+    is_key = fun k => 'Ok == key_validator k,
+
+    to_json_value = fun _k =>
+      std.fail_with "K.trans must be lowered (use as tap/hold of a layered column)",
+
+    map_accum = fun f acc k => { include acc, include k },
+  },
+
   keymap_ncl.key = {
     # Dispatch order = outermost wrapper wins when several modules' is_key match
     # the same record (Nickel record "abuse"). Used by key_validator and
@@ -332,6 +351,7 @@
       keymap_ncl.tap_hold,
       keymap_ncl.layer_modifier,
       keymap_ncl.transparent_layer_exit,
+      keymap_ncl.portion_transparent,
       keymap_ncl.keyboard,
     ],
 
@@ -651,6 +671,8 @@
       # Named order: `named_layer_order` if set, else alphabetical. Skipped if unused.
       # Layer_mod fields may use those names as strings; resolve to 1-based indices.
       let keys = prepare_keys_named_layers keys in
+      # TH portion transparency / hold.tlex: project from column below.
+      let keys = keymap_ncl.layered.apply_lower_th_portions keys in
       # Tap-hold profiles: lower name map → array; resolve key name selectors → indices.
       let { tap_hold = th_config, ..km_config_after_th } = config & { tap_hold = {} } in
       let th_profile_names = tap_hold_profile_names th_config in

--- a/ncl/smart_keys/layered/key-extensions.ncl
+++ b/ncl/smart_keys/layered/key-extensions.ncl
@@ -61,6 +61,11 @@
       layer
       |> std.array.map (fun cell => if cell == null then tlex else cell),
 
+    # Portion transparency (FAK tap.trans / hold.trans): not a whole-cell hole.
+    # Use as TH child, e.g. `K.J & K.hold K.trans` or `K.trans & K.hold K.LeftShift`.
+    # Lowered by column projection before JSON (see lower_th_portions).
+    trans = { transparent = true },
+
     # Semantic / variant key sugar: `named_layers` form of LayeredKey.
     # Unit `{}` base (keyboard noop) so callers can use `K.semantic {..}` without
     # `K.NO &`. Indices for names are assigned globally when compiling the keymap.

--- a/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/layered/keymap-ncl-to-json.ncl
@@ -367,6 +367,113 @@
           },
       },
 
+      # tlex authoring cell (same as K.tlex); used by TH continuation lowers.
+      tlex_cell = { transparent_layer_exit = true },
+
+      is_trans_key = fun k =>
+        k
+        |> match {
+          { transparent = true } => true,
+          { transparent = {} } => true,
+          _ => false,
+        },
+
+      is_th_key = fun k =>
+        std.is_record k && std.record.has_field "hold" k,
+
+      project_hold = fun k =>
+        if is_th_key k then k.hold else k,
+
+      project_tap = fun k =>
+        if is_th_key k then
+          let { hold = _, ..tap } = k in
+          tap
+        else
+          k,
+
+      # Highest non-null binding strictly below `layer_idx` (1-based) in the column.
+      # column[0] = base, column[i] = layered[i-1] for i >= 1.
+      binding_below = fun column layer_idx =>
+        let rec go = fun i =>
+          if i < 0 then
+            null
+          else
+            let cell = std.array.at i column in
+            if cell == null || is_tlex_key cell || is_trans_key cell then
+              go (i - 1)
+            else
+              cell
+        in
+        go (layer_idx - 1),
+
+      # Continuation LayeredKey: base binding + tlex hole on defining layer.
+      # Press while that layer is active → Deactivated + base.
+      continuation_with_exit = fun base_binding layer_idx =>
+        let cont_layered =
+          std.array.generate
+            (fun j => if j + 1 == layer_idx then tlex_cell else null)
+            layer_idx
+        in
+        base_binding & { layered = cont_layered },
+
+      # Rewrite TH portion transparency / hold.tlex using the column below.
+      # hold.trans → concrete hold from below.
+      # hold.tlex  → continuation_with_exit (projected hold) so hold resolve exits.
+      # tap.trans / tap-as-tlex analogous for the tap half of the TH record.
+      lower_th_portions_in_layered = fun k =>
+        k
+        |> match {
+          { layered = layered_arr, ..base_key } =>
+            let column = [base_key] @ layered_arr in
+            let new_layered =
+              std.array.map_with_index
+                (fun i cell =>
+                  let layer_idx = i + 1 in
+                  if !(is_th_key cell) then
+                    cell
+                  else
+                    let below = binding_below column layer_idx in
+                    let { hold = hold_child, ..tap_part } = cell in
+                    let new_hold =
+                      if is_trans_key hold_child then
+                        if below == null then
+                          std.fail_with "hold.trans: nothing below to project"
+                        else
+                          project_hold below
+                      else if is_tlex_key hold_child then
+                        if below == null then
+                          std.fail_with "hold.tlex: nothing below to project"
+                        else
+                          continuation_with_exit (project_hold below) layer_idx
+                      else
+                        hold_child
+                    in
+                    let new_tap =
+                      if is_trans_key tap_part then
+                        if below == null then
+                          std.fail_with "tap.trans: nothing below to project"
+                        else
+                          project_tap below
+                      else if is_tlex_key tap_part then
+                        if below == null then
+                          std.fail_with "tap.tlex as TH tap: nothing below to project"
+                        else
+                          continuation_with_exit (project_tap below) layer_idx
+                      else
+                        tap_part
+                    in
+                    new_tap & { hold = new_hold }
+                )
+                layered_arr
+            in
+            base_key & { layered = new_layered },
+          k => k,
+        },
+
+      apply_lower_th_portions = fun keys =>
+        keys
+        |> std.array.map lower_th_portions_in_layered,
+
       # Keymap.ncl authoring: if_layers as 1-based layer index list.
       ConditionalLayer = {
         then_layer | Number,

--- a/tests/rust/layered/tlex.rs
+++ b/tests/rust/layered/tlex.rs
@@ -104,6 +104,70 @@ fn exit_on_transparent_maps_null_cells_to_tlex() {
 }
 
 #[test]
+fn hold_trans_projects_hold_from_below() {
+    // Assemble -- layer 1: J on tap, hold.trans → Shift from base
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                layers = [
+                    [K.layer_mod.hold 1, K.A & K.hold K.LeftShift],
+                    [K.TTTT, K.J & K.hold K.trans],
+                ],
+            }
+        "#
+    ));
+
+    // Act -- hold layer, hold the TH long enough for hold
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert -- Shift held (layer still on; hold.trans does not exit)
+    let expected: [u8; 8] = [0x02, 0, 0, 0, 0, 0, 0, 0];
+    assert_eq!(expected, keymap.boot_keyboard_report());
+}
+
+#[test]
+fn hold_tlex_exits_layer_and_registers_hold_from_below() {
+    // Assemble -- FAK-shaped hold.tlex: tap Z, hold exits + Shift
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                layers = [
+                    [K.layer_mod.toggle 1, K.A & K.hold K.LeftShift],
+                    [K.TTTT, K.Z & K.hold K.tlex],
+                ],
+            }
+        "#
+    ));
+
+    // Act -- toggle layer 1, hold the TH to hold
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert -- Shift held after layer exit
+    let expected_shift: [u8; 8] = [0x02, 0, 0, 0, 0, 0, 0, 0];
+    assert_eq!(expected_shift, keymap.boot_keyboard_report());
+
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+    // After exit, tap of base TH is A
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+    keymap.tick_until_no_scheduled_events();
+    // Tap already released — check distinct reports include A
+    let reports = keymap.distinct_reports();
+    assert!(
+        reports.reports().iter().any(|r| r[2] == KC_A),
+        "expected a tap of A after layer exit, reports={:?}",
+        reports.reports()
+    );
+}
+
+#[test]
 fn tlex_under_hold_layer_still_active_resolves_base_for_this_press() {
     // Assemble -- hold-layer still held; tlex continue-evals for this press
     let mut keymap = ObservedKeymap::new(keymap!(


### PR DESCRIPTION
## Summary

FAK-shaped **tap-hold portion** handling on layered columns:

- `K.trans` — portion transparency (`hold.trans` / `tap.trans`): project the hold or tap binding from the column below (layer stays on).
- `K.hold K.tlex` — **hold.tlex**: project hold from below into a nested `LayeredKey` continuation (tlex hole on the defining layer) so hold resolve deactivates that layer and registers the hold from below.

Nickel column lower only; no new `Ref` family.

## Stack

**PR 3 of 3** — base: `master` (after #701 and #702)

1. #701 — bare tlex (merged)
2. #702 — `K.exit_on_transparent` layer map (merged)
3. **This PR** — TH transparency + hold.tlex

## Test plan

- [x] `cargo test -p smart-keymap --test rust-integration layered::tlex` (6 tests)
- [ ] CI green