### PR TITLE
core: add tri-state key (start / continue / interrupt)

### DIFF
--- a/features/keymap/key/tri_state.feature
+++ b/features/keymap/key/tri_state.feature
@@ -1,0 +1,67 @@
+Feature: Tri-state Key
+
+  A tri-state key owns a session across later presses of the same key.
+  The first press starts (typically a modifier and tap a key),
+   later presses of the same key continue (tap again while the hold stays),
+   and any other resolved key interrupts (releases the hold).
+
+  Classic use is Alt-Tab (a "swapper"):
+   one key holds Alt and taps Tab on the first press,
+   taps Tab again on re-press,
+   and releases Alt when another key is pressed.
+
+  For examples of this key in other smart keyboard firmware, see e.g.:
+
+  - [Getreuer's Cyclotab](https://getreuer.info/posts/keyboards/cyclotab/)
+
+  - [DhruvinSh's ZMK tri-state](https://github.com/dhruvinsh/zmk-tri-state)
+
+  Background:
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        keys = [
+          K.tri_state.alt_tab,
+          K.A,
+        ]
+      }
+      """
+
+  Example: first press is the Alt+Tab chord; Alt stays after release
+    When the keymap registers the following input
+      """
+      [
+        press K.tri_state.alt_tab,
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { modifiers = { left_alt = true }, key_codes = [K.Tab] }
+      """
+
+  Example: releasing the tri-state key leaves Alt held
+    When the keymap registers the following input
+      """
+      [
+        tap K.tri_state.alt_tab,
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { modifiers = { left_alt = true } }
+      """
+
+  Example: re-press leaves Alt held
+    When the keymap registers the following input
+      """
+      [
+        tap K.tri_state.alt_tab,
+        tap K.tri_state.alt_tab,
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { modifiers = { left_alt = true } }
+      """

--- a/ncl/key-extensions.ncl
+++ b/ncl/key-extensions.ncl
@@ -12,6 +12,7 @@
 & (import "smart_keys/sequence/key-extensions.ncl")
 & (import "smart_keys/sticky/key-extensions.ncl")
 & (import "smart_keys/tap_hold/key-extensions.ncl")
+& (import "smart_keys/tri_state/key-extensions.ncl")
 & {
   extend_keys = fun K key_extension =>
     std.typeof key_extension

--- a/ncl/key_system/families.ncl
+++ b/ncl/key_system/families.ncl
@@ -755,6 +755,27 @@
             expr = "%{module}::Context::from_config(config.tap_hold)",
           },
         },
+        tri_state = {
+          module = "smart_keymap::key::tri_state",
+          context_events = 'ContextEvents,
+          system =
+            'SystemWithData {
+              data_lengths = [{ const_name = "TRI_STATE", data_field = "tri_state" }],
+              rust_expr = smart_keymap.tri_state.system.rust_expr,
+              ty.array = m%"%{module}::System<
+            Ref,
+            [%{module}::Key; super::TRI_STATE]
+          >"%,
+              ty.vec = m%"%{module}::System<
+            Ref,
+            Vec<%{module}::Key>
+          >"%,
+            },
+          context = {
+            ty = "%{module}::Context",
+            expr = "%{module}::Context::new()",
+          },
+        },
       },
     },
 }

--- a/ncl/key_system/keymap-codegen.ncl
+++ b/ncl/key_system/keymap-codegen.ncl
@@ -1064,6 +1064,7 @@ pub mod key_system {
             "Sticky",
             "TapDance",
             "TapHold",
+            "TriState",
           ],
         },
         check_pending = {
@@ -1114,6 +1115,7 @@ pub mod key_system {
             "Sticky",
             "TapDance",
             "TapHold",
+            "TriState",
           ]
           |> std.array.all (fun needle => std.string.is_match needle rust_mod),
         expected = true,

--- a/ncl/keymap-codegen.ncl
+++ b/ncl/keymap-codegen.ncl
@@ -14,6 +14,7 @@
 & (import "smart_keys/sticky/keymap-codegen.ncl")
 & (import "smart_keys/tap_dance/keymap-codegen.ncl")
 & (import "smart_keys/tap_hold/keymap-codegen.ncl")
+& (import "smart_keys/tri_state/keymap-codegen.ncl")
 & (import "key_system/families.ncl")
 & (import "key_system/keymap-codegen.ncl")
 & {
@@ -235,6 +236,7 @@
       smart_keymap.sticky.key,
       smart_keymap.tap_dance.key,
       smart_keymap.tap_hold.key,
+      smart_keymap.tri_state.key,
     ],
 
     json_validator =

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -80,6 +80,7 @@
 & (import "smart_keys/sticky/keymap-ncl-to-json.ncl")
 & (import "smart_keys/tap_dance/keymap-ncl-to-json.ncl")
 & (import "smart_keys/tap_hold/keymap-ncl-to-json.ncl")
+& (import "smart_keys/tri_state/keymap-ncl-to-json.ncl")
 & (import "passes/fold-layers.ncl")
 & (import "passes/attach-chords.ncl")
 & (import "passes/attach-sequences.ncl")
@@ -330,6 +331,7 @@
       keymap_ncl.tap_dance,
       keymap_ncl.layered,
       keymap_ncl.tap_hold,
+      keymap_ncl.tri_state,
       keymap_ncl.layer_modifier,
       keymap_ncl.transparent_layer_exit,
       keymap_ncl.keyboard,

--- a/ncl/keys.ncl
+++ b/ncl/keys.ncl
@@ -24,4 +24,5 @@ std.array.fold_left
     key_extensions.sequence,
     key_extensions.sticky,
     key_extensions.tap_hold,
+    key_extensions.tri_state,
   ]

--- a/ncl/smart_keys/tri_state/key-extensions.ncl
+++ b/ncl/smart_keys/tri_state/key-extensions.ncl
@@ -1,0 +1,12 @@
+{
+  key_extensions.tri_state = fun keys =>
+    {
+      tri_state = {
+        # General constructor: K.tri_state.custom { hold = K.LeftAlt, tap = K.Tab }
+        custom = fun spec => { tri_state = spec },
+        alt_tab = { tri_state = { hold = keys.LeftAlt, tap = keys.Tab } },
+        cmd_tab = { tri_state = { hold = keys.LeftGUI, tap = keys.Tab } },
+        ctrl_tab = { tri_state = { hold = keys.LeftCtrl, tap = keys.Tab } },
+      },
+    },
+}

--- a/ncl/smart_keys/tri_state/keymap-codegen.ncl
+++ b/ncl/smart_keys/tri_state/keymap-codegen.ncl
@@ -1,0 +1,65 @@
+{
+  validators,
+
+  lib,
+
+  key_data_and_refs,
+
+  key_output,
+
+  smart_keymap.tri_state
+    | doc "for key::tri_state::Key."
+    = {
+      module = "smart_keymap::key::tri_state",
+
+      key = {
+        Json = std.contract.from_validator json_validator,
+
+        key_type = "%{module}::Key",
+
+        json_validator =
+          validators.record.validator {
+            fields_validator = validators.record.has_exact_fields ["hold", "tap"],
+            field_validators = {
+              hold = key_output.json_validator,
+              tap = key_output.json_validator,
+            },
+          },
+
+        is_json = fun json => 'Ok == json_validator json,
+
+        codegen_values = fun json @ { hold, tap } =>
+          {
+            include json,
+            include module,
+            include key_type,
+            rust_expr = "%{module}::Key::new(%{key_output.rust_expr hold}, %{key_output.rust_expr tap})",
+          },
+
+        traverse = fun f acc cv => f acc cv,
+
+        data_and_ref = fun key_data cv =>
+          let { tri_state = tri_state_, ..other_data } = key_data & { tri_state | default = [] } in
+          let new_index = std.array.length tri_state_ in
+          let new_key = {
+            json = cv.json,
+            rust_expr = cv.rust_expr,
+          }
+          in
+          {
+            key_data = other_data & { tri_state = std.array.append new_key tri_state_ },
+            ref = {
+              include module,
+              json = new_index,
+              rust_expr = "%{module}::Ref(%{std.to_string new_index})",
+            },
+          },
+      },
+
+      system = {
+        rust_expr =
+          let tri_state_data = (key_data_and_refs.key_data & { tri_state | default = [] }).tri_state in
+          "%{module}::System::new(%{tri_state_data |> lib.array_rust_expr})",
+      },
+    },
+}

--- a/ncl/smart_keys/tri_state/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/tri_state/keymap-ncl-to-json.ncl
@@ -1,0 +1,78 @@
+{
+  validators,
+
+  keyboard_modifiers,
+
+  keymap_ncl.tri_state
+    | doc "for key::tri_state::Key."
+    = {
+      Key = std.contract.from_validator key_validator,
+
+      spec_validator =
+        validators.record.validator {
+          fields_validator = validators.record.has_exact_fields ["hold", "tap"],
+          field_validators = {
+            hold = keymap_ncl.keyboard.key_validator,
+            tap = keymap_ncl.keyboard.key_validator,
+          },
+        },
+
+      key_validator = fun k =>
+        k
+        |> match {
+          { tri_state = spec } => spec_validator spec,
+          _ => 'Error { message = "Expected { tri_state = { hold, tap } }" },
+        },
+
+      is_key = fun k => 'Ok == key_validator k,
+
+      # Keyboard key (author form) → KeyOutput JSON used by codegen / serde.
+      keyboard_key_to_key_output = fun k =>
+        k
+        |> match {
+          { key_code = kc, modifiers = km } =>
+            {
+              key_code = { Keyboard = kc },
+              key_modifiers = keyboard_modifiers.to_json_value km,
+            },
+          { key_code = kc } => { key_code = { Keyboard = kc } },
+          { modifiers = km } =>
+            {
+              key_modifiers = keyboard_modifiers.to_json_value km,
+            },
+          {} => {},
+        },
+
+      to_json_value = fun { tri_state = spec } =>
+        {
+          hold = keyboard_key_to_key_output spec.hold,
+          tap = keyboard_key_to_key_output spec.tap,
+        },
+
+      # Leaves have no nested keys; map_accum maps children only.
+      map_accum = fun f acc k => { include acc, include k },
+    },
+
+  checks.check_tri_state =
+    let K = import "keys.ncl" in
+    {
+      check_custom_ok =
+        keymap_ncl.tri_state.key_validator (
+          K.tri_state.custom {
+            hold = K.LeftAlt,
+            tap = K.Tab,
+          }
+        ) == 'Ok,
+
+      check_alt_tab_ok =
+        keymap_ncl.tri_state.key_validator K.tri_state.alt_tab == 'Ok,
+
+      check_alt_tab_json = {
+        actual = keymap_ncl.tri_state.to_json_value K.tri_state.alt_tab,
+        expected = {
+          hold = { key_modifiers = 4 },
+          tap = { key_code = { Keyboard = 43 } },
+        },
+      },
+    },
+}

--- a/smart-keymap-core/src/key.rs
+++ b/smart-keymap-core/src/key.rs
@@ -36,6 +36,8 @@ pub mod sticky;
 pub mod tap_dance;
 /// Tap-Hold keys.
 pub mod tap_hold;
+/// Tri-state keys (start / continue / interrupt; e.g. Alt-Tab swapper).
+pub mod tri_state;
 
 /// The maximum number of key events that are emitted by [crate::key::System] implementations.
 pub const MAX_KEY_EVENTS: usize = 4;

--- a/smart-keymap-core/src/key/tri_state.rs
+++ b/smart-keymap-core/src/key/tri_state.rs
@@ -1,0 +1,338 @@
+//! Tri-state keys: start / continue / interrupt.
+//!
+//! A tri-state key owns a session across later presses of the same key.
+//! The first press *starts*
+//!  (typically virtual-hold a modifier and tap a key),
+//! later presses of the same key *continue*
+//!  (tap again while the hold stays),
+//! and any other resolved key *interrupts*
+//!  (releases the hold).
+//!
+//! The physical key is a [`crate::key::NewPressedKey::NoOp`]; HID output is
+//!  injected with [`crate::input::Event::VirtualKeyPress`] /
+//!  [`crate::input::Event::VirtualKeyRelease`].
+//! Hold is pressed before tap so the first report is the chord, not a
+//!  naked tap.
+//!
+//! Classic use is Alt-Tab (a "swapper"): start holds Left Alt and taps Tab,
+//!  continue taps Tab, interrupt releases Left Alt.
+
+use core::fmt::Debug;
+use core::marker::PhantomData;
+use core::ops::Index;
+
+use serde::Deserialize;
+
+use crate::input;
+use crate::key;
+use crate::keymap;
+
+/// Reference for a tri-state key (index into [System] key data).
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
+pub struct Ref(pub u8);
+
+/// A tri-state key: virtual-hold `hold` across taps of `tap`.
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
+pub struct Key {
+    /// Output held for the life of the session (start press, interrupt release).
+    pub hold: key::KeyOutput,
+    /// Output tapped on start and on each continue.
+    pub tap: key::KeyOutput,
+}
+
+impl Key {
+    /// Constructs a tri-state key.
+    pub const fn new(hold: key::KeyOutput, tap: key::KeyOutput) -> Self {
+        Self { hold, tap }
+    }
+}
+
+/// Armed session: `hold` is virtually pressed until interrupt.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct Session {
+    keymap_index: u16,
+    hold: key::KeyOutput,
+    tap: key::KeyOutput,
+    tap_held: bool,
+}
+
+/// Tri-state context: at most one session is armed.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Context {
+    session: Option<Session>,
+}
+
+impl Default for Context {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Context {
+    /// Constructs an idle context.
+    pub const fn new() -> Self {
+        Context { session: None }
+    }
+
+    /// Clear the session without emitting virtual releases.
+    pub fn reset(&mut self) {
+        *self = Self::new();
+    }
+
+    /// Whether a session is currently armed.
+    pub fn is_active(&self) -> bool {
+        self.session.is_some()
+    }
+
+    /// Whether the armed session belongs to `keymap_index`.
+    pub fn is_session_for(&self, keymap_index: u16) -> bool {
+        matches!(self.session, Some(s) if s.keymap_index == keymap_index)
+    }
+
+    fn end_session(&mut self) -> key::KeyEvents<Event> {
+        match self.session.take() {
+            None => key::KeyEvents::no_events(),
+            Some(session) => {
+                let mut pke = key::KeyEvents::no_events();
+                if session.tap_held {
+                    pke.add_event(key::Event::Input(input::Event::VirtualKeyRelease {
+                        key_output: session.tap,
+                    }));
+                }
+                pke.add_event(key::Event::Input(input::Event::VirtualKeyRelease {
+                    key_output: session.hold,
+                }));
+                pke
+            }
+        }
+    }
+
+    fn handle_event(&mut self, event: key::Event<Event>) -> key::KeyEvents<Event> {
+        match event {
+            key::Event::Key {
+                keymap_index,
+                key_event: Event::Start { hold, tap },
+            } => {
+                let mut pke = self.end_session();
+                self.session = Some(Session {
+                    keymap_index,
+                    hold,
+                    tap,
+                    tap_held: true,
+                });
+                pke.add_event(key::Event::Input(input::Event::VirtualKeyPress {
+                    key_output: hold,
+                }));
+                pke.add_event(key::Event::Input(input::Event::VirtualKeyPress {
+                    key_output: tap,
+                }));
+                pke
+            }
+            key::Event::Key {
+                keymap_index,
+                key_event: Event::Continue,
+            } => match self.session.as_mut() {
+                Some(session) if session.keymap_index == keymap_index => {
+                    session.tap_held = true;
+                    key::KeyEvents::event(key::Event::Input(input::Event::VirtualKeyPress {
+                        key_output: session.tap,
+                    }))
+                }
+                _ => key::KeyEvents::no_events(),
+            },
+            key::Event::Input(input::Event::Release { keymap_index }) => {
+                match self.session.as_mut() {
+                    Some(session) if session.keymap_index == keymap_index && session.tap_held => {
+                        session.tap_held = false;
+                        key::KeyEvents::event(key::Event::Input(input::Event::VirtualKeyRelease {
+                            key_output: session.tap,
+                        }))
+                    }
+                    _ => key::KeyEvents::no_events(),
+                }
+            }
+            key::Event::Keymap(keymap::KeymapEvent::ResolvedKeyOutput { keymap_index, .. }) => {
+                match self.session {
+                    Some(session) if session.keymap_index != keymap_index => self.end_session(),
+                    _ => key::KeyEvents::no_events(),
+                }
+            }
+            _ => key::KeyEvents::no_events(),
+        }
+    }
+}
+
+impl key::Context for Context {
+    type Event = Event;
+
+    fn handle_event(&mut self, event: key::Event<Self::Event>) -> key::KeyEvents<Self::Event> {
+        self.handle_event(event)
+    }
+
+    fn reset(&mut self) {
+        Context::reset(self);
+    }
+}
+
+/// Tri-state events.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Event {
+    /// First press (or a different tri-state key): arm `hold` and tap `tap`.
+    Start {
+        /// Output to virtual-hold for the session.
+        hold: key::KeyOutput,
+        /// Output to tap now.
+        tap: key::KeyOutput,
+    },
+    /// Re-press of the armed key: tap again; `hold` stays.
+    Continue,
+}
+
+/// Pending key state type for tri-state keys. (No pending state.)
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PendingKeyState;
+
+/// Key state used by [System]. (No per-key state; behaviour is on [Context].)
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct KeyState;
+
+/// The [key::System] implementation for tri-state keys.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct System<R, Keys: Index<usize, Output = Key>> {
+    keys: Keys,
+    marker: PhantomData<R>,
+}
+
+impl<R, Keys: Index<usize, Output = Key>> System<R, Keys> {
+    /// Constructs a new [System] with the given key data.
+    pub const fn new(keys: Keys) -> Self {
+        Self {
+            keys,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<R: Debug, Keys: Debug + Index<usize, Output = Key>> key::System<R> for System<R, Keys> {
+    type Ref = Ref;
+    type Context = Context;
+    type Event = Event;
+    type PendingKeyState = PendingKeyState;
+    type KeyState = KeyState;
+
+    fn new_pressed_key(
+        &self,
+        keymap_index: u16,
+        context: &Self::Context,
+        Ref(key_index): Ref,
+    ) -> (
+        key::PressedKeyResult<R, Self::PendingKeyState, Self::KeyState>,
+        key::KeyEvents<Self::Event>,
+    ) {
+        let Key { hold, tap } = self.keys[key_index as usize];
+        let key_event = if context.is_session_for(keymap_index) {
+            Event::Continue
+        } else {
+            Event::Start { hold, tap }
+        };
+        let pkr = key::PressedKeyResult::NewPressedKey(key::NewPressedKey::NoOp);
+        let pke = key::KeyEvents::event(key::Event::key_event(keymap_index, key_event));
+        (pkr, pke)
+    }
+
+    fn update_pending_state(
+        &self,
+        _pending_state: &mut Self::PendingKeyState,
+        _keymap_index: u16,
+        _context: &Self::Context,
+        _key_ref: Ref,
+        _event: key::Event<Self::Event>,
+    ) -> (Option<key::NewPressedKey<R>>, key::KeyEvents<Self::Event>) {
+        panic!()
+    }
+
+    fn update_state(
+        &self,
+        _key_state: &mut Self::KeyState,
+        _ref: &Self::Ref,
+        _context: &Self::Context,
+        _keymap_index: u16,
+        _event: key::Event<Self::Event>,
+    ) -> key::KeyEvents<Self::Event> {
+        panic!()
+    }
+
+    fn key_output(
+        &self,
+        _key_ref: &Self::Ref,
+        _key_state: &Self::KeyState,
+    ) -> Option<key::KeyOutput> {
+        panic!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sizeof_ref() {
+        assert_eq!(1, core::mem::size_of::<Ref>());
+    }
+
+    #[test]
+    fn test_sizeof_event() {
+        assert_eq!(14, core::mem::size_of::<Event>());
+    }
+
+    #[test]
+    fn start_arms_session() {
+        let mut ctx = Context::new();
+        let hold = key::KeyOutput::from_key_code(0xE2);
+        let tap = key::KeyOutput::from_key_code(0x2B);
+        let _ = key::Context::handle_event(
+            &mut ctx,
+            key::Event::key_event(0, Event::Start { hold, tap }),
+        );
+        assert!(ctx.is_active());
+        assert!(ctx.is_session_for(0));
+    }
+
+    #[test]
+    fn other_resolved_output_ends_session() {
+        let mut ctx = Context::new();
+        let hold = key::KeyOutput::from_key_code(0xE2);
+        let tap = key::KeyOutput::from_key_code(0x2B);
+        let _ = key::Context::handle_event(
+            &mut ctx,
+            key::Event::key_event(0, Event::Start { hold, tap }),
+        );
+        let _ = key::Context::handle_event(
+            &mut ctx,
+            key::Event::Keymap(keymap::KeymapEvent::ResolvedKeyOutput {
+                keymap_index: 1,
+                key_output: key::KeyOutput::from_key_code(0x04),
+            }),
+        );
+        assert!(!ctx.is_active());
+    }
+
+    #[test]
+    fn own_resolved_output_does_not_end_session() {
+        let mut ctx = Context::new();
+        let hold = key::KeyOutput::from_key_code(0xE2);
+        let tap = key::KeyOutput::from_key_code(0x2B);
+        let _ = key::Context::handle_event(
+            &mut ctx,
+            key::Event::key_event(0, Event::Start { hold, tap }),
+        );
+        let _ = key::Context::handle_event(
+            &mut ctx,
+            key::Event::Keymap(keymap::KeymapEvent::ResolvedKeyOutput {
+                keymap_index: 0,
+                key_output: tap,
+            }),
+        );
+        assert!(ctx.is_active());
+    }
+}

--- a/smart-keymap-full-system-std/tests/keymap_full_system.rs
+++ b/smart-keymap-full-system-std/tests/keymap_full_system.rs
@@ -50,6 +50,7 @@ fn tap_hold_interrupt_keymap(
                 hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(0xE0)),
                 profile: 0,
             }]),
+            smart_keymap::key::tri_state::System::new(Vec::new()),
         ),
     )
 }
@@ -83,6 +84,7 @@ macro_rules! simple_keyboard_keymap {
                 smart_keymap::key::sticky::System::new(Vec::new()),
                 smart_keymap::key::tap_dance::System::new(Vec::new()),
                 smart_keymap::key::tap_hold::System::new(Vec::new()),
+                smart_keymap::key::tri_state::System::new(Vec::new()),
             ),
         )
     }};
@@ -598,6 +600,7 @@ fn test_keymap_many_input_events_without_tick_or_report() {
                 smart_keymap::key::sticky::System::new(Vec::new()),
                 smart_keymap::key::tap_dance::System::new(Vec::new()),
                 smart_keymap::key::tap_hold::System::new(Vec::new()),
+                smart_keymap::key::tri_state::System::new(Vec::new()),
             ),
         )
     };

--- a/tests/cucumber/keymap.rs
+++ b/tests/cucumber/keymap.rs
@@ -176,6 +176,8 @@ struct KeyVecs {
     tap_dance: Vec<key::tap_dance::Key<Ref, TAP_DANCE_MAX_DEFS>>,
     #[serde(default)]
     tap_hold: Vec<key::tap_hold::Key<Ref>>,
+    #[serde(default)]
+    tri_state: Vec<key::tri_state::Key>,
 }
 
 #[derive(Deserialize)]
@@ -201,6 +203,7 @@ fn system_from_key_data(keys: KeyVecs) -> System {
         smart_keymap::key::sticky::System::new(keys.sticky),
         smart_keymap::key::tap_dance::System::new(keys.tap_dance),
         smart_keymap::key::tap_hold::System::new(keys.tap_hold),
+        smart_keymap::key::tri_state::System::new(keys.tri_state),
     )
 }
 

--- a/tests/rust/hid_keycodes.rs
+++ b/tests/rust/hid_keycodes.rs
@@ -20,6 +20,7 @@ pub const KC_O: u8 = 0x12;
 pub const KC_P: u8 = 0x13;
 pub const KC_U: u8 = 0x18;
 pub const KC_ESCAPE: u8 = 0x29;
+pub const KC_TAB: u8 = 0x2B;
 pub const KC_BACKSPACE: u8 = 0x2A;
 pub const KC_SPACE: u8 = 0x2C;
 pub const KC_GRAVE: u8 = 0x35;
@@ -33,5 +34,7 @@ pub const KC_UP: u8 = 0x52;
 /// Modifier bits in HID boot keyboard report byte 0.
 pub const MOD_LCTL: u8 = 0x01;
 pub const MOD_LSHFT: u8 = 0x02;
+pub const MOD_LALT: u8 = 0x04;
+pub const MOD_LGUI: u8 = 0x08;
 pub const MOD_LCTL_LSHFT: u8 = MOD_LCTL | MOD_LSHFT;
 pub const MOD_RSHFT: u8 = 0x20;

--- a/tests/rust/keymap.rs
+++ b/tests/rust/keymap.rs
@@ -13,6 +13,7 @@ mod sequence;
 mod sticky;
 mod tap_dance;
 mod tap_hold;
+mod tri_state;
 
 mod ms_per_tick;
 

--- a/tests/rust/tri_state.rs
+++ b/tests/rust/tri_state.rs
@@ -1,0 +1,136 @@
+use smart_keymap::input;
+use smart_keymap::keymap::ObservedKeymap;
+
+use crate::hid_keycodes::*;
+use smart_keymap_macros::keymap;
+
+#[test]
+fn first_press_holds_alt_then_taps_tab() {
+    // Assemble -- Alt-Tab tri-state on index 0
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                keys = [
+                    K.tri_state.alt_tab,
+                    K.A,
+                ],
+            }
+        "#
+    ));
+
+    // Act -- tap the tri-state key
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert -- first report is the Alt+Tab chord; Alt stays after release
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LALT, 0, KC_TAB, 0, 0, 0, 0, 0],
+        [MOD_LALT, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn repress_taps_tab_again_while_alt_held() {
+    // Assemble -- Alt-Tab tri-state on index 0
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                keys = [
+                    K.tri_state.alt_tab,
+                    K.A,
+                ],
+            }
+        "#
+    ));
+
+    // Act -- tap the tri-state key twice
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert -- two Tab pulses, Alt held throughout
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LALT, 0, KC_TAB, 0, 0, 0, 0, 0],
+        [MOD_LALT, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LALT, 0, KC_TAB, 0, 0, 0, 0, 0],
+        [MOD_LALT, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn other_key_releases_alt() {
+    // Assemble -- Alt-Tab tri-state, then A
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                keys = [
+                    K.tri_state.alt_tab,
+                    K.A,
+                ],
+            }
+        "#
+    ));
+
+    // Act -- open the session, then tap A
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.handle_input(input::Event::Release { keymap_index: 1 });
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert -- A interrupts: hold is released in the same turn as A,
+    //  so the host sees A, not Alt+A
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LALT, 0, KC_TAB, 0, 0, 0, 0, 0],
+        [MOD_LALT, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, KC_A, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}
+
+#[test]
+fn custom_hold_tap_ctrl_tab() {
+    // Assemble -- custom Ctrl+Tab tri-state
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+            let K = import "keys.ncl" in
+            {
+                keys = [
+                    K.tri_state.custom {
+                        hold = K.LeftCtrl,
+                        tap = K.Tab,
+                    },
+                ],
+            }
+        "#
+    ));
+
+    // Act -- tap the tri-state key
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    keymap.tick_until_no_scheduled_events();
+
+    // Assert -- first report is the Ctrl+Tab chord; Ctrl stays
+    let expected_reports: &[[u8; 8]] = &[
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, KC_TAB, 0, 0, 0, 0, 0],
+        [MOD_LCTL, 0, 0, 0, 0, 0, 0, 0],
+    ];
+    let actual_reports = keymap.distinct_reports();
+    assert_eq!(expected_reports, actual_reports.reports());
+}


### PR DESCRIPTION
## Summary

New `key::tri_state` family for a session that owns a modifier across later presses of the same key (Alt-Tab / swapper / ZMK tri-state).

- **Start** (first press): virtual-hold `hold`, tap `tap`. First HID report is the chord (e.g. Alt+Tab), not a naked Tab.
- **Continue** (re-press of the same key): tap `tap` again; `hold` stays down.
- **Interrupt** (any other resolved key): release `hold` in the same turn, so the host sees `A`, not `Alt+A`.

The physical key is `NoOp`; HID comes from `VirtualKeyPress` / `VirtualKeyRelease`. At most one session is armed.

### Authoring

```nickel
K.tri_state.alt_tab
K.tri_state.cmd_tab
K.tri_state.ctrl_tab
K.tri_state.custom { hold = K.LeftCtrl, tap = K.Tab }
```

Not in this PR: timeout, layer-off end, reverse/continue allow-list (`Shift+Tab`), swallowing the interrupting key.

## Test plan

- [x] `cargo test -p smart-keymap-core --lib key::tri_state`
- [x] `cargo test --test rust-integration tri_state`
- [x] `cargo test -p smart-keymap-full-system-std --test cucumber-keymap -- -n 'Alt'`
- [x] `just check-quick`
- [ ] CI green