### PR TITLE
keymap: nested pending timeouts from the physical press

### DIFF
--- a/smart-keymap-core/src/key.rs
+++ b/smart-keymap-core/src/key.rs
@@ -114,6 +114,21 @@ impl<E: Copy + Debug> KeyEvents<E> {
     }
 }
 
+impl<E, const M: usize> KeyEvents<E, M> {
+    /// Subtract `elapsed` tick/ms units from each delayed event.
+    ///
+    /// [`Schedule::Immediate`] is unchanged.
+    /// A remaining delay of 0 becomes Immediate so it runs this turn.
+    pub fn backdate(self, elapsed: u32) -> Self {
+        KeyEvents(
+            self.0
+                .into_iter()
+                .map(|sch_ev| sch_ev.backdate(elapsed))
+                .collect(),
+        )
+    }
+}
+
 impl<E: Debug, const M: usize> IntoIterator for KeyEvents<E, M> {
     type Item = ScheduledEvent<E>;
     type IntoIter = <heapless::Vec<ScheduledEvent<E>, M> as IntoIterator>::IntoIter;
@@ -232,6 +247,11 @@ pub trait System<R>: Debug {
     /// (e.g. [tap_hold::Key] may schedule a [tap_hold::Event::TapHoldTimeout]
     ///  so that holding the key resolves as a hold,
     ///  when a timeout is configured).
+    ///
+    /// Delays are from this call.
+    /// When the keymap replaces a pending key with another pending key
+    ///  (e.g. chorded passthrough to tap-hold),
+    ///  it backdates those `After` delays by time already spent on this press.
     fn new_pressed_key(
         &self,
         keymap_index: u16,
@@ -868,6 +888,23 @@ pub enum Schedule {
     After(u16),
 }
 
+impl Schedule {
+    /// Subtract `elapsed` tick/ms units from an [`Schedule::After`] delay.
+    ///
+    /// [`Schedule::Immediate`] is unchanged.
+    /// If the remaining delay is 0, becomes Immediate so it runs this turn
+    ///  (not [`Schedule::After`] 0, which still waits for a tick).
+    pub fn backdate(self, elapsed: u32) -> Self {
+        match self {
+            Schedule::Immediate => Schedule::Immediate,
+            Schedule::After(delay) => match (delay as u32).saturating_sub(elapsed) {
+                0 => Schedule::Immediate,
+                remaining => Schedule::After(remaining as u16),
+            },
+        }
+    }
+}
+
 /// An [Event] with a [Schedule] for the keymap event scheduler.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ScheduledEvent<T> {
@@ -875,6 +912,18 @@ pub struct ScheduledEvent<T> {
     pub schedule: Schedule,
     /// The event.
     pub event: Event<T>,
+}
+
+impl<T> ScheduledEvent<T> {
+    /// Subtract `elapsed` from this event's [`Schedule`].
+    ///
+    /// See [`Schedule::backdate`].
+    pub fn backdate(self, elapsed: u32) -> Self {
+        ScheduledEvent {
+            schedule: self.schedule.backdate(elapsed),
+            event: self.event,
+        }
+    }
 }
 
 impl<T: Copy> ScheduledEvent<T> {
@@ -952,5 +1001,39 @@ mod tests {
         assert_eq!(2, result.len());
         assert_eq!(Event::from(input::Event::press(1)), result[0]);
         assert_eq!(Event::from(input::Event::release(0)), result[1]);
+    }
+
+    #[test]
+    fn schedule_backdate_leaves_immediate_unchanged() {
+        assert_eq!(Schedule::Immediate, Schedule::Immediate.backdate(50));
+    }
+
+    #[test]
+    fn schedule_backdate_zero_elapsed_keeps_after_delay() {
+        assert_eq!(Schedule::After(200), Schedule::After(200).backdate(0));
+    }
+
+    #[test]
+    fn schedule_backdate_shortens_after_delay() {
+        assert_eq!(Schedule::After(150), Schedule::After(200).backdate(50));
+    }
+
+    #[test]
+    fn schedule_backdate_expired_after_becomes_immediate() {
+        assert_eq!(Schedule::Immediate, Schedule::After(200).backdate(200));
+        assert_eq!(Schedule::Immediate, Schedule::After(50).backdate(200));
+    }
+
+    #[test]
+    fn key_events_backdate_only_rewrites_after() {
+        let ev: Event<()> = Event::from(input::Event::press(0));
+        let mut events = KeyEvents::event(ev);
+        events.schedule_event(200, ev);
+
+        let mut backdated = events.backdate(50).into_iter();
+
+        assert_eq!(Schedule::Immediate, backdated.next().unwrap().schedule);
+        assert_eq!(Schedule::After(150), backdated.next().unwrap().schedule);
+        assert!(backdated.next().is_none());
     }
 }

--- a/smart-keymap-core/src/key/chorded.rs
+++ b/smart-keymap-core/src/key/chorded.rs
@@ -66,6 +66,10 @@ pub struct Config<const MAX_CHORDS: usize, const MAX_CHORD_SIZE: usize> {
     /// The timeout (in number of milliseconds) for a chorded key to resolve.
     ///
     /// (Resolves as passthrough key if no chord is satisfied).
+    ///
+    /// This is the outer decision clock for a chorded position.
+    /// An inner pending key (e.g. tap-hold) then uses time remaining
+    ///  from this same physical press; the two timeouts do not add.
     #[serde(default = "default_timeout")]
     pub timeout: u16,
 

--- a/smart-keymap-core/src/key/tap_dance.rs
+++ b/smart-keymap-core/src/key/tap_dance.rs
@@ -14,6 +14,9 @@ pub struct Ref(pub u8);
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct Config {
     /// The timeout (in number of milliseconds) for the next press of the tap-dance.
+    ///
+    /// The first timeout is from the physical press of this keymap index.
+    /// Later timeouts are from the re-press that scheduled them.
     #[serde(default = "default_timeout")]
     pub timeout: u16,
 }

--- a/smart-keymap-core/src/key/tap_hold.rs
+++ b/smart-keymap-core/src/key/tap_hold.rs
@@ -34,6 +34,11 @@ pub const MAX_HOLD_TRIGGER_POSITIONS: usize = 16;
 pub struct Profile {
     /// The timeout (in number of milliseconds) for a tap-hold key to resolve as hold.
     ///
+    /// Counted from the physical press of this keymap index.
+    /// When this tap-hold is nested under another pending key
+    ///  (e.g. chorded passthrough), the keymap folds already-elapsed
+    ///  time into the scheduled delay so the configured timeout is not additive.
+    ///
     /// When `None`, the tap/hold decision does not timeout;
     ///  the key resolves only on release (as tap) or interruption
     ///  (depending on [InterruptResponse]).

--- a/smart-keymap-core/src/keymap.rs
+++ b/smart-keymap-core/src/keymap.rs
@@ -591,6 +591,12 @@ impl<
                 let pkr = match npk {
                     key::NewPressedKey::Key(new_key_ref) => {
                         *key_ref = new_key_ref;
+                        // Drop the previous pending key's delayed events
+                        //  (e.g. the chord timeout after passthrough or
+                        //  chord resolve) so they do not steal a tick from
+                        //  the replacement key's timeout.
+                        self.event_scheduler
+                            .cancel_events_for_keymap_index(keymap_index);
                         // This press is already in the ring (recorded on the
                         //  original input).
                         // Exclude it before constructing the replacement key.
@@ -608,6 +614,19 @@ impl<
                             &self.context,
                             new_key_ref,
                         );
+                        // Decision timeouts are from this physical press.
+                        // Fold time already spent waiting (e.g. chorded
+                        //  timeout before passthrough) into After delays.
+                        // Remaining 0 is Immediate so an expired inner
+                        //  timeout resolves in this turn.
+                        let elapsed_ms = self
+                            .event_scheduler
+                            .schedule_counter
+                            .saturating_sub(nested_press_ctx.time_ms);
+                        let pke = match &pkr {
+                            key::PressedKeyResult::Pending(_) => pke.backdate(elapsed_ms),
+                            _ => pke,
+                        };
                         pke.into_iter()
                             .for_each(|sch_ev| self.event_scheduler.schedule_event(sch_ev));
                         pkr

--- a/tests/rust/chorded.rs
+++ b/tests/rust/chorded.rs
@@ -1,3 +1,4 @@
+mod nested_timeout;
 mod over_layered_tap_hold;
 mod overlapping;
 mod overlapping_aux;

--- a/tests/rust/chorded/nested_timeout.rs
+++ b/tests/rust/chorded/nested_timeout.rs
@@ -1,0 +1,250 @@
+//! Nested pending timeouts are counted from the physical press.
+//!
+//! Chorded wrap tap-hold or tap-dance; without backdating, hold waits
+//!  for the chord timeout plus the inner timeout.
+//!
+//! A *resolved chord* whose binding is tap-hold is a different path:
+//!  the completing press is a fresh `new_pressed_key` on the activator
+//!  index, so that hold clock starts when the chord is completed.
+
+use smart_keymap::input;
+use smart_keymap::keymap::ObservedKeymap;
+
+use crate::hid_keycodes::*;
+use smart_keymap_macros::keymap;
+
+#[test]
+fn passthrough_hold_resolves_at_tap_hold_timeout_not_sum() {
+    // Assemble -- equal 200ms chord + tap-hold timeouts.
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.chorded.timeout = 200,
+                config.tap_hold.timeout = 200,
+                chords = [
+                    { indices = [0, 1], key = K.C },
+                ],
+                keys = [
+                    K.A & K.hold K.LeftCtrl,
+                    K.B,
+                ],
+            }
+        "#
+    ));
+
+    // Act -- press the chorded tap-hold; ObservedKeymap::handle_input
+    //  already ticks once, so 198 more ticks is t=199.
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    for _ in 0..198 {
+        keymap.tick();
+    }
+
+    // Assert -- still pending just before the chord timeout.
+    #[rustfmt::skip]
+    let expected_before: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_before, keymap.distinct_reports().reports());
+
+    // Act -- one more tick reaches t=200: chord passthroughs and the
+    //  inner tap-hold timeout is already expired, so hold is Immediate.
+    keymap.tick();
+
+    // Assert -- hold, not another 200ms of pending.
+    #[rustfmt::skip]
+    let expected_hold: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_hold, keymap.distinct_reports().reports());
+}
+
+#[test]
+fn aux_passthrough_hold_resolves_at_tap_hold_timeout_not_sum() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.chorded.timeout = 200,
+                config.tap_hold.timeout = 200,
+                chords = [
+                    { indices = [0, 1], key = K.C },
+                ],
+                keys = [
+                    K.A,
+                    K.B & K.hold K.LeftShift,
+                ],
+            }
+        "#
+    ));
+
+    // Act -- hold the auxiliary chorded tap-hold until t=200.
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    for _ in 0..199 {
+        keymap.tick();
+    }
+
+    // Assert
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LSHFT, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, keymap.distinct_reports().reports());
+}
+
+#[test]
+fn shorter_chord_timeout_leaves_remaining_tap_hold_delay() {
+    // Assemble -- chord 50ms, tap-hold 200ms: hold at 200 from press.
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.chorded.timeout = 50,
+                config.tap_hold.timeout = 200,
+                chords = [
+                    { indices = [0, 1], key = K.C },
+                ],
+                keys = [
+                    K.A & K.hold K.LeftCtrl,
+                    K.B,
+                ],
+            }
+        "#
+    ));
+
+    // Act -- t=50: chord passthroughs; tap-hold still has 150ms remaining.
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    for _ in 0..49 {
+        keymap.tick();
+    }
+
+    // Assert -- not hold yet (would be if we Immediate-fired the inner timeout).
+    #[rustfmt::skip]
+    let expected_pending: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_pending, keymap.distinct_reports().reports());
+
+    // Act -- remaining tap-hold delay; hold at t=200 from the press.
+    for _ in 0..150 {
+        keymap.tick();
+    }
+
+    // Assert
+    #[rustfmt::skip]
+    let expected_hold: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_hold, keymap.distinct_reports().reports());
+}
+
+#[test]
+fn shorter_tap_hold_timeout_resolves_when_chord_passthroughs() {
+    // Assemble -- chord 200ms, tap-hold 50ms: cannot hold before the chord
+    //  decides; at passthrough the inner timeout is already expired.
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.chorded.timeout = 200,
+                config.tap_hold.timeout = 50,
+                chords = [
+                    { indices = [0, 1], key = K.C },
+                ],
+                keys = [
+                    K.A & K.hold K.LeftCtrl,
+                    K.B,
+                ],
+            }
+        "#
+    ));
+
+    // Act
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    for _ in 0..199 {
+        keymap.tick();
+    }
+
+    // Assert -- hold as soon as the chord passthroughs, not 50ms later.
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, keymap.distinct_reports().reports());
+}
+
+#[test]
+fn layered_passthrough_hold_resolves_at_tap_hold_timeout_not_sum() {
+    // Assemble -- chorded → layered → tap-hold (layered adds no timeout).
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.chorded.timeout = 200,
+                config.tap_hold.timeout = 200,
+                chords = [
+                    { indices = [0, 1], key = K.E },
+                ],
+                layers = [
+                    [K.A & K.hold K.LeftCtrl, K.B],
+                    [K.F & K.hold K.LeftShift, K.D],
+                ],
+            }
+        "#
+    ));
+
+    // Act
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    for _ in 0..199 {
+        keymap.tick();
+    }
+
+    // Assert
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, keymap.distinct_reports().reports());
+}
+
+#[test]
+fn tap_dance_under_chord_resolves_at_its_timeout_not_sum() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                config.chorded.timeout = 200,
+                config.tap_dance.timeout = 200,
+                chords = [
+                    { indices = [0, 1], key = K.E },
+                ],
+                keys = [
+                    K.A & { tap_dances = [K.B] },
+                    K.C,
+                ],
+            }
+        "#
+    ));
+
+    // Act -- hold the chorded tap-dance; at t=200 chord passthroughs and
+    //  the first tap-dance timeout is already expired.
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    for _ in 0..199 {
+        keymap.tick();
+    }
+
+    // Assert -- first tap-dance definition (A), not another 200ms wait.
+    #[rustfmt::skip]
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
+    ];
+    assert_eq!(expected_reports, keymap.distinct_reports().reports());
+}

