### PR TITLE
Document HID modifier codes (0xE0..0xE7) with hex and constants

### DIFF
--- a/ncl/key_system/keymap-codegen.ncl
+++ b/ncl/key_system/keymap-codegen.ncl
@@ -1016,7 +1016,7 @@ pub mod key_system {
       let profile =
         composite.profile_from_keys [
           {
-            hold = { key_code = 224 },
+            hold = { key_code = 0xE0 }, # LeftCtrl
             tap = { key_code = 4 },
           }
         ]

--- a/ncl/smart_keys/keyboard/key-extensions.ncl
+++ b/ncl/smart_keys/keyboard/key-extensions.ncl
@@ -1,28 +1,25 @@
 {
   key_extensions = {
     keyboard =
-      (import "hid-usage-keyboard.ncl")
+      let hid = import "hid-usage-keyboard.ncl" in
+      let modifier_by_key_code = {
+        "%{std.to_string hid.LeftCtrl}" = { left_ctrl = true }, # 0xE0 LeftCtrl -> left_ctrl
+        "%{std.to_string hid.LeftShift}" = { left_shift = true }, # 0xE1 LeftShift -> left_shift
+        "%{std.to_string hid.LeftAlt}" = { left_alt = true }, # 0xE2 LeftAlt -> left_alt
+        "%{std.to_string hid.LeftGUI}" = { left_gui = true }, # 0xE3 LeftGUI -> left_gui
+        "%{std.to_string hid.RightCtrl}" = { right_ctrl = true }, # 0xE4 RightCtrl -> right_ctrl
+        "%{std.to_string hid.RightShift}" = { right_shift = true }, # 0xE5 RightShift -> right_shift
+        "%{std.to_string hid.RightAlt}" = { right_alt = true }, # 0xE6 RightAlt -> right_alt
+        "%{std.to_string hid.RightGUI}" = { right_gui = true }, # 0xE7 RightGUI -> right_gui
+      }
+      in
+      hid
       |> std.record.map_values (fun kc =>
-        kc
-        |> match {
-          # 0xE0 .. 0xE7
-          _ if 224 <= kc && kc <= 231 =>
-            {
-              modifiers =
-                kc
-                |> match {
-                  224 => { left_ctrl = true },
-                  225 => { left_shift = true },
-                  226 => { left_alt = true },
-                  227 => { left_gui = true },
-                  228 => { right_ctrl = true },
-                  229 => { right_shift = true },
-                  230 => { right_alt = true },
-                  231 => { right_gui = true },
-                },
-            },
-          kc => { key_code = kc },
-        }
+        let kc_str = std.to_string kc in
+        if std.record.has_field kc_str modifier_by_key_code then
+          { modifiers = std.record.get kc_str modifier_by_key_code }
+        else
+          { key_code = kc }
       ),
 
     keyboard_abbreviations = fun keys =>

--- a/ncl/smart_keys/layered/keymap-codegen.ncl
+++ b/ncl/smart_keys/layered/keymap-codegen.ncl
@@ -47,7 +47,7 @@
       check_layered_composite_taphold_keyboard =
         let json = {
           base = {
-            hold = { key_code = 224 },
+            hold = { key_code = 0xE0 }, # LeftCtrl
             tap = { key_code = 4 },
           },
           layered = [

--- a/ncl/smart_keys/tap_hold/keymap-codegen.ncl
+++ b/ncl/smart_keys/tap_hold/keymap-codegen.ncl
@@ -15,7 +15,7 @@
     # Use a json value to check the "is" predicate.
     check_json_tap_keyboard_hold_keyboard_is =
       let json = {
-        hold = { key_code = 224 },
+        hold = { key_code = 0xE0 }, # LeftCtrl
         tap = { key_code = 4 },
       }
       in
@@ -25,7 +25,7 @@
       # Nested keys are validated/codegen'd via smart_key (keyboard, etc.).
       check_taphold_keyboard =
         let json = {
-          hold = { key_code = 224 },
+          hold = { key_code = 0xE0 }, # LeftCtrl
           tap = { key_code = 4 },
         }
         in
@@ -39,7 +39,7 @@
 
       check_taphold_with_profile =
         let json = {
-          hold = { key_code = 224 },
+          hold = { key_code = 0xE0 }, # LeftCtrl
           tap = { key_code = 4 },
           profile = 1,
         }
@@ -120,9 +120,8 @@
 
         check_left_ctrl_keycode =
           let cv =
-            smart_keymap.keyboard.key.codegen_values { key_code = 224 }
-          in
-          {
+            smart_keymap.keyboard.key.codegen_values { key_code = 0xE0 } # LeftCtrl
+          in {
             actual = smart_keymap.tap_hold.speculative_hold_output cv,
             expected =
               'Some {
@@ -133,21 +132,19 @@
 
         check_left_gui_modifiers_refused =
           let cv =
-            smart_keymap.keyboard.key.codegen_values { modifiers = 8 }
-          in
-          smart_keymap.tap_hold.speculative_hold_output cv == 'None,
+            smart_keymap.keyboard.key.codegen_values { modifiers = 8 } # LeftGUI bit
+          in smart_keymap.tap_hold.speculative_hold_output cv == 'None,
 
         check_left_gui_keycode_refused =
           let cv =
-            smart_keymap.keyboard.key.codegen_values { key_code = 227 }
-          in
-          smart_keymap.tap_hold.speculative_hold_output cv == 'None,
+            smart_keymap.keyboard.key.codegen_values { key_code = 0xE3 } # LeftGUI 0xE3
+          in smart_keymap.tap_hold.speculative_hold_output cv == 'None,
 
         check_non_keyboard_refused =
           let cv =
             smart_keymap.tap_hold.key.codegen_values {
               tap = { key_code = 4 },
-              hold = { key_code = 224 },
+              hold = { key_code = 0xE0 }, # LeftCtrl
             }
           in
           smart_keymap.tap_hold.speculative_hold_output cv == 'None,
@@ -209,19 +206,24 @@
               0
               [0, 1, 2, 3, 4, 5, 6, 7]
           in
+          let hid = import "hid-usage-keyboard.ncl" in
+          let key_code_to_mod_byte = {
+            "%{std.to_string hid.LeftCtrl}" = 1, # 0xE0 LeftCtrl -> 0x01
+            "%{std.to_string hid.LeftShift}" = 2, # 0xE1 LeftShift -> 0x02
+            "%{std.to_string hid.LeftAlt}" = 4, # 0xE2 LeftAlt -> 0x04
+            "%{std.to_string hid.LeftGUI}" = 8, # 0xE3 LeftGUI -> 0x08
+            "%{std.to_string hid.RightCtrl}" = 16, # 0xE4 RightCtrl -> 0x10
+            "%{std.to_string hid.RightShift}" = 32, # 0xE5 RightShift -> 0x20
+            "%{std.to_string hid.RightAlt}" = 64, # 0xE6 RightAlt -> 0x40
+            "%{std.to_string hid.RightGUI}" = 128, # 0xE7 RightGUI -> 0x80
+          }
+          in
+          let kc_str = std.to_string key_code in
           let kc_mod =
-            key_code
-            |> match {
-              224 => 1,
-              225 => 2,
-              226 => 4,
-              227 => 8,
-              228 => 16,
-              229 => 32,
-              230 => 64,
-              231 => 128,
-              _ => 0,
-            }
+            if std.record.has_field kc_str key_code_to_mod_byte then
+              std.record.get kc_str key_code_to_mod_byte
+            else
+              0
           in
           let remaining_kc = if kc_mod != 0 then 0 else key_code in
           let merged = bit_or8 modifiers kc_mod in

--- a/smart-keymap-core/src/key.rs
+++ b/smart-keymap-core/src/key.rs
@@ -377,6 +377,23 @@ impl KeyboardModifiers {
     /// Byte value for right gui.
     pub const RIGHT_GUI_U8: u8 = 0x80;
 
+    /// HID usage for LeftCtrl (0xE0).
+    pub const HID_LEFT_CTRL: u8 = 0xE0;
+    /// HID usage for LeftShift (0xE1).
+    pub const HID_LEFT_SHIFT: u8 = 0xE1;
+    /// HID usage for LeftAlt (0xE2).
+    pub const HID_LEFT_ALT: u8 = 0xE2;
+    /// HID usage for LeftGUI (0xE3).
+    pub const HID_LEFT_GUI: u8 = 0xE3;
+    /// HID usage for RightCtrl (0xE4).
+    pub const HID_RIGHT_CTRL: u8 = 0xE4;
+    /// HID usage for RightShift (0xE5).
+    pub const HID_RIGHT_SHIFT: u8 = 0xE5;
+    /// HID usage for RightAlt (0xE6).
+    pub const HID_RIGHT_ALT: u8 = 0xE6;
+    /// HID usage for RightGUI (0xE7).
+    pub const HID_RIGHT_GUI: u8 = 0xE7;
+
     /// Constructs with modifiers defaulting to false.
     pub const fn new() -> Self {
         KeyboardModifiers(0x00)
@@ -390,16 +407,17 @@ impl KeyboardModifiers {
     /// Constructs with the given key_code.
     ///
     /// Returns None if the key_code is not a modifier key code.
+    /// Uses HID usages 0xE0..0xE7 (LeftCtrl..RightGUI).
     pub const fn from_key_code(key_code: u8) -> Option<Self> {
         match key_code {
-            0xE0 => Some(Self::LEFT_CTRL),
-            0xE1 => Some(Self::LEFT_SHIFT),
-            0xE2 => Some(Self::LEFT_ALT),
-            0xE3 => Some(Self::LEFT_GUI),
-            0xE4 => Some(Self::RIGHT_CTRL),
-            0xE5 => Some(Self::RIGHT_SHIFT),
-            0xE6 => Some(Self::RIGHT_ALT),
-            0xE7 => Some(Self::RIGHT_GUI),
+            Self::HID_LEFT_CTRL => Some(Self::LEFT_CTRL),
+            Self::HID_LEFT_SHIFT => Some(Self::LEFT_SHIFT),
+            Self::HID_LEFT_ALT => Some(Self::LEFT_ALT),
+            Self::HID_LEFT_GUI => Some(Self::LEFT_GUI),
+            Self::HID_RIGHT_CTRL => Some(Self::RIGHT_CTRL),
+            Self::HID_RIGHT_SHIFT => Some(Self::RIGHT_SHIFT),
+            Self::HID_RIGHT_ALT => Some(Self::RIGHT_ALT),
+            Self::HID_RIGHT_GUI => Some(Self::RIGHT_GUI),
             _ => None,
         }
     }
@@ -434,47 +452,50 @@ impl KeyboardModifiers {
     pub const RIGHT_GUI: KeyboardModifiers = KeyboardModifiers(Self::RIGHT_GUI_U8);
 
     /// Predicate for whether the key code is a modifier key code.
+    /// HID modifier range is 0xE0..0xE7 (LeftCtrl..RightGUI).
     pub const fn is_modifier_key_code(key_code: u8) -> bool {
-        matches!(key_code, 0xE0..=0xE7)
+        matches!(key_code, Self::HID_LEFT_CTRL..=Self::HID_RIGHT_GUI)
     }
 
     /// Constructs a Vec of key codes from the modifiers.
+    /// Each set bit maps to its HID usage 0xE0..0xE7.
     pub fn as_key_codes(&self) -> heapless::Vec<u8, 8> {
         let mut key_codes = heapless::Vec::new();
 
         if self.0 & Self::LEFT_CTRL_U8 != 0 {
-            let _ = key_codes.push(0xE0);
+            let _ = key_codes.push(Self::HID_LEFT_CTRL);
         }
         if self.0 & Self::LEFT_SHIFT_U8 != 0 {
-            let _ = key_codes.push(0xE1);
+            let _ = key_codes.push(Self::HID_LEFT_SHIFT);
         }
         if self.0 & Self::LEFT_ALT_U8 != 0 {
-            let _ = key_codes.push(0xE2);
+            let _ = key_codes.push(Self::HID_LEFT_ALT);
         }
         if self.0 & Self::LEFT_GUI_U8 != 0 {
-            let _ = key_codes.push(0xE3);
+            let _ = key_codes.push(Self::HID_LEFT_GUI);
         }
         if self.0 & Self::RIGHT_CTRL_U8 != 0 {
-            let _ = key_codes.push(0xE4);
+            let _ = key_codes.push(Self::HID_RIGHT_CTRL);
         }
         if self.0 & Self::RIGHT_SHIFT_U8 != 0 {
-            let _ = key_codes.push(0xE5);
+            let _ = key_codes.push(Self::HID_RIGHT_SHIFT);
         }
         if self.0 & Self::RIGHT_ALT_U8 != 0 {
-            let _ = key_codes.push(0xE6);
+            let _ = key_codes.push(Self::HID_RIGHT_ALT);
         }
         if self.0 & Self::RIGHT_GUI_U8 != 0 {
-            let _ = key_codes.push(0xE7);
+            let _ = key_codes.push(Self::HID_RIGHT_GUI);
         }
 
         key_codes
     }
 
     /// Constructs the byte for the modifiers of an HID keyboard report.
+    /// HID usages 0xE0..0xE7 map to bits 0..7.
     pub fn as_byte(&self) -> u8 {
         self.as_key_codes()
             .iter()
-            .fold(0u8, |acc, &kc| acc | (1 << (kc - 0xE0)))
+            .fold(0u8, |acc, &kc| acc | (1 << (kc - Self::HID_LEFT_CTRL)))
     }
 
     /// Union of two KeyboardModifiers, taking "or" of each modifier.

--- a/smart-keymap-core/src/key/caps_word.rs
+++ b/smart-keymap-core/src/key/caps_word.rs
@@ -59,16 +59,16 @@ impl Context {
                     0x2A => false,                       // Backspace
                     0x2D => false,                       // `-` minus
                     0x4C => false,                       // Delete
-                    0xE1 => false,                       // Left Shift
-                    0xE5 => false,                       // Right Shift
-                    0x00 => false,                       // No key code (modifier)
+                    key::KeyboardModifiers::HID_LEFT_SHIFT => false,
+                    key::KeyboardModifiers::HID_RIGHT_SHIFT => false,
+                    0x00 => false, // No key code (modifier)
                     _ => true,
                 };
 
                 if exit_caps_word {
                     self.is_active = false;
 
-                    let key_code = 0xE1;
+                    let key_code = key::KeyboardModifiers::HID_LEFT_SHIFT;
                     let vk_ev = input::Event::VirtualKeyRelease {
                         key_output: key::KeyOutput::from_key_code(key_code),
                     };
@@ -81,7 +81,7 @@ impl Context {
                 Event::EnableCapsWord => {
                     self.is_active = true;
 
-                    let key_code = 0xE1;
+                    let key_code = key::KeyboardModifiers::HID_LEFT_SHIFT;
                     let vk_ev = input::Event::VirtualKeyPress {
                         key_output: key::KeyOutput::from_key_code(key_code),
                     };
@@ -90,7 +90,7 @@ impl Context {
                 Event::DisableCapsWord => {
                     self.is_active = false;
 
-                    let key_code = 0xE1;
+                    let key_code = key::KeyboardModifiers::HID_LEFT_SHIFT;
                     let vk_ev = input::Event::VirtualKeyRelease {
                         key_output: key::KeyOutput::from_key_code(key_code),
                     };

--- a/smart-keymap-core/src/key/key_lock.rs
+++ b/smart-keymap-core/src/key/key_lock.rs
@@ -313,7 +313,9 @@ mod tests {
 
     #[test]
     fn is_lockable_accepts_modifier() {
-        assert!(is_lockable(&key::KeyOutput::from_key_code(0xE1)));
+        assert!(is_lockable(&key::KeyOutput::from_key_code(
+            key::KeyboardModifiers::HID_LEFT_SHIFT,
+        )));
     }
 
     #[test]

--- a/smart-keymap-core/src/key/tri_state.rs
+++ b/smart-keymap-core/src/key/tri_state.rs
@@ -288,7 +288,7 @@ mod tests {
     #[test]
     fn start_arms_session() {
         let mut ctx = Context::new();
-        let hold = key::KeyOutput::from_key_code(0xE2);
+        let hold = key::KeyOutput::from_key_code(key::KeyboardModifiers::HID_LEFT_ALT);
         let tap = key::KeyOutput::from_key_code(0x2B);
         let _ = key::Context::handle_event(
             &mut ctx,
@@ -301,7 +301,7 @@ mod tests {
     #[test]
     fn other_resolved_output_ends_session() {
         let mut ctx = Context::new();
-        let hold = key::KeyOutput::from_key_code(0xE2);
+        let hold = key::KeyOutput::from_key_code(key::KeyboardModifiers::HID_LEFT_ALT);
         let tap = key::KeyOutput::from_key_code(0x2B);
         let _ = key::Context::handle_event(
             &mut ctx,
@@ -320,7 +320,7 @@ mod tests {
     #[test]
     fn own_resolved_output_does_not_end_session() {
         let mut ctx = Context::new();
-        let hold = key::KeyOutput::from_key_code(0xE2);
+        let hold = key::KeyOutput::from_key_code(key::KeyboardModifiers::HID_LEFT_ALT);
         let tap = key::KeyOutput::from_key_code(0x2B);
         let _ = key::Context::handle_event(
             &mut ctx,

--- a/smart-keymap-core/src/keymap.rs
+++ b/smart-keymap-core/src/keymap.rs
@@ -1108,31 +1108,39 @@ mod tests {
 
     #[test]
     fn test_keymap_output_pressed_key_codes_includes_modifier_key_code() {
-        // Assemble - include modifier key left ctrl
+        // Assemble - include modifier key left ctrl (HID 0xE0)
         let mut input: heapless::Vec<key::KeyOutput, { MAX_PRESSED_KEYS }> = heapless::Vec::new();
         input.push(key::KeyOutput::from_key_code(0x04)).unwrap();
-        input.push(key::KeyOutput::from_key_code(0xE0)).unwrap();
+        input
+            .push(key::KeyOutput::from_key_code(
+                key::KeyboardModifiers::HID_LEFT_CTRL,
+            ))
+            .unwrap();
 
         // Act - construct the output
         let keymap_output = KeymapOutput::new(input);
         let pressed_key_codes = keymap_output.pressed_key_codes();
 
-        // Assert - check the 0xE0 gets included as a key code.
-        assert!(pressed_key_codes.contains(&0xE0))
+        // Assert - check the HID_LEFT_CTRL gets included as a key code.
+        assert!(pressed_key_codes.contains(&key::KeyboardModifiers::HID_LEFT_CTRL))
     }
 
     #[test]
     fn test_keymap_output_as_hid_boot_keyboard_report_gathers_modifiers() {
-        // Assemble - include modifier key left ctrl
+        // Assemble - include modifier key left ctrl (HID 0xE0)
         let mut input: heapless::Vec<key::KeyOutput, { MAX_PRESSED_KEYS }> = heapless::Vec::new();
         input.push(key::KeyOutput::from_key_code(0x04)).unwrap();
-        input.push(key::KeyOutput::from_key_code(0xE0)).unwrap();
+        input
+            .push(key::KeyOutput::from_key_code(
+                key::KeyboardModifiers::HID_LEFT_CTRL,
+            ))
+            .unwrap();
 
         // Act - construct the output
         let keymap_output = KeymapOutput::new(input);
         let actual_report: [u8; 8] = keymap_output.as_hid_boot_keyboard_report();
 
-        // Assert - check the 0xE0 gets considered as a "modifier".
+        // Assert - check the HID_LEFT_CTRL gets considered as a "modifier".
         let expected_report: [u8; 8] = [0x01, 0, 0x04, 0, 0, 0, 0, 0];
         assert_eq!(expected_report, actual_report);
     }

--- a/smart-keymap-full-system-std/tests/keymap_full_system.rs
+++ b/smart-keymap-full-system-std/tests/keymap_full_system.rs
@@ -47,7 +47,9 @@ fn tap_hold_interrupt_keymap(
             smart_keymap::key::tap_dance::System::new(Vec::new()),
             smart_keymap::key::tap_hold::System::new(vec![smart_keymap::key::tap_hold::Key {
                 tap: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(0x04)),
-                hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(0xE0)),
+                hold: key_system::Ref::Keyboard(smart_keymap::key::keyboard::Ref::KeyCode(
+                    smart_keymap::key::KeyboardModifiers::HID_LEFT_CTRL,
+                )),
                 profile: 0,
                 hold_output: None,
             }]),
@@ -149,7 +151,7 @@ fn scheduled_input_during_pending_does_not_reprocess_as_physical_press() {
     }));
 
     // Assert -- hold only; interrupt key not pressed (#578).
-    let hold = key::KeyOutput::from_key_code(0xE0);
+    let hold = key::KeyOutput::from_key_code(key::KeyboardModifiers::HID_LEFT_CTRL);
     let interrupt_key = key::KeyOutput::from_key_code(0x05);
     assert_eq!(
         heapless::Vec::<key::KeyOutput, { MAX_PRESSED_KEYS }>::from_slice(&[hold]).unwrap(),
@@ -314,7 +316,7 @@ fn resolve_by_timeout_leaves_delay_line_inputs_queued() {
     // Assert -- hold; delay-line Press(1) still queued, not applied as a press.
     assert!(!keymap.test_is_pending());
     assert_eq!(1, keymap.test_input_queue_len());
-    let hold = key::KeyOutput::from_key_code(0xE0);
+    let hold = key::KeyOutput::from_key_code(key::KeyboardModifiers::HID_LEFT_CTRL);
     assert_eq!(
         heapless::Vec::<key::KeyOutput, { MAX_PRESSED_KEYS }>::from_slice(&[hold]).unwrap(),
         keymap.pressed_keys()


### PR DESCRIPTION
Replaces decimal 224..231 magic numbers with self-documenting forms.

Nickel (45a75aa3): key-extensions and tap_hold codegen now use hid.LeftCtrl etc via record lookup with 0xE0..0xE7; checks use 0xE0 LeftCtrl hex where const not available.

Rust (166c9576): adds HID_LEFT_CTRL..HID_RIGHT_GUI constants and updates from_key_code, is_modifier_key_code, as_key_codes, as_byte and tests; no redundant comments after HID const.