### PR TITLE
fix: clippy map_or_identity in smart_keymap

### DIFF
--- a/smart_keymap/src/lib.rs
+++ b/smart_keymap/src/lib.rs
@@ -346,7 +346,7 @@ pub unsafe extern "C" fn keymap_register_input_after_ms(
             debug_assert!(next_ms > 0);
         }
 
-        next_ev.map_or(0, |t| t)
+        next_ev.unwrap_or(0)
     }
 }
 
@@ -371,7 +371,7 @@ pub unsafe extern "C" fn keymap_next_event_timeout(report: &mut KeymapHidReport)
             debug_assert!(next_ms > 0);
         }
 
-        next_ev.map_or(0, |t| t)
+        next_ev.unwrap_or(0)
     }
 }
 


### PR DESCRIPTION
GitHub `ubuntu-latest` now ships Clippy 1.98, which denies `map_or_identity` under `-D warnings`. Local devenv is still 1.97.1, so `just check-quick` / `just test` do not catch it.

Replace `next_ev.map_or(0, |t| t)` with `next_ev.unwrap_or(0)` in the C FFI event-timeout helpers.

```rust
next_ev.unwrap_or(0)
```