--- a/tests/rust/tap_hold/chorded_quick_tap.rs
+++ b/tests/rust/tap_hold/chorded_quick_tap.rs
@@ -68,7 +68,8 @@ fn first_press_timeout_hold_activates_layer() {
 }
 
 /// After 2000 ms idle the chord waits, then passthroughs.
-/// Timeout-hold of the inner tap-hold must activate the layer.
+/// Timeout-hold of the inner tap-hold is from the physical press
+///  (not chord timeout plus tap-hold timeout).
 #[test]
 fn after_idle_timeout_hold_activates_layer() {
     let mut keymap = keymap_under_test!();
@@ -77,7 +78,7 @@ fn after_idle_timeout_hold_activates_layer() {
         keymap.tick();
     }
     keymap.handle_input(input::Event::Press { keymap_index: 2 });
-    for _ in 0..401 {
+    for _ in 0..201 {
         keymap.tick();
     }
     keymap.handle_input(input::Event::Press { keymap_index: 0 });


### PR DESCRIPTION
## Summary

Decision timeouts (tap-hold, tap-dance) are counted from the **physical press**, not from when `new_pressed_key` runs.

A chorded tap-hold used to wait for the chord timeout *plus* the inner timeout (default 200+200 = 400ms). After a pending key is replaced (e.g. chorded passthrough), the keymap now folds already-elapsed time into the inner `After` delay. Remaining 0 is `Immediate`, so an expired inner timeout resolves in the same turn.

Also cancels the previous pending key's delayed events so a leftover chord timeout does not steal a tick.

A *resolved chord* whose binding is itself tap-hold is unchanged: that hold is a fresh `new_pressed_key` on the completing (activator) index.

## Test plan

- [x] `just check-quick`
- [x] `cargo test -p smart-keymap-core --lib`
- [x] `cargo test --test rust-integration` for `chorded`, `tap_hold`, `tap_dance`