### PR TITLE
tap-hold pending_output (speculative Hold)

### DIFF
--- a/features/keymap/key/tap_hold-config-pending_output.feature
+++ b/features/keymap/key/tap_hold-config-pending_output.feature
@@ -1,0 +1,90 @@
+Feature: TapHold Key (configure pending_output)
+
+  The `pending_output` config for tap-hold keys controls speculative HID
+   while the tap-vs-hold decision is still pending.
+
+  Default `NoOutput` produces no output while pending.
+  No HID is emitted until timeout, interrupt, or release settles tap vs hold.
+  `Hold` emits the hold binding's HID while still pending, then keeps it
+   or retracts it when tap vs hold settles. Decision logic is unchanged.
+  Only the timing of hold appearance changes.
+
+  This matches FAK `eager_decision = 'hold'`, ZMK
+   `hold-while-undecided`, and QMK Speculative Hold.
+
+  For examples of this key in other smart keyboard firmware, see e.g.:
+
+  - [FAK's eager_decision](https://github.com/semickolon/fak)
+
+  - [ZMK's hold-while-undecided](https://zmk.dev/docs/keymaps/behaviors/hold-tap#hold-while-undecided)
+
+  - [QMK's Speculative Hold](https://docs.qmk.fm/tap_hold#speculative-hold)
+
+  Background:
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        config.tap_hold.pending_output = "Hold",
+        keys = [
+          K.A & K.hold K.LeftCtrl,
+          K.B
+        ]
+      }
+      """
+
+  Example: Hold with timeout shows mod from first tick and stays hold
+
+    When the keymap registers the following input
+      """
+      [
+        press (K.A & K.hold K.LeftCtrl),
+        wait 1,
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { modifiers = { left_ctrl = true } }
+      """
+
+  Example: Hold with quick release retracts mod and ends as tap
+
+    When the keymap registers the following input
+      """
+      [
+        press (K.A & K.hold K.LeftCtrl),
+        wait 1,
+        release (K.A & K.hold K.LeftCtrl),
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { key_codes = [K.A] }
+      """
+
+  Example: Hold with HoldOnKeyPress interrupt shows mod already down when other key taps
+
+    Given a keymap.ncl:
+      """
+      let K = import "keys.ncl" in
+      {
+        config.tap_hold.interrupt_response = "HoldOnKeyPress",
+        keys = [
+          K.A & K.hold K.LeftCtrl,
+          K.B
+        ]
+      }
+      """
+    When the keymap registers the following input
+      """
+      [
+        press (K.A & K.hold K.LeftCtrl),
+        wait 1,
+        tap K.B,
+      ]
+      """
+    Then the HID keyboard report should equal
+      """
+      { modifiers = { left_ctrl = true }, key_codes = [K.B] }
+      """

--- a/ncl/key_system/families.ncl
+++ b/ncl/key_system/families.ncl
@@ -734,7 +734,7 @@
             },
           pending =
             'PendingKeyState {
-              ty = "%{module}::PendingKeyState",
+              ty = "%{module}::PendingKeyState<Ref>",
             },
           keymap_context = 'UpdatesKeymapContext,
           system =

--- a/ncl/key_system/keymap-codegen.ncl
+++ b/ncl/key_system/keymap-codegen.ncl
@@ -575,6 +575,22 @@ Ref::%{f.variant}(key_ref) => {
         )
         ++ "\n(_, _) => None,",
 
+      pending_output_arms =
+        if pending_systems == [] then
+          "_ => None,"
+        else
+          (
+            pending_systems
+            |> std.array.map (fun f =>
+              if f.variant == "TapHold" then
+                m%"PendingKeyState::%{f.variant}(pks) => pks.speculative_keyboard_output(|kb_ref| self.keyboard.key_output(kb_ref, &smart_keymap::key::keyboard::KeyState)),"%
+              else
+                m%"PendingKeyState::%{f.variant}(_) => None,"%
+            )
+            |> join
+          )
+          ++ "\n_ => None,",
+
       key_state_from_family =
         systems
         |> std.array.map (fun f =>
@@ -859,6 +875,15 @@ pub mod key_system {
         ) -> Option<key::KeyOutput> {
             match (key_ref, key_state) {
 %{key_output_arms}
+            }
+        }
+
+        fn pending_output(
+            &self,
+            pending_key_state: &Self::PendingKeyState,
+        ) -> Option<key::KeyOutput> {
+            match pending_key_state {
+%{pending_output_arms}
             }
         }
     }

--- a/ncl/key_system/keymap-codegen.ncl
+++ b/ncl/key_system/keymap-codegen.ncl
@@ -712,6 +712,9 @@ pub mod key_system {
 %{enum_variants (fun f => f.ref_ty)}
     }
 
+%{from_impls "Ref" (fun f => f.ref_ty)}
+%{try_from_impls "Ref" (fun f => f.ref_ty)}
+
 %{config_struct}
 
     /// Aggregate context.

--- a/ncl/keymap-ncl-to-json.ncl
+++ b/ncl/keymap-ncl-to-json.ncl
@@ -699,6 +699,12 @@
             else
               {}
           )
+          & (
+            if std.record.has_field "pending_output" th_config then
+              { pending_output = th_config.pending_output }
+            else
+              {}
+          )
         in
         let profiles_array =
           th_profile_names
@@ -725,6 +731,43 @@
         keys
         |> std.array.map (pad_key_layered_arrays layer_count)
         |> std.array.map keymap_ncl.key.to_json_value
+      in
+      let _tap_hold_pending_output_keyboard_check =
+        if th_config_json == {} then
+          null
+        else
+          keys
+          |> std.array.filter (fun k => keymap_ncl.tap_hold.is_key k)
+          |> std.array.fold_left
+            (fun _acc k =>
+              let profile_id =
+                if std.record.has_field "tap_hold_profile" k then
+                  if std.is_number k.tap_hold_profile then k.tap_hold_profile else 0
+                else
+                  0
+              in
+              let pending_output =
+                if profile_id == 0 then
+                  if std.record.has_field "default_profile" th_config_json
+                  && std.record.has_field "pending_output" th_config_json.default_profile then
+                    th_config_json.default_profile.pending_output
+                  else
+                    "NoOutput"
+                else
+                  let idx = profile_id - 1 in
+                  let profiles = if std.record.has_field "profiles" th_config_json then th_config_json.profiles else [] in
+                  if idx < std.array.length profiles then
+                    let p = std.array.at idx profiles in
+                    if std.record.has_field "pending_output" p then p.pending_output else "NoOutput"
+                  else
+                    "NoOutput"
+              in
+              if pending_output == "Hold" && !(keymap_ncl.keyboard.is_key k.hold) then
+                std.fail_with "tap_hold pending_output Hold requires hold to be a keyboard key (keyboard modifier or key_code)"
+              else
+                null
+            )
+            null
       in
       let { chorded = km_config_chorded, ..km_config } = km_config_after_th & { chorded = {} } in
       let chord_indices = chords |> std.array.map (fun { key, indices, .. } => indices) in

--- a/ncl/smart_keys/tap_hold/keymap-codegen.ncl
+++ b/ncl/smart_keys/tap_hold/keymap-codegen.ncl
@@ -102,6 +102,15 @@
           ]
         ),
 
+      TapHoldPendingOutputJson =
+        std.contract.from_validator (
+          validators.is_elem_of [
+            "NoOutput",
+            "Hold",
+            "None",
+          ]
+        ),
+
       module = "smart_keymap::key::tap_hold",
 
       hold_trigger_positions_expr = fun positions =>
@@ -153,6 +162,18 @@
           if std.record.has_field "quick_tap_ms" c then
             {
               quick_tap_ms = "Some(%{std.to_string c.quick_tap_ms})",
+            }
+          else
+            {}
+        )
+        & (
+          if std.record.has_field "pending_output" c then
+            {
+              pending_output =
+                if c.pending_output == "None" then
+                  "%{module}::PendingOutput::NoOutput"
+                else
+                  "%{module}::PendingOutput::%{c.pending_output}",
             }
           else
             {}
@@ -297,6 +318,7 @@
           required_idle_time | optional | Number,
           hold_trigger_key_positions | optional | Array Number,
           quick_tap_ms | optional | Number,
+          pending_output | optional | TapHoldPendingOutputJson,
         },
 
         # Lowered JSON form: nested default_profile + profiles array.

--- a/ncl/smart_keys/tap_hold/keymap-ncl-to-json.ncl
+++ b/ncl/smart_keys/tap_hold/keymap-ncl-to-json.ncl
@@ -63,6 +63,15 @@
           ]
         ),
 
+      TapHoldPendingOutput =
+        std.contract.from_validator (
+          validators.is_elem_of [
+            "NoOutput",
+            "Hold",
+            "None",
+          ]
+        ),
+
       # One behavior profile. Profile 0 is Config's default (flat on config.tap_hold);
       # extras live under config.tap_hold.profiles.
       Profile = {
@@ -80,6 +89,7 @@
         hold_trigger_key_positions | optional | Array Number,
         # Re-press of same key within this many ms forces tap (ZMK quick-tap-ms).
         quick_tap_ms | optional | Number,
+        pending_output | optional | TapHoldPendingOutput,
       },
 
       # Authoring keeps default-profile knobs flat on config.tap_hold;
@@ -99,6 +109,7 @@
         hold_trigger_key_positions | optional | Array Number,
         # Re-press of same key within this many ms forces tap (ZMK quick-tap-ms).
         quick_tap_ms | optional | Number,
+        pending_output | optional | TapHoldPendingOutput,
         # Authoring: name → profile record. Lowered to a JSON array (indices 1..).
         profiles | optional | { _ | Profile },
       },

--- a/smart-keymap-core/src/key.rs
+++ b/smart-keymap-core/src/key.rs
@@ -287,6 +287,13 @@ pub trait System<R>: Debug {
     fn key_output(&self, _ref: &Self::Ref, _key_state: &Self::KeyState) -> Option<KeyOutput> {
         None
     }
+
+    /// Speculative HID while a pending session is live.
+    ///
+    /// Default: `NoOutput` (no output while pending).
+    fn pending_output(&self, _pending_key_state: &Self::PendingKeyState) -> Option<KeyOutput> {
+        None
+    }
 }
 
 /// Used to provide state that may affect behaviour when pressing the key.

--- a/smart-keymap-core/src/key/tap_hold.rs
+++ b/smart-keymap-core/src/key/tap_hold.rs
@@ -3,6 +3,8 @@ use core::ops::Index;
 
 use serde::Deserialize;
 
+use core::convert::TryInto;
+
 use crate::input;
 use crate::key;
 use crate::keymap;
@@ -76,6 +78,15 @@ pub struct Profile {
     /// scoped to re-presses of the same keymap index.
     #[serde(default)]
     pub quick_tap_ms: Option<u16>,
+
+    /// Speculative output while this tap-hold is pending.
+    ///
+    /// - `NoOutput` (default): silent until tap vs hold settles.
+    /// - `Hold`: emit the hold binding's HID while still pending
+    ///   (ZMK `hold-while-undecided` / QMK Speculative Hold /
+    ///   FAK `eager_decision = 'hold`).
+    #[serde(default = "default_pending_output")]
+    pub pending_output: PendingOutput,
 }
 
 impl Profile {
@@ -152,6 +163,16 @@ impl<R: Default> Default for Key<R> {
     }
 }
 
+/// Speculative output while tap-hold is pending.
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
+pub enum PendingOutput {
+    /// No speculative output (default).
+    #[serde(alias = "None")]
+    NoOutput,
+    /// Emit hold binding while still pending.
+    Hold,
+}
+
 /// How the tap hold key should respond to interruptions (input events from other keys).
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
 pub enum InterruptResponse {
@@ -191,12 +212,19 @@ pub const DEFAULT_TIMEOUT: u16 = 200;
 /// The default interrupt response.
 pub const DEFAULT_INTERRUPT_RESPONSE: InterruptResponse = InterruptResponse::Ignore;
 
+/// The default pending output.
+pub const DEFAULT_PENDING_OUTPUT: PendingOutput = PendingOutput::NoOutput;
+
 fn default_timeout() -> Option<u16> {
     Some(DEFAULT_TIMEOUT)
 }
 
 fn default_interrupt_response() -> InterruptResponse {
     DEFAULT_INTERRUPT_RESPONSE
+}
+
+fn default_pending_output() -> PendingOutput {
+    DEFAULT_PENDING_OUTPUT
 }
 
 fn default_profile_value() -> Profile {
@@ -210,6 +238,7 @@ pub const DEFAULT_PROFILE: Profile = Profile {
     required_idle_time: None,
     hold_trigger_positions: None,
     quick_tap_ms: None,
+    pending_output: DEFAULT_PENDING_OUTPUT,
 };
 
 /// Default tap hold config.
@@ -337,16 +366,70 @@ pub enum Event {
 
 /// The state of a pressed tap-hold key.
 #[derive(Debug, Clone, PartialEq)]
-pub struct PendingKeyState {
+pub struct PendingKeyState<R> {
     // For tracking 'tap' interruptions
     other_pressed_keymap_index: Option<u16>,
+    /// Speculative hold ref while undecided (`pending_output = Hold`).
+    pub speculative: Option<R>,
 }
 
-impl PendingKeyState {
+impl<R> PendingKeyState<R> {
     /// Constructs the initial pressed key state
-    fn new() -> PendingKeyState {
+    #[allow(dead_code)]
+    fn new() -> PendingKeyState<R> {
         PendingKeyState {
             other_pressed_keymap_index: None,
+            speculative: None,
+        }
+    }
+
+    /// Constructs with a speculative hold ref.
+    fn new_with_speculative(speculative: Option<R>) -> Self {
+        Self {
+            other_pressed_keymap_index: None,
+            speculative,
+        }
+    }
+
+    /// Returns speculative hold output for keyboard, filtered for GUI.
+    ///
+    /// Only keyboard holds are speculated; non-keyboard holds return `None`.
+    /// Nickel validation ensures `Hold` is only used with keyboard holds,
+    ///  so this is the common path.
+    pub fn speculative_keyboard_output<F>(&self, f: F) -> Option<key::KeyOutput>
+    where
+        F: Fn(&crate::key::keyboard::Ref) -> Option<key::KeyOutput>,
+        R: Copy + TryInto<crate::key::keyboard::Ref>,
+    {
+        let spec = self.speculative?;
+        let kb_ref: crate::key::keyboard::Ref = spec.try_into().ok()?;
+        let ko = f(&kb_ref)?;
+        let mods = ko.key_modifiers();
+        if mods.has_modifiers(&key::KeyboardModifiers::LEFT_GUI)
+            || mods.has_modifiers(&key::KeyboardModifiers::RIGHT_GUI)
+        {
+            None
+        } else {
+            Some(ko)
+        }
+    }
+
+    /// Returns speculative hold output, filtered to avoid GUI host effects.
+    ///
+    /// Resolves the speculative `R` via `resolve` and suppresses GUI modifiers.
+    pub fn speculative_output(
+        &self,
+        resolve: impl Fn(&R) -> Option<key::KeyOutput>,
+    ) -> Option<key::KeyOutput> {
+        let spec = self.speculative.as_ref()?;
+        let ko = resolve(spec)?;
+        let mods = ko.key_modifiers();
+        if mods.has_modifiers(&key::KeyboardModifiers::LEFT_GUI)
+            || mods.has_modifiers(&key::KeyboardModifiers::RIGHT_GUI)
+        {
+            None
+        } else {
+            Some(ko)
         }
     }
 
@@ -474,8 +557,16 @@ impl<R, Keys: Index<usize, Output = Key<R>>> System<R, Keys> {
         &self,
         profile: &Profile,
         keymap_index: u16,
-    ) -> (PendingKeyState, Option<key::ScheduledEvent<Event>>) {
-        let pending = PendingKeyState::new();
+        hold: R,
+    ) -> (PendingKeyState<R>, Option<key::ScheduledEvent<Event>>)
+    where
+        R: Copy,
+    {
+        let speculative = match profile.pending_output {
+            PendingOutput::Hold => Some(hold),
+            PendingOutput::NoOutput => None,
+        };
+        let pending = PendingKeyState::new_with_speculative(speculative);
         let scheduled = profile.timeout.map(|timeout| {
             key::ScheduledEvent::after(
                 timeout,
@@ -489,7 +580,7 @@ impl<R, Keys: Index<usize, Output = Key<R>>> System<R, Keys> {
         &self,
         key_index: u8,
     ) -> (
-        key::PressedKeyResult<R, PendingKeyState, KeyState>,
+        key::PressedKeyResult<R, PendingKeyState<R>, KeyState>,
         key::KeyEvents<Event>,
     )
     where
@@ -511,7 +602,7 @@ impl<R: Copy + Debug, Keys: Debug + Index<usize, Output = Key<R>>> key::System<R
     type Ref = Ref;
     type Context = Context;
     type Event = Event;
-    type PendingKeyState = PendingKeyState;
+    type PendingKeyState = PendingKeyState<R>;
     type KeyState = KeyState;
 
     fn new_pressed_key(
@@ -535,7 +626,8 @@ impl<R: Copy + Debug, Keys: Debug + Index<usize, Output = Key<R>>> key::System<R
             Some(required_idle_time) => {
                 if context.idle_time_ms >= required_idle_time as u32 {
                     // Keymap has been idle long enough; use pending tap-hold key state.
-                    let (th_pks, maybe_sch_ev) = self.new_pending_key(&profile, keymap_index);
+                    let (th_pks, maybe_sch_ev) =
+                        self.new_pending_key(&profile, keymap_index, key_def.hold);
                     let pk = key::PressedKeyResult::Pending(th_pks);
                     let pke = match maybe_sch_ev {
                         Some(sch_ev) => {
@@ -552,7 +644,8 @@ impl<R: Copy + Debug, Keys: Debug + Index<usize, Output = Key<R>>> key::System<R
             }
             None => {
                 // Idle time not considered. Use pending tap-hold key state.
-                let (th_pks, maybe_sch_ev) = self.new_pending_key(&profile, keymap_index);
+                let (th_pks, maybe_sch_ev) =
+                    self.new_pending_key(&profile, keymap_index, key_def.hold);
                 let pk = key::PressedKeyResult::Pending(th_pks);
                 let pke = match maybe_sch_ev {
                     Some(sch_ev) => key::KeyEvents::scheduled_event(sch_ev.into_scheduled_event()),
@@ -642,6 +735,7 @@ mod tests {
                 required_idle_time,
                 hold_trigger_positions: None,
                 quick_tap_ms: None,
+                pending_output: PendingOutput::NoOutput,
             },
             profiles: Slice::from_slice(&[]),
         }
@@ -685,7 +779,7 @@ mod tests {
             InterruptResponse::Ignore,
             None,
         ));
-        let mut pks = PendingKeyState::new();
+        let mut pks = PendingKeyState::<u8>::new();
 
         // Act
         let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, release(KEYMAP_INDEX));
@@ -702,7 +796,7 @@ mod tests {
             InterruptResponse::Ignore,
             None,
         ));
-        let mut pks = PendingKeyState::new();
+        let mut pks = PendingKeyState::<u8>::new();
 
         // Act
         let resolution =
@@ -720,7 +814,7 @@ mod tests {
             InterruptResponse::Ignore,
             None,
         ));
-        let mut pks = PendingKeyState::new();
+        let mut pks = PendingKeyState::<u8>::new();
 
         // Act
         let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, press(OTHER_INDEX));
@@ -737,7 +831,7 @@ mod tests {
             InterruptResponse::Ignore,
             None,
         ));
-        let mut pks = PendingKeyState::new();
+        let mut pks = PendingKeyState::<u8>::new();
 
         // Act
         let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, release(OTHER_INDEX));
@@ -756,7 +850,7 @@ mod tests {
             InterruptResponse::HoldOnKeyPress,
             None,
         ));
-        let mut pks = PendingKeyState::new();
+        let mut pks = PendingKeyState::<u8>::new();
 
         // Act
         let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, press(OTHER_INDEX));
@@ -773,7 +867,7 @@ mod tests {
             InterruptResponse::HoldOnKeyPress,
             None,
         ));
-        let mut pks = PendingKeyState::new();
+        let mut pks = PendingKeyState::<u8>::new();
 
         // Act
         let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, release(KEYMAP_INDEX));
@@ -790,7 +884,7 @@ mod tests {
             InterruptResponse::HoldOnKeyPress,
             None,
         ));
-        let mut pks = PendingKeyState::new();
+        let mut pks = PendingKeyState::<u8>::new();
 
         // Act
         let resolution =
@@ -808,7 +902,7 @@ mod tests {
             InterruptResponse::HoldOnKeyPress,
             None,
         ));
-        let mut pks = PendingKeyState::new();
+        let mut pks = PendingKeyState::<u8>::new();
 
         // Act
         let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, release(OTHER_INDEX));
@@ -827,7 +921,7 @@ mod tests {
             InterruptResponse::HoldOnKeyTap,
             None,
         ));
-        let mut pks = PendingKeyState::new();
+        let mut pks = PendingKeyState::<u8>::new();
 
         // Act
         let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, release(KEYMAP_INDEX));
@@ -844,7 +938,7 @@ mod tests {
             InterruptResponse::HoldOnKeyTap,
             None,
         ));
-        let mut pks = PendingKeyState::new();
+        let mut pks = PendingKeyState::<u8>::new();
 
         // Act
         let resolution =
@@ -862,7 +956,7 @@ mod tests {
             InterruptResponse::HoldOnKeyTap,
             None,
         ));
-        let mut pks = PendingKeyState::new();
+        let mut pks = PendingKeyState::<u8>::new();
 
         // Act
         let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, press(OTHER_INDEX));
@@ -879,7 +973,7 @@ mod tests {
             InterruptResponse::HoldOnKeyTap,
             None,
         ));
-        let mut pks = PendingKeyState::new();
+        let mut pks = PendingKeyState::<u8>::new();
         let _ = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, press(OTHER_INDEX));
 
         // Act
@@ -897,7 +991,7 @@ mod tests {
             InterruptResponse::HoldOnKeyTap,
             None,
         ));
-        let mut pks = PendingKeyState::new();
+        let mut pks = PendingKeyState::<u8>::new();
 
         // Act
         let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, release(OTHER_INDEX));
@@ -914,7 +1008,7 @@ mod tests {
             InterruptResponse::HoldOnKeyTap,
             None,
         ));
-        let mut pks = PendingKeyState::new();
+        let mut pks = PendingKeyState::<u8>::new();
         let _ = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, press(OTHER_INDEX));
 
         // Act
@@ -1068,7 +1162,7 @@ mod tests {
         // Assemble
         let system = system();
         let ctx = default_context();
-        let mut pks = PendingKeyState::new();
+        let mut pks = PendingKeyState::<u8>::new();
 
         // Act
         let (resolved, _) = system.update_pending_state(
@@ -1088,7 +1182,7 @@ mod tests {
         // Assemble
         let system = system();
         let ctx = default_context();
-        let mut pks = PendingKeyState::new();
+        let mut pks = PendingKeyState::<u8>::new();
 
         // Act
         let (resolved, _) = system.update_pending_state(
@@ -1112,7 +1206,7 @@ mod tests {
             InterruptResponse::HoldOnKeyPress,
             None,
         ));
-        let mut pks = PendingKeyState::new();
+        let mut pks = PendingKeyState::<u8>::new();
 
         // Act
         let (resolved, _) =
@@ -1127,7 +1221,7 @@ mod tests {
         // Assemble
         let system = system();
         let ctx = default_context();
-        let mut pks = PendingKeyState::new();
+        let mut pks = PendingKeyState::<u8>::new();
 
         // Act
         let (resolved, _) =
@@ -1142,7 +1236,7 @@ mod tests {
         // Assemble
         let system = system();
         let ctx = default_context();
-        let mut pks = PendingKeyState::new();
+        let mut pks = PendingKeyState::<u8>::new();
 
         // Act
         let (_, events) = system.update_pending_state(
@@ -1214,6 +1308,7 @@ mod tests {
                 required_idle_time: Some(10),
                 hold_trigger_positions: None,
                 quick_tap_ms: None,
+                pending_output: PendingOutput::NoOutput,
             },
             profiles: Slice::from_slice(&[]),
         };
@@ -1237,6 +1332,7 @@ mod tests {
             required_idle_time: None,
             hold_trigger_positions: None,
             quick_tap_ms: None,
+            pending_output: PendingOutput::NoOutput,
         };
         let config = Config {
             default_profile: Profile {
@@ -1245,6 +1341,7 @@ mod tests {
                 required_idle_time: None,
                 hold_trigger_positions: None,
                 quick_tap_ms: None,
+                pending_output: PendingOutput::NoOutput,
             },
             profiles: Slice::from_slice(&[extra]),
         };
@@ -1263,6 +1360,7 @@ mod tests {
                 required_idle_time: None,
                 hold_trigger_positions: None,
                 quick_tap_ms: None,
+                pending_output: PendingOutput::NoOutput,
             },
             profiles: Slice::from_slice(&[]),
         };
@@ -1337,10 +1435,11 @@ mod tests {
                 required_idle_time: None,
                 hold_trigger_positions: Some(Slice::from_slice(&[2])),
                 quick_tap_ms: None,
+                pending_output: PendingOutput::NoOutput,
             },
             profiles: Slice::from_slice(&[]),
         });
-        let mut pks = PendingKeyState::new();
+        let mut pks = PendingKeyState::<u8>::new();
 
         // Act: interrupt from a non-trigger position (OTHER_INDEX = 1).
         let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, press(OTHER_INDEX));
@@ -1359,10 +1458,11 @@ mod tests {
                 required_idle_time: None,
                 hold_trigger_positions: Some(Slice::from_slice(&[2])),
                 quick_tap_ms: None,
+                pending_output: PendingOutput::NoOutput,
             },
             profiles: Slice::from_slice(&[]),
         });
-        let mut pks = PendingKeyState::new();
+        let mut pks = PendingKeyState::<u8>::new();
 
         // Act: interrupt from trigger position 2.
         let resolution = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, press(2));
@@ -1381,10 +1481,11 @@ mod tests {
                 required_idle_time: None,
                 hold_trigger_positions: Some(Slice::from_slice(&[2])),
                 quick_tap_ms: None,
+                pending_output: PendingOutput::NoOutput,
             },
             profiles: Slice::from_slice(&[]),
         });
-        let mut pks = PendingKeyState::new();
+        let mut pks = PendingKeyState::<u8>::new();
         let _ = pks.handle_event(&ctx.profile(0), KEYMAP_INDEX, press(OTHER_INDEX));
 
         // Act: complete the non-trigger key's tap (release).
@@ -1405,6 +1506,7 @@ mod tests {
                 required_idle_time: None,
                 hold_trigger_positions: Some(triggers),
                 quick_tap_ms: None,
+                pending_output: PendingOutput::NoOutput,
             },
             profiles: Slice::from_slice(&[]),
         };
@@ -1426,6 +1528,7 @@ mod tests {
             required_idle_time: None,
             hold_trigger_positions: Some(triggers),
             quick_tap_ms: None,
+            pending_output: PendingOutput::NoOutput,
         };
         let config = Config {
             default_profile: Profile::new(),

--- a/smart-keymap-core/src/keymap.rs
+++ b/smart-keymap-core/src/keymap.rs
@@ -869,8 +869,12 @@ impl<
     }
 
     /// Aggregate keyboard modifiers from already-pressed inputs (no suppress).
+    ///
+    /// Includes speculative [`key::System::pending_output`] while a pending
+    ///  session is live so the next key sees the mod (Ctrl+mouse / roll).
     fn aggregate_pressed_modifiers(&self) -> key::KeyboardModifiers {
-        self.pressed_inputs
+        let base = self
+            .pressed_inputs
             .iter()
             .filter_map(|pi| match pi {
                 input::PressedInput::Key(input::PressedKey {
@@ -880,7 +884,13 @@ impl<
             })
             .fold(key::KeyboardModifiers::NONE, |acc, ko| {
                 acc.union(&ko.key_modifiers())
-            })
+            });
+        let pending_mod = self
+            .pending_state
+            .as_ref()
+            .and_then(|pending| self.key_system.pending_output(&pending.pending_key_state))
+            .map_or(key::KeyboardModifiers::NONE, |ko| ko.key_modifiers());
+        base.union(&pending_mod)
     }
 
     fn push_keymap_context(&mut self) {
@@ -926,23 +936,30 @@ impl<
     /// Returns the the pressed key outputs.
     pub fn pressed_keys(&self) -> heapless::Vec<key::KeyOutput, { MAX_PRESSED_KEYS }> {
         let suppress = self.context.suppressed_modifiers();
-        let pressed_key_codes = self.pressed_inputs.iter().filter_map(|pi| {
-            let ko = match pi {
-                input::PressedInput::Key(input::PressedKey {
-                    key_ref, key_state, ..
-                }) => self.key_system.key_output(key_ref, key_state)?,
-                &input::PressedInput::Virtual(key_output) => key_output,
-            };
-            let ko = ko.without_modifiers(suppress);
-            // Drop pure-mod outputs that are fully suppressed.
-            if ko == key::KeyOutput::NO_OUTPUT {
-                None
-            } else {
-                Some(ko)
-            }
-        });
-
-        pressed_key_codes.collect()
+        let mut outputs: heapless::Vec<key::KeyOutput, { MAX_PRESSED_KEYS }> = self
+            .pressed_inputs
+            .iter()
+            .filter_map(|pi| {
+                let ko = match pi {
+                    input::PressedInput::Key(input::PressedKey {
+                        key_ref, key_state, ..
+                    }) => self.key_system.key_output(key_ref, key_state)?,
+                    &input::PressedInput::Virtual(key_output) => key_output,
+                };
+                let ko = ko.without_modifiers(suppress);
+                (ko != key::KeyOutput::NO_OUTPUT).then_some(ko)
+            })
+            .collect();
+        if let Some(ko) = self
+            .pending_state
+            .as_ref()
+            .and_then(|pending| self.key_system.pending_output(&pending.pending_key_state))
+            .map(|ko| ko.without_modifiers(suppress))
+            .filter(|ko| *ko != key::KeyOutput::NO_OUTPUT)
+        {
+            let _ = outputs.push(ko);
+        }
+        outputs
     }
 
     fn tick_by(&mut self, delta_ms: u32) {

--- a/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
+++ b/tests/ncl/keymap-1key-2layer-th-lmod/expected.rs
@@ -55,6 +55,52 @@ pub mod init {
             TapHold(smart_keymap::key::tap_hold::Ref),
         }
 
+        impl From<smart_keymap::key::keyboard::Ref> for Ref {
+            fn from(v: smart_keymap::key::keyboard::Ref) -> Self {
+                Ref::Keyboard(v)
+            }
+        }
+        impl From<smart_keymap::key::layered::Ref> for Ref {
+            fn from(v: smart_keymap::key::layered::Ref) -> Self {
+                Ref::Layered(v)
+            }
+        }
+        impl From<smart_keymap::key::tap_hold::Ref> for Ref {
+            fn from(v: smart_keymap::key::tap_hold::Ref) -> Self {
+                Ref::TapHold(v)
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::keyboard::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Keyboard(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::layered::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Layered(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::tap_hold::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::TapHold(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+
         /// Aggregate config for families used by this keymap.
         #[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq)]
         pub struct Config {
@@ -211,7 +257,7 @@ pub mod init {
             /// [smart_keymap::key::layered] variant.
             Layered(smart_keymap::key::layered::PendingKeyState),
             /// [smart_keymap::key::tap_hold] variant.
-            TapHold(smart_keymap::key::tap_hold::PendingKeyState),
+            TapHold(smart_keymap::key::tap_hold::PendingKeyState<Ref>),
         }
 
         impl From<smart_keymap::key::keyboard::PendingKeyState> for PendingKeyState {
@@ -224,14 +270,14 @@ pub mod init {
                 PendingKeyState::Layered(pks)
             }
         }
-        impl From<smart_keymap::key::tap_hold::PendingKeyState> for PendingKeyState {
-            fn from(pks: smart_keymap::key::tap_hold::PendingKeyState) -> Self {
+        impl From<smart_keymap::key::tap_hold::PendingKeyState<Ref>> for PendingKeyState {
+            fn from(pks: smart_keymap::key::tap_hold::PendingKeyState<Ref>) -> Self {
                 PendingKeyState::TapHold(pks)
             }
         }
         #[allow(unreachable_patterns)]
         impl<'pks> TryFrom<&'pks mut PendingKeyState>
-            for &'pks mut smart_keymap::key::tap_hold::PendingKeyState
+            for &'pks mut smart_keymap::key::tap_hold::PendingKeyState<Ref>
         {
             type Error = ();
             fn try_from(pks: &'pks mut PendingKeyState) -> Result<Self, Self::Error> {
@@ -447,6 +493,19 @@ pub mod init {
                         self.layered.key_output(r, ks)
                     }
                     (_, _) => None,
+                }
+            }
+
+            fn pending_output(
+                &self,
+                pending_key_state: &Self::PendingKeyState,
+            ) -> Option<key::KeyOutput> {
+                match pending_key_state {
+                    PendingKeyState::TapHold(pks) => pks.speculative_keyboard_output(|kb_ref| {
+                        self.keyboard
+                            .key_output(kb_ref, &smart_keymap::key::keyboard::KeyState)
+                    }),
+                    _ => None,
                 }
             }
         }

--- a/tests/ncl/keymap-1key-abbrev-ent/expected.rs
+++ b/tests/ncl/keymap-1key-abbrev-ent/expected.rs
@@ -48,6 +48,22 @@ pub mod init {
             Keyboard(smart_keymap::key::keyboard::Ref),
         }
 
+        impl From<smart_keymap::key::keyboard::Ref> for Ref {
+            fn from(v: smart_keymap::key::keyboard::Ref) -> Self {
+                Ref::Keyboard(v)
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::keyboard::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Keyboard(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+
         /// Aggregate config (no configurable families in this keymap).
         #[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq)]
         pub struct Config {}
@@ -274,6 +290,15 @@ pub mod init {
                 match (key_ref, key_state) {
                     (Ref::Keyboard(r), KeyState::Keyboard(ks)) => self.keyboard.key_output(r, ks),
                     (_, _) => None,
+                }
+            }
+
+            fn pending_output(
+                &self,
+                pending_key_state: &Self::PendingKeyState,
+            ) -> Option<key::KeyOutput> {
+                match pending_key_state {
+                    _ => None,
                 }
             }
         }

--- a/tests/ncl/keymap-1key-automation/expected.rs
+++ b/tests/ncl/keymap-1key-automation/expected.rs
@@ -48,6 +48,22 @@ pub mod init {
             Automation(smart_keymap::key::automation::Ref),
         }
 
+        impl From<smart_keymap::key::automation::Ref> for Ref {
+            fn from(v: smart_keymap::key::automation::Ref) -> Self {
+                Ref::Automation(v)
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::automation::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Automation(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+
         /// Aggregate config for families used by this keymap.
         #[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq)]
         pub struct Config {
@@ -288,6 +304,15 @@ pub mod init {
             ) -> Option<key::KeyOutput> {
                 match (key_ref, key_state) {
                     (_, _) => None,
+                }
+            }
+
+            fn pending_output(
+                &self,
+                pending_key_state: &Self::PendingKeyState,
+            ) -> Option<key::KeyOutput> {
+                match pending_key_state {
+                    _ => None,
                 }
             }
         }

--- a/tests/ncl/keymap-1key-callback-custom/expected.rs
+++ b/tests/ncl/keymap-1key-callback-custom/expected.rs
@@ -48,6 +48,22 @@ pub mod init {
             Callback(smart_keymap::key::callback::Ref),
         }
 
+        impl From<smart_keymap::key::callback::Ref> for Ref {
+            fn from(v: smart_keymap::key::callback::Ref) -> Self {
+                Ref::Callback(v)
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::callback::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Callback(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+
         /// Aggregate config (no configurable families in this keymap).
         #[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq)]
         pub struct Config {}
@@ -258,6 +274,15 @@ pub mod init {
             ) -> Option<key::KeyOutput> {
                 match (key_ref, key_state) {
                     (_, _) => None,
+                }
+            }
+
+            fn pending_output(
+                &self,
+                pending_key_state: &Self::PendingKeyState,
+            ) -> Option<key::KeyOutput> {
+                match pending_key_state {
+                    _ => None,
                 }
             }
         }

--- a/tests/ncl/keymap-1key-custom/expected.rs
+++ b/tests/ncl/keymap-1key-custom/expected.rs
@@ -46,6 +46,22 @@ pub mod init {
             Custom(smart_keymap::key::custom::Ref),
         }
 
+        impl From<smart_keymap::key::custom::Ref> for Ref {
+            fn from(v: smart_keymap::key::custom::Ref) -> Self {
+                Ref::Custom(v)
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::custom::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Custom(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+
         /// Aggregate config (no configurable families in this keymap).
         #[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq)]
         pub struct Config {}
@@ -251,6 +267,15 @@ pub mod init {
                 match (key_ref, key_state) {
                     (Ref::Custom(r), KeyState::Custom(ks)) => self.custom.key_output(r, ks),
                     (_, _) => None,
+                }
+            }
+
+            fn pending_output(
+                &self,
+                pending_key_state: &Self::PendingKeyState,
+            ) -> Option<key::KeyOutput> {
+                match pending_key_state {
+                    _ => None,
                 }
             }
         }

--- a/tests/ncl/keymap-1key-simple/expected.rs
+++ b/tests/ncl/keymap-1key-simple/expected.rs
@@ -48,6 +48,22 @@ pub mod init {
             Keyboard(smart_keymap::key::keyboard::Ref),
         }
 
+        impl From<smart_keymap::key::keyboard::Ref> for Ref {
+            fn from(v: smart_keymap::key::keyboard::Ref) -> Self {
+                Ref::Keyboard(v)
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::keyboard::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Keyboard(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+
         /// Aggregate config (no configurable families in this keymap).
         #[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq)]
         pub struct Config {}
@@ -274,6 +290,15 @@ pub mod init {
                 match (key_ref, key_state) {
                     (Ref::Keyboard(r), KeyState::Keyboard(ks)) => self.keyboard.key_output(r, ks),
                     (_, _) => None,
+                }
+            }
+
+            fn pending_output(
+                &self,
+                pending_key_state: &Self::PendingKeyState,
+            ) -> Option<key::KeyOutput> {
+                match pending_key_state {
+                    _ => None,
                 }
             }
         }

--- a/tests/ncl/keymap-1key-tap_dance/expected.rs
+++ b/tests/ncl/keymap-1key-tap_dance/expected.rs
@@ -51,6 +51,37 @@ pub mod init {
             TapDance(smart_keymap::key::tap_dance::Ref),
         }
 
+        impl From<smart_keymap::key::keyboard::Ref> for Ref {
+            fn from(v: smart_keymap::key::keyboard::Ref) -> Self {
+                Ref::Keyboard(v)
+            }
+        }
+        impl From<smart_keymap::key::tap_dance::Ref> for Ref {
+            fn from(v: smart_keymap::key::tap_dance::Ref) -> Self {
+                Ref::TapDance(v)
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::keyboard::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Keyboard(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::tap_dance::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::TapDance(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+
         /// Aggregate config for families used by this keymap.
         #[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq)]
         pub struct Config {
@@ -365,6 +396,16 @@ pub mod init {
                 match (key_ref, key_state) {
                     (Ref::Keyboard(r), KeyState::Keyboard(ks)) => self.keyboard.key_output(r, ks),
                     (_, _) => None,
+                }
+            }
+
+            fn pending_output(
+                &self,
+                pending_key_state: &Self::PendingKeyState,
+            ) -> Option<key::KeyOutput> {
+                match pending_key_state {
+                    PendingKeyState::TapDance(_) => None,
+                    _ => None,
                 }
             }
         }

--- a/tests/ncl/keymap-1key-tap_hold/expected.rs
+++ b/tests/ncl/keymap-1key-tap_hold/expected.rs
@@ -51,6 +51,37 @@ pub mod init {
             TapHold(smart_keymap::key::tap_hold::Ref),
         }
 
+        impl From<smart_keymap::key::keyboard::Ref> for Ref {
+            fn from(v: smart_keymap::key::keyboard::Ref) -> Self {
+                Ref::Keyboard(v)
+            }
+        }
+        impl From<smart_keymap::key::tap_hold::Ref> for Ref {
+            fn from(v: smart_keymap::key::tap_hold::Ref) -> Self {
+                Ref::TapHold(v)
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::keyboard::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Keyboard(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::tap_hold::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::TapHold(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+
         /// Aggregate config for families used by this keymap.
         #[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq)]
         pub struct Config {
@@ -177,7 +208,7 @@ pub mod init {
             /// [smart_keymap::key::keyboard] variant.
             Keyboard(smart_keymap::key::keyboard::PendingKeyState),
             /// [smart_keymap::key::tap_hold] variant.
-            TapHold(smart_keymap::key::tap_hold::PendingKeyState),
+            TapHold(smart_keymap::key::tap_hold::PendingKeyState<Ref>),
         }
 
         impl From<smart_keymap::key::keyboard::PendingKeyState> for PendingKeyState {
@@ -185,14 +216,14 @@ pub mod init {
                 PendingKeyState::Keyboard(pks)
             }
         }
-        impl From<smart_keymap::key::tap_hold::PendingKeyState> for PendingKeyState {
-            fn from(pks: smart_keymap::key::tap_hold::PendingKeyState) -> Self {
+        impl From<smart_keymap::key::tap_hold::PendingKeyState<Ref>> for PendingKeyState {
+            fn from(pks: smart_keymap::key::tap_hold::PendingKeyState<Ref>) -> Self {
                 PendingKeyState::TapHold(pks)
             }
         }
         #[allow(unreachable_patterns)]
         impl<'pks> TryFrom<&'pks mut PendingKeyState>
-            for &'pks mut smart_keymap::key::tap_hold::PendingKeyState
+            for &'pks mut smart_keymap::key::tap_hold::PendingKeyState<Ref>
         {
             type Error = ();
             fn try_from(pks: &'pks mut PendingKeyState) -> Result<Self, Self::Error> {
@@ -357,6 +388,19 @@ pub mod init {
                 match (key_ref, key_state) {
                     (Ref::Keyboard(r), KeyState::Keyboard(ks)) => self.keyboard.key_output(r, ks),
                     (_, _) => None,
+                }
+            }
+
+            fn pending_output(
+                &self,
+                pending_key_state: &Self::PendingKeyState,
+            ) -> Option<key::KeyOutput> {
+                match pending_key_state {
+                    PendingKeyState::TapHold(pks) => pks.speculative_keyboard_output(|kb_ref| {
+                        self.keyboard
+                            .key_output(kb_ref, &smart_keymap::key::keyboard::KeyState)
+                    }),
+                    _ => None,
                 }
             }
         }

--- a/tests/ncl/keymap-2key-2layer-composite/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-composite/expected.rs
@@ -55,6 +55,52 @@ pub mod init {
             TapHold(smart_keymap::key::tap_hold::Ref),
         }
 
+        impl From<smart_keymap::key::keyboard::Ref> for Ref {
+            fn from(v: smart_keymap::key::keyboard::Ref) -> Self {
+                Ref::Keyboard(v)
+            }
+        }
+        impl From<smart_keymap::key::layered::Ref> for Ref {
+            fn from(v: smart_keymap::key::layered::Ref) -> Self {
+                Ref::Layered(v)
+            }
+        }
+        impl From<smart_keymap::key::tap_hold::Ref> for Ref {
+            fn from(v: smart_keymap::key::tap_hold::Ref) -> Self {
+                Ref::TapHold(v)
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::keyboard::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Keyboard(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::layered::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Layered(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::tap_hold::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::TapHold(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+
         /// Aggregate config for families used by this keymap.
         #[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq)]
         pub struct Config {
@@ -211,7 +257,7 @@ pub mod init {
             /// [smart_keymap::key::layered] variant.
             Layered(smart_keymap::key::layered::PendingKeyState),
             /// [smart_keymap::key::tap_hold] variant.
-            TapHold(smart_keymap::key::tap_hold::PendingKeyState),
+            TapHold(smart_keymap::key::tap_hold::PendingKeyState<Ref>),
         }
 
         impl From<smart_keymap::key::keyboard::PendingKeyState> for PendingKeyState {
@@ -224,14 +270,14 @@ pub mod init {
                 PendingKeyState::Layered(pks)
             }
         }
-        impl From<smart_keymap::key::tap_hold::PendingKeyState> for PendingKeyState {
-            fn from(pks: smart_keymap::key::tap_hold::PendingKeyState) -> Self {
+        impl From<smart_keymap::key::tap_hold::PendingKeyState<Ref>> for PendingKeyState {
+            fn from(pks: smart_keymap::key::tap_hold::PendingKeyState<Ref>) -> Self {
                 PendingKeyState::TapHold(pks)
             }
         }
         #[allow(unreachable_patterns)]
         impl<'pks> TryFrom<&'pks mut PendingKeyState>
-            for &'pks mut smart_keymap::key::tap_hold::PendingKeyState
+            for &'pks mut smart_keymap::key::tap_hold::PendingKeyState<Ref>
         {
             type Error = ();
             fn try_from(pks: &'pks mut PendingKeyState) -> Result<Self, Self::Error> {
@@ -447,6 +493,19 @@ pub mod init {
                         self.layered.key_output(r, ks)
                     }
                     (_, _) => None,
+                }
+            }
+
+            fn pending_output(
+                &self,
+                pending_key_state: &Self::PendingKeyState,
+            ) -> Option<key::KeyOutput> {
+                match pending_key_state {
+                    PendingKeyState::TapHold(pks) => pks.speculative_keyboard_output(|kb_ref| {
+                        self.keyboard
+                            .key_output(kb_ref, &smart_keymap::key::keyboard::KeyState)
+                    }),
+                    _ => None,
                 }
             }
         }

--- a/tests/ncl/keymap-2key-2layer-named-layer_string/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-named-layer_string/expected.rs
@@ -52,6 +52,37 @@ pub mod init {
             Layered(smart_keymap::key::layered::Ref),
         }
 
+        impl From<smart_keymap::key::keyboard::Ref> for Ref {
+            fn from(v: smart_keymap::key::keyboard::Ref) -> Self {
+                Ref::Keyboard(v)
+            }
+        }
+        impl From<smart_keymap::key::layered::Ref> for Ref {
+            fn from(v: smart_keymap::key::layered::Ref) -> Self {
+                Ref::Layered(v)
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::keyboard::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Keyboard(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::layered::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Layered(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+
         /// Aggregate config for families used by this keymap.
         #[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq)]
         pub struct Config {
@@ -362,6 +393,15 @@ pub mod init {
                         self.layered.key_output(r, ks)
                     }
                     (_, _) => None,
+                }
+            }
+
+            fn pending_output(
+                &self,
+                pending_key_state: &Self::PendingKeyState,
+            ) -> Option<key::KeyOutput> {
+                match pending_key_state {
+                    _ => None,
                 }
             }
         }

--- a/tests/ncl/keymap-2key-2layer-named/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-named/expected.rs
@@ -52,6 +52,37 @@ pub mod init {
             Layered(smart_keymap::key::layered::Ref),
         }
 
+        impl From<smart_keymap::key::keyboard::Ref> for Ref {
+            fn from(v: smart_keymap::key::keyboard::Ref) -> Self {
+                Ref::Keyboard(v)
+            }
+        }
+        impl From<smart_keymap::key::layered::Ref> for Ref {
+            fn from(v: smart_keymap::key::layered::Ref) -> Self {
+                Ref::Layered(v)
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::keyboard::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Keyboard(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::layered::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Layered(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+
         /// Aggregate config for families used by this keymap.
         #[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq)]
         pub struct Config {
@@ -362,6 +393,15 @@ pub mod init {
                         self.layered.key_output(r, ks)
                     }
                     (_, _) => None,
+                }
+            }
+
+            fn pending_output(
+                &self,
+                pending_key_state: &Self::PendingKeyState,
+            ) -> Option<key::KeyOutput> {
+                match pending_key_state {
+                    _ => None,
                 }
             }
         }

--- a/tests/ncl/keymap-2key-2layer-simple/expected.rs
+++ b/tests/ncl/keymap-2key-2layer-simple/expected.rs
@@ -52,6 +52,37 @@ pub mod init {
             Layered(smart_keymap::key::layered::Ref),
         }
 
+        impl From<smart_keymap::key::keyboard::Ref> for Ref {
+            fn from(v: smart_keymap::key::keyboard::Ref) -> Self {
+                Ref::Keyboard(v)
+            }
+        }
+        impl From<smart_keymap::key::layered::Ref> for Ref {
+            fn from(v: smart_keymap::key::layered::Ref) -> Self {
+                Ref::Layered(v)
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::keyboard::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Keyboard(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::layered::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Layered(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+
         /// Aggregate config for families used by this keymap.
         #[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq)]
         pub struct Config {
@@ -362,6 +393,15 @@ pub mod init {
                         self.layered.key_output(r, ks)
                     }
                     (_, _) => None,
+                }
+            }
+
+            fn pending_output(
+                &self,
+                pending_key_state: &Self::PendingKeyState,
+            ) -> Option<key::KeyOutput> {
+                match pending_key_state {
+                    _ => None,
                 }
             }
         }

--- a/tests/ncl/keymap-2key-chorded-named-th-lmod/expected.rs
+++ b/tests/ncl/keymap-2key-chorded-named-th-lmod/expected.rs
@@ -61,6 +61,67 @@ pub mod init {
             TapHold(smart_keymap::key::tap_hold::Ref),
         }
 
+        impl From<smart_keymap::key::chorded::Ref> for Ref {
+            fn from(v: smart_keymap::key::chorded::Ref) -> Self {
+                Ref::Chorded(v)
+            }
+        }
+        impl From<smart_keymap::key::keyboard::Ref> for Ref {
+            fn from(v: smart_keymap::key::keyboard::Ref) -> Self {
+                Ref::Keyboard(v)
+            }
+        }
+        impl From<smart_keymap::key::layered::Ref> for Ref {
+            fn from(v: smart_keymap::key::layered::Ref) -> Self {
+                Ref::Layered(v)
+            }
+        }
+        impl From<smart_keymap::key::tap_hold::Ref> for Ref {
+            fn from(v: smart_keymap::key::tap_hold::Ref) -> Self {
+                Ref::TapHold(v)
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::chorded::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Chorded(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::keyboard::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Keyboard(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::layered::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Layered(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::tap_hold::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::TapHold(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+
         /// Aggregate config for families used by this keymap.
         #[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq)]
         pub struct Config {
@@ -259,7 +320,7 @@ pub mod init {
             /// [smart_keymap::key::layered] variant.
             Layered(smart_keymap::key::layered::PendingKeyState),
             /// [smart_keymap::key::tap_hold] variant.
-            TapHold(smart_keymap::key::tap_hold::PendingKeyState),
+            TapHold(smart_keymap::key::tap_hold::PendingKeyState<Ref>),
         }
 
         impl
@@ -291,8 +352,8 @@ pub mod init {
                 PendingKeyState::Layered(pks)
             }
         }
-        impl From<smart_keymap::key::tap_hold::PendingKeyState> for PendingKeyState {
-            fn from(pks: smart_keymap::key::tap_hold::PendingKeyState) -> Self {
+        impl From<smart_keymap::key::tap_hold::PendingKeyState<Ref>> for PendingKeyState {
+            fn from(pks: smart_keymap::key::tap_hold::PendingKeyState<Ref>) -> Self {
                 PendingKeyState::TapHold(pks)
             }
         }
@@ -314,7 +375,7 @@ pub mod init {
         }
         #[allow(unreachable_patterns)]
         impl<'pks> TryFrom<&'pks mut PendingKeyState>
-            for &'pks mut smart_keymap::key::tap_hold::PendingKeyState
+            for &'pks mut smart_keymap::key::tap_hold::PendingKeyState<Ref>
         {
             type Error = ();
             fn try_from(pks: &'pks mut PendingKeyState) -> Result<Self, Self::Error> {
@@ -598,6 +659,20 @@ pub mod init {
                         self.layered.key_output(r, ks)
                     }
                     (_, _) => None,
+                }
+            }
+
+            fn pending_output(
+                &self,
+                pending_key_state: &Self::PendingKeyState,
+            ) -> Option<key::KeyOutput> {
+                match pending_key_state {
+                    PendingKeyState::Chorded(_) => None,
+                    PendingKeyState::TapHold(pks) => pks.speculative_keyboard_output(|kb_ref| {
+                        self.keyboard
+                            .key_output(kb_ref, &smart_keymap::key::keyboard::KeyState)
+                    }),
+                    _ => None,
                 }
             }
         }

--- a/tests/ncl/keymap-2key-chorded/expected.rs
+++ b/tests/ncl/keymap-2key-chorded/expected.rs
@@ -54,6 +54,37 @@ pub mod init {
             Keyboard(smart_keymap::key::keyboard::Ref),
         }
 
+        impl From<smart_keymap::key::chorded::Ref> for Ref {
+            fn from(v: smart_keymap::key::chorded::Ref) -> Self {
+                Ref::Chorded(v)
+            }
+        }
+        impl From<smart_keymap::key::keyboard::Ref> for Ref {
+            fn from(v: smart_keymap::key::keyboard::Ref) -> Self {
+                Ref::Keyboard(v)
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::chorded::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Chorded(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::keyboard::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Keyboard(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+
         /// Aggregate config for families used by this keymap.
         #[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq)]
         pub struct Config {
@@ -425,6 +456,16 @@ pub mod init {
                 match (key_ref, key_state) {
                     (Ref::Keyboard(r), KeyState::Keyboard(ks)) => self.keyboard.key_output(r, ks),
                     (_, _) => None,
+                }
+            }
+
+            fn pending_output(
+                &self,
+                pending_key_state: &Self::PendingKeyState,
+            ) -> Option<key::KeyOutput> {
+                match pending_key_state {
+                    PendingKeyState::Chorded(_) => None,
+                    _ => None,
                 }
             }
         }

--- a/tests/ncl/keymap-34key-seniply/expected.rs
+++ b/tests/ncl/keymap-34key-seniply/expected.rs
@@ -55,6 +55,52 @@ pub mod init {
             Sticky(smart_keymap::key::sticky::Ref),
         }
 
+        impl From<smart_keymap::key::keyboard::Ref> for Ref {
+            fn from(v: smart_keymap::key::keyboard::Ref) -> Self {
+                Ref::Keyboard(v)
+            }
+        }
+        impl From<smart_keymap::key::layered::Ref> for Ref {
+            fn from(v: smart_keymap::key::layered::Ref) -> Self {
+                Ref::Layered(v)
+            }
+        }
+        impl From<smart_keymap::key::sticky::Ref> for Ref {
+            fn from(v: smart_keymap::key::sticky::Ref) -> Self {
+                Ref::Sticky(v)
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::keyboard::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Keyboard(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::layered::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Layered(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::sticky::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Sticky(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+
         /// Aggregate config for families used by this keymap.
         #[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq)]
         pub struct Config {
@@ -439,6 +485,15 @@ pub mod init {
                     }
                     (Ref::Sticky(r), KeyState::Sticky(ks)) => self.sticky.key_output(r, ks),
                     (_, _) => None,
+                }
+            }
+
+            fn pending_output(
+                &self,
+                pending_key_state: &Self::PendingKeyState,
+            ) -> Option<key::KeyOutput> {
+                match pending_key_state {
+                    _ => None,
                 }
             }
         }

--- a/tests/ncl/keymap-48key-basic/expected.rs
+++ b/tests/ncl/keymap-48key-basic/expected.rs
@@ -55,6 +55,52 @@ pub mod init {
             Layered(smart_keymap::key::layered::Ref),
         }
 
+        impl From<smart_keymap::key::callback::Ref> for Ref {
+            fn from(v: smart_keymap::key::callback::Ref) -> Self {
+                Ref::Callback(v)
+            }
+        }
+        impl From<smart_keymap::key::keyboard::Ref> for Ref {
+            fn from(v: smart_keymap::key::keyboard::Ref) -> Self {
+                Ref::Keyboard(v)
+            }
+        }
+        impl From<smart_keymap::key::layered::Ref> for Ref {
+            fn from(v: smart_keymap::key::layered::Ref) -> Self {
+                Ref::Layered(v)
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::callback::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Callback(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::keyboard::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Keyboard(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::layered::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Layered(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+
         /// Aggregate config for families used by this keymap.
         #[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq)]
         pub struct Config {
@@ -417,6 +463,15 @@ pub mod init {
                         self.layered.key_output(r, ks)
                     }
                     (_, _) => None,
+                }
+            }
+
+            fn pending_output(
+                &self,
+                pending_key_state: &Self::PendingKeyState,
+            ) -> Option<key::KeyOutput> {
+                match pending_key_state {
+                    _ => None,
                 }
             }
         }

--- a/tests/ncl/keymap-48key-rgoulter/expected.rs
+++ b/tests/ncl/keymap-48key-rgoulter/expected.rs
@@ -76,6 +76,142 @@ pub mod init {
             TapHold(smart_keymap::key::tap_hold::Ref),
         }
 
+        impl From<smart_keymap::key::callback::Ref> for Ref {
+            fn from(v: smart_keymap::key::callback::Ref) -> Self {
+                Ref::Callback(v)
+            }
+        }
+        impl From<smart_keymap::key::chorded::Ref> for Ref {
+            fn from(v: smart_keymap::key::chorded::Ref) -> Self {
+                Ref::Chorded(v)
+            }
+        }
+        impl From<smart_keymap::key::consumer::Ref> for Ref {
+            fn from(v: smart_keymap::key::consumer::Ref) -> Self {
+                Ref::Consumer(v)
+            }
+        }
+        impl From<smart_keymap::key::keyboard::Ref> for Ref {
+            fn from(v: smart_keymap::key::keyboard::Ref) -> Self {
+                Ref::Keyboard(v)
+            }
+        }
+        impl From<smart_keymap::key::layered::Ref> for Ref {
+            fn from(v: smart_keymap::key::layered::Ref) -> Self {
+                Ref::Layered(v)
+            }
+        }
+        impl From<smart_keymap::key::mouse::Ref> for Ref {
+            fn from(v: smart_keymap::key::mouse::Ref) -> Self {
+                Ref::Mouse(v)
+            }
+        }
+        impl From<smart_keymap::key::sticky::Ref> for Ref {
+            fn from(v: smart_keymap::key::sticky::Ref) -> Self {
+                Ref::Sticky(v)
+            }
+        }
+        impl From<smart_keymap::key::tap_dance::Ref> for Ref {
+            fn from(v: smart_keymap::key::tap_dance::Ref) -> Self {
+                Ref::TapDance(v)
+            }
+        }
+        impl From<smart_keymap::key::tap_hold::Ref> for Ref {
+            fn from(v: smart_keymap::key::tap_hold::Ref) -> Self {
+                Ref::TapHold(v)
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::callback::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Callback(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::chorded::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Chorded(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::consumer::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Consumer(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::keyboard::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Keyboard(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::layered::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Layered(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::mouse::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Mouse(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::sticky::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Sticky(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::tap_dance::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::TapDance(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::tap_hold::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::TapHold(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+
         /// Aggregate config for families used by this keymap.
         #[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq)]
         pub struct Config {
@@ -393,7 +529,7 @@ pub mod init {
             /// [smart_keymap::key::tap_dance] variant.
             TapDance(smart_keymap::key::tap_dance::PendingKeyState),
             /// [smart_keymap::key::tap_hold] variant.
-            TapHold(smart_keymap::key::tap_hold::PendingKeyState),
+            TapHold(smart_keymap::key::tap_hold::PendingKeyState<Ref>),
         }
 
         impl From<smart_keymap::key::callback::PendingKeyState> for PendingKeyState {
@@ -450,8 +586,8 @@ pub mod init {
                 PendingKeyState::TapDance(pks)
             }
         }
-        impl From<smart_keymap::key::tap_hold::PendingKeyState> for PendingKeyState {
-            fn from(pks: smart_keymap::key::tap_hold::PendingKeyState) -> Self {
+        impl From<smart_keymap::key::tap_hold::PendingKeyState<Ref>> for PendingKeyState {
+            fn from(pks: smart_keymap::key::tap_hold::PendingKeyState<Ref>) -> Self {
                 PendingKeyState::TapHold(pks)
             }
         }
@@ -485,7 +621,7 @@ pub mod init {
         }
         #[allow(unreachable_patterns)]
         impl<'pks> TryFrom<&'pks mut PendingKeyState>
-            for &'pks mut smart_keymap::key::tap_hold::PendingKeyState
+            for &'pks mut smart_keymap::key::tap_hold::PendingKeyState<Ref>
         {
             type Error = ();
             fn try_from(pks: &'pks mut PendingKeyState) -> Result<Self, Self::Error> {
@@ -932,6 +1068,21 @@ pub mod init {
                     (Ref::Mouse(r), KeyState::Mouse(ks)) => self.mouse.key_output(r, ks),
                     (Ref::Sticky(r), KeyState::Sticky(ks)) => self.sticky.key_output(r, ks),
                     (_, _) => None,
+                }
+            }
+
+            fn pending_output(
+                &self,
+                pending_key_state: &Self::PendingKeyState,
+            ) -> Option<key::KeyOutput> {
+                match pending_key_state {
+                    PendingKeyState::Chorded(_) => None,
+                    PendingKeyState::TapDance(_) => None,
+                    PendingKeyState::TapHold(pks) => pks.speculative_keyboard_output(|kb_ref| {
+                        self.keyboard
+                            .key_output(kb_ref, &smart_keymap::key::keyboard::KeyState)
+                    }),
+                    _ => None,
                 }
             }
         }

--- a/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple-with-tap_hold/expected.rs
@@ -51,6 +51,37 @@ pub mod init {
             TapHold(smart_keymap::key::tap_hold::Ref),
         }
 
+        impl From<smart_keymap::key::keyboard::Ref> for Ref {
+            fn from(v: smart_keymap::key::keyboard::Ref) -> Self {
+                Ref::Keyboard(v)
+            }
+        }
+        impl From<smart_keymap::key::tap_hold::Ref> for Ref {
+            fn from(v: smart_keymap::key::tap_hold::Ref) -> Self {
+                Ref::TapHold(v)
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::keyboard::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Keyboard(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::tap_hold::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::TapHold(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+
         /// Aggregate config for families used by this keymap.
         #[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq)]
         pub struct Config {
@@ -177,7 +208,7 @@ pub mod init {
             /// [smart_keymap::key::keyboard] variant.
             Keyboard(smart_keymap::key::keyboard::PendingKeyState),
             /// [smart_keymap::key::tap_hold] variant.
-            TapHold(smart_keymap::key::tap_hold::PendingKeyState),
+            TapHold(smart_keymap::key::tap_hold::PendingKeyState<Ref>),
         }
 
         impl From<smart_keymap::key::keyboard::PendingKeyState> for PendingKeyState {
@@ -185,14 +216,14 @@ pub mod init {
                 PendingKeyState::Keyboard(pks)
             }
         }
-        impl From<smart_keymap::key::tap_hold::PendingKeyState> for PendingKeyState {
-            fn from(pks: smart_keymap::key::tap_hold::PendingKeyState) -> Self {
+        impl From<smart_keymap::key::tap_hold::PendingKeyState<Ref>> for PendingKeyState {
+            fn from(pks: smart_keymap::key::tap_hold::PendingKeyState<Ref>) -> Self {
                 PendingKeyState::TapHold(pks)
             }
         }
         #[allow(unreachable_patterns)]
         impl<'pks> TryFrom<&'pks mut PendingKeyState>
-            for &'pks mut smart_keymap::key::tap_hold::PendingKeyState
+            for &'pks mut smart_keymap::key::tap_hold::PendingKeyState<Ref>
         {
             type Error = ();
             fn try_from(pks: &'pks mut PendingKeyState) -> Result<Self, Self::Error> {
@@ -357,6 +388,19 @@ pub mod init {
                 match (key_ref, key_state) {
                     (Ref::Keyboard(r), KeyState::Keyboard(ks)) => self.keyboard.key_output(r, ks),
                     (_, _) => None,
+                }
+            }
+
+            fn pending_output(
+                &self,
+                pending_key_state: &Self::PendingKeyState,
+            ) -> Option<key::KeyOutput> {
+                match pending_key_state {
+                    PendingKeyState::TapHold(pks) => pks.speculative_keyboard_output(|kb_ref| {
+                        self.keyboard
+                            .key_output(kb_ref, &smart_keymap::key::keyboard::KeyState)
+                    }),
+                    _ => None,
                 }
             }
         }

--- a/tests/ncl/keymap-60key-dvorak-simple/expected.rs
+++ b/tests/ncl/keymap-60key-dvorak-simple/expected.rs
@@ -48,6 +48,22 @@ pub mod init {
             Keyboard(smart_keymap::key::keyboard::Ref),
         }
 
+        impl From<smart_keymap::key::keyboard::Ref> for Ref {
+            fn from(v: smart_keymap::key::keyboard::Ref) -> Self {
+                Ref::Keyboard(v)
+            }
+        }
+        #[allow(unreachable_patterns)]
+        impl TryFrom<Ref> for smart_keymap::key::keyboard::Ref {
+            type Error = smart_keymap::key::EventError;
+            fn try_from(v: Ref) -> Result<Self, Self::Error> {
+                match v {
+                    Ref::Keyboard(v) => Ok(v),
+                    _ => Err(smart_keymap::key::EventError::UnmappableEvent),
+                }
+            }
+        }
+
         /// Aggregate config (no configurable families in this keymap).
         #[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq)]
         pub struct Config {}
@@ -274,6 +290,15 @@ pub mod init {
                 match (key_ref, key_state) {
                     (Ref::Keyboard(r), KeyState::Keyboard(ks)) => self.keyboard.key_output(r, ks),
                     (_, _) => None,
+                }
+            }
+
+            fn pending_output(
+                &self,
+                pending_key_state: &Self::PendingKeyState,
+            ) -> Option<key::KeyOutput> {
+                match pending_key_state {
+                    _ => None,
                 }
             }
         }

--- a/tests/rust/keymap.rs
+++ b/tests/rust/keymap.rs
@@ -10,6 +10,7 @@ mod key_lock;
 mod layered;
 mod mod_conditioned;
 mod mouse;
+mod pending_output;
 mod sequence;
 mod sticky;
 mod tap_dance;

--- a/tests/rust/pending_output.rs
+++ b/tests/rust/pending_output.rs
@@ -1,0 +1,203 @@
+use smart_keymap::input;
+use smart_keymap::key::KeyboardModifiers;
+use smart_keymap::keymap::ObservedKeymap;
+use smart_keymap_macros::keymap;
+
+use crate::hid_keycodes::*;
+
+/// LEFT_CTRL modifier byte as used in HID report `report[0]`.
+const MOD_LEFT_CTRL: u8 = KeyboardModifiers::LEFT_CTRL_U8;
+/// LEFT_GUI modifier byte.
+const MOD_LEFT_GUI: u8 = KeyboardModifiers::LEFT_GUI_U8;
+
+/// Returns true if any HID report contains `modifier` byte.
+fn has_report_with_mod(reports: &[[u8; 8]], modifier: u8) -> bool {
+    reports.iter().any(|r| r[0] == modifier)
+}
+
+/// Returns true if any report has `modifier` and `key_code` together
+///  (e.g. mod + A flash).
+fn has_report_with_mod_and_key(reports: &[[u8; 8]], modifier: u8, key_code: u8) -> bool {
+    reports.iter().any(|r| r[0] == modifier && r[2] == key_code)
+}
+
+#[test]
+fn default_none_still_silent_until_settle() {
+    // Assemble -- default NoOutput pending_output
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+        let K = import "keys.ncl" in
+        { keys = [ K.A & K.hold K.LeftCtrl ] }
+    "#
+    ));
+
+    // Act -- press TH
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+
+    // Assert -- silent while pending
+    let reports = keymap.distinct_reports().reports().to_vec();
+    assert_eq!(
+        vec![[0, 0, 0, 0, 0, 0, 0, 0]],
+        reports,
+        "should be silent while pending"
+    );
+
+    // Act -- tick to timeout
+    for _ in 0..210 {
+        keymap.tick();
+    }
+
+    // Assert -- after timeout should be hold
+    let reports2 = keymap.distinct_reports().reports().to_vec();
+    assert!(
+        has_report_with_mod(&reports2, MOD_LEFT_CTRL),
+        "after timeout should be hold"
+    );
+}
+
+#[test]
+fn hold_pending_shows_mod_after_first_tick() {
+    // Assemble -- tap-hold with Hold pending_output
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+        let K = import "keys.ncl" in
+        {
+            config.tap_hold.pending_output = "Hold",
+            keys = [ K.A & K.hold K.LeftCtrl ],
+        }
+    "#
+    ));
+
+    // Act -- press, tick once
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.tick();
+
+    // Assert -- mod from first tick
+    let reports = keymap.distinct_reports().reports().to_vec();
+    assert!(
+        has_report_with_mod(&reports, MOD_LEFT_CTRL),
+        "speculative hold should appear after first tick, got {:?}",
+        reports
+    );
+}
+
+#[test]
+fn hold_pending_timeout_stays_hold() {
+    // Assemble -- tap-hold with Hold pending_output
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+        let K = import "keys.ncl" in
+        {
+            config.tap_hold.pending_output = "Hold",
+            keys = [ K.A & K.hold K.LeftCtrl ],
+        }
+    "#
+    ));
+
+    // Act -- press, tick, then timeout
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.tick();
+    for _ in 0..210 {
+        keymap.tick();
+    }
+
+    // Assert -- still hold after timeout
+    let reports = keymap.distinct_reports().reports().to_vec();
+    assert!(has_report_with_mod(&reports, MOD_LEFT_CTRL));
+}
+
+#[test]
+fn hold_pending_quick_release_cancels_then_tap() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+        let K = import "keys.ncl" in
+        {
+            config.tap_hold.pending_output = "Hold",
+            keys = [ K.A & K.hold K.LeftCtrl ],
+        }
+    "#
+    ));
+
+    // Act -- press and tick to show speculative hold
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.tick();
+    let before = keymap.distinct_reports().reports().to_vec();
+    assert!(
+        has_report_with_mod(&before, MOD_LEFT_CTRL),
+        "speculative hold should be present"
+    );
+
+    // Act -- quick release before timeout
+    keymap.handle_input(input::Event::Release { keymap_index: 0 });
+    keymap.tick_until_no_scheduled_events();
+    let reports = keymap.distinct_reports().reports().to_vec();
+
+    // Assert -- should have tap A without mod, and no Ctrl+A flash
+    assert!(
+        reports.iter().any(|r| r[2] == KC_A && r[0] == 0),
+        "tap A without mod after cancel"
+    );
+    let has_flash = has_report_with_mod_and_key(&reports, MOD_LEFT_CTRL, KC_A);
+    assert!(
+        !has_flash,
+        "should not have Ctrl+A flash, reports {:?}",
+        reports
+    );
+}
+
+#[test]
+fn hold_pending_interrupt_mod_already_down() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+        let K = import "keys.ncl" in
+        {
+            config.tap_hold.pending_output = "Hold",
+            config.tap_hold.interrupt_response = "HoldOnKeyPress",
+            keys = [ K.A & K.hold K.LeftCtrl, K.B ],
+        }
+    "#
+    ));
+
+    // Act -- press TH, tick, then interrupt with B
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.tick();
+    keymap.handle_input(input::Event::Press { keymap_index: 1 });
+    keymap.tick_until_no_scheduled_events();
+    let reports = keymap.distinct_reports().reports().to_vec();
+
+    // Assert -- mod already down when B taps (distinct: MOD then MOD+B)
+    assert!(has_report_with_mod(&reports, MOD_LEFT_CTRL));
+    assert!(
+        has_report_with_mod_and_key(&reports, MOD_LEFT_CTRL, KC_B),
+        "B should be with mod, reports {:?}",
+        reports
+    );
+}
+
+#[test]
+fn gui_hold_refused_speculation() {
+    // Assemble
+    let mut keymap = ObservedKeymap::new(keymap!(
+        r#"
+        let K = import "keys.ncl" in
+        {
+            config.tap_hold.pending_output = "Hold",
+            keys = [ K.A & K.hold K.LeftGUI ],
+        }
+    "#
+    ));
+
+    // Act -- press GUI hold
+    keymap.handle_input(input::Event::Press { keymap_index: 0 });
+    keymap.tick();
+    let reports = keymap.distinct_reports().reports().to_vec();
+
+    // Assert -- should remain silent (GUI not speculated)
+    assert!(
+        !has_report_with_mod(&reports, MOD_LEFT_GUI),
+        "GUI should not speculate, reports {:?}",
+        reports
+    );
+}


### PR DESCRIPTION
Implements speculative eager Hold for tap-hold (FAK `eager_decision='hold'` / ZMK `hold-while-undecided` / QMK Speculative Hold) behind a generic `System::pending_output` seam.

### Stack

1. **core: add System::pending_output hook** — adds defaulted `System::pending_output(&PendingKeyState) -> Option<KeyOutput>` and includes it in `Keymap`'s `pressed_keys` / `aggregate_pressed_modifiers` fold while a pending session is live. Keeps `keymap.rs` generic (no tap-hold type).
2. **ncl: tap-hold pending_output authoring and codegen** — adds `pending_output` (`None|Hold`) to `Profile`/`Config`, lowers flat `config.tap_hold.pending_output` to `default_profile`, generates composite `System::pending_output` that decodes the speculative hold ref (keyboard only; GUI `LEFT_GUI`/`RIGHT_GUI` refused via `has_modifiers`). Updates `families.ncl` to `PendingKeyState<Ref>`.
3. **core: tap-hold pending_output profile and speculative state** — `PendingOutput` enum, `PendingKeyState<R> { speculative: Option<R> }`, `new_pending_key` stores hold ref when `pending_output=Hold`.
4. **test: refresh expected.rs snapshots** — `ncl/scripts/save-test-snapshots.sh`.
5. **test: add pending_output integration tests** — 5 AAA tests in `tests/rust/pending_output.rs` (default silent, Hold+timeout, Hold+quick-release cancel, Hold+HoldOnKeyPress interrupt, GUI refusal); AAA prose is inline `// Assemble --`/`// Act --`/`// Assert --` inside bodies.
6. **test: add pending_output cucumber feature** — `tap_hold-config-pending_output.feature` (4 scenarios).

### Verification

- `cargo test --test rust-integration pending_output` 5 passed
- `just test-fast` 218 passed
- `just check-quick` green (fmt, clippy, doc, nickel format)

Linger / same-mod ZMK tap deferred to follow-on.